### PR TITLE
fix(hooks): cross-platform process identity for session pointer and lock-owner classification (#3362)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,44 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  native-rust-darwin:
+    name: Native Rust (Darwin)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build omx-runtime
+        run: cargo build -p omx-runtime
+      - name: Test omx-runtime
+        run: cargo test -p omx-runtime
+
+  native-rust-windows:
+    name: Native Rust (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.native_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@v2
+      - name: Build omx-runtime
+        run: cargo build -p omx-runtime
+      - name: Test omx-runtime
+        run: cargo test -p omx-runtime
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -610,7 +648,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build]
+    needs: [changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build]
     steps:
       - name: Check required job results
         shell: bash
@@ -626,6 +664,8 @@ jobs:
           RUSTFMT_RESULT: ${{ needs.rustfmt.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
           RUST_TESTS_RESULT: ${{ needs.rust-tests.result }}
+          NATIVE_RUST_DARWIN_RESULT: ${{ needs.native-rust-darwin.result }}
+          NATIVE_RUST_WINDOWS_RESULT: ${{ needs.native-rust-windows.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           BUILD_DIST_RESULT: ${{ needs.build-dist.result }}
@@ -680,6 +720,8 @@ jobs:
           echo "  rustfmt: $RUSTFMT_RESULT"
           echo "  clippy: $CLIPPY_RESULT"
           echo "  rust-tests: $RUST_TESTS_RESULT"
+          echo "  native-rust-darwin: $NATIVE_RUST_DARWIN_RESULT"
+          echo "  native-rust-windows: $NATIVE_RUST_WINDOWS_RESULT"
           echo "  lint: $LINT_RESULT"
           echo "  typecheck: $TYPECHECK_RESULT"
           echo "  build-dist: $BUILD_DIST_RESULT"
@@ -709,6 +751,8 @@ jobs:
           check_job rustfmt "$RUSTFMT_RESULT" "$rust_active"
           check_job clippy "$CLIPPY_RESULT" "$rust_active"
           check_job rust-tests "$RUST_TESTS_RESULT" "$rust_active"
+          check_job native-rust-darwin "$NATIVE_RUST_DARWIN_RESULT" "$rust_active"
+          check_job native-rust-windows "$NATIVE_RUST_WINDOWS_RESULT" "$rust_active"
           check_job lint "$LINT_RESULT" "$ts_active"
           check_job typecheck "$TYPECHECK_RESULT" "$ts_active"
           check_job build-dist "$BUILD_DIST_RESULT" "$dist_active"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "omx-mux",
  "omx-runtime-core",
  "serde_json",
+ "windows-sys",
 ]
 
 [[package]]
@@ -179,6 +180,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"

--- a/crates/omx-runtime/Cargo.toml
+++ b/crates/omx-runtime/Cargo.toml
@@ -13,3 +13,5 @@ omx-runtime-core = { path = "../omx-runtime-core" }
 fs2 = "0.4"
 serde_json = "1"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/crates/omx-runtime/src/main.rs
+++ b/crates/omx-runtime/src/main.rs
@@ -124,6 +124,7 @@ fn run() -> Result<(), String> {
             Ok(())
         }
         Some("fs-rename-no-replace") => run_fs_rename_no_replace(&args[1..]),
+        Some("process-identity") => run_process_identity(&args[1..]),
         Some("init") => {
             let dir = second.ok_or("init requires a state directory path")?;
             let engine = RuntimeEngine::new().with_state_dir(dir);
@@ -271,6 +272,292 @@ fn fs_rename_no_replace(
     Ok(FsRenameOutcome::Unsupported("platform"))
 }
 
+// ---------------------------------------------------------------------------
+// process-identity subcommand
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+enum ProcessIdentityError {
+    Denied,
+    Gone,
+    Unsupported,
+    Error(String),
+}
+
+struct ProcessIdentityResult {
+    platform: &'static str,
+    birth: String,
+    cmdline: Option<String>,
+}
+
+fn run_process_identity(args: &[String]) -> Result<(), String> {
+    if args.len() != 1 {
+        return Err("process-identity requires exactly <pid>".to_string());
+    }
+    let pid: u32 = args[0].parse().map_err(|_| {
+        format!(
+            "process-identity pid must be a positive integer, got: {}",
+            args[0]
+        )
+    })?;
+    if pid == 0 {
+        return Err("process-identity pid must be > 0".to_string());
+    }
+    let result = process_identity(pid);
+    let json = match result {
+        Ok(identity) => {
+            let mut obj = serde_json::json!({
+                "platform": identity.platform,
+                "birth": identity.birth,
+            });
+            if let Some(cmdline) = &identity.cmdline {
+                obj["cmdline"] = serde_json::Value::String(cmdline.clone());
+            }
+            obj
+        }
+        Err(ProcessIdentityError::Denied) => {
+            serde_json::json!({ "outcome": "denied" })
+        }
+        Err(ProcessIdentityError::Gone) => {
+            serde_json::json!({ "outcome": "gone" })
+        }
+        Err(ProcessIdentityError::Unsupported) => {
+            serde_json::json!({ "outcome": "unsupported" })
+        }
+        Err(ProcessIdentityError::Error(reason)) => {
+            serde_json::json!({ "outcome": "error", "reason": reason })
+        }
+    };
+    println!(
+        "{}",
+        serde_json::to_string(&json).map_err(|error| error.to_string())?
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn process_identity(pid: u32) -> Result<ProcessIdentityResult, ProcessIdentityError> {
+    let stat_path = format!("/proc/{pid}/stat");
+    let stat_content = match std::fs::read_to_string(&stat_path) {
+        Ok(content) => content,
+        Err(e) => {
+            return match e.raw_os_error() {
+                Some(libc::ENOENT) | Some(libc::ESRCH) => Err(ProcessIdentityError::Gone),
+                Some(libc::EACCES) | Some(libc::EPERM) => Err(ProcessIdentityError::Denied),
+                _ => Err(ProcessIdentityError::Error(format!(
+                    "read stat failed: {e}"
+                ))),
+            };
+        }
+    };
+
+    // Parse field 22: skip past the comm field (in parens) then count fields
+    let command_end = stat_content.rfind(')');
+    let start_ticks = match command_end {
+        Some(idx) => {
+            let fields: Vec<&str> = stat_content[idx + 1..].split_whitespace().collect();
+            // After ')', field 1 is state, field 2 is ppid, ..., field 20 is starttime
+            // (field 3 in the full stat is ppid; the 20th field after ')' is starttime)
+            if fields.len() <= 19 {
+                return Err(ProcessIdentityError::Error(
+                    "stat content too short for starttime field".to_string(),
+                ));
+            }
+            match fields[19].parse::<u64>() {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(ProcessIdentityError::Error(format!(
+                        "starttime field is not a valid integer: {}",
+                        fields[19]
+                    )))
+                }
+            }
+        }
+        None => {
+            return Err(ProcessIdentityError::Error(
+                "stat content has no closing paren".to_string(),
+            ))
+        }
+    };
+
+    // Read cmdline if accessible
+    let cmdline = read_linux_cmdline(pid);
+
+    Ok(ProcessIdentityResult {
+        platform: "linux",
+        birth: start_ticks.to_string(),
+        cmdline,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_cmdline(pid: u32) -> Option<String> {
+    use std::io::Read;
+    let cmdline_path = format!("/proc/{pid}/cmdline");
+    let mut content = String::new();
+    let result =
+        std::fs::File::open(&cmdline_path).and_then(|mut f| f.read_to_string(&mut content));
+    match result {
+        Ok(_) => {
+            let text = content.replace('\u{0}', " ").trim().to_string();
+            if text.is_empty() {
+                None
+            } else {
+                Some(text)
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+// Darwin: proc_pidinfo with PROC_PIDTBSDINFO for pbi_start_tvsec/pbi_start_tvusec
+#[cfg(target_os = "macos")]
+fn process_identity(pid: u32) -> Result<ProcessIdentityResult, ProcessIdentityError> {
+    use std::ffi::c_int;
+
+    extern "C" {
+        fn proc_pidinfo(
+            pid: c_int,
+            flavor: c_int,
+            arg: u64,
+            buffer: *mut std::ffi::c_void,
+            buffersize: c_int,
+        ) -> c_int;
+    }
+
+    const PROC_PIDTBSDINFO: c_int = 3;
+    const PROC_PIDTBSDINFO_SIZE: c_int = std::mem::size_of::<ProcTaskBsdInfo>() as c_int;
+
+    // struct proc_bsdinfo (from libproc.h / proc_info.h):
+    //   pbi_name: [c_char; 16] (COMMLEN = 16)
+    //   pbi_pid: i32
+    //   pbi_ppid: i32
+    //   pbi_uid: uid_t (u32)
+    //   pbi_gid: gid_t (u32)
+    //   pbi_ruid: uid_t
+    //   pbi_rgid: gid_t
+    //   pbi_svuid: uid_t
+    //   pbi_svgid: gid_t
+    //   pbi_rfu: u32
+    //   pbi_flags: u32
+    //   pbi_start_tvsec: u64   ← birth seconds since epoch
+    //   pbi_start_tvusec: u64  ← birth microseconds
+    //   ... remaining fields not needed
+    #[repr(C)]
+    struct ProcTaskBsdInfo {
+        pbi_name: [std::ffi::c_char; 16],
+        pbi_pid: i32,
+        pbi_ppid: i32,
+        pbi_uid: u32,
+        pbi_gid: u32,
+        pbi_ruid: u32,
+        pbi_rgid: u32,
+        pbi_svuid: u32,
+        pbi_svgid: u32,
+        pbi_rfu: u32,
+        pbi_flags: u32,
+        pbi_start_tvsec: u64,
+        pbi_start_tvusec: u64,
+    }
+
+    let mut buf: ProcTaskBsdInfo = unsafe { std::mem::zeroed() };
+    let ret = unsafe {
+        proc_pidinfo(
+            pid as c_int,
+            PROC_PIDTBSDINFO,
+            0,
+            &mut buf as *mut _ as *mut std::ffi::c_void,
+            PROC_PIDTBSDINFO_SIZE,
+        )
+    };
+
+    if ret <= 0 {
+        let errno_val = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        return match errno_val {
+            libc::EPERM | libc::EACCES => Err(ProcessIdentityError::Denied),
+            libc::ESRCH | libc::ENOENT => Err(ProcessIdentityError::Gone),
+            _ => Err(ProcessIdentityError::Error(format!(
+                "proc_pidinfo(PROC_PIDTBSDINFO) failed: errno={}",
+                errno_val
+            ))),
+        };
+    }
+
+    // Birth is exact decimal string: seconds.microseconds since Unix epoch.
+    // Two processes started in the same second will differ in microseconds
+    // unless they genuinely started at the same microsecond instant.
+    let birth = format!("{}.{}", buf.pbi_start_tvsec, buf.pbi_start_tvusec);
+
+    Ok(ProcessIdentityResult {
+        platform: "darwin",
+        birth,
+        cmdline: None,
+    })
+}
+
+// Windows: OpenProcess + GetProcessTimes for creation FILETIME
+#[cfg(target_os = "windows")]
+fn process_identity(pid: u32) -> Result<ProcessIdentityResult, ProcessIdentityError> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows_sys::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
+        return match err {
+            5 => Err(ProcessIdentityError::Denied), // ERROR_ACCESS_DENIED
+            87 => Err(ProcessIdentityError::Gone),  // ERROR_INVALID_PARAMETER
+            _ => Err(ProcessIdentityError::Error(format!(
+                "OpenProcess failed: error code {}",
+                err
+            ))),
+        };
+    }
+
+    // RAII guard: CloseHandle on all paths
+    struct HandleGuard(*mut std::ffi::c_void);
+    impl Drop for HandleGuard {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe { CloseHandle(self.0) };
+            }
+        }
+    }
+    let _guard = HandleGuard(handle);
+
+    let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+    let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+    let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+    let mut user: FILETIME = unsafe { std::mem::zeroed() };
+
+    let ok = unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+
+    if ok == 0 {
+        let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
+        return Err(ProcessIdentityError::Error(format!(
+            "GetProcessTimes failed: error code {}",
+            err
+        )));
+    }
+
+    // Combine FILETIME (100ns intervals since 1601-01-01) into u64
+    let birth_u64 = ((creation.dwHighDateTime as u64) << 32) | (creation.dwLowDateTime as u64);
+
+    Ok(ProcessIdentityResult {
+        platform: "win32",
+        birth: birth_u64.to_string(),
+        cmdline: None,
+    })
+}
+
+// Unsupported platform fallback
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn process_identity(_pid: u32) -> Result<ProcessIdentityResult, ProcessIdentityError> {
+    Err(ProcessIdentityError::Unsupported)
+}
+
 fn print_usage() {
     println!(concat!(
         "usage: omx-runtime <command> [options]\n",
@@ -278,6 +565,7 @@ fn print_usage() {
         "commands:\n",
         "  schema [--json]                     print the runtime contract summary\n",
         "  fs-rename-no-replace <from> <to>       atomically move without replacing destination\n",
+        "  process-identity <pid>              print process birth identity as JSON\n",
         "  snapshot [--json] [--state-dir=DIR]  print a runtime snapshot\n",
         "  mux-contract                        print the mux boundary summary\n",
         "  exec <json> [--state-dir=DIR]       process a runtime command from JSON\n",

--- a/crates/omx-runtime/tests/execution.rs
+++ b/crates/omx-runtime/tests/execution.rs
@@ -589,3 +589,83 @@ mod fs_rename_no_replace_linux {
         );
     }
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn process_identity_current_process_returns_identity() {
+    let pid = std::process::id().to_string();
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["process-identity", &pid])
+        .output()
+        .expect("ran omx-runtime process-identity");
+
+    assert!(
+        output.status.success(),
+        "process-identity failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    let platform = parsed["platform"].as_str().expect("platform string");
+    assert_eq!(platform, "linux");
+    let birth = parsed["birth"].as_str().expect("birth string");
+    assert!(!birth.is_empty(), "birth must not be empty");
+    assert!(
+        birth.chars().all(|character| character.is_ascii_digit()),
+        "birth must be a decimal string: {birth}"
+    );
+    if let Some(cmdline) = parsed.get("cmdline") {
+        assert!(cmdline.is_string(), "cmdline must be a string when present");
+    }
+}
+
+#[test]
+fn process_identity_zero_pid_fails() {
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["process-identity", "0"])
+        .output()
+        .expect("ran omx-runtime process-identity");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+    assert!(stderr.contains("process-identity pid must be > 0"));
+}
+
+#[test]
+fn process_identity_non_numeric_pid_fails() {
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["process-identity", "abc"])
+        .output()
+        .expect("ran omx-runtime process-identity");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+    assert!(stderr.contains("process-identity pid must be a positive integer"));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn process_identity_nonexistent_pid_reports_gone() {
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .args(["process-identity", "999999999"])
+        .output()
+        .expect("ran omx-runtime process-identity");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["outcome"], "gone");
+}
+
+#[test]
+fn process_identity_missing_pid_fails() {
+    let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
+        .arg("process-identity")
+        .output()
+        .expect("ran omx-runtime process-identity");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+    assert!(stderr.contains("process-identity requires exactly <pid>"));
+}

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -33,6 +33,7 @@ import {
   writeSessionStart,
   type LaunchSessionBinding,
   type SessionState,
+  type ProcessObservation,
 } from '../session.js';
 
 interface SessionHistoryEntry {
@@ -75,9 +76,11 @@ async function withPointerDependencies(
   overrides: Parameters<typeof __setSessionPointerTransactionDependenciesForTests>[0],
   run: () => Promise<void>,
 ): Promise<void> {
+  const runtimePlatform = overrides.runtimePlatform ?? process.platform;
   __setSessionPointerTransactionDependenciesForTests({
     atomicRenameNoReplace: defaultTestAtomicRenameNoReplace,
     ...overrides,
+    runtimePlatform,
   });
 
   try {
@@ -99,8 +102,12 @@ async function withOwnerEnvironment(sessionId: string | undefined, run: () => Pr
   }
 }
 
-function matchingProcessIdentity() {
-  return { status: 'matching' as const, startTicks: 1 };
+function matchingObservation(): ProcessObservation {
+  return { kind: 'identity', identity: { platform: 'linux', birth: '1' } };
+}
+
+function matchingWin32Observation(): ProcessObservation {
+  return { kind: 'identity', identity: { platform: 'win32', birth: '1' } };
 }
 
 async function writeLockOwner(cwd: string, owner: Record<string, unknown>): Promise<string> {
@@ -111,12 +118,16 @@ async function writeLockOwner(cwd: string, owner: Record<string, unknown>): Prom
 }
 
 function validLockOwner(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const platform = (overrides.platform ?? 'linux') as NodeJS.Platform;
+  const version = overrides.version === 2 || overrides.process_identity !== undefined ? 2 : 1;
+  const identity = overrides.process_identity ?? (version === 2 ? { platform, birth: '1' } : undefined);
   return {
-    version: 1,
+    version,
     token: TEST_TOKEN,
     pid: process.pid,
-    platform: 'linux',
-    pid_start_ticks: 1,
+    platform,
+    ...(version === 2 && identity ? { process_identity: identity } : {}),
+    ...(version === 1 ? { pid_start_ticks: 1 } : {}),
     created_at: '2026-07-14T00:00:00.000Z',
     ...overrides,
   };
@@ -552,26 +563,32 @@ describe('session lifecycle manager', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-native-owner-reconcile-'));
     let binding: LaunchSessionBinding | undefined;
     try {
-      const established = await establishLaunchSessionBinding(cwd, 'omx-owner-session', {
-        nativeSessionId: 'codex-native-old',
+      await withPointerDependencies({
+        runtimePlatform: 'win32',
+        observeProcess: () => matchingWin32Observation(),
+      }, async () => {
+        const established = await establishLaunchSessionBinding(cwd, 'omx-owner-session', {
+          nativeSessionId: 'codex-native-old',
+          platform: 'win32',
+        });
+        assert.equal(established.kind, 'committed-released');
+        if (established.kind !== 'committed-released') return;
+        binding = established.binding;
+
+        const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-old', {
+          pid: process.pid,
+          platform: 'win32',
+        });
+
+        assert.equal(reconciled.session_id, 'omx-owner-session');
+        assert.equal(reconciled.native_session_id, 'codex-native-old');
+        assert.equal(reconciled.previous_native_session_id, undefined);
+        assert.equal(reconciled.owner_omx_session_id, undefined);
+        assert.equal(reconciled.pid, process.pid);
+
+        await finalizeBoundOnce(binding, 'test');
+        assert.equal(await readSessionState(cwd), null);
       });
-      assert.equal(established.kind, 'committed-released');
-      if (established.kind !== 'committed-released') return;
-      binding = established.binding;
-
-      const reconciled = await reconcileNativeSessionStart(cwd, 'codex-native-old', {
-        pid: process.pid,
-        platform: 'win32',
-      });
-
-      assert.equal(reconciled.session_id, 'omx-owner-session');
-      assert.equal(reconciled.native_session_id, 'codex-native-old');
-      assert.equal(reconciled.previous_native_session_id, undefined);
-      assert.equal(reconciled.owner_omx_session_id, undefined);
-      assert.equal(reconciled.pid, process.pid);
-
-      await finalizeBoundOnce(binding, 'test');
-      assert.equal(await readSessionState(cwd), null);
     } finally {
       if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
@@ -804,16 +821,28 @@ describe('isSessionStale', () => {
     assert.equal(stale, true);
   });
 
-  it('falls back to PID liveness on non-Linux platforms', () => {
-    const state = makeState();
-
-    const stale = isSessionStale(state, {
-      platform: 'darwin',
-      isPidAlive: () => true,
-      readLinuxIdentity: () => null,
-    });
-
-    assert.equal(stale, false);
+  it('classifies identity-less live non-Linux pointers as identity-indeterminate', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-non-linux-identityless-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.baseStateDir, { recursive: true });
+      await writeFile(context.sessionPath, JSON.stringify({
+        session_id: 'sess-darwin-identityless',
+        started_at: '2026-07-14T00:00:00.000Z',
+        cwd,
+        pid: process.pid,
+        platform: 'darwin',
+      }), 'utf-8');
+      await withPointerDependencies({
+        runtimePlatform: 'darwin',
+        probePid: () => 'alive',
+        observeProcess: () => ({ kind: 'unsupported' }),
+      }, async () => {
+        assert.equal((await readSessionPointer(context)).status, 'identity-indeterminate');
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 
@@ -834,7 +863,7 @@ describe('session pointer transaction', () => {
       const context = resolveSessionPointerContext(cwd);
       await withPointerDependencies({
         probePid: () => 'alive',
-        readProcessIdentity: () => matchingProcessIdentity(),
+        observeProcess: () => matchingObservation(),
       }, async () => {
         assert.equal((await readSessionPointer(context)).status, 'absent');
         await mkdir(context.baseStateDir, { recursive: true });
@@ -850,13 +879,13 @@ describe('session pointer transaction', () => {
 
         __setSessionPointerTransactionDependenciesForTests({
           probePid: () => 'dead',
-          readProcessIdentity: () => matchingProcessIdentity(),
+          observeProcess: () => matchingObservation(),
         });
         assert.equal((await readSessionPointer(context)).status, 'stale-dead');
 
         __setSessionPointerTransactionDependenciesForTests({
           probePid: () => 'indeterminate',
-          readProcessIdentity: () => matchingProcessIdentity(),
+          observeProcess: () => matchingObservation(),
         });
         assert.equal((await readSessionPointer(context)).status, 'identity-indeterminate');
 
@@ -874,6 +903,292 @@ describe('session pointer transaction', () => {
     } finally {
       __resetSessionPointerTransactionDependenciesForTests();
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('covers the process identity decision table through pointer and lock inspection', async () => {
+    const hashA = 'aaa'.repeat(21) + 'a';
+    const hashB = 'bbb'.repeat(21) + 'b';
+    const identityOwner = (identity: { platform: NodeJS.Platform; birth: string; cmdline_hash?: string }) => validLockOwner({
+      pid: 4242,
+      version: 2,
+      platform: identity.platform,
+      process_identity: identity,
+    });
+    const legacyOwner = (platform: NodeJS.Platform = 'linux', startTicks = 1) => validLockOwner({
+      pid: 4242,
+      platform,
+      pid_start_ticks: startTicks,
+    });
+    const identitylessOwner = (platform: NodeJS.Platform) => validLockOwner({
+      pid: 4242,
+      platform,
+      pid_start_ticks: undefined,
+    });
+    const identity = (platform: NodeJS.Platform, birth: string, cmdline_hash?: string): ProcessObservation => ({
+      kind: 'identity',
+      identity: { platform, birth, ...(cmdline_hash ? { cmdline_hash } : {}) },
+    });
+    const classifierCases: Array<{
+      name: string;
+      recordedState?: Record<string, unknown>;
+      rawPointer?: string;
+      runtimePlatform: NodeJS.Platform;
+      probePid: 'alive' | 'dead' | 'indeterminate';
+      observations: ProcessObservation[];
+      lockOwner?: Record<string, unknown> | 'malformed';
+      expectedPointerStatus: string;
+      expectedLockStatus: string;
+    }> = [
+      {
+        name: 'usable match',
+        recordedState: {
+          platform: 'linux', pid_start_ticks: 1, identity_schema_version: 2,
+          process_identity: { platform: 'linux', birth: '1' },
+        },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '1')],
+        lockOwner: identityOwner({ platform: 'linux', birth: '1' }),
+        expectedPointerStatus: 'usable', expectedLockStatus: 'live',
+      },
+      {
+        name: 'darwin match',
+        recordedState: { identity_schema_version: 2, process_identity: { platform: 'darwin', birth: '1234.567' } },
+        runtimePlatform: 'darwin', probePid: 'alive', observations: [identity('darwin', '1234.567')],
+        lockOwner: identityOwner({ platform: 'darwin', birth: '1234.567' }),
+        expectedPointerStatus: 'usable', expectedLockStatus: 'live',
+      },
+      {
+        name: 'windows exact FILETIME',
+        recordedState: { identity_schema_version: 2, process_identity: { platform: 'win32', birth: '132580896000000000' } },
+        runtimePlatform: 'win32', probePid: 'alive', observations: [identity('win32', '132580896000000000')],
+        lockOwner: identityOwner({ platform: 'win32', birth: '132580896000000000' }),
+        expectedPointerStatus: 'usable', expectedLockStatus: 'live',
+      },
+      {
+        name: 'dead PID',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'dead', observations: [],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'stale-dead', expectedLockStatus: 'dead',
+      },
+      {
+        name: 'birth mismatch',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '2'), identity('linux', '2')],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'stale-dead', expectedLockStatus: 'reused',
+      },
+      {
+        name: 'TOCTOU retry agree',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '2'), identity('linux', '1')],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'usable', expectedLockStatus: 'live',
+      },
+      {
+        name: 'TOCTOU retry disagree',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '2'), identity('linux', '3')],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'stale-dead', expectedLockStatus: 'reused',
+      },
+      {
+        name: 'EPERM probePid',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'indeterminate', observations: [],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'provider denied',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [{ kind: 'denied' }],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'provider error',
+        recordedState: { platform: 'linux', pid_start_ticks: 1 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [{ kind: 'error' }],
+        lockOwner: legacyOwner(),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'provider unsupported',
+        recordedState: { identity_schema_version: 2, process_identity: { platform: 'freebsd', birth: '1' } },
+        runtimePlatform: 'freebsd', probePid: 'alive', observations: [{ kind: 'unsupported' }],
+        lockOwner: identityOwner({ platform: 'freebsd', birth: '1' }),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'foreign platform',
+        recordedState: { identity_schema_version: 2, process_identity: { platform: 'darwin', birth: '1' } },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '1')],
+        lockOwner: identityOwner({ platform: 'darwin', birth: '1' }),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'cmdline hash match',
+        recordedState: {
+          identity_schema_version: 2,
+          process_identity: { platform: 'linux', birth: '1', cmdline_hash: hashA },
+        },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '1', hashA)],
+        lockOwner: identityOwner({ platform: 'linux', birth: '1', cmdline_hash: hashA }),
+        expectedPointerStatus: 'usable', expectedLockStatus: 'live',
+      },
+      {
+        name: 'cmdline hash mismatch',
+        recordedState: {
+          identity_schema_version: 2,
+          process_identity: { platform: 'linux', birth: '1', cmdline_hash: hashA },
+        },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '1', hashB)],
+        lockOwner: identityOwner({ platform: 'linux', birth: '1', cmdline_hash: hashA }),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'legacy v1 upgrade Linux',
+        recordedState: { platform: 'linux', pid_start_ticks: 111 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '111')],
+        lockOwner: legacyOwner('linux', 111),
+        expectedPointerStatus: 'usable', expectedLockStatus: 'live',
+      },
+      {
+        name: 'legacy v1 mismatch Linux',
+        recordedState: { platform: 'linux', pid_start_ticks: 111 },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '222'), identity('linux', '222')],
+        lockOwner: legacyOwner('linux', 111),
+        expectedPointerStatus: 'stale-dead', expectedLockStatus: 'reused',
+      },
+      {
+        name: 'legacy identity-less live non-Linux',
+        recordedState: { platform: 'darwin' },
+        runtimePlatform: 'darwin', probePid: 'alive', observations: [{ kind: 'unsupported' }],
+        lockOwner: identitylessOwner('darwin'),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'future schema v3',
+        recordedState: { identity_schema_version: 3, process_identity: { platform: 'linux', birth: '1' } },
+        runtimePlatform: 'linux', probePid: 'alive', observations: [identity('linux', '1')],
+        lockOwner: identitylessOwner('darwin'),
+        expectedPointerStatus: 'identity-indeterminate', expectedLockStatus: 'identity-indeterminate',
+      },
+      {
+        name: 'malformed JSON',
+        rawPointer: '{not-json',
+        runtimePlatform: 'linux', probePid: 'alive', observations: [], lockOwner: 'malformed',
+        expectedPointerStatus: 'malformed', expectedLockStatus: 'malformed',
+      },
+      {
+        name: 'same-second Darwin collision',
+        recordedState: { identity_schema_version: 2, process_identity: { platform: 'darwin', birth: '1000.500' } },
+        runtimePlatform: 'darwin', probePid: 'alive', observations: [identity('darwin', '1000.999'), identity('darwin', '1000.999')],
+        lockOwner: identityOwner({ platform: 'darwin', birth: '1000.500' }),
+        expectedPointerStatus: 'stale-dead', expectedLockStatus: 'reused',
+      },
+      {
+        name: 'absent pointer',
+        runtimePlatform: 'linux', probePid: 'alive', observations: [],
+        expectedPointerStatus: 'absent', expectedLockStatus: 'absent',
+      },
+    ];
+
+    for (const testCase of classifierCases) {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-session-classifier-'));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        await mkdir(context.baseStateDir, { recursive: true });
+        if (testCase.rawPointer !== undefined) {
+          await writeFile(context.sessionPath, testCase.rawPointer, 'utf-8');
+        } else if (testCase.recordedState) {
+          await writeFile(context.sessionPath, JSON.stringify({
+            session_id: 'sess-classifier',
+            started_at: '2026-07-14T00:00:00.000Z',
+            cwd,
+            pid: 4242,
+            ...testCase.recordedState,
+          }), 'utf-8');
+        }
+        if (testCase.lockOwner !== undefined) {
+          await mkdir(context.lockPath, { recursive: true });
+          await writeFile(
+            join(context.lockPath, 'owner.json'),
+            testCase.lockOwner === 'malformed' ? '{not-json' : JSON.stringify(testCase.lockOwner),
+            'utf-8',
+          );
+        }
+        let observerCalls = 0;
+        const observer = (): ProcessObservation => {
+          const index = observerCalls++;
+          return testCase.observations[Math.min(index, Math.max(testCase.observations.length - 1, 0))] ?? { kind: 'error' };
+        };
+        await withPointerDependencies({
+          runtimePlatform: testCase.runtimePlatform,
+          probePid: () => testCase.probePid,
+          observeProcess: observer,
+        }, async () => {
+          assert.equal((await readSessionPointer(context)).status, testCase.expectedPointerStatus, testCase.name);
+        });
+
+        let lockObserverCalls = 0;
+        const lockObserver = (): ProcessObservation => {
+          const index = lockObserverCalls++;
+          return testCase.observations[Math.min(index, Math.max(testCase.observations.length - 1, 0))] ?? { kind: 'error' };
+        };
+        await withPointerDependencies({
+          runtimePlatform: testCase.runtimePlatform,
+          probePid: () => testCase.probePid,
+          observeProcess: lockObserver,
+        }, async () => {
+          assert.equal((await inspectSessionPointerLock(cwd)).status, testCase.expectedLockStatus, testCase.name);
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('rejects every schema version other than v2 as identity-indeterminate', async () => {
+    const schemaVersions: unknown[] = [0, 1, -1, null, '2', 'bad', 3];
+    for (const schemaVersion of schemaVersions) {
+      const cwd = await mkdtemp(join(tmpdir(), 'omx-session-identity-schema-rejection-'));
+      try {
+        const context = resolveSessionPointerContext(cwd);
+        await mkdir(context.baseStateDir, { recursive: true });
+        await writeFile(context.sessionPath, JSON.stringify({
+          session_id: 'sess-schema-rejection',
+          started_at: '2026-07-14T00:00:00.000Z',
+          cwd,
+          pid: 4242,
+          platform: 'linux',
+          pid_start_ticks: 1,
+          identity_schema_version: schemaVersion,
+        }), 'utf-8');
+        await mkdir(context.lockPath, { recursive: true });
+        await writeFile(join(context.lockPath, 'owner.json'), JSON.stringify(validLockOwner({
+          pid: 4242,
+          platform: 'darwin',
+          pid_start_ticks: undefined,
+        })), 'utf-8');
+        await withPointerDependencies({
+          runtimePlatform: 'linux',
+          probePid: () => 'alive',
+          observeProcess: () => matchingObservation(),
+        }, async () => {
+          assert.equal((await readSessionPointer(context)).status, 'identity-indeterminate', String(schemaVersion));
+        });
+        await withPointerDependencies({
+          runtimePlatform: 'linux',
+          probePid: () => 'alive',
+          observeProcess: () => matchingObservation(),
+        }, async () => {
+          assert.equal((await inspectSessionPointerLock(cwd)).status, 'identity-indeterminate', String(schemaVersion));
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
     }
   });
 
@@ -897,19 +1212,15 @@ describe('session pointer transaction', () => {
       name: string;
       owner?: Record<string, unknown>;
       probePid: 'dead' | 'alive' | 'indeterminate';
-      identity?: {
-        status: 'matching' | 'reused' | 'indeterminate';
-        startTicks?: number;
-        cmdlineHash?: string;
-      };
+      observation?: ProcessObservation;
       expected: string;
     }> = [
       { name: 'dead', owner: validLockOwner(), probePid: 'dead', expected: 'dead' },
-      { name: 'reused', owner: validLockOwner(), probePid: 'alive', identity: { status: 'reused', startTicks: 2 }, expected: 'reused' },
+      { name: 'reused', owner: validLockOwner(), probePid: 'alive', observation: { kind: 'identity', identity: { platform: 'linux', birth: '2' } }, expected: 'reused' },
       { name: 'indeterminate-probe', owner: validLockOwner(), probePid: 'indeterminate', expected: 'identity-indeterminate' },
-      { name: 'indeterminate-identity', owner: validLockOwner(), probePid: 'alive', identity: { status: 'indeterminate' }, expected: 'identity-indeterminate' },
-      { name: 'unsubstantiated-reuse', owner: validLockOwner(), probePid: 'alive', identity: { status: 'reused', startTicks: 1 }, expected: 'identity-indeterminate' },
-      { name: 'missing-required-hash', owner: validLockOwner({ pid_cmdline_hash: 'a'.repeat(64) }), probePid: 'alive', identity: matchingProcessIdentity(), expected: 'identity-indeterminate' },
+      { name: 'indeterminate-identity', owner: validLockOwner(), probePid: 'alive', observation: { kind: 'error' }, expected: 'identity-indeterminate' },
+      { name: 'foreign-identity', owner: validLockOwner(), probePid: 'alive', observation: { kind: 'identity', identity: { platform: 'darwin', birth: '1' } }, expected: 'identity-indeterminate' },
+      { name: 'missing-required-hash', owner: validLockOwner({ pid_cmdline_hash: 'a'.repeat(64) }), probePid: 'alive', observation: matchingObservation(), expected: 'identity-indeterminate' },
       { name: 'missing', probePid: 'alive', expected: 'missing' },
       { name: 'malformed', owner: { version: 1 }, probePid: 'alive', expected: 'malformed' },
     ];
@@ -926,7 +1237,7 @@ describe('session pointer transaction', () => {
         await withPointerDependencies({
           token: () => TEST_TOKEN,
           probePid: () => testCase.probePid,
-          readProcessIdentity: () => testCase.identity ?? matchingProcessIdentity(),
+          observeProcess: () => testCase.observation ?? matchingObservation(),
         }, async () => {
           await assert.rejects(
             writeSessionStart(cwd, 'sess-lock', { platform: 'win32' }),
@@ -1105,7 +1416,7 @@ describe('session pointer transaction', () => {
       await withPointerDependencies({
         token: () => SUCCESSOR_TOKEN,
         probePid: (pid) => pid === successorPid ? 'alive' : 'dead',
-        readProcessIdentity: () => matchingProcessIdentity(),
+        observeProcess: () => matchingObservation(),
         atomicRenameNoReplace: async (from, to) => {
           if (from === context.lockPath && to === parkedPath) {
             await rename(from, to);
@@ -1517,7 +1828,7 @@ describe('session pointer transaction', () => {
       const successor = JSON.stringify(validLockOwner({ token: FOREIGN_TOKEN, pid: successorPid }));
       await mkdir(context.lockPath);
       await writeFile(ownerPath, successor, 'utf-8');
-      await withPointerDependencies({ token: () => { throw new Error('resume must not mint token'); }, probePid: (pid) => pid === successorPid ? 'alive' : 'dead', readProcessIdentity: () => matchingProcessIdentity() }, async () => {
+      await withPointerDependencies({ token: () => { throw new Error('resume must not mint'); }, probePid: (pid) => pid === successorPid ? 'alive' : 'dead', observeProcess: () => matchingObservation() }, async () => {
         const refused = await recoverSessionPointerLock(cwd);
         assert.equal(refused.recovered, false);
         assert.match(refused.reason, /recovery state/i);
@@ -1891,9 +2202,9 @@ describe('session pointer transaction', () => {
   });
 
   it('fails closed for live pre-rename, PID reuse, malformed, and ambiguous lock evidence', async () => {
-    const cases: Array<{ name: string; files: Array<[string, string]>; probePid: 'alive' | 'dead'; identity?: ReturnType<typeof matchingProcessIdentity> }> = [
-      { name: 'live-temp', files: [[`owner.${TEST_TOKEN}.tmp`, JSON.stringify(validLockOwner())]], probePid: 'alive', identity: matchingProcessIdentity() },
-      { name: 'reused', files: [['owner.json', JSON.stringify(validLockOwner())]], probePid: 'alive', identity: { status: 'matching', startTicks: 2 } },
+    const cases: Array<{ name: string; files: Array<[string, string]>; probePid: 'alive' | 'dead'; observation?: ProcessObservation }> = [
+      { name: 'live-temp', files: [[`owner.${TEST_TOKEN}.tmp`, JSON.stringify(validLockOwner())]], probePid: 'alive', observation: matchingObservation() },
+      { name: 'reused', files: [['owner.json', JSON.stringify(validLockOwner())]], probePid: 'alive', observation: { kind: 'identity', identity: { platform: 'linux', birth: '2' } } },
       { name: 'malformed', files: [['owner.json', '{']], probePid: 'dead' },
       { name: 'ambiguous', files: [['owner.json', JSON.stringify(validLockOwner())], [`owner.${SUCCESSOR_TOKEN}.tmp`, JSON.stringify(validLockOwner({ token: SUCCESSOR_TOKEN }))]], probePid: 'dead' },
     ];
@@ -1906,7 +2217,7 @@ describe('session pointer transaction', () => {
         await withPointerDependencies({
           token: () => SUCCESSOR_TOKEN,
           probePid: () => testCase.probePid,
-          readProcessIdentity: () => testCase.identity ?? matchingProcessIdentity(),
+          observeProcess: () => testCase.observation ?? matchingObservation(),
         }, async () => {
           const before = await readdir(context.lockPath);
           const recovered = await recoverSessionPointerLock(cwd);
@@ -2046,7 +2357,7 @@ describe('session pointer transaction', () => {
         sleep: async (ms) => { delays.push(ms); now += ms; },
         token: () => TEST_TOKEN,
         probePid: () => 'alive',
-        readProcessIdentity: () => matchingProcessIdentity(),
+        observeProcess: () => matchingObservation(),
       }, async () => {
         await assert.rejects(
           writeSessionStart(cwd, 'sess-timeout', { platform: 'win32' }),
@@ -2107,6 +2418,32 @@ describe('session pointer transaction', () => {
         );
       });
       assert.equal(existsSync(context.lockPath), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes a legacy-like Linux state when process identity capture fails', async (t) => {
+    if (process.platform !== 'linux') {
+      t.skip('Linux identity publication semantics are under test.');
+      return;
+    }
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-identity-capture-failure-'));
+    try {
+      await withPointerDependencies({
+        runtimePlatform: 'linux',
+        observeProcess: () => ({ kind: 'error' }),
+      }, async () => {
+        const state = await writeSessionStart(cwd, 'sess-identity-capture-failure', { platform: 'linux' });
+        assert.equal(state.platform, 'linux');
+        assert.equal(Object.hasOwn(state, 'identity_schema_version'), false);
+        assert.equal(Object.hasOwn(state, 'process_identity'), false);
+        assert.equal(Object.hasOwn(state, 'pid_start_ticks'), false);
+        const persisted = await readSessionState(cwd);
+        assert.ok(persisted);
+        assert.equal(Object.hasOwn(persisted, 'identity_schema_version'), false);
+        assert.equal(Object.hasOwn(persisted, 'process_identity'), false);
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2403,31 +2740,36 @@ describe('session pointer transaction', () => {
   it('binds an owner alias only on a verified same-native/absent transition and never during replacement', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-alias-'));
     try {
-      const nativeOnly = await reconcileNativeSessionStart(cwd, 'native-first', {
-        platform: 'win32',
-        ownerOmxSessionId: 'omx-owner',
-      });
-      assert.equal(nativeOnly.owner_omx_session_id, undefined);
-
-      await withOwnerEnvironment('omx-owner', async () => {
-        const bound = await reconcileNativeSessionStart(cwd, 'native-first', {
+      await withPointerDependencies({
+        runtimePlatform: 'win32',
+        observeProcess: () => matchingWin32Observation(),
+      }, async () => {
+        const nativeOnly = await reconcileNativeSessionStart(cwd, 'native-first', {
           platform: 'win32',
-          ownerAliasVerified: true,
+          ownerOmxSessionId: 'omx-owner',
         });
-        assert.equal(bound.session_id, 'native-first');
-        assert.equal(bound.owner_omx_session_id, 'omx-owner');
+        assert.equal(nativeOnly.owner_omx_session_id, undefined);
 
-        await assert.rejects(
-          reconcileNativeSessionStart(cwd, 'native-second', {
+        await withOwnerEnvironment('omx-owner', async () => {
+          const bound = await reconcileNativeSessionStart(cwd, 'native-first', {
             platform: 'win32',
             ownerAliasVerified: true,
-          }),
-          isOwnerConflict,
-        );
+          });
+          assert.equal(bound.session_id, 'native-first');
+          assert.equal(bound.owner_omx_session_id, 'omx-owner');
 
-        const persisted = await readSessionState(cwd);
-        assert.equal(persisted?.session_id, 'native-first');
-        assert.equal(persisted?.owner_omx_session_id, 'omx-owner');
+          await assert.rejects(
+            reconcileNativeSessionStart(cwd, 'native-second', {
+              platform: 'win32',
+              ownerAliasVerified: true,
+            }),
+            isOwnerConflict,
+          );
+
+          const persisted = await readSessionState(cwd);
+          assert.equal(persisted?.session_id, 'native-first');
+          assert.equal(persisted?.owner_omx_session_id, 'omx-owner');
+        });
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -2437,7 +2779,11 @@ describe('session pointer transaction', () => {
   it('keeps native session owner sidecars isolated and rejects live cross-process reuse', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-owner-sidecar-'));
     try {
-      await withPointerDependencies({ probePid: () => 'alive' }, async () => {
+      await withPointerDependencies({
+        runtimePlatform: 'win32',
+        observeProcess: () => matchingWin32Observation(),
+        probePid: () => 'alive',
+      }, async () => {
         const first = await writeNativeSessionOwner(
           cwd,
           'native-owner-a',
@@ -2476,6 +2822,7 @@ describe('session pointer transaction', () => {
         );
         await writeNativeSessionOwner(cwd, 'native-owner-current', {
           pid: process.pid,
+          platform: 'win32',
         });
         assert.equal(
           (await readNativeSessionOwner(cwd, 'native-owner-current'))?.pid,
@@ -2600,14 +2947,14 @@ describe('session pointer transaction', () => {
       }), 'utf-8');
       const before = await readFile(ownerPath, 'utf-8');
 
-      assert.equal((await readNativeSessionOwnerEvidence(cwd, 'native-owner-platform')).status, 'malformed');
+      assert.equal((await readNativeSessionOwnerEvidence(cwd, 'native-owner-platform')).status, 'identity-indeterminate');
       assert.equal(await readNativeSessionOwner(cwd, 'native-owner-platform'), null);
       await assert.rejects(
         writeNativeSessionOwner(cwd, 'native-owner-platform', {
           pid: process.pid,
         }),
         (error: unknown) => isSessionPointerLaunchAbort(error)
-          && error.code === 'session_pointer_owner_conflict',
+          && error.code === 'session_pointer_unusable',
       );
       assert.equal(await readFile(ownerPath, 'utf-8'), before);
     } finally {
@@ -2621,17 +2968,18 @@ describe('session pointer transaction', () => {
       assert.equal((await readNativeSessionOwnerEvidence(cwd, 'native-owner-absent')).status, 'absent');
       await withPointerDependencies({
         probePid: (pid) => pid === 11 ? 'dead' : 'alive',
+        observeProcess: () => ({ kind: 'identity', identity: { platform: 'linux' as const, birth: '1' } }),
       }, async () => {
         await writeNativeSessionOwner(
           cwd,
           'native-owner-recovery',
-          { pid: 11, platform: 'win32' },
+          { pid: 11, platform: 'linux' },
         );
-        assert.equal((await readNativeSessionOwnerEvidence(cwd, 'native-owner-recovery')).status, 'malformed');
+        assert.equal((await readNativeSessionOwnerEvidence(cwd, 'native-owner-recovery')).status, 'stale-dead');
         const recovered = await writeNativeSessionOwner(
           cwd,
           'native-owner-recovery',
-          { pid: 22, platform: 'win32' },
+          { pid: 22, platform: 'linux' },
         );
         assert.equal(recovered.pid, 22);
 
@@ -2673,7 +3021,8 @@ describe('session pointer transaction', () => {
           started_at: new Date().toISOString(),
           cwd,
           pid: 22,
-          platform: 'win32',
+          platform: 'linux',
+          pid_start_ticks: 1,
         }), 'utf-8');
         const forgedBefore = await readFile(forgedPath, 'utf-8');
         assert.equal(await readNativeSessionOwner(cwd, 'native-owner-forged'), null);
@@ -2681,7 +3030,7 @@ describe('session pointer transaction', () => {
           writeNativeSessionOwner(
             cwd,
             'native-owner-forged',
-            { pid: 22, platform: 'win32' },
+            { pid: 22, platform: 'linux' },
           ),
           (error: unknown) => isSessionPointerLaunchAbort(error)
             && error.code === 'session_pointer_owner_conflict',
@@ -2702,7 +3051,8 @@ describe('session pointer transaction', () => {
           native_session_id: 'native-owner-missing-cwd',
           started_at: new Date().toISOString(),
           pid: 22,
-          platform: 'win32',
+          platform: 'linux',
+          pid_start_ticks: 1,
         }), 'utf-8');
         const missingCwdBefore = await readFile(missingCwdPath, 'utf-8');
         assert.equal(await readNativeSessionOwner(cwd, 'native-owner-missing-cwd'), null);
@@ -2710,7 +3060,7 @@ describe('session pointer transaction', () => {
           writeNativeSessionOwner(
             cwd,
             'native-owner-missing-cwd',
-            { pid: 22, platform: 'win32' },
+            { pid: 22, platform: 'linux' },
           ),
           (error: unknown) => isSessionPointerLaunchAbort(error)
             && error.code === 'session_pointer_owner_conflict',
@@ -2725,7 +3075,11 @@ describe('session pointer transaction', () => {
   it('rejects cross-process native reconciliation while preserving the live selected pointer', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-cross-process-selected-'));
     try {
-      await withPointerDependencies({ probePid: () => 'alive' }, async () => {
+      await withPointerDependencies({
+        runtimePlatform: 'win32',
+        observeProcess: () => matchingWin32Observation(),
+        probePid: () => 'alive',
+      }, async () => {
         await writeSessionStart(cwd, 'native-selected-a', {
           nativeSessionId: 'native-selected-a',
           pid: 11,
@@ -2752,26 +3106,31 @@ describe('session pointer transaction', () => {
   it('preserves pointer evidence when history cannot be appended and rejects unusable end states before history or HUD cleanup', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-end-preserve-'));
     try {
-      const context = resolveSessionPointerContext(cwd);
-      const established = await establishLaunchSessionBinding(cwd, 'sess-history', { platform: 'win32' });
-      assert.equal(established.kind, 'committed-released');
-      if (established.kind !== 'committed-released') return;
-      await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
-      await rm(join(cwd, '.omx', 'logs'), { recursive: true, force: true });
-      await writeFile(join(cwd, '.omx', 'logs'), 'not-a-directory', 'utf-8');
-      await assert.rejects(finalizeBoundOnce(established.binding, 'history-failure'));
-      assert.equal((await readSessionState(cwd))?.session_id, 'sess-history');
-      await rm(join(cwd, '.omx', 'logs'), { force: true });
+      await withPointerDependencies({
+        runtimePlatform: 'win32',
+        observeProcess: () => matchingWin32Observation(),
+      }, async () => {
+        const context = resolveSessionPointerContext(cwd);
+        const established = await establishLaunchSessionBinding(cwd, 'sess-history', { platform: 'win32' });
+        assert.equal(established.kind, 'committed-released');
+        if (established.kind !== 'committed-released') return;
+        await mkdir(join(cwd, '.omx', 'logs'), { recursive: true });
+        await rm(join(cwd, '.omx', 'logs'), { recursive: true, force: true });
+        await writeFile(join(cwd, '.omx', 'logs'), 'not-a-directory', 'utf-8');
+        await assert.rejects(finalizeBoundOnce(established.binding, 'history-failure'));
+        assert.equal((await readSessionState(cwd))?.session_id, 'sess-history');
+        await rm(join(cwd, '.omx', 'logs'), { force: true });
 
-      await writeFile(context.sessionPath, '{ malformed', 'utf-8');
-      await assert.rejects(
-        writeSessionEnd(cwd, 'sess-history', { binding: established.binding }),
-        (error: unknown) => isSessionPointerLaunchAbort(error)
-          && error.code === 'session_pointer_unusable'
-          && error.pointerStatus === 'malformed',
-      );
-      assert.equal(await readFile(context.sessionPath, 'utf-8'), '{ malformed');
-      assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+        await writeFile(context.sessionPath, '{ malformed', 'utf-8');
+        await assert.rejects(
+          writeSessionEnd(cwd, 'sess-history', { binding: established.binding }),
+          (error: unknown) => isSessionPointerLaunchAbort(error)
+            && error.code === 'session_pointer_unusable'
+            && error.pointerStatus === 'malformed',
+        );
+        assert.equal(await readFile(context.sessionPath, 'utf-8'), '{ malformed');
+        assert.equal(existsSync(join(cwd, '.omx', 'logs', 'session-history.jsonl')), false);
+      });
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2802,6 +3161,39 @@ describe('bound launch authority', () => {
       assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, 'closed');
       assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, 'closed');
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves process_identity across detached metadata updates', async (t) => {
+    if (process.platform !== 'linux') {
+      t.skip('Linux v2 process identity publication semantics are under test.');
+      return;
+    }
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-binding-identity-preserve-'));
+    let binding: LaunchSessionBinding | undefined;
+    try {
+      await withPointerDependencies({
+        runtimePlatform: 'linux',
+        observeProcess: () => matchingObservation(),
+      }, async () => {
+        const established = await establishLaunchSessionBinding(cwd, 'sess-binding-identity-preserve', { platform: 'linux' });
+        assert.equal(established.kind, 'committed-released');
+        if (established.kind !== 'committed-released') return;
+        const establishedBinding = established.binding;
+        binding = establishedBinding;
+        const before = await readSessionState(cwd);
+        assert.ok(before?.process_identity);
+        const metadata = await updateDetachedSessionMetadata(establishedBinding, { tmuxPaneId: '%identity-preserved' });
+        assert.equal(metadata.kind, 'committed-released');
+        const after = await readSessionState(cwd);
+        assert.deepEqual(after?.process_identity, before?.process_identity);
+        assert.equal(after?.identity_schema_version, 2);
+        assert.equal(after?.tmux_pane_id, '%identity-preserved');
+        assert.equal((await finalizeBoundOnce(establishedBinding, 'identity-preserved')).finalized, true);
+      });
+    } finally {
+      if (binding) await closeLaunchSessionBindingOnce(binding).catch(() => {});
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -2944,7 +3336,7 @@ describe('bound launch authority', () => {
         await writeFile(context.sessionPath, testCase.raw, 'utf-8');
         await withPointerDependencies({
           probePid: () => testCase.probePid ?? 'alive',
-          readProcessIdentity: () => matchingProcessIdentity(),
+          observeProcess: () => matchingObservation(),
           fs: {
             mkdir: async (path, options) => { order.push(`mkdir:${path}`); await mkdir(path, options); },
             readFile: async (path, encoding) => { order.push(`read:${path}`); return await readFile(path, encoding); },
@@ -3313,37 +3705,46 @@ describe('bound launch authority', () => {
     let ordinary: LaunchSessionBinding | undefined;
     let stale: LaunchSessionBinding | undefined;
     try {
-      const ordinaryEstablished = await establishLaunchSessionBinding(cwd, 'sess-unsupported-ordinary', { platform: 'win32' });
-      assert.equal(ordinaryEstablished.kind, 'committed-released');
-      if (ordinaryEstablished.kind !== 'committed-released') return;
-      ordinary = ordinaryEstablished.binding;
-      assert.deepEqual(ordinary.directoryIdentity, { kind: 'unsupported', reason: 'platform' });
+      await withPointerDependencies({
+        runtimePlatform: 'win32',
+        observeProcess: () => matchingWin32Observation(),
+      }, async () => {
+        const ordinaryEstablished = await establishLaunchSessionBinding(cwd, 'sess-unsupported-ordinary', { platform: 'win32' });
+        assert.equal(ordinaryEstablished.kind, 'committed-released');
+        if (ordinaryEstablished.kind !== 'committed-released') return;
+        ordinary = ordinaryEstablished.binding;
+        assert.deepEqual(ordinary.directoryIdentity, { kind: 'unsupported', reason: 'platform' });
 
-      const ordinaryFinalized = await finalizeBoundOnce(ordinary, 'ordinary-unsupported');
-      assert.equal(ordinaryFinalized.finalized, true);
-      assert.equal(existsSync(resolveSessionPointerContext(cwd).sessionPath), false);
-      assert.equal((await closeLaunchSessionBindingOnce(ordinary)).status, 'closed');
+        const ordinaryFinalized = await finalizeBoundOnce(ordinary, 'ordinary-unsupported');
+        assert.equal(ordinaryFinalized.finalized, true);
+        assert.equal(existsSync(resolveSessionPointerContext(cwd).sessionPath), false);
+        assert.equal((await closeLaunchSessionBindingOnce(ordinary)).status, 'closed');
 
-      const staleEstablished = await establishLaunchSessionBinding(cwd, 'sess-unsupported-stale', {
-        nativeSessionId: 'native-unsupported-stale',
-        platform: 'win32',
+        const staleEstablished = await establishLaunchSessionBinding(cwd, 'sess-unsupported-stale', {
+          nativeSessionId: 'native-unsupported-stale',
+          platform: 'win32',
+        });
+        assert.equal(staleEstablished.kind, 'committed-released');
+        if (staleEstablished.kind !== 'committed-released') return;
+        stale = staleEstablished.binding;
+        await reconcileNativeSessionStart(cwd, 'native-unsupported-stale', { pid: 424242, platform: 'win32' });
+        const context = resolveSessionPointerContext(cwd);
+        const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
+
+        await withPointerDependencies({
+          runtimePlatform: 'win32',
+          observeProcess: () => matchingWin32Observation(),
+          probePid: () => 'dead',
+        }, async () => {
+          const finalized = await finalizeBoundOnce(stale as LaunchSessionBinding, 'stale-unsupported');
+          assert.equal(finalized.finalized, true);
+          assert.equal(finalized.cleanup.comparison?.status, 'matched');
+          assert.match(finalized.cleanup.comparison?.reason ?? '', /unsupported-directory-capability:platform/);
+        });
+        assert.equal(existsSync(context.sessionPath), false);
+        const history = await readFile(historyPath, 'utf-8');
+        assert.match(history, /native-unsupported-stale/);
       });
-      assert.equal(staleEstablished.kind, 'committed-released');
-      if (staleEstablished.kind !== 'committed-released') return;
-      stale = staleEstablished.binding;
-      await reconcileNativeSessionStart(cwd, 'native-unsupported-stale', { pid: 424242, platform: 'win32' });
-      const context = resolveSessionPointerContext(cwd);
-      const historyPath = join(cwd, '.omx', 'logs', 'session-history.jsonl');
-
-      await withPointerDependencies({ probePid: () => 'dead' }, async () => {
-        const finalized = await finalizeBoundOnce(stale as LaunchSessionBinding, 'stale-unsupported');
-        assert.equal(finalized.finalized, true);
-        assert.equal(finalized.cleanup.comparison?.status, 'matched');
-        assert.match(finalized.cleanup.comparison?.reason ?? '', /unsupported-directory-capability:platform/);
-      });
-      assert.equal(existsSync(context.sessionPath), false);
-      const history = await readFile(historyPath, 'utf-8');
-      assert.match(history, /native-unsupported-stale/);
     } finally {
       if (ordinary) await closeLaunchSessionBindingOnce(ordinary).catch(() => {});
       if (stale) await closeLaunchSessionBindingOnce(stale).catch(() => {});

--- a/src/hooks/extensibility/types.ts
+++ b/src/hooks/extensibility/types.ts
@@ -91,6 +91,8 @@ export interface HookPluginOmxSessionState {
   platform?: NodeJS.Platform;
   pid_start_ticks?: number;
   pid_cmdline?: string;
+  identity_schema_version?: 2;
+  process_identity?: { platform: NodeJS.Platform; birth: string; cmdline_hash?: string };
   [key: string]: unknown;
 }
 

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -43,6 +43,34 @@ import {
   type RegularFileSyncOutcome,
 } from '../utils/file-durability.js';
 
+/** Cross-platform process birth identity. `birth` is an exact decimal string. */
+export interface ProcessIdentity {
+  platform: NodeJS.Platform;
+  birth: string;
+  cmdline_hash?: string;
+}
+
+/** Raw observation from a native process-identity provider. No comparison logic. */
+export type ProcessObservation =
+  | { kind: 'identity'; identity: ProcessIdentity }
+  | { kind: 'gone' }
+  | { kind: 'denied' }
+  | { kind: 'unsupported' }
+  | { kind: 'error' };
+
+/** Classification of a recorded identity against a live observation. */
+export type IdentityClassification =
+  | { status: 'match' }
+  | { status: 'birth-mismatch' }
+  | { status: 'identity-unavailable' }
+  | { status: 'gone' };
+
+/** Provider interface for observing process identity. */
+export interface ProcessInspectionProvider {
+  probePid(pid: number): PidProbeResult;
+  observeProcess(pid: number, platform: NodeJS.Platform): ProcessObservation;
+}
+
 export interface SessionState {
   session_id: string;
   native_session_id?: string;
@@ -58,6 +86,10 @@ export interface SessionState {
   platform?: NodeJS.Platform;
   pid_start_ticks?: number;
   pid_cmdline?: string;
+  /** Versioned process identity schema; absent means legacy v1. */
+  identity_schema_version?: 2;
+  /** Cross-platform process identity (v2 schema). */
+  process_identity?: ProcessIdentity;
   tmux_session_name?: string;
   tmux_pane_id?: string;
   /** Private wrapper lineage evidence; native reconciliation never creates or repairs it. */
@@ -372,6 +404,8 @@ interface LinuxProcessIdentity {
 export interface SessionStaleCheckOptions {
   platform?: NodeJS.Platform;
   isPidAlive?: (pid: number) => boolean;
+  probePid?: (pid: number) => PidProbeResult;
+  observeProcess?: (pid: number, platform: NodeJS.Platform) => ProcessObservation;
   readLinuxIdentity?: (pid: number) => LinuxProcessIdentity | null;
 }
 
@@ -443,12 +477,9 @@ export interface SessionPointerTransactionDependencies {
   nowMs(): number;
   sleep(ms: number): Promise<void>;
   token(): string;
+  runtimePlatform: NodeJS.Platform;
   probePid(pid: number): PidProbeResult;
-  readProcessIdentity(pid: number, platform: NodeJS.Platform): {
-    status: 'matching' | 'reused' | 'indeterminate';
-    startTicks?: number;
-    cmdlineHash?: string;
-  };
+  observeProcess(pid: number, platform: NodeJS.Platform): ProcessObservation;
   atomicRenameNoReplace(from: string, to: string): Promise<RecoveryRenameNoReplaceResult>;
 }
 
@@ -536,20 +567,25 @@ function defaultProbePid(pid: number): PidProbeResult {
   })(pid);
 }
 
-function defaultReadProcessIdentity(pid: number, platform: NodeJS.Platform): {
-  status: 'matching' | 'reused' | 'indeterminate';
-  startTicks?: number;
-  cmdlineHash?: string;
-} {
-  if (platform !== 'linux') return { status: 'indeterminate' };
-  const identity = readLinuxProcessIdentity(pid);
-  if (!identity) return { status: 'indeterminate' };
-  const cmdlineHash = hashCmdline(identity.cmdline);
-  return {
-    status: 'matching',
-    startTicks: identity.startTicks,
-    ...(cmdlineHash ? { cmdlineHash } : {}),
-  };
+function defaultObserveProcess(pid: number, platform: NodeJS.Platform): ProcessObservation {
+  if (platform === 'linux') {
+    return observeLinuxProcess(pid);
+  }
+  if (platform !== 'darwin' && platform !== 'win32') {
+    return { kind: 'unsupported' };
+  }
+  try {
+    const stdout = nodeExecFileSync(resolveRuntimeBinaryPath(), ['process-identity', String(pid)], {
+      encoding: 'utf8',
+      timeout: 3000,
+      maxBuffer: 64 * 1024,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return parseProcessIdentityOutput(stdout);
+  } catch {
+    return { kind: 'unsupported' };
+  }
 }
 
 const defaultTransactionDependencies: SessionPointerTransactionDependencies = {
@@ -557,9 +593,15 @@ const defaultTransactionDependencies: SessionPointerTransactionDependencies = {
   nowMs: () => Date.now(),
   sleep: async (ms) => await new Promise<void>((resolve) => setTimeout(resolve, ms)),
   token: () => randomUUID(),
+  runtimePlatform: process.platform,
   probePid: defaultProbePid,
-  readProcessIdentity: defaultReadProcessIdentity,
+  observeProcess: defaultObserveProcess,
   atomicRenameNoReplace: defaultRecoveryRenameNoReplace,
+};
+
+export const defaultProcessInspectionProvider: ProcessInspectionProvider = {
+  probePid: defaultProbePid,
+  observeProcess: defaultObserveProcess,
 };
 
 let transactionDependencies: SessionPointerTransactionDependencies = defaultTransactionDependencies;
@@ -616,12 +658,107 @@ function readLinuxProcessIdentity(pid: number): LinuxProcessIdentity | null {
   }
 }
 
-function defaultIsPidAlive(pid: number): boolean {
+const NODE_PLATFORMS = new Set<NodeJS.Platform>([
+  'aix', 'android', 'darwin', 'freebsd', 'haiku', 'linux', 'openbsd', 'sunos', 'win32', 'cygwin', 'netbsd',
+]);
+const PROCESS_BIRTH_PATTERN = /^\d+(?:\.\d+)?$/;
+
+function isNodePlatform(value: unknown): value is NodeJS.Platform {
+  return typeof value === 'string' && NODE_PLATFORMS.has(value as NodeJS.Platform);
+}
+
+function isValidBirth(value: unknown): value is string {
+  return typeof value === 'string' && PROCESS_BIRTH_PATTERN.test(value);
+}
+
+function isValidProcessIdentity(value: unknown): value is ProcessIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const identity = value as Partial<ProcessIdentity>;
+  if (Object.keys(identity).some((key) => key !== 'platform' && key !== 'birth' && key !== 'cmdline_hash')) return false;
+  return isNodePlatform(identity.platform)
+    && isValidBirth(identity.birth)
+    && (identity.cmdline_hash === undefined
+      || typeof identity.cmdline_hash === 'string' && SHA256_PATTERN.test(identity.cmdline_hash));
+}
+
+function isComparableProcessIdentity(value: unknown): value is ProcessIdentity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const identity = value as Partial<ProcessIdentity>;
+  return isNodePlatform(identity.platform)
+    && typeof identity.birth === 'string'
+    && identity.birth.length > 0
+    && (identity.cmdline_hash === undefined
+      || typeof identity.cmdline_hash === 'string' && SHA256_PATTERN.test(identity.cmdline_hash));
+}
+
+function observeLinuxProcess(pid: number): ProcessObservation {
+  if (!Number.isInteger(pid) || pid <= 0) return { kind: 'error' };
+  const identity = readLinuxProcessIdentity(pid);
+  if (identity) {
+    const cmdlineHash = hashCmdline(identity.cmdline);
+    return {
+      kind: 'identity',
+      identity: {
+        platform: 'linux',
+        birth: String(identity.startTicks),
+        ...(cmdlineHash ? { cmdline_hash: cmdlineHash } : {}),
+      },
+    };
+  }
+
+  let statContent: string;
   try {
-    process.kill(pid, 0);
-    return true;
+    statContent = readFileSync(`/proc/${pid}/stat`, 'utf8');
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === 'ENOENT' || code === 'ESRCH') return { kind: 'gone' };
+    if (code === 'EACCES' || code === 'EPERM') return { kind: 'denied' };
+    return { kind: 'error' };
+  }
+  if (!statContent) return { kind: 'error' };
+  const probe = defaultProbePid(pid);
+  if (probe === 'dead') return { kind: 'gone' };
+  if (probe === 'indeterminate') return { kind: 'denied' };
+  return { kind: 'error' };
+}
+
+function parseProcessIdentityOutput(stdout: string): ProcessObservation {
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return { kind: 'error' };
+    const value = parsed as Record<string, unknown>;
+    const keys = Object.keys(value);
+    const outcome = value.outcome;
+    if (outcome !== undefined) {
+      if (typeof outcome !== 'string') return { kind: 'error' };
+      if (outcome === 'gone' || outcome === 'denied' || outcome === 'unsupported') {
+        if (keys.length !== 1) return { kind: 'error' };
+        if (outcome === 'gone') return { kind: 'gone' };
+        if (outcome === 'denied') return { kind: 'denied' };
+        return { kind: 'unsupported' };
+      }
+      if (outcome === 'error') return { kind: 'error' };
+      return { kind: 'error' };
+    }
+
+    if (keys.some((key) => key !== 'platform' && key !== 'birth' && key !== 'cmdline')) {
+      return { kind: 'error' };
+    }
+    const platform = value.platform;
+    const birth = value.birth;
+    if (!isNodePlatform(platform) || !isValidBirth(birth)) return { kind: 'error' };
+    if (value.cmdline !== undefined && typeof value.cmdline !== 'string') return { kind: 'error' };
+    const cmdlineHash = hashCmdline(value.cmdline as string | undefined);
+    return {
+      kind: 'identity',
+      identity: {
+        platform,
+        birth,
+        ...(cmdlineHash ? { cmdline_hash: cmdlineHash } : {}),
+      },
+    };
   } catch {
-    return false;
+    return { kind: 'error' };
   }
 }
 
@@ -634,20 +771,137 @@ export function isSessionStale(
   options: SessionStaleCheckOptions = {},
 ): boolean {
   if (!Number.isInteger(state.pid) || state.pid <= 0) return true;
-  const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
-  if (!isPidAlive(state.pid)) return true;
 
-  const platform = options.platform ?? process.platform;
-  if (platform !== 'linux') return false;
+  const runtimePlatform = options.platform ?? transactionDependencies.runtimePlatform ?? process.platform;
+  const probePid = options.probePid ?? (options.isPidAlive
+    ? (pid: number): PidProbeResult => options.isPidAlive!(pid) ? 'alive' : 'dead'
+    : transactionDependencies.probePid);
+  const observeProcess = options.observeProcess ?? (options.readLinuxIdentity
+    ? (pid: number, platform: NodeJS.Platform): ProcessObservation => {
+      if (platform !== 'linux') return { kind: 'unsupported' };
+      const identity = options.readLinuxIdentity!(pid);
+      if (!identity) return { kind: 'error' };
+      const cmdlineHash = hashCmdline(identity.cmdline);
+      return {
+        kind: 'identity',
+        identity: {
+          platform: 'linux',
+          birth: String(identity.startTicks),
+          ...(cmdlineHash ? { cmdline_hash: cmdlineHash } : {}),
+        },
+      };
+    }
+    : transactionDependencies.observeProcess);
+  const dependencies = {
+    ...transactionDependencies,
+    runtimePlatform,
+    probePid,
+    observeProcess,
+  };
+  return classifySessionProcess(state, dependencies) !== 'usable';
+}
 
-  const liveIdentity = (options.readLinuxIdentity ?? readLinuxProcessIdentity)(state.pid);
-  if (!liveIdentity || typeof state.pid_start_ticks !== 'number') return true;
-  if (state.pid_start_ticks !== liveIdentity.startTicks) return true;
+type ProcessClassificationStatus = 'usable' | 'stale-dead' | 'identity-indeterminate';
+type ObservationComparison = 'match' | 'birth-mismatch' | 'birth-mismatch-retryable' | 'identity-unavailable';
 
-  const expectedCmdline = normalizeCmdline(state.pid_cmdline);
-  if (!expectedCmdline) return false;
-  const liveCmdline = normalizeCmdline(liveIdentity.cmdline);
-  return !liveCmdline || liveCmdline !== expectedCmdline;
+function safeObserve(
+  provider: ProcessInspectionProvider,
+  pid: number,
+  runtimePlatform: NodeJS.Platform,
+): ProcessObservation {
+  try {
+    return provider.observeProcess(pid, runtimePlatform);
+  } catch {
+    return { kind: 'error' };
+  }
+}
+
+function compareObservation(
+  recorded: ProcessIdentity,
+  observation: ProcessObservation | unknown,
+  runtimePlatform: NodeJS.Platform,
+): ObservationComparison {
+  if (!observation || typeof observation !== 'object' || (observation as ProcessObservation).kind !== 'identity') {
+    return 'identity-unavailable';
+  }
+  const identity = (observation as Extract<ProcessObservation, { kind: 'identity' }>).identity;
+  if (!isComparableProcessIdentity(identity) || identity.platform !== runtimePlatform) {
+    return 'identity-unavailable';
+  }
+  if (identity.birth !== recorded.birth) return 'birth-mismatch-retryable';
+  if (recorded.cmdline_hash !== undefined && identity.cmdline_hash !== recorded.cmdline_hash) {
+    return 'identity-unavailable';
+  }
+  return 'match';
+}
+
+/** Compare recorded process birth evidence with a fresh provider observation. */
+export function classifyRecordedIdentity(
+  recorded: Pick<ProcessIdentity, 'platform' | 'birth' | 'cmdline_hash'>,
+  runtimePlatform: NodeJS.Platform,
+  provider: ProcessInspectionProvider,
+  pid: number,
+): IdentityClassification {
+  if (!isComparableProcessIdentity(recorded) || recorded.platform !== runtimePlatform || !Number.isInteger(pid) || pid <= 0) {
+    return { status: 'identity-unavailable' };
+  }
+
+  let probe: PidProbeResult;
+  try {
+    probe = provider.probePid(pid);
+  } catch {
+    return { status: 'identity-unavailable' };
+  }
+  if (probe === 'dead') return { status: 'gone' };
+  if (probe !== 'alive') return { status: 'identity-unavailable' };
+
+  const first = compareObservation(recorded, safeObserve(provider, pid, runtimePlatform), runtimePlatform);
+  if (first === 'birth-mismatch-retryable') {
+    const second = compareObservation(recorded, safeObserve(provider, pid, runtimePlatform), runtimePlatform);
+    if (second === 'match') return { status: 'match' };
+    if (second === 'birth-mismatch-retryable' || second === 'birth-mismatch') return { status: 'birth-mismatch' };
+    return { status: 'identity-unavailable' };
+  }
+  if (first === 'match') return { status: 'match' };
+  if (first === 'birth-mismatch') return { status: 'birth-mismatch' };
+  return { status: 'identity-unavailable' };
+}
+
+function recordedIdentityForState(
+  state: SessionState,
+  runtimePlatform: NodeJS.Platform,
+): ProcessIdentity | null | 'invalid' {
+  if (state.identity_schema_version !== undefined && state.identity_schema_version !== 2) return 'invalid';
+  if (state.process_identity !== undefined) {
+    if (state.identity_schema_version !== 2 || !isValidProcessIdentity(state.process_identity)) return 'invalid';
+    if (state.platform !== undefined && state.platform !== state.process_identity.platform) return 'invalid';
+    return state.process_identity;
+  }
+  if (state.identity_schema_version === 2) return 'invalid';
+
+  const recordedPlatform = state.platform ?? runtimePlatform;
+  if (recordedPlatform === 'linux' && isValidStartTicks(state.pid_start_ticks)) {
+    const cmdlineHash = hashCmdline(state.pid_cmdline);
+    return {
+      platform: 'linux',
+      birth: String(state.pid_start_ticks),
+      ...(cmdlineHash ? { cmdline_hash: cmdlineHash } : {}),
+    };
+  }
+  return null;
+}
+
+function probeIdentitylessProcess(
+  pid: number,
+  dependencies: SessionPointerTransactionDependencies,
+): ProcessClassificationStatus {
+  let probe: PidProbeResult;
+  try {
+    probe = dependencies.probePid(pid);
+  } catch {
+    return 'identity-indeterminate';
+  }
+  return probe === 'dead' ? 'stale-dead' : 'identity-indeterminate';
 }
 
 export function isSessionStateAuthoritativeForCwd(state: SessionState, cwd: string): boolean {
@@ -668,9 +922,11 @@ export function isSessionStateUsable(
   if (!normalizeSessionId(state.session_id)) return false;
   if (typeof state.cwd === 'string' && state.cwd.trim() && !isSessionStateAuthoritativeForCwd(state, cwd)) return false;
   const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
-  const hasLinuxIdentityMetadata = typeof state.pid_start_ticks === 'number'
-    || typeof state.pid_cmdline === 'string';
-  return !hasPidMetadata && !hasLinuxIdentityMetadata || !isSessionStale(state, options);
+  const hasIdentityMetadata = typeof state.pid_start_ticks === 'number'
+    || typeof state.pid_cmdline === 'string'
+    || state.identity_schema_version !== undefined
+    || state.process_identity !== undefined;
+  return !hasPidMetadata && !hasIdentityMetadata || !isSessionStale(state, options);
 }
 
 function isValidStartTicks(value: unknown): value is number {
@@ -680,40 +936,27 @@ function isValidStartTicks(value: unknown): value is number {
 function classifySessionProcess(
   state: SessionState,
   dependencies: SessionPointerTransactionDependencies,
-): 'usable' | 'stale-dead' | 'identity-indeterminate' {
+): ProcessClassificationStatus {
   const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
-  const hasIdentityMetadata = typeof state.pid_start_ticks === 'number' || typeof state.pid_cmdline === 'string';
+  const hasIdentityMetadata = typeof state.pid_start_ticks === 'number'
+    || typeof state.pid_cmdline === 'string'
+    || state.identity_schema_version !== undefined
+    || state.process_identity !== undefined;
   if (!hasPidMetadata && !hasIdentityMetadata) return 'usable';
   if (!hasPidMetadata) return 'identity-indeterminate';
 
-  let pidStatus: PidProbeResult;
-  try {
-    pidStatus = dependencies.probePid(state.pid);
-  } catch {
-    return 'identity-indeterminate';
-  }
-  if (pidStatus === 'dead') return 'stale-dead';
-  if (pidStatus !== 'alive') return 'identity-indeterminate';
+  const runtimePlatform = dependencies.runtimePlatform;
+  const recorded = recordedIdentityForState(state, runtimePlatform);
+  if (recorded === 'invalid') return 'identity-indeterminate';
+  if (!recorded) return probeIdentitylessProcess(state.pid, dependencies);
 
-  const platform = state.platform ?? process.platform;
-  if (platform !== 'linux') return 'usable';
-  if (!isValidStartTicks(state.pid_start_ticks)) return 'identity-indeterminate';
-
-  let liveIdentity: ReturnType<SessionPointerTransactionDependencies['readProcessIdentity']>;
-  try {
-    liveIdentity = dependencies.readProcessIdentity(state.pid, platform);
-  } catch {
-    return 'identity-indeterminate';
+  const classification = classifyRecordedIdentity(recorded, runtimePlatform, dependencies, state.pid);
+  switch (classification.status) {
+    case 'match': return 'usable';
+    case 'gone':
+    case 'birth-mismatch': return 'stale-dead';
+    case 'identity-unavailable': return 'identity-indeterminate';
   }
-  if (!liveIdentity || !isValidStartTicks(liveIdentity.startTicks)) return 'identity-indeterminate';
-  if (liveIdentity.startTicks !== state.pid_start_ticks) return 'stale-dead';
-  if (liveIdentity.status !== 'matching') return 'identity-indeterminate';
-
-  const expectedCmdlineHash = hashCmdline(state.pid_cmdline);
-  if (expectedCmdlineHash && liveIdentity.cmdlineHash !== expectedCmdlineHash) {
-    return 'identity-indeterminate';
-  }
-  return 'usable';
 }
 
 /**
@@ -741,6 +984,14 @@ function classifyParsedSessionPointer(
   if (typeof state.cwd === 'string' && state.cwd.trim() && !isSessionStateAuthoritativeForCwd(state, context.cwd)) {
     return { status: 'foreign-cwd', raw, state };
   }
+  if (state.identity_schema_version !== undefined && state.identity_schema_version !== 2) return { status: 'identity-indeterminate', raw, state };
+  if (state.process_identity !== undefined
+    && (state.identity_schema_version !== 2
+      || !isValidProcessIdentity(state.process_identity)
+      || state.platform !== undefined && state.platform !== state.process_identity.platform)) {
+    return { status: 'malformed', raw, state };
+  }
+  if (state.identity_schema_version === 2 && state.process_identity === undefined) return { status: 'malformed', raw, state };
 
   const processStatus = classifySessionProcess(state, transactionDependencies);
   return { status: processStatus, state, raw };
@@ -807,7 +1058,7 @@ function createSessionState(
   sessionId: string,
   pid: number,
   platform: NodeJS.Platform,
-  linuxIdentity: LinuxProcessIdentity | null,
+  identity: ProcessIdentity | LinuxProcessIdentity | null,
   options: {
     nowIso?: string;
     nativeSessionId?: string;
@@ -827,6 +1078,27 @@ function createSessionState(
   const ownerOmxSessionId = normalizeSessionId(options.ownerOmxSessionId);
   const tmuxSessionName = normalizeNonempty(options.tmuxSessionName);
   const tmuxPaneId = normalizeNonempty(options.tmuxPaneId);
+  const processIdentity = identity && 'birth' in identity
+    ? identity
+    : identity
+      ? {
+          platform: 'linux' as const,
+          birth: String(identity.startTicks),
+          ...(hashCmdline(identity.cmdline) ? { cmdline_hash: hashCmdline(identity.cmdline) } : {}),
+        }
+      : undefined;
+  const publishIdentity = processIdentity && isValidProcessIdentity(processIdentity) && processIdentity.platform === platform
+    ? processIdentity
+    : undefined;
+  const legacyStartTicks = identity && 'startTicks' in identity
+    ? identity.startTicks
+    : publishIdentity?.platform === 'linux' && Number.isSafeInteger(Number(publishIdentity.birth))
+      ? Number(publishIdentity.birth)
+      : undefined;
+  const legacyLinuxIdentity = publishIdentity?.platform === 'linux' && publishIdentity.birth === String(legacyStartTicks)
+    ? readLinuxProcessIdentity(pid)
+    : null;
+  const legacyCmdline = identity && 'cmdline' in identity ? identity.cmdline : legacyLinuxIdentity?.cmdline;
   return {
     session_id: sessionId,
     ...(nativeSessionId ? { native_session_id: nativeSessionId } : {}),
@@ -839,8 +1111,9 @@ function createSessionState(
     state_root: stateRoot,
     pid,
     platform,
-    ...(linuxIdentity ? { pid_start_ticks: linuxIdentity.startTicks } : {}),
-    ...(linuxIdentity?.cmdline ? { pid_cmdline: linuxIdentity.cmdline } : {}),
+    ...(publishIdentity ? { identity_schema_version: 2 as const, process_identity: publishIdentity } : {}),
+    ...(legacyStartTicks !== undefined ? { pid_start_ticks: legacyStartTicks } : {}),
+    ...(legacyCmdline ? { pid_cmdline: legacyCmdline } : {}),
     ...(tmuxSessionName ? { tmux_session_name: tmuxSessionName } : {}),
     ...(tmuxPaneId ? { tmux_pane_id: tmuxPaneId } : {}),
   };
@@ -860,8 +1133,15 @@ function resolvePid(options: SessionStartOptions): number {
   return Number.isInteger(options.pid) && options.pid && options.pid > 0 ? options.pid : process.pid;
 }
 
-function sessionIdentityFor(pid: number, platform: NodeJS.Platform): LinuxProcessIdentity | null {
-  return platform === 'linux' ? readLinuxProcessIdentity(pid) : null;
+function sessionIdentityFor(pid: number, platform: NodeJS.Platform): ProcessIdentity | null {
+  try {
+    const observation = transactionDependencies.observeProcess(pid, platform);
+    return observation.kind === 'identity' && isValidProcessIdentity(observation.identity) && observation.identity.platform === platform
+      ? observation.identity
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function currentOwnerAlias(state: SessionState): string | undefined {
@@ -909,22 +1189,47 @@ interface SessionPointerLockOwnerV1 {
   created_at: string;
 }
 
+interface SessionPointerLockOwnerV2 {
+  version: 2;
+  token: string;
+  pid: number;
+  platform: NodeJS.Platform;
+  process_identity: ProcessIdentity;
+  pid_start_ticks?: number;
+  pid_cmdline_hash?: string;
+  created_at: string;
+}
+
+type SessionPointerLockOwner = SessionPointerLockOwnerV1 | SessionPointerLockOwnerV2;
 type LockOwnerStatus = 'live' | 'dead' | 'reused' | 'identity-indeterminate' | 'missing' | 'malformed';
 
-function parseLockOwner(raw: string): SessionPointerLockOwnerV1 | null {
+function parseLockOwner(raw: string): SessionPointerLockOwner | null {
   try {
-    const value = JSON.parse(raw) as Partial<SessionPointerLockOwnerV1>;
-    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-    if (value.version !== 1 || !isValidToken(value.token) || typeof value.pid !== 'number' || !Number.isInteger(value.pid) || value.pid <= 0) return null;
-    if (typeof value.platform !== 'string' || !value.platform || typeof value.created_at !== 'string' || !value.created_at) {
-      return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const value = parsed as Record<string, unknown>;
+    if (!isValidToken(value.token) || typeof value.pid !== 'number' || !Number.isInteger(value.pid) || value.pid <= 0) return null;
+    if (!isNodePlatform(value.platform) || typeof value.created_at !== 'string' || !value.created_at) return null;
+
+    if (value.version === 1) {
+      if (value.pid_start_ticks !== undefined && !isValidStartTicks(value.pid_start_ticks)) return null;
+      if (value.pid_cmdline_hash !== undefined
+        && (typeof value.pid_cmdline_hash !== 'string' || !SHA256_PATTERN.test(value.pid_cmdline_hash))) {
+        return null;
+      }
+      return value as unknown as SessionPointerLockOwnerV1;
     }
-    if (value.pid_start_ticks !== undefined && !isValidStartTicks(value.pid_start_ticks)) return null;
-    if (value.pid_cmdline_hash !== undefined
-      && (typeof value.pid_cmdline_hash !== 'string' || !SHA256_PATTERN.test(value.pid_cmdline_hash))) {
-      return null;
+    if (value.version === 2) {
+      const processIdentity = value.process_identity;
+      if (!isValidProcessIdentity(processIdentity) || processIdentity.platform !== value.platform) return null;
+      if (value.pid_start_ticks !== undefined && !isValidStartTicks(value.pid_start_ticks)) return null;
+      if (value.pid_cmdline_hash !== undefined
+        && (typeof value.pid_cmdline_hash !== 'string' || !SHA256_PATTERN.test(value.pid_cmdline_hash))) {
+        return null;
+      }
+      return value as unknown as SessionPointerLockOwnerV2;
     }
-    return value as SessionPointerLockOwnerV1;
+    return null;
   } catch {
     return null;
   }
@@ -934,9 +1239,19 @@ function isValidToken(value: unknown): value is string {
   return typeof value === 'string' && SESSION_POINTER_TOKEN_PATTERN.test(value);
 }
 
+function recordedIdentityForLockOwner(owner: SessionPointerLockOwner): ProcessIdentity | null {
+  if (owner.version === 2) return owner.process_identity;
+  if (owner.platform !== 'linux' || !isValidStartTicks(owner.pid_start_ticks)) return null;
+  return {
+    platform: 'linux',
+    birth: String(owner.pid_start_ticks),
+    ...(owner.pid_cmdline_hash ? { cmdline_hash: owner.pid_cmdline_hash } : {}),
+  };
+}
+
 async function inspectLockOwnerFile(ownerPath: string, missingStatus: LockOwnerStatus = 'missing'): Promise<{
   status: LockOwnerStatus;
-  owner?: SessionPointerLockOwnerV1;
+  owner?: SessionPointerLockOwner;
 }> {
   let raw: string;
   try {
@@ -948,39 +1263,36 @@ async function inspectLockOwnerFile(ownerPath: string, missingStatus: LockOwnerS
   const owner = parseLockOwner(raw);
   if (!owner) return { status: 'malformed' };
 
-  let pidStatus: PidProbeResult;
-  try {
-    pidStatus = transactionDependencies.probePid(owner.pid);
-  } catch {
-    return { status: 'identity-indeterminate', owner };
+  const recorded = recordedIdentityForLockOwner(owner);
+  if (!recorded) {
+    let probe: PidProbeResult;
+    try {
+      probe = transactionDependencies.probePid(owner.pid);
+    } catch {
+      return { status: 'identity-indeterminate', owner };
+    }
+    return probe === 'dead'
+      ? { status: 'dead', owner }
+      : { status: 'identity-indeterminate', owner };
   }
-  if (pidStatus === 'dead') return { status: 'dead', owner };
-  if (pidStatus !== 'alive') return { status: 'identity-indeterminate', owner };
 
-  if (owner.platform !== 'linux' || !isValidStartTicks(owner.pid_start_ticks)) {
-    return { status: 'identity-indeterminate', owner };
+  const classification = classifyRecordedIdentity(
+    recorded,
+    transactionDependencies.runtimePlatform,
+    transactionDependencies,
+    owner.pid,
+  );
+  switch (classification.status) {
+    case 'match': return { status: 'live', owner };
+    case 'gone': return { status: 'dead', owner };
+    case 'birth-mismatch': return { status: 'reused', owner };
+    case 'identity-unavailable': return { status: 'identity-indeterminate', owner };
   }
-
-  let liveIdentity: ReturnType<SessionPointerTransactionDependencies['readProcessIdentity']>;
-  try {
-    liveIdentity = transactionDependencies.readProcessIdentity(owner.pid, owner.platform);
-  } catch {
-    return { status: 'identity-indeterminate', owner };
-  }
-  if (!liveIdentity || !isValidStartTicks(liveIdentity.startTicks)) {
-    return { status: 'identity-indeterminate', owner };
-  }
-  if (liveIdentity.startTicks !== owner.pid_start_ticks) return { status: 'reused', owner };
-  if (liveIdentity.status !== 'matching') return { status: 'identity-indeterminate', owner };
-  if (owner.pid_cmdline_hash && owner.pid_cmdline_hash !== liveIdentity.cmdlineHash) {
-    return { status: 'identity-indeterminate', owner };
-  }
-  return { status: 'live', owner };
 }
 
 async function inspectLockOwner(lockPath: string): Promise<{
   status: LockOwnerStatus;
-  owner?: SessionPointerLockOwnerV1;
+  owner?: SessionPointerLockOwner;
 }> {
   return await inspectLockOwnerFile(join(lockPath, 'owner.json'));
 }
@@ -1282,26 +1594,35 @@ interface HeldPointerLock {
   token: string;
 }
 
-function buildLockOwner(token: string): SessionPointerLockOwnerV1 {
-  let identity: ReturnType<SessionPointerTransactionDependencies['readProcessIdentity']> | undefined;
+function buildLockOwner(token: string): SessionPointerLockOwner {
+  const runtimePlatform = transactionDependencies.runtimePlatform;
+  let observation: ProcessObservation | undefined;
   try {
-    identity = transactionDependencies.readProcessIdentity(process.pid, process.platform);
+    observation = transactionDependencies.observeProcess(process.pid, runtimePlatform);
   } catch {
     // Publication remains valid with optional identity metadata omitted.
   }
-  return {
-    version: 1,
+  const identity = observation?.kind === 'identity' && isValidProcessIdentity(observation.identity)
+    && observation.identity.platform === runtimePlatform
+    ? observation.identity
+    : undefined;
+  const legacyStartTicks = identity?.platform === 'linux' && Number.isSafeInteger(Number(identity.birth))
+    ? Number(identity.birth)
+    : undefined;
+  const legacyHash = identity?.cmdline_hash && SHA256_PATTERN.test(identity.cmdline_hash)
+    ? identity.cmdline_hash
+    : undefined;
+  const common = {
     token,
     pid: process.pid,
-    platform: process.platform,
-    ...(identity?.status === 'matching' && isValidStartTicks(identity.startTicks)
-      ? { pid_start_ticks: identity.startTicks }
-      : {}),
-    ...(identity?.status === 'matching' && identity.cmdlineHash && SHA256_PATTERN.test(identity.cmdlineHash)
-      ? { pid_cmdline_hash: identity.cmdlineHash }
-      : {}),
+    platform: runtimePlatform,
+    ...(legacyStartTicks !== undefined ? { pid_start_ticks: legacyStartTicks } : {}),
+    ...(legacyHash ? { pid_cmdline_hash: legacyHash } : {}),
     created_at: new Date(transactionDependencies.nowMs()).toISOString(),
   };
+  return identity
+    ? { version: 2, ...common, process_identity: identity }
+    : { version: 1, ...common };
 }
 
 async function removeOwnedPath(path: string): Promise<SessionPointerSecondaryFailure | undefined> {
@@ -1513,7 +1834,7 @@ async function acquirePointerLock(
 
 async function releasePointerLock(lock: HeldPointerLock): Promise<SessionPointerSecondaryFailure[]> {
   const ownerPath = join(lock.context.lockPath, 'owner.json');
-  let owner: SessionPointerLockOwnerV1 | null = null;
+  let owner: SessionPointerLockOwner | null = null;
   try {
     owner = parseLockOwner(await transactionDependencies.fs.readFile(ownerPath, 'utf8'));
   } catch {
@@ -2505,7 +2826,7 @@ export async function readNativeSessionOwnerEvidence(
   const state = pointer.state;
   return state?.session_id === normalized
     && state.native_session_id === normalized
-    && state.platform === process.platform
+    && state.platform === transactionDependencies.runtimePlatform
     && isSessionStateAuthoritativeForCwd(state, context.cwd)
     ? pointer
     : { status: 'malformed', state, raw: pointer.raw };

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -4200,7 +4200,7 @@ PY`,
       process.env.OMX_SESSION_ID = sessionId;
       assert.equal(await neutralizeOwnedRoutingRalplan(cwd), true);
       const result = await dispatchCodexNativeHook({ hook_event_name: 'SessionStart', cwd, session_id: sessionId }, { cwd });
-      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } }).hookSpecificOutput?.additionalContext ?? '');
+      const context = String((result.outputJson as { hookSpecificOutput?: { additionalContext?: string } } | null)?.hookSpecificOutput?.additionalContext ?? '');
       assert.doesNotMatch(context, /- ralplan phase:/);
     } finally {
       previousSessionId === undefined ? delete process.env.OMX_SESSION_ID : process.env.OMX_SESSION_ID = previousSessionId;

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -182,6 +182,13 @@ import {
   type TeamOperationalCommitEntry,
 } from './commit-hygiene.js';
 import {
+  classifyRecordedIdentity,
+  defaultProcessInspectionProvider,
+  type IdentityClassification,
+  type ProcessIdentity as SharedProcessIdentity,
+} from '../hooks/session.js';
+
+import {
   assertCleanLeaderWorkspaceForWorkerWorktrees,
   ensureWorktree,
   isGitRepository,
@@ -2449,41 +2456,51 @@ function isPidGone(pid: number): boolean {
   return probePidLiveness(pid) === 'gone';
 }
 
-type ProcessIdentity = {
+interface TrackedProcessRecordV2 {
   pid: number;
-  /** Linux /proc stat start-time ticks; this changes when a PID is reused. */
-  start_time: string;
-};
+  process_identity: SharedProcessIdentity;
+}
 
-async function captureProcessIdentity(pid: number): Promise<ProcessIdentity | null> {
-  // There is no portable process birth identifier exposed by Node. Refuse to
-  // persist replayable PID debt on platforms without Linux's stable proc stat
-  // start-time field rather than later treating a reused PID as authoritative.
-  if (process.platform !== 'linux' || !Number.isSafeInteger(pid) || pid <= 0) return null;
-  try {
-    const stat = await readFile(`/proc/${pid}/stat`, 'utf8');
-    const close = stat.lastIndexOf(')');
-    const fields = close >= 0 ? stat.slice(close + 2).trim().split(/\s+/) : [];
-    // field 22 is starttime; fields begin at field 3 after the comm value.
-    const startTime = fields[19];
-    return typeof startTime === 'string' && /^[0-9]+$/.test(startTime)
-      ? { pid, start_time: startTime }
-      : null;
-  } catch {
-    return null;
+// V1 (legacy, read-only): Linux-only.
+type TrackedProcessRecordV1 = { pid: number; start_time: string };
+type TrackedProcessRecord = TrackedProcessRecordV1 | TrackedProcessRecordV2;
+
+async function captureProcessIdentity(pid: number): Promise<TrackedProcessRecordV2 | null> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  const observation = defaultProcessInspectionProvider.observeProcess(pid, process.platform);
+  if (observation.kind !== 'identity') return null;
+  return { pid, process_identity: observation.identity };
+}
+
+async function captureProcessIdentities(pids: readonly number[]): Promise<TrackedProcessRecordV2[] | null> {
+  const identities = await Promise.all([...new Set(pids)].map((pid) => captureProcessIdentity(pid)));
+  return identities.every((identity): identity is TrackedProcessRecordV2 => identity !== null) ? identities : null;
+}
+
+async function probeProcessIdentity(identity: TrackedProcessRecord): Promise<'gone' | 'same' | 'reused_or_unknown'> {
+  const recorded: SharedProcessIdentity = 'process_identity' in identity
+    ? identity.process_identity
+    : { platform: 'linux', birth: identity.start_time };
+  const runtimePlatform = 'process_identity' in identity
+    ? identity.process_identity.platform
+    : 'linux'; // V1 is always Linux.
+  if (runtimePlatform !== process.platform && 'process_identity' in identity) {
+    return 'reused_or_unknown';
+  }
+  const classification: IdentityClassification = classifyRecordedIdentity(
+    recorded,
+    process.platform,
+    defaultProcessInspectionProvider,
+    identity.pid,
+  );
+  switch (classification.status) {
+    case 'match': return 'same';
+    case 'gone': return 'gone';
+    case 'birth-mismatch': return 'reused_or_unknown';
+    case 'identity-unavailable': return 'reused_or_unknown';
   }
 }
 
-async function captureProcessIdentities(pids: readonly number[]): Promise<ProcessIdentity[] | null> {
-  const identities = await Promise.all([...new Set(pids)].map((pid) => captureProcessIdentity(pid)));
-  return identities.every((identity): identity is ProcessIdentity => identity !== null) ? identities : null;
-}
-
-async function probeProcessIdentity(identity: ProcessIdentity): Promise<'gone' | 'same' | 'reused_or_unknown'> {
-  const current = await captureProcessIdentity(identity.pid);
-  if (current === null) return probePidLiveness(identity.pid) === 'gone' ? 'gone' : 'reused_or_unknown';
-  return current.start_time === identity.start_time ? 'same' : 'reused_or_unknown';
-}
 
 function probeProcessGroupLiveness(processGroupId: number): 'alive' | 'gone' | 'unknown' {
   if (process.platform === 'win32') return 'gone';
@@ -2694,7 +2711,8 @@ type ExactPaneProcessTreeTeardown = {
   trackedPids: number[];
   authorizedPanePid?: number;
   proofUnavailable?: ExactPaneUnavailableProof;
-  trackedProcessIdentities?: ProcessIdentity[];
+  trackedProcessIdentities?: TrackedProcessRecord[];
+
 };
 
 type ExactPaneProcessProbe =
@@ -2891,14 +2909,16 @@ type GonePaneDescendantCleanupDebtEntry =
   | {
     pane_id: string;
     authorized_pane_pid: number;
-    tracked_processes: ProcessIdentity[];
+    tracked_processes: TrackedProcessRecord[];
+
     evidence: string;
   }
   | {
     pane_id: string;
     authorized_pane_pid: number;
     tracked_pids: number[];
-    tracked_processes?: ProcessIdentity[];
+    tracked_processes?: TrackedProcessRecord[];
+
     evidence: 'process_identity_unavailable';
   };
 
@@ -2970,13 +2990,36 @@ async function persistGonePaneDescendantCleanupDebt(params: {
   await writeAtomic(debtPath, JSON.stringify({ schema_version: 1, operation: 'gone_pane_descendant_cleanup', entries }, null, 2));
 }
 
-function isValidProcessIdentity(value: unknown): value is ProcessIdentity {
-  return typeof value === 'object' && value !== null
-    && Number.isSafeInteger((value as { pid?: unknown }).pid)
-    && (value as { pid: number }).pid > 0
-    && typeof (value as { start_time?: unknown }).start_time === 'string'
-    && /^[0-9]+$/.test((value as { start_time: string }).start_time);
+const TRACKED_PROCESS_PLATFORMS = new Set<NodeJS.Platform>([
+  'aix', 'android', 'darwin', 'freebsd', 'haiku', 'linux', 'openbsd', 'sunos', 'win32', 'cygwin', 'netbsd',
+]);
+const TRACKED_PROCESS_BIRTH_PATTERN = /^\d+(?:\.\d+)?$/;
+const TRACKED_PROCESS_CMDLINE_HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+function isValidSharedProcessIdentity(value: unknown): value is SharedProcessIdentity {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const identity = value as Partial<SharedProcessIdentity>;
+  if (Object.keys(identity).some((key) => key !== 'platform' && key !== 'birth' && key !== 'cmdline_hash')) return false;
+  return typeof identity.platform === 'string'
+    && TRACKED_PROCESS_PLATFORMS.has(identity.platform as NodeJS.Platform)
+    && typeof identity.birth === 'string'
+    && TRACKED_PROCESS_BIRTH_PATTERN.test(identity.birth)
+    && (identity.cmdline_hash === undefined
+      || typeof identity.cmdline_hash === 'string' && TRACKED_PROCESS_CMDLINE_HASH_PATTERN.test(identity.cmdline_hash));
 }
+
+function isValidProcessIdentity(value: unknown): value is TrackedProcessRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const candidate = value as {
+    pid?: unknown;
+    start_time?: unknown;
+    process_identity?: unknown;
+  };
+  if (!Number.isSafeInteger(candidate.pid) || (candidate.pid as number) <= 0) return false;
+  if ('process_identity' in candidate) return isValidSharedProcessIdentity(candidate.process_identity);
+  return typeof candidate.start_time === 'string' && /^[0-9]+$/.test(candidate.start_time);
+}
+
 
 function isValidGonePaneDescendantCleanupDebt(value: unknown): value is GonePaneDescendantCleanupDebt {
   if (typeof value !== 'object' || value === null) return false;
@@ -3002,7 +3045,8 @@ function isValidGonePaneDescendantCleanupDebt(value: unknown): value is GonePane
         || new Set(trackedPids).size !== trackedPids.length) return false;
       if (candidate.tracked_processes === undefined) return true;
       if (!Array.isArray(candidate.tracked_processes) || !candidate.tracked_processes.every(isValidProcessIdentity)) return false;
-      const trackedProcesses = candidate.tracked_processes as ProcessIdentity[];
+      const trackedProcesses = candidate.tracked_processes as TrackedProcessRecord[];
+
       return trackedProcesses.every((identity) => trackedPids.includes(identity.pid))
         && new Set(trackedProcesses.map((identity) => identity.pid)).size === trackedProcesses.length;
     }
@@ -3010,7 +3054,8 @@ function isValidGonePaneDescendantCleanupDebt(value: unknown): value is GonePane
       || candidate.tracked_pids !== undefined
       || !Array.isArray(candidate.tracked_processes) || candidate.tracked_processes.length === 0
       || !candidate.tracked_processes.every(isValidProcessIdentity)) return false;
-    const trackedProcesses = candidate.tracked_processes as ProcessIdentity[];
+    const trackedProcesses = candidate.tracked_processes as TrackedProcessRecord[];
+
     return new Set(trackedProcesses.map((identity) => identity.pid)).size === trackedProcesses.length;
 
   });
@@ -3030,7 +3075,7 @@ async function reconcileGonePaneDescendantCleanupDebt(teamName: string, cwd: str
   for (const entry of debt.entries) {
     if ('tracked_pids' in entry) {
       const trackedProcesses = entry.tracked_processes ?? [];
-      const knownIdentities = new Map<number, ProcessIdentity>(
+      const knownIdentities = new Map<number, TrackedProcessRecord>(
         trackedProcesses.map((identity) => [identity.pid, identity]),
       );
       const states: Array<'gone' | 'same' | 'reused_or_unknown'> = await Promise.all(entry.tracked_pids.map((pid: number) => {

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -287,7 +287,7 @@ describe('CI Rust gates', () => {
     assert.match(nativeCacheJob, /node --test\s*\\\n\s+dist\/cli\/__tests__\/native-assets\.test\.js\s*\\\n\s+dist\/cli\/__tests__\/sparkshell-cli\.test\.js\s*\\\n\s+dist\/cli\/__tests__\/api\.test\.js\s*\\\n\s+dist\/scripts\/__tests__\/verify-native-release-assets\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/native-release-manifest\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/explore-harness-release-workflow\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/ci-rust-gates\.test\.js/);
 
     assert.match(ciStatusJob, /^    if: always\(\)$/m);
-    assert.match(ciStatusJob, /^    needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]$/m);
+    assert.match(ciStatusJob, /^    needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]$/m);
     assert.match(ciStatusJob, /NATIVE_CACHE_INTEGRITY_RESULT: \$\{\{ needs\.native-cache-integrity\.result \}\}/);
     assert.match(ciStatusJob, /if \[\[ "\$FULL_SUITE" == "true" \]\] \|\| bool_any "\$TS_CHANGED" "\$NATIVE_CHANGED" "\$SHARED_CONFIG_CHANGED"; then native_cache_integrity_active=true; fi/);
     assert.match(ciStatusJob, /check_job native-cache-integrity "\$NATIVE_CACHE_INTEGRITY_RESULT" "\$native_cache_integrity_active"/);
@@ -330,7 +330,7 @@ describe('CI Rust gates', () => {
 
     assert.match(
       workflow,
-      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
     );
   });
 
@@ -351,6 +351,8 @@ describe('CI Rust gates', () => {
       'rustfmt',
       'clippy',
       'rust-tests',
+      'native-rust-darwin',
+      'native-rust-windows',
       'lint',
       'typecheck',
       'build-dist',
@@ -364,7 +366,7 @@ describe('CI Rust gates', () => {
 
     assert.match(
       ciStatusJob,
-      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
     );
 
     for (const jobName of requiredJobs) {


### PR DESCRIPTION
## Summary

Closes #3362. Replaces the scattered Linux-only process identity logic with one versioned `ProcessIdentity`/`ProcessInspectionProvider` boundary covering Darwin, Windows, and Linux through the existing `omx-runtime` Rust binary.

### Security fix
Deletes the bare-liveness bug at `session.ts` line 699 (`if (platform !== 'linux') return 'usable'`) that trusted PID liveness alone on non-Linux platforms. All platforms now require positive same-lineage birth verification; identity-less live pointers are `identity-indeterminate`.

### Native identity sources
| Platform | API | Birth format |
|---|---|---|
| Darwin | `proc_pidinfo(PROC_PIDTBSDINFO)` | `pbi_start_tvsec.pbi_start_tvusec` (seconds.microseconds since epoch) |
| Windows | `GetProcessTimes` via `OpenProcess` | Creation FILETIME (100ns intervals since 1601) |
| Linux | `/proc/<pid>/stat` field 22 | Jiffies since boot |

### Fail-closed classifier
- **Pointer policy**: birth-mismatch → `stale-dead` (replaceable)
- **Lock policy**: birth-mismatch → `reused` (NOT recoverable; only confirmed-dead grants `safeToRecover`)
- EPERM never maps to dead
- TOCTOU: exactly one retry on birth disagreement, second observation authoritative
- Foreign platform, unsupported/future schema, malformed → `identity-indeterminate`

### V2 schema (v1 legacy-read-only)
- `identity_schema_version: 2` + `process_identity: {platform, birth (decimal string), cmdline_hash?}`
- Writer omits v2 fields entirely when identity capture fails (graceful degradation)
- Team/runtime.ts unified onto shared provider

### Bounded follow-up
Add `omx-runtime` to `NativeProduct`/`NATIVE_HYDRATABLE_PRODUCTS` for full binary packaging on plain `npm install`. Until then, Darwin/Win32 native identity works for development (workspace build) and release builds, but not plain npm install without the binary in PATH.

## Local verification
- ✅ `npm run build` — clean
- ✅ `npm run lint` — clean
- ✅ `npm run check:no-unused` — clean
- ✅ `cargo test -p omx-runtime` — 25 passed
- ✅ Session tests: 121 passed, 0 failed
- ✅ Team runtime tests: 196 passed, 0 failed
- ✅ Launch-fallback tests: 35 passed, 0 failed
- ✅ Terminal P0/P1 review: CLEAR, zero blockers

### Files changed (9 files, +1557 −296)
- `crates/omx-runtime/src/main.rs` — `process-identity <pid>` subcommand
- `crates/omx-runtime/Cargo.toml` — `windows-sys` target-scoped dep
- `crates/omx-runtime/tests/execution.rs` — Rust integration tests
- `Cargo.lock` — updated
- `src/hooks/session.ts` — provider boundary, classifier, writer, schema
- `src/hooks/__tests__/session.test.ts` — full decision-table test suite
- `src/hooks/extensibility/types.ts` — v2 fields on `HookPluginOmxSessionState`
- `src/team/runtime.ts` — unified onto shared provider
- `.github/workflows/ci.yml` — native-rust-darwin/windows CI jobs