### PR TITLE
fix(state): unlock Autopilot Ralplan self-cancel and fresh admission (#3369)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7732,10 +7732,18 @@ function assertCancellationOwnerMetadata(
   ownerIds: Set<string>,
   path: string,
 ): void {
-  for (const ownerField of ["session_id", "owner_omx_session_id", "owner_codex_session_id"] as const) {
+  if (Object.prototype.hasOwnProperty.call(value, "session_id")) {
+    const sessionId = normalizeSessionId(value.session_id);
+    if (!sessionId || !ownerIds.has(sessionId)) {
+      throw new Error(`Refusing contradictory session_id in ${path}.`);
+    }
+  }
+  for (const ownerField of ["owner_omx_session_id", "owner_codex_session_id"] as const) {
     if (!Object.prototype.hasOwnProperty.call(value, ownerField)) continue;
-    const owner = normalizeSessionId(value[ownerField]);
-    if (!owner || !ownerIds.has(owner)) {
+    const rawOwner = value[ownerField];
+    const blankOwner = typeof rawOwner === "string" && rawOwner.trim() === "";
+    const owner = normalizeSessionId(rawOwner);
+    if (!blankOwner && (!owner || !ownerIds.has(owner))) {
       throw new Error(`Refusing contradictory ${ownerField} in ${path}.`);
     }
   }
@@ -7779,15 +7787,25 @@ function assertExactSkillOwner(
   path: string,
   allowStaleTopCodexOwner: boolean = false,
 ): void {
-  for (const field of ["session_id", "owner_omx_session_id"] as const) {
-    if (!Object.prototype.hasOwnProperty.call(value, field)) continue;
-    if (normalizeSessionId(value[field]) !== authority.sessionId) {
-      throw new Error(`Refusing contradictory ${field} in ${path}.`);
+  if (
+    Object.prototype.hasOwnProperty.call(value, "session_id")
+    && normalizeSessionId(value.session_id) !== authority.sessionId
+  ) {
+    throw new Error(`Refusing contradictory session_id in ${path}.`);
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "owner_omx_session_id")) {
+    const rawOwner = value.owner_omx_session_id;
+    const blankOwner = typeof rawOwner === "string" && rawOwner.trim() === "";
+    const owner = normalizeSessionId(rawOwner);
+    if (!blankOwner && (!owner || owner !== authority.sessionId)) {
+      throw new Error(`Refusing contradictory owner_omx_session_id in ${path}.`);
     }
   }
   if (Object.prototype.hasOwnProperty.call(value, "owner_codex_session_id")) {
-    const owner = normalizeSessionId(value.owner_codex_session_id);
-    if (!owner || (!allowStaleTopCodexOwner && owner !== authority.nativeSessionId)) {
+    const rawOwner = value.owner_codex_session_id;
+    const blankOwner = typeof rawOwner === "string" && rawOwner.trim() === "";
+    const owner = normalizeSessionId(rawOwner);
+    if (!blankOwner && (!owner || (!allowStaleTopCodexOwner && owner !== authority.nativeSessionId))) {
       throw new Error(`Refusing contradictory owner_codex_session_id in ${path}.`);
     }
   }
@@ -7909,7 +7927,9 @@ async function cancelModes(
           const displacedOwnerId = hasTopCodexOwner
             ? normalizeSessionId(parsedState.owner_codex_session_id)
             : undefined;
-          if (hasTopCodexOwner && !displacedOwnerId) {
+          const blankTopCodexOwner = typeof parsedState.owner_codex_session_id === "string"
+            && parsedState.owner_codex_session_id.trim() === "";
+          if (hasTopCodexOwner && !blankTopCodexOwner && !displacedOwnerId) {
             throw new Error(`Refusing contradictory owner_codex_session_id in ${ref.path}.`);
           }
           assertExactSkillOwner(parsedState, exactAuthority, ref.path, hasTopCodexOwner);

--- a/src/scripts/__tests__/issue-3369-autopilot-ralplan-state-machine.test.ts
+++ b/src/scripts/__tests__/issue-3369-autopilot-ralplan-state-machine.test.ts
@@ -172,6 +172,27 @@ describe("issue #3369 Autopilot Ralplan state-machine self-lock", () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-3369-fresh-admission-"));
     try {
       await withEnv({ OMX_ROOT: cwd, OMX_SESSION_ID: undefined }, async () => {
+        const sessionDir = join(cwd, ".omx", "state", "sessions", "sess-3369-fresh");
+        await writeJson(join(sessionDir, "ralplan-state.json"), {
+          active: true,
+          current_phase: "planning",
+          run_outcome: "continue",
+        });
+        await writeJson(join(sessionDir, "skill-active-state.json"), {
+          version: 1,
+          active: true,
+          skill: "ralplan",
+          phase: "planning",
+          source: "test-fixture",
+          session_id: "sess-3369-fresh",
+          active_skills: [{
+            skill: "ralplan",
+            phase: "planning",
+            active: true,
+            session_id: "sess-3369-fresh",
+          }],
+        });
+
         const response = await executeStateOperation("state_write", {
           workingDirectory: cwd,
           mode: "autopilot",
@@ -181,8 +202,7 @@ describe("issue #3369 Autopilot Ralplan state-machine self-lock", () => {
         });
         assert.equal(response.isError, true);
         assert.match(String((response.payload as { error?: string }).error || ""), /documented_host_consensus_receipt_unavailable/);
-        await assert.rejects(readFile(join(cwd, ".omx", "state", "sessions", "sess-3369-fresh", "autopilot-state.json")));
-        await assert.rejects(readFile(join(cwd, ".omx", "state", "sessions", "sess-3369-fresh", "skill-active-state.json")));
+        await assert.rejects(readFile(join(sessionDir, "autopilot-state.json")));
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/scripts/__tests__/issue-3369-autopilot-ralplan-state-machine.test.ts
+++ b/src/scripts/__tests__/issue-3369-autopilot-ralplan-state-machine.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { dispatchCodexNativeHook } from "../codex-native-hook.js";
+import { executeStateOperation } from "../../state/operations.js";
+
+const omxBin = fileURLToPath(new URL("../../cli/omx.js", import.meta.url));
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+function runOmx(cwd: string, env: NodeJS.ProcessEnv, ...args: string[]) {
+  return spawnSync(process.execPath, [omxBin, ...args], {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  });
+}
+
+async function withEnv<T>(values: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+  const before = new Map(Object.keys(values).map((name) => [name, process.env[name]]));
+  try {
+    for (const [name, value] of Object.entries(values)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    return await run();
+  } finally {
+    for (const [name, value] of before) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
+
+describe("issue #3369 Autopilot Ralplan state-machine self-lock", () => {
+  it("cancels identity-stripped Autopilot Ralplan state without executing Bash", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3369-ralplan-cancel-"));
+    const sessionId = "sess-3369-ralplan-cancel";
+    const threadId = "thread-3369-ralplan-cancel";
+    const stateDir = join(cwd, ".omx", "state");
+    const sessionDir = join(stateDir, "sessions", sessionId);
+    try {
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: sessionId,
+        cwd,
+        leader_thread_id: threadId,
+      });
+      await writeJson(join(stateDir, "subagent-tracking.json"), {
+        schemaVersion: 1,
+        sessions: {
+          [sessionId]: {
+            session_id: sessionId,
+            leader_thread_id: threadId,
+            threads: { [threadId]: { thread_id: threadId, kind: "leader" } },
+          },
+        },
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        current_phase: "ralplan",
+        run_outcome: "continue",
+      });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        version: 1,
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        source: "state-operations",
+        session_id: sessionId,
+        active_skills: [{
+          skill: "autopilot",
+          phase: "ralplan",
+          active: true,
+          session_id: sessionId,
+        }],
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: threadId,
+        agent_id: threadId,
+        tool_name: "Bash",
+        tool_input: { command: "omx cancel" },
+      }, { cwd });
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+      assert.equal(JSON.parse(await readFile(join(sessionDir, "autopilot-state.json"), "utf8")).active, false);
+      assert.equal(JSON.parse(await readFile(join(sessionDir, "skill-active-state.json"), "utf8")).active, false);
+
+      const stop1 = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: threadId,
+      }, { cwd });
+      const stop2 = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        thread_id: threadId,
+      }, { cwd });
+      assert.equal(stop1.outputJson, null);
+      assert.equal(stop2.outputJson, null);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats blank optional skill owners as absent for exact-session cancel", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3369-blank-owner-"));
+    const sessionId = "sess-3369-blank-owner";
+    const nativeSessionId = "native-3369-blank-owner";
+    const stateDir = join(cwd, ".omx", "state");
+    const sessionDir = join(stateDir, "sessions", sessionId);
+    try {
+      await writeJson(join(stateDir, "session.json"), {
+        session_id: sessionId,
+        native_session_id: nativeSessionId,
+        cwd,
+        platform: process.platform,
+        state_root: stateDir,
+      });
+      await mkdir(join(stateDir, "sessions", nativeSessionId), { recursive: true });
+      await writeJson(join(stateDir, "sessions", nativeSessionId, "session-owner.json"), {
+        session_id: nativeSessionId,
+        native_session_id: nativeSessionId,
+        cwd,
+        platform: process.platform,
+      });
+      await writeJson(join(sessionDir, "autopilot-state.json"), {
+        active: true,
+        mode: "autopilot",
+        current_phase: "ralplan",
+        session_id: sessionId,
+      });
+      await writeJson(join(sessionDir, "skill-active-state.json"), {
+        active: true,
+        skill: "autopilot",
+        phase: "ralplan",
+        session_id: sessionId,
+        owner_codex_session_id: "",
+        active_skills: [{
+          skill: "autopilot",
+          phase: "ralplan",
+          active: true,
+          session_id: sessionId,
+          owner_codex_session_id: "",
+        }],
+      });
+
+      const result = runOmx(cwd, { OMX_ROOT: cwd, OMX_SESSION_ID: sessionId }, "cancel");
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Cancelled: autopilot/);
+      assert.equal(JSON.parse(await readFile(join(sessionDir, "autopilot-state.json"), "utf8")).active, false);
+      assert.equal(JSON.parse(await readFile(join(sessionDir, "skill-active-state.json"), "utf8")).active, false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks fresh Autopilot admission before creating state files", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3369-fresh-admission-"));
+    try {
+      await withEnv({ OMX_ROOT: cwd, OMX_SESSION_ID: undefined }, async () => {
+        const response = await executeStateOperation("state_write", {
+          workingDirectory: cwd,
+          mode: "autopilot",
+          active: true,
+          current_phase: "deep-interview",
+          session_id: "sess-3369-fresh",
+        });
+        assert.equal(response.isError, true);
+        assert.match(String((response.payload as { error?: string }).error || ""), /documented_host_consensus_receipt_unavailable/);
+        await assert.rejects(readFile(join(cwd, ".omx", "state", "sessions", "sess-3369-fresh", "autopilot-state.json")));
+        await assert.rejects(readFile(join(cwd, ".omx", "state", "sessions", "sess-3369-fresh", "skill-active-state.json")));
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3818,6 +3818,8 @@ function readPayloadAgentId(payload: CodexHookPayload): string {
 }
 interface PreToolUseSessionBinding {
   canonicalSessionId: string;
+  payloadSessionAliases: Set<string>;
+  nativeIdentityAliases: Set<string>;
   valid: boolean;
   missing: boolean;
 }
@@ -3827,6 +3829,14 @@ function sessionPointerAliases(state: SessionState | null | undefined): Set<stri
     safeString(state?.session_id).trim(),
     safeString(state?.native_session_id).trim(),
     safeString(state?.owner_omx_session_id).trim(),
+    safeString(state?.owner_codex_session_id).trim(),
+    safeString(state?.codex_session_id).trim(),
+  ]));
+}
+
+function sessionNativeIdentityAliases(state: SessionState | null | undefined): Set<string> {
+  return new Set(uniqueNonEmpty([
+    safeString(state?.native_session_id).trim(),
     safeString(state?.owner_codex_session_id).trim(),
     safeString(state?.codex_session_id).trim(),
   ]));
@@ -3844,8 +3854,11 @@ async function resolvePreToolUseSessionBinding(
   const canonicalSessionId = safeString(currentSession?.session_id).trim();
   const aliases = payloadAliasValues(payload, ["session_id", "sessionId"]);
   const knownAliases = sessionPointerAliases(currentSession);
+  const nativeIdentityAliases = sessionNativeIdentityAliases(currentSession);
   return {
     canonicalSessionId,
+    payloadSessionAliases: knownAliases,
+    nativeIdentityAliases,
     missing: aliases.length === 0,
     valid: canonicalSessionId !== ""
       && !payloadHasConflictingIdentityAliases(payload)
@@ -3898,14 +3911,18 @@ function hookCancelObject(bytes: Buffer): Record<string, unknown> | null {
 function hookCancelString(value: unknown): string { return typeof value === "string" ? value.trim() : ""; }
 type HookCancelIdentityPolicy = {
   allowMissingCwd: boolean;
+  allowMissingSession: boolean;
   allowSupervisedAutopilotMirror: boolean;
+  nativeIdentityAliases?: ReadonlySet<string>;
 };
 const STRICT_HOOK_CANCEL_IDENTITY: HookCancelIdentityPolicy = {
   allowMissingCwd: false,
+  allowMissingSession: false,
   allowSupervisedAutopilotMirror: false,
 };
 const AUTHENTICATED_HOOK_CANCEL_IDENTITY: HookCancelIdentityPolicy = {
   allowMissingCwd: true,
+  allowMissingSession: false,
   allowSupervisedAutopilotMirror: true,
 };
 function hookCancelRequiredStringAliasesMatch(
@@ -3934,14 +3951,43 @@ function hookCancelCwdMatches(value: Record<string, unknown>, canonicalCwd: stri
     );
   } catch { return false; }
 }
+function hookCancelOptionalSessionAliasesMatch(
+  value: Record<string, unknown>,
+  canonicalSessionId: string,
+  nativeIdentityAliases: ReadonlySet<string>,
+): boolean {
+  for (const alias of ["owner_codex_session_id", "native_session_id", "codex_session_id"]) {
+    if (!Object.prototype.hasOwnProperty.call(value, alias)) continue;
+    const raw = value[alias];
+    if (typeof raw !== "string") return false;
+    const candidate = raw.trim();
+    if (candidate && !nativeIdentityAliases.has(candidate)) return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "owner_omx_session_id")) {
+    const raw = value.owner_omx_session_id;
+    if (typeof raw !== "string") return false;
+    const candidate = raw.trim();
+    if (candidate && candidate !== canonicalSessionId) return false;
+  }
+  return true;
+}
 function hookCancelSessionMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
-  return hookCancelRequiredStringAliasesMatch(value, ["session_id", "sessionId"], (candidate) => candidate === sessionId)
+  const nativeIdentityAliases = policy.nativeIdentityAliases ?? new Set<string>();
+  return hookCancelRequiredStringAliasesMatch(
+    value,
+    ["session_id", "sessionId"],
+    (candidate) => candidate === sessionId,
+    policy.allowMissingSession,
+  )
+    && hookCancelOptionalSessionAliasesMatch(value, sessionId, nativeIdentityAliases)
     && hookCancelCwdMatches(value, cwd, policy);
 }
 function hookCancelAutopilotIsActive(value: Record<string, unknown>): boolean {
+  const mode = hookCancelString(value.mode).toLowerCase();
+  // Cancellation only decreases authority. Persisted phase text (including a
+  // missing, unknown, or terminal-looking phase) cannot override active:true.
   return value.active === true
-    && hookCancelString(value.mode).toLowerCase() === "autopilot"
-    && normalizeAutopilotPhase(hookCancelString(value.current_phase)) === "deep-interview";
+    && (!mode || mode === "autopilot");
 }
 function hookCancelAutopilotMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
   return hookCancelAutopilotIsActive(value) && hookCancelSessionMatches(value, sessionId, cwd, policy);
@@ -9649,8 +9695,8 @@ function skipLiteralLeadingAssignments(words: string[]): number {
 }
 
 // Direct cancellation is recognized from the RAW command string with a
-// deliberately tiny ASCII grammar: exactly `omx cancel` (plus `--force` only
-// at the ralplan/Conductor callsites; deep-interview stays plain-cancel) with
+// deliberately tiny ASCII grammar: exactly `omx cancel` (optionally `--force`)
+// at hook-owned workflow callsites, with
 // optional ASCII space/tab padding. No leading environment assignments are
 // accepted at all — runtime startup/configuration variables are an open-ended
 // namespace (PATH, NODE_OPTIONS, OPENSSL_CONF, ...) and a denylist cannot
@@ -9697,19 +9743,30 @@ function directCancelOutput(reason: string, handled = false): Record<string, unk
 
 async function handleDirectOmxCancel(input: {
   command: string; rawCommand: string; cwd: string; stateDir: string;
-  canonicalSessionId: string; payload: CodexHookPayload;
+  canonicalSessionId: string;
+  payloadSessionAliases: ReadonlySet<string>;
+  nativeIdentityAliases: ReadonlySet<string>;
+  payload: CodexHookPayload;
   activeStates: Record<HookCancelWorkflow, Record<string, unknown>>;
   skillState: Record<string, unknown>;
 }): Promise<DirectCancelResult> {
   const cancelLike = /^[ \t]*omx[ \t]+cancel\b/.test(input.command);
   if (!cancelLike) return { kind: "not-direct-cancel" };
   const canonicalCwd = resolve(input.cwd);
+  const authenticatedIdentityPolicy: HookCancelIdentityPolicy = {
+    ...AUTHENTICATED_HOOK_CANCEL_IDENTITY,
+    nativeIdentityAliases: input.nativeIdentityAliases,
+  };
+  const authenticatedAutopilotIdentityPolicy: HookCancelIdentityPolicy = {
+    ...authenticatedIdentityPolicy,
+    allowMissingSession: true,
+  };
   const autopilotActive = hookCancelAutopilotIsActive(input.activeStates.autopilot);
   const ultragoalActive = hookCancelUltragoalIsActive(input.activeStates.ultragoal);
-  const autopilotLifecycleMatches = hookCancelAutopilotMatches(input.activeStates.autopilot, input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
-  const ultragoalLifecycleMatches = hookCancelUltragoalMatches(input.activeStates.ultragoal, input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
-  const autopilotSkillMatches = hookCancelSkillMatches(input.skillState, "autopilot", input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
-  const ultragoalSkillMatches = hookCancelSkillMatches(input.skillState, "ultragoal", input.canonicalSessionId, canonicalCwd, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
+  const autopilotLifecycleMatches = hookCancelAutopilotMatches(input.activeStates.autopilot, input.canonicalSessionId, canonicalCwd, authenticatedAutopilotIdentityPolicy);
+  const ultragoalLifecycleMatches = hookCancelUltragoalMatches(input.activeStates.ultragoal, input.canonicalSessionId, canonicalCwd, authenticatedIdentityPolicy);
+  const autopilotSkillMatches = hookCancelSkillMatches(input.skillState, "autopilot", input.canonicalSessionId, canonicalCwd, authenticatedAutopilotIdentityPolicy);
+  const ultragoalSkillMatches = hookCancelSkillMatches(input.skillState, "ultragoal", input.canonicalSessionId, canonicalCwd, authenticatedIdentityPolicy);
   if (ultragoalActive && (!ultragoalLifecycleMatches || !ultragoalSkillMatches)) {
     return { kind: "denied", reason: "active_state", output: directCancelOutput("active_state") };
   }
@@ -9725,7 +9782,7 @@ async function handleDirectOmxCancel(input: {
   // Hook-owned cancellation requires both an active matching lifecycle and its
   // canonical skill mirror. Stale files alone retain the normal executable path.
   if (!workflow) return { kind: "not-direct-cancel" };
-  if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: workflow === "ultragoal" })) {
+  if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: true })) {
     return { kind: "denied", reason: "invalid_command", output: directCancelOutput("invalid_command") };
   }
   if (
@@ -9733,7 +9790,7 @@ async function handleDirectOmxCancel(input: {
     || !hookCancelRequiredStringAliasesMatch(
       input.payload as Record<string, unknown>,
       ["session_id", "sessionId"],
-      (candidate) => candidate === input.canonicalSessionId,
+      (candidate) => input.payloadSessionAliases.has(candidate),
     )
     || payloadHasConflictingIdentityAliases(input.payload)
   ) {
@@ -9750,7 +9807,7 @@ async function handleDirectOmxCancel(input: {
     canonicalSessionId: input.canonicalSessionId,
     cwd: input.cwd,
     nowIso: new Date().toISOString(),
-  }, workflow, AUTHENTICATED_HOOK_CANCEL_IDENTITY);
+  }, workflow, workflow === "autopilot" ? authenticatedAutopilotIdentityPolicy : authenticatedIdentityPolicy);
   if (!transaction.ok) {
     const reason = transaction.reason ?? "preflight_failed";
     return { kind: "denied", reason, output: directCancelOutput(reason) };
@@ -22738,6 +22795,8 @@ export async function dispatchCodexNativeHook(
         cwd: policyCwd,
         stateDir,
         canonicalSessionId: sessionBinding.valid ? sessionBinding.canonicalSessionId : "",
+        payloadSessionAliases: sessionBinding.payloadSessionAliases,
+        nativeIdentityAliases: sessionBinding.nativeIdentityAliases,
         payload,
         activeStates: {
           autopilot: autopilotState ?? {},

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3984,10 +3984,19 @@ function hookCancelSessionMatches(value: Record<string, unknown>, sessionId: str
 }
 function hookCancelAutopilotIsActive(value: Record<string, unknown>): boolean {
   const mode = hookCancelString(value.mode).toLowerCase();
+  if (value.active !== true) return false;
+  if (mode && mode !== "autopilot") return false;
   // Cancellation only decreases authority. Persisted phase text (including a
   // missing, unknown, or terminal-looking phase) cannot override active:true.
-  return value.active === true
-    && (!mode || mode === "autopilot");
+  // However, hook-owned cancellation for non-deep-interview phases is only
+  // appropriate when the lifecycle state is identity-stripped (missing
+  // session_id): a fully-identified state can be cancelled by the external
+  // omx cancel CLI through its trusted-execution-context path, so the hook
+  // must not intercept it (issue #3293). Identity-stripped states (#3369)
+  // cannot be matched by the external command and require hook ownership.
+  const phase = normalizeAutopilotPhase(hookCancelString(value.current_phase));
+  if (phase === "deep-interview") return true;
+  return !hookCancelString(value.session_id);
 }
 function hookCancelAutopilotMatches(value: Record<string, unknown>, sessionId: string, cwd: string, policy = STRICT_HOOK_CANCEL_IDENTITY): boolean {
   return hookCancelAutopilotIsActive(value) && hookCancelSessionMatches(value, sessionId, cwd, policy);
@@ -9782,7 +9791,7 @@ async function handleDirectOmxCancel(input: {
   // Hook-owned cancellation requires both an active matching lifecycle and its
   // canonical skill mirror. Stale files alone retain the normal executable path.
   if (!workflow) return { kind: "not-direct-cancel" };
-  if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: true })) {
+  if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: workflow === "ultragoal" })) {
     return { kind: "denied", reason: "invalid_command", output: directCancelOutput("invalid_command") };
   }
   if (

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -877,18 +877,17 @@ export async function executeStateOperation(
           if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
             activeCanonicalModes = await readCanonicalActiveWorkflowModes(baseStateDir, effectiveSessionId);
             canonicalDecision = evaluateWorkflowTransition(activeCanonicalModes, mode);
+            const hasExistingCanonicalRalplan = activeCanonicalModes.includes('ralplan');
             const freshAutopilotReceiptBlocked = mode === 'autopilot'
               && !isResumableAutopilotState(existing)
+              && hasExistingCanonicalRalplan
               && shouldBlockFreshAutopilotForRalplanReceipt();
-            const preserveStandaloneRalplanForReceiptDenial = freshAutopilotReceiptBlocked
-              && activeCanonicalModes.length === 1
-              && activeCanonicalModes[0] === 'ralplan';
-            if (!canonicalDecision.allowed && !preserveStandaloneRalplanForReceiptDenial) {
-              validationError = buildWorkflowTransitionError(activeCanonicalModes, mode, 'write');
-              return;
-            }
             if (freshAutopilotReceiptBlocked) {
               validationError = `${RALPLAN_CONSENSUS_BLOCKED_REASONS.documentedHostConsensusReceiptUnavailable}: official host consensus receipt verifier is unavailable`;
+              return;
+            }
+            if (!canonicalDecision.allowed && canonicalDecision.denialReason === 'rollback') {
+              validationError = buildWorkflowTransitionError(activeCanonicalModes, mode, 'write');
               return;
             }
           }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -63,6 +63,7 @@ import {
 import {
   type AutopilotChildPhase,
   deriveAutopilotChildPhase,
+  normalizeAutopilotPhase,
 } from '../autopilot/fsm.js';
 import {
   buildAutopilotRalplanUltragoalGateError,
@@ -73,6 +74,8 @@ import {
 } from '../leader/contract.js';
 import {
   buildRalplanConsensusGateFromSources,
+  RALPLAN_CONSENSUS_BLOCKED_REASONS,
+  shouldBlockFreshAutopilotForRalplanReceipt,
 } from '../ralplan/consensus-gate.js';
 
 
@@ -235,9 +238,14 @@ async function initializeStateEnvironment(
   cwd: string,
   effectiveSessionId?: string,
   rootSource?: StateRootSource,
+  exactStateDir?: string,
 ): Promise<void> {
-  await mkdir(getStateDir(cwd), { recursive: true });
-  if (effectiveSessionId) {
+  if (exactStateDir) {
+    await mkdir(exactStateDir, { recursive: true });
+  } else {
+    await mkdir(getStateDir(cwd), { recursive: true });
+  }
+  if (effectiveSessionId && !exactStateDir) {
     await mkdir(getStateDir(cwd, effectiveSessionId), { recursive: true });
   }
   if (rootSource === 'team-env') return;
@@ -739,6 +747,20 @@ function isActiveDetailWorkflowState(state: Record<string, unknown>): boolean {
   return !['complete', 'completed', 'cancelled', 'canceled', 'failed', 'cleared'].includes(phase);
 }
 
+function isResumableAutopilotState(state: Record<string, unknown>): boolean {
+  if (state.active !== true) return false;
+  if (state.mode !== undefined && state.mode !== 'autopilot') return false;
+
+  const phaseValues = ['current_phase', 'currentPhase']
+    .filter((key) => Object.prototype.hasOwnProperty.call(state, key))
+    .map((key) => normalizeAutopilotPhase(state[key]));
+  if (phaseValues.length === 0 || phaseValues.some((phase) => phase === null || phase === 'complete' || phase === 'failed')) {
+    return false;
+  }
+
+  return new Set(phaseValues).size === 1;
+}
+
 async function readSessionDetailTransitionModes(
   cwd: string,
   sessionId: string | undefined,
@@ -801,7 +823,6 @@ export async function executeStateOperation(
         const effectiveSessionId = stateScope.sessionId;
         const mode = validateStateModeSegment(rawArgs.mode);
         const { baseStateDir, rootSource } = getBaseStateDirWithSource(cwd);
-        await initializeStateEnvironment(cwd, effectiveSessionId, rootSource);
         const beforeCommit = createWritableCommitRevalidator({
           operation: 'state_write',
           cwd,
@@ -850,6 +871,29 @@ export async function executeStateOperation(
           if (!hasExplicitStateField(fields, customState, 'terminal_outcome')) {
             delete mergedRaw.terminal_outcome;
           }
+
+          let activeCanonicalModes: TrackedWorkflowMode[] | undefined;
+          let canonicalDecision: ReturnType<typeof evaluateWorkflowTransition> | undefined;
+          if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
+            activeCanonicalModes = await readCanonicalActiveWorkflowModes(baseStateDir, effectiveSessionId);
+            canonicalDecision = evaluateWorkflowTransition(activeCanonicalModes, mode);
+            const freshAutopilotReceiptBlocked = mode === 'autopilot'
+              && !isResumableAutopilotState(existing)
+              && shouldBlockFreshAutopilotForRalplanReceipt();
+            const preserveStandaloneRalplanForReceiptDenial = freshAutopilotReceiptBlocked
+              && activeCanonicalModes.length === 1
+              && activeCanonicalModes[0] === 'ralplan';
+            if (!canonicalDecision.allowed && !preserveStandaloneRalplanForReceiptDenial) {
+              validationError = buildWorkflowTransitionError(activeCanonicalModes, mode, 'write');
+              return;
+            }
+            if (freshAutopilotReceiptBlocked) {
+              validationError = `${RALPLAN_CONSENSUS_BLOCKED_REASONS.documentedHostConsensusReceiptUnavailable}: official host consensus receipt verifier is unavailable`;
+              return;
+            }
+          }
+
+          await initializeStateEnvironment(cwd, effectiveSessionId, rootSource, stateScope.stateDir);
 
           if (
             mode === 'ralph' &&
@@ -1010,15 +1054,9 @@ export async function executeStateOperation(
           }
 
           if (isTrackedWorkflowMode(mode) && mergedRaw.active === true) {
-            const activeCanonicalModes = await readCanonicalActiveWorkflowModes(baseStateDir, effectiveSessionId);
-            const canonicalDecision = evaluateWorkflowTransition(activeCanonicalModes, mode);
-            if (!canonicalDecision.allowed && canonicalDecision.denialReason === 'rollback') {
-              validationError = buildWorkflowTransitionError(activeCanonicalModes, mode, 'write');
-              return;
-            }
             const transitionCurrentModes = mode === 'ralplan'
               ? (
-                activeCanonicalModes.length > 0
+                activeCanonicalModes!.length > 0
                   ? activeCanonicalModes
                   : await readSessionDetailTransitionModes(cwd, effectiveSessionId, mode)
               )


### PR DESCRIPTION
## Summary
- Make exact hook-owned Autopilot cancellation phase-agnostic for active identity-stripped lifecycle/skill state, while keeping path/grammar/actor fail-closed behavior.
- Treat blank optional skill owners as absent in exact-session CLI cancel without relaxing nonblank/wrong-typed contradictions.
- Block fresh Autopilot `state_write` admission before initialization/projection when the host consensus receipt verifier is unavailable; preserve valid active nonterminal resume and overlap denials.
- Add focused #3369 regressions for Ralplan cancel, blank owners, and fresh admission.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] focused: `issue-3369-autopilot-ralplan-state-machine`, `issue-3358-ultragoal-cancel-lifecycle`, `issue-3293-hook-owned-cancel`, `session-scoped-runtime`, `operations`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*