### PR TITLE
feat(review): add explicit GitHub PR review publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ $ultragoal "turn the approved plan into durable Codex goals"
 ```
 
 That is the main path.
+
+### Publishing actionable PR review findings
+
+`$code-review` remains local and read-only. To preflight an immutable structured findings artifact against an open GitHub PR without writing anything, run:
+
+```bash
+omx code-review --github-pr 123 --findings review-findings.json --dry-run
+```
+
+Only an explicit `--publish` changes external state. Dry-run remains supported on Windows, but win32 publication fails before any guard, receipt, or POST because crash durability is not claimed there. On supported platforms, every REST read and write is pinned to `github.com`. Each publish first reserves a canonical, exclusive guard under `.omx/reviews/guards/`. Guard and default-receipt filenames are fixed-length lowercase SHA-256 digests of the complete canonical identity (host, repository, PR, reviewed head, and artifact SHA-256), with separate guard/receipt domains; full readable identity remains inside the JSON. `--receipt` controls only a separate receipt destination and cannot bypass any pending, ambiguous, final, or stale guard. The command submits one `REQUEST_CHANGES` review pinned to the artifact's exact reviewed head SHA, immediately re-reads the PR head, then verifies the stored review and inline comments. An unchanged head requires current line/side coordinates; a moved head requires the stored review to remain bound to the reviewed commit and verifies each comment through its original commit/line/side coordinates. The canonical guard is durably finalized before the destination receipt, so a receipt fault still prevents duplicate publication. Final and stale records use an fsynced same-directory temporary file, atomic rename, and directory fsync. Stale heads, invalid diff anchors, missing permissions, partially invalid finding sets, and existing guards fail closed. See [`skills/code-review/SKILL.md`](./skills/code-review/SKILL.md) for the exact artifact schema and full grammar.
+
 Before you treat the runtime as ready, run the quick-start smoke test below: `omx doctor` verifies the install shape, while `omx exec` proves the active Codex runtime can actually authenticate and complete a model call from the current environment.
 Start OMX strongly, clarify first when needed, approve the plan, optionally use `$prometheus-strict` for interview-driven plan hardening on high-risk work, then use `$ultragoal` as the default durable completion wrapper. Use `$team` inside that execution path only when a specific Ultragoal story needs coordinated parallel work; use `$ralph` when you intentionally want a single-owner completion loop instead of a durable multi-goal run.
 

--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -83,6 +83,54 @@ Minimal Autopilot phase declaration when the review stage begins:
 omx state write --input '{"mode":"autopilot","active":true,"current_phase":"code-review"}' --json
 ```
 
+## Optional GitHub PR Review Publication
+
+Plain `$code-review` is local and read-only. Autopilot and pipeline review phases also remain read-only and must never publish implicitly. Publication is a separate, explicit operator action after the review artifact exists.
+
+The executable grammar is:
+
+```sh
+# Read-only preflight (the default; --dry-run is an explicit synonym)
+omx code-review --github-pr <number> --findings <artifact.json> [--repo <owner/name>] [--head <40-char-sha>] [--dry-run]
+
+# One external write, requiring the explicit approval boundary
+omx code-review --github-pr <number> --findings <artifact.json> [--repo <owner/name>] [--head <40-char-sha>] --publish [--receipt <path>]
+```
+
+The immutable JSON artifact must use this exact schema:
+
+```json
+{
+  "schema_version": 1,
+  "repository": "owner/name",
+  "pull_request": 123,
+  "reviewed_head_sha": "0123456789abcdef0123456789abcdef01234567",
+  "findings": [
+    {
+      "id": "review-P1-001",
+      "severity": "P1",
+      "body": "Explain the actionable defect and its impact.",
+      "fix": "State the concrete required fix.",
+      "path": "src/example.ts",
+      "line": 42,
+      "side": "RIGHT"
+    }
+  ]
+}
+```
+
+Only actionable `P0`, `P1`, and `P2` findings are publishable. IDs must be stable and unique; body and fix must be nonempty; paths must be PR-relative; line/side anchors must exist in the current PR diff. Any invalid finding rejects the entire set. Preflight verifies `gh` authentication, write permission, an open PR in the exact repository, the exact current head SHA, and every diff anchor. After diff validation, the command re-reads the PR immediately before any receipt or review write and refuses submission if the head moved.
+
+Without `--publish`, the command prints the auditable proposed `REQUEST_CHANGES` payload and performs no writes. Dry-run is supported on Windows, but explicit publication on win32 raises `publish_unsupported_platform` before reading the artifact, invoking `gh`, or creating any guard or receipt; crash durability is not claimed on Windows. On supported platforms, every `gh api` read and write includes `--hostname github.com`, so a configured default or enterprise host cannot receive the request.
+
+`--publish` first reserves an exclusive, fully written and fsynced canonical guard under `<cwd>/.omx/reviews/guards/`. The guard filename is `guard-<64 lowercase hex>.json`; the default receipt is `receipt-<64 lowercase hex>.json` under `.omx/reviews/receipts/`. Each digest covers the complete canonical identity—`github.com`, repository, PR number, reviewed head SHA, and the artifact's byte-level SHA-256—with separate guard and receipt domains. Thus filenames remain comfortably below filesystem component limits even at GitHub's maximum owner/repository lengths, while each pending/final JSON record retains the full readable identity and artifact hash. This guard is independent of `--receipt`: a custom receipt changes only the separate destination receipt. Any existing pending, ambiguous, final, or stale guard blocks publication, including a retry that selects another receipt path. Distinct canonical identities or artifact hashes receive distinct opaque paths. Non-`EEXIST` reservation errors, including `ENAMETOOLONG`, report `publish_guard_reservation_failed` rather than falsely claiming that a guard exists.
+
+After the canonical guard, the command reserves the destination `publish-pending` receipt. A receipt-reservation failure durably records a non-submitted pending phase in the canonical guard and conservatively blocks automatic retry. Before the POST, the guard transitions durably to an ambiguous submission-in-progress state. The command then submits exactly one REST create-review request pinned with `commit_id`. It never falls back to timeline comments, never retries an ambiguous write failure, and never resolves threads.
+
+The create response supplies only the review ID. Immediately after validating that ID, the command re-reads the current PR head before interpreting stored comment coordinates. It then reads the stored review and its paginated review-comments endpoint and verifies the exact repository/PR/review URLs, reviewed commit, `CHANGES_REQUESTED` state, summary body, observed comment count, and every inline comment's review identity, path, coordinates, and body. If the head is unchanged, each comment must retain the reviewed commit plus its current `line` and `side`. If the head moved, the review must still bind to the reviewed commit and each comment must provide that `original_commit_id`, the requested `original_line`, and the requested original side (using `original_side` when present, otherwise GitHub's `side` field); a null current `line` is valid in this stale case. Missing, foreign, or ambiguous stored evidence is `publish_ambiguous_response`; the pending receipt remains unchanged and no retry occurs.
+
+If stored verification fails after submission, the canonical guard is durably finalized as ambiguous with the available review identity before the error is returned. If the already-read post-submit head moved and the original-coordinate evidence passes, the canonical guard is finalized as stale with both heads and verified review evidence; otherwise it is finalized as final. Only after that canonical transition does the command finalize the destination `mode: "publish-stale"` or `publish` receipt. The stale path raises `post_submit_stale_head`, and both destination modes record the observed stored count. Thus a custom/default receipt failure cannot permit a duplicate POST: the canonical guard already contains final, stale, or conservative ambiguous evidence. Guard and receipt transitions use fully written and fsynced exclusive same-directory temporary files, atomic rename, directory fsync, and temporary-file cleanup.
+
 ## Agent Delegation
 
 Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.
@@ -112,7 +160,9 @@ Output: Code review report with:
 - Issues by severity (CRITICAL, HIGH, MEDIUM, LOW)
 - Specific file:line locations
 - Fix recommendations
-- Approval recommendation (APPROVE / REQUEST CHANGES / COMMENT)"
+- Approval recommendation (APPROVE / REQUEST CHANGES / COMMENT)
+
+Remain read-only. Do not publish GitHub comments or reviews. When an immutable publication artifact is requested, emit only actionable P0/P1/P2 findings with stable IDs, nonempty body/fix, PR-relative path, and exact line+side anchors."
 )
 
 task(

--- a/prompts/code-reviewer.md
+++ b/prompts/code-reviewer.md
@@ -14,6 +14,7 @@ Code review is the last line of defense before bugs and vulnerabilities reach pr
 <constraints>
 <scope_guard>
 - Read-only: Write and Edit tools are blocked.
+- Do not publish GitHub comments or reviews. Publication requires a separate explicit operator action outside this reviewer lane.
 - Never approve code with CRITICAL or HIGH severity issues.
 - Never skip Stage 1 (spec compliance) to jump to style nitpicks.
 - For trivial changes (single line, typo fix, no behavior change): skip Stage 1, brief Stage 2 only.
@@ -47,6 +48,7 @@ Do not ask about requirements. Read the spec, PR description, or issue tracker t
 - lsp_diagnostics run on all modified files (no type errors approved)
 - Clear verdict: APPROVE, REQUEST CHANGES, or COMMENT
 - In dual-lane reviews, architecture concerns are surfaced upward to `architect` instead of being absorbed into this lane's verdict
+- When a structured publication artifact is explicitly requested, include only actionable P0/P1/P2 findings with stable IDs, nonempty body/fix, PR-relative paths, and exact diff-valid line/side anchors
 </success_criteria>
 
 <verification_loop>

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -83,6 +83,54 @@ Minimal Autopilot phase declaration when the review stage begins:
 omx state write --input '{"mode":"autopilot","active":true,"current_phase":"code-review"}' --json
 ```
 
+## Optional GitHub PR Review Publication
+
+Plain `$code-review` is local and read-only. Autopilot and pipeline review phases also remain read-only and must never publish implicitly. Publication is a separate, explicit operator action after the review artifact exists.
+
+The executable grammar is:
+
+```sh
+# Read-only preflight (the default; --dry-run is an explicit synonym)
+omx code-review --github-pr <number> --findings <artifact.json> [--repo <owner/name>] [--head <40-char-sha>] [--dry-run]
+
+# One external write, requiring the explicit approval boundary
+omx code-review --github-pr <number> --findings <artifact.json> [--repo <owner/name>] [--head <40-char-sha>] --publish [--receipt <path>]
+```
+
+The immutable JSON artifact must use this exact schema:
+
+```json
+{
+  "schema_version": 1,
+  "repository": "owner/name",
+  "pull_request": 123,
+  "reviewed_head_sha": "0123456789abcdef0123456789abcdef01234567",
+  "findings": [
+    {
+      "id": "review-P1-001",
+      "severity": "P1",
+      "body": "Explain the actionable defect and its impact.",
+      "fix": "State the concrete required fix.",
+      "path": "src/example.ts",
+      "line": 42,
+      "side": "RIGHT"
+    }
+  ]
+}
+```
+
+Only actionable `P0`, `P1`, and `P2` findings are publishable. IDs must be stable and unique; body and fix must be nonempty; paths must be PR-relative; line/side anchors must exist in the current PR diff. Any invalid finding rejects the entire set. Preflight verifies `gh` authentication, write permission, an open PR in the exact repository, the exact current head SHA, and every diff anchor. After diff validation, the command re-reads the PR immediately before any receipt or review write and refuses submission if the head moved.
+
+Without `--publish`, the command prints the auditable proposed `REQUEST_CHANGES` payload and performs no writes. Dry-run is supported on Windows, but explicit publication on win32 raises `publish_unsupported_platform` before reading the artifact, invoking `gh`, or creating any guard or receipt; crash durability is not claimed on Windows. On supported platforms, every `gh api` read and write includes `--hostname github.com`, so a configured default or enterprise host cannot receive the request.
+
+`--publish` first reserves an exclusive, fully written and fsynced canonical guard under `<cwd>/.omx/reviews/guards/`. The guard filename is `guard-<64 lowercase hex>.json`; the default receipt is `receipt-<64 lowercase hex>.json` under `.omx/reviews/receipts/`. Each digest covers the complete canonical identity—`github.com`, repository, PR number, reviewed head SHA, and the artifact's byte-level SHA-256—with separate guard and receipt domains. Thus filenames remain comfortably below filesystem component limits even at GitHub's maximum owner/repository lengths, while each pending/final JSON record retains the full readable identity and artifact hash. This guard is independent of `--receipt`: a custom receipt changes only the separate destination receipt. Any existing pending, ambiguous, final, or stale guard blocks publication, including a retry that selects another receipt path. Distinct canonical identities or artifact hashes receive distinct opaque paths. Non-`EEXIST` reservation errors, including `ENAMETOOLONG`, report `publish_guard_reservation_failed` rather than falsely claiming that a guard exists.
+
+After the canonical guard, the command reserves the destination `publish-pending` receipt. A receipt-reservation failure durably records a non-submitted pending phase in the canonical guard and conservatively blocks automatic retry. Before the POST, the guard transitions durably to an ambiguous submission-in-progress state. The command then submits exactly one REST create-review request pinned with `commit_id`. It never falls back to timeline comments, never retries an ambiguous write failure, and never resolves threads.
+
+The create response supplies only the review ID. Immediately after validating that ID, the command re-reads the current PR head before interpreting stored comment coordinates. It then reads the stored review and its paginated review-comments endpoint and verifies the exact repository/PR/review URLs, reviewed commit, `CHANGES_REQUESTED` state, summary body, observed comment count, and every inline comment's review identity, path, coordinates, and body. If the head is unchanged, each comment must retain the reviewed commit plus its current `line` and `side`. If the head moved, the review must still bind to the reviewed commit and each comment must provide that `original_commit_id`, the requested `original_line`, and the requested original side (using `original_side` when present, otherwise GitHub's `side` field); a null current `line` is valid in this stale case. Missing, foreign, or ambiguous stored evidence is `publish_ambiguous_response`; the pending receipt remains unchanged and no retry occurs.
+
+If stored verification fails after submission, the canonical guard is durably finalized as ambiguous with the available review identity before the error is returned. If the already-read post-submit head moved and the original-coordinate evidence passes, the canonical guard is finalized as stale with both heads and verified review evidence; otherwise it is finalized as final. Only after that canonical transition does the command finalize the destination `mode: "publish-stale"` or `publish` receipt. The stale path raises `post_submit_stale_head`, and both destination modes record the observed stored count. Thus a custom/default receipt failure cannot permit a duplicate POST: the canonical guard already contains final, stale, or conservative ambiguous evidence. Guard and receipt transitions use fully written and fsynced exclusive same-directory temporary files, atomic rename, directory fsync, and temporary-file cleanup.
+
 ## Agent Delegation
 
 Do not self-review as a fallback. If the `code-reviewer` or `architect` agent path is missing, unavailable, skipped, or fails, emit a clear unavailable-review result and block approval until the independent lane evidence exists.
@@ -112,7 +160,9 @@ Output: Code review report with:
 - Issues by severity (CRITICAL, HIGH, MEDIUM, LOW)
 - Specific file:line locations
 - Fix recommendations
-- Approval recommendation (APPROVE / REQUEST CHANGES / COMMENT)"
+- Approval recommendation (APPROVE / REQUEST CHANGES / COMMENT)
+
+Remain read-only. Do not publish GitHub comments or reviews. When an immutable publication artifact is requested, emit only actionable P0/P1/P2 findings with stable IDs, nonempty body/fix, PR-relative path, and exact line+side anchors."
 )
 
 task(

--- a/src/cli/code-review.ts
+++ b/src/cli/code-review.ts
@@ -1,0 +1,82 @@
+import { publishGithubPrReview } from "../github-pr-review/publisher.js";
+import { classifyCodeReviewExternalMutationArgs } from "../github-pr-review/guard.js";
+
+export const CODE_REVIEW_HELP = `
+Usage:
+  omx code-review --github-pr <number> --findings <artifact.json> [--repo <owner/name>] [--head <sha>] [--dry-run]
+  omx code-review --github-pr <number> --findings <artifact.json> [--repo <owner/name>] [--head <sha>] --publish [--receipt <path>]
+
+Without --publish, the command performs a read-only preflight and prints the exact proposed REQUEST_CHANGES payload.
+--publish is the explicit external-write approval boundary and submits exactly one pinned GitHub review.
+Publishing is unavailable on Windows; win32 fails before any guard, receipt, or POST, while dry-run remains supported.
+Each publish reserves a canonical artifact-keyed guard under .omx/reviews/guards using a bounded opaque identity digest independently of --receipt.
+--receipt selects only the destination receipt and cannot bypass an existing pending, ambiguous, final, or stale guard.
+`;
+
+interface ParsedArgs {
+	pullRequest: number;
+	artifactPath: string;
+	repository?: string;
+	reviewedHeadSha?: string;
+	publish: boolean;
+	receiptPath?: string;
+}
+
+function parseArgs(args: readonly string[]): ParsedArgs {
+	if (args.includes("--help") || args.includes("-h")) {
+		console.log(CODE_REVIEW_HELP);
+		throw new Error("__help__");
+	}
+	const values = new Map<string, string>();
+	let publish = false;
+	let dryRun = false;
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--publish") {
+			if (publish) throw new Error("duplicate --publish");
+			publish = true;
+			continue;
+		}
+		if (arg === "--dry-run") {
+			if (dryRun) throw new Error("duplicate --dry-run");
+			dryRun = true;
+			continue;
+		}
+		if (!arg || !["--github-pr", "--findings", "--repo", "--head", "--receipt"].includes(arg)) throw new Error(`unknown argument: ${arg ?? ""}`);
+		const value = args[index + 1];
+		if (!value || value.startsWith("--")) throw new Error(`missing value for ${arg}`);
+		if (values.has(arg)) throw new Error(`duplicate ${arg}`);
+		values.set(arg, value);
+		index += 1;
+	}
+	if (publish && dryRun) throw new Error("--publish and --dry-run are mutually exclusive");
+	if (!publish && values.has("--receipt")) throw new Error("--receipt is available only with --publish; dry-run performs zero writes");
+	const prText = values.get("--github-pr");
+	const pullRequest = Number(prText);
+	if (!prText || !Number.isSafeInteger(pullRequest) || pullRequest <= 0) throw new Error("--github-pr must be a positive integer");
+	const artifactPath = values.get("--findings");
+	if (!artifactPath) throw new Error("--findings is required");
+	return {
+		pullRequest,
+		artifactPath,
+		repository: values.get("--repo"),
+		reviewedHeadSha: values.get("--head"),
+		publish,
+		receiptPath: values.get("--receipt"),
+	};
+}
+
+export async function codeReviewCommand(args: readonly string[]): Promise<void> {
+	if (!args.includes("--help") && !args.includes("-h") && classifyCodeReviewExternalMutationArgs(args) === "invalid") {
+		throw new Error("invalid code-review arguments; see `omx code-review --help`");
+	}
+	let parsed: ParsedArgs;
+	try {
+		parsed = parseArgs(args);
+	} catch (error) {
+		if (error instanceof Error && error.message === "__help__") return;
+		throw error;
+	}
+	const result = await publishGithubPrReview(parsed);
+	console.log(JSON.stringify(result, null, 2));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -55,6 +55,7 @@ import { adaptCommand } from "./adapt.js";
 import { listCommand } from "./list.js";
 import { authCommand } from "./auth.js";
 import { missionCommand } from "./mission.js";
+import { codeReviewCommand } from "./code-review.js";
 import {
   resolveCodexGlobalOptionValue,
   runAuthHotswap,
@@ -263,6 +264,8 @@ Usage:
   omx cleanup   Kill orphaned OMX MCP server processes and remove stale OMX /tmp directories
   omx doctor --team  Check team/swarm runtime health diagnostics
   omx ask       Ask local provider CLI (claude|gemini) and write artifact output
+  omx code-review
+                Validate or explicitly publish one pinned GitHub PR REQUEST_CHANGES review
   omx auth      Manage Codex OAuth auth slots (add|list|use)
   omx question  OMX-owned blocking question UI entrypoint for agent-invoked user questions
   omx adapt     Scaffold OMX-owned adapter foundations for persistent external targets
@@ -475,6 +478,7 @@ Read-only help does not prepare or launch a Codex session.`;
 
 const NESTED_HELP_COMMANDS = new Set<CliCommand>([
   "ask",
+  "code-review",
   "question",
   "cleanup",
   "auth",
@@ -3235,6 +3239,7 @@ export async function main(args: string[]): Promise<void> {
     "cleanup",
     "auth",
     "ask",
+    "code-review",
     "question",
     "autoresearch",
   "autoresearch-goal",
@@ -3353,6 +3358,9 @@ if (command !== "launch" && command !== "resume") {
       }
       case "ask":
         await askCommand(args.slice(1));
+        break;
+      case "code-review":
+        await codeReviewCommand(args.slice(1));
         break;
       case "question":
         await questionCommand(args.slice(1));

--- a/src/github-pr-review/__tests__/publisher.test.ts
+++ b/src/github-pr-review/__tests__/publisher.test.ts
@@ -1,0 +1,636 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { describe, it } from "node:test";
+import { classifyCodeReviewExternalMutationArgs } from "../guard.js";
+import {
+	createDefaultReviewReceiptFileOps,
+	publishGithubPrReview,
+	reviewPublicationStateFilename,
+	ReviewPublisherError,
+	validateDiffAnchors,
+	validateFindingsArtifact,
+	type GhResult,
+	type ReviewFindingsArtifact,
+	type ReviewReceiptFileOps,
+} from "../publisher.js";
+
+const SHA = "a".repeat(40);
+const MOVED_SHA = "b".repeat(40);
+const REPO = "owner/repo";
+const REVIEW_ID = 99;
+const REVIEW_BODY = "Requested changes for 1 actionable finding: G007-P1-001";
+const COMMENT_BODY = "**P1 G007-P1-001**\n\nThis accepts stale input and can publish an incorrect result.\n\n**Required fix:** Compare the immutable reviewed SHA before submission.";
+
+function artifact(overrides: Partial<ReviewFindingsArtifact> = {}): ReviewFindingsArtifact {
+	return {
+		schema_version: 1,
+		repository: REPO,
+		pull_request: 7,
+		reviewed_head_sha: SHA,
+		findings: [{
+			id: "G007-P1-001",
+			severity: "P1",
+			body: "This accepts stale input and can publish an incorrect result.",
+			fix: "Compare the immutable reviewed SHA before submission.",
+			path: "src/example.ts",
+			line: 2,
+			side: "RIGHT",
+		}],
+		...overrides,
+	};
+}
+
+interface MockGh {
+	run: (args: readonly string[], input?: string) => GhResult;
+	calls: Array<{ args: readonly string[]; input?: string }>;
+}
+
+interface MockGhOptions {
+	repository?: string;
+	pullRequest?: number;
+	publishResult?: GhResult;
+	pullRequests?: unknown[];
+	storedReview?: unknown;
+	storedComments?: unknown;
+	readFailures?: Record<string, GhResult>;
+}
+
+function pullRequest(headSha = SHA, repository = REPO): unknown {
+	return { state: "open", head: { sha: headSha }, base: { repo: { full_name: repository } } };
+}
+
+function storedReview(overrides: Record<string, unknown> = {}, repository = REPO, pullRequestNumber = 7): unknown {
+	return {
+		id: REVIEW_ID,
+		url: `https://api.github.com/repos/${repository}/pulls/${pullRequestNumber}/reviews/${REVIEW_ID}`,
+		html_url: `https://github.com/${repository}/pull/${pullRequestNumber}#pullrequestreview-${REVIEW_ID}`,
+		pull_request_url: `https://api.github.com/repos/${repository}/pulls/${pullRequestNumber}`,
+		commit_id: SHA,
+		body: REVIEW_BODY,
+		state: "CHANGES_REQUESTED",
+		...overrides,
+	};
+}
+
+function storedComment(overrides: Record<string, unknown> = {}, repository = REPO, pullRequestNumber = 7): unknown {
+	return {
+		id: 501,
+		pull_request_review_id: REVIEW_ID,
+		pull_request_url: `https://api.github.com/repos/${repository}/pulls/${pullRequestNumber}`,
+		commit_id: SHA,
+		path: "src/example.ts",
+		line: 2,
+		side: "RIGHT",
+		body: COMMENT_BODY,
+		...overrides,
+	};
+}
+
+function normalizedGhKey(args: readonly string[]): string {
+	return args[0] === "api" ? ["api", ...args.slice(3)].join(" ") : args.join(" ");
+}
+
+function mockGh(options: MockGhOptions = {}): MockGh {
+	const calls: Array<{ args: readonly string[]; input?: string }> = [];
+	let pullRequestRead = 0;
+	const repository = options.repository ?? REPO;
+	const pullRequestNumber = options.pullRequest ?? 7;
+	return {
+		calls,
+		run(args, input) {
+			calls.push({ args, input });
+			if (args[0] === "api") assert.deepEqual(args.slice(0, 3), ["api", "--hostname", "github.com"]);
+			const key = normalizedGhKey(args);
+			const readFailure = options.readFailures?.[key];
+			if (readFailure) return readFailure;
+			if (key === "auth status --hostname github.com") return { status: 0, stdout: "", stderr: "" };
+			if (key === `api repos/${repository}`) return { status: 0, stdout: JSON.stringify({ full_name: repository, permissions: { push: true } }), stderr: "" };
+			if (key === `api repos/${repository}/pulls/${pullRequestNumber}`) {
+				const responses = options.pullRequests ?? [pullRequest(SHA, repository)];
+				const response = responses[Math.min(pullRequestRead, responses.length - 1)];
+				pullRequestRead += 1;
+				return { status: 0, stdout: JSON.stringify(response), stderr: "" };
+			}
+			if (key === `api repos/${repository}/pulls/${pullRequestNumber}/files --paginate --slurp`) return { status: 0, stdout: JSON.stringify([[{ filename: "src/example.ts", patch: "@@ -1,2 +1,3 @@\n const a = 1;\n+const b = 2;\n const c = 3;" }]]), stderr: "" };
+			if (key === `api -X POST repos/${repository}/pulls/${pullRequestNumber}/reviews --input -`) return options.publishResult ?? { status: 0, stdout: JSON.stringify({ id: REVIEW_ID }), stderr: "" };
+			if (key === `api repos/${repository}/pulls/${pullRequestNumber}/reviews/${REVIEW_ID}`) return { status: 0, stdout: JSON.stringify(options.storedReview ?? storedReview({}, repository, pullRequestNumber)), stderr: "" };
+			if (key === `api repos/${repository}/pulls/${pullRequestNumber}/reviews/${REVIEW_ID}/comments --paginate --slurp`) return { status: 0, stdout: JSON.stringify(options.storedComments ?? [[storedComment({}, repository, pullRequestNumber)]]), stderr: "" };
+			throw new Error(`unexpected gh call: ${key}`);
+		},
+	};
+}
+
+type FinalizationFault = "open" | "write" | "fsync" | "rename" | "directory-fsync";
+
+function faultingReceiptFileOps(fault: FinalizationFault, receiptPath: string): ReviewReceiptFileOps {
+	const base = createDefaultReviewReceiptFileOps();
+	let finalRenamed = false;
+	return {
+		...base,
+		token: () => "fault-injection",
+		async open(path, flags, mode) {
+			const isFinalTemp = path.startsWith(`${receiptPath}.tmp.`);
+			if (isFinalTemp && fault === "open") throw new Error("injected temp open failure");
+			const handle = await base.open(path, flags, mode);
+			if (!isFinalTemp) return handle;
+			return {
+				writeFile: fault === "write" ? async () => { throw new Error("injected temp write failure"); } : handle.writeFile.bind(handle),
+				sync: fault === "fsync" ? async () => { throw new Error("injected temp fsync failure"); } : handle.sync.bind(handle),
+				close: handle.close.bind(handle),
+			};
+		},
+		async rename(from, to) {
+			if (fault === "rename" && to === receiptPath) throw new Error("injected rename failure");
+			await base.rename(from, to);
+			if (to === receiptPath) finalRenamed = true;
+		},
+		async syncDirectory(path) {
+			if (fault === "directory-fsync" && finalRenamed) throw new Error("injected directory fsync failure");
+			await base.syncDirectory(path);
+		},
+	};
+}
+
+async function withArtifact(run: (root: string, path: string) => Promise<void>): Promise<void> {
+	const root = await mkdtemp(join(tmpdir(), "omx-review-publisher-"));
+	const path = join(root, "findings.json");
+	await writeFile(path, JSON.stringify(artifact()));
+	try {
+		await run(root, path);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+async function guards(root: string): Promise<Array<Record<string, unknown>>> {
+	const guardDirectory = join(root, ".omx", "reviews", "guards");
+	return Promise.all((await readdir(guardDirectory)).filter((name) => name.endsWith(".json")).map(async (name) => JSON.parse(await readFile(join(guardDirectory, name), "utf8")) as Record<string, unknown>));
+}
+
+describe("GitHub PR review artifact contract", () => {
+	it("uses bounded domain-separated opaque filenames for every identity component", () => {
+		const baseArtifact = artifact();
+		const artifactHash = "c".repeat(64);
+		const filenames = [
+			reviewPublicationStateFilename("guard", baseArtifact, artifactHash),
+			reviewPublicationStateFilename("receipt", baseArtifact, artifactHash),
+			reviewPublicationStateFilename("guard", { ...baseArtifact, repository: "other/repo" }, artifactHash),
+			reviewPublicationStateFilename("guard", { ...baseArtifact, pull_request: 8 }, artifactHash),
+			reviewPublicationStateFilename("guard", { ...baseArtifact, reviewed_head_sha: MOVED_SHA }, artifactHash),
+			reviewPublicationStateFilename("guard", baseArtifact, "d".repeat(64)),
+		];
+		assert.equal(new Set(filenames).size, filenames.length);
+		for (const filename of filenames) {
+			assert.match(filename, /^(?:guard|receipt)-[0-9a-f]{64}\.json$/);
+			assert.ok(filename.length <= 96);
+		}
+	});
+
+	it("accepts only actionable P0/P1/P2 findings with stable ids and exact identity", () => {
+		assert.deepEqual(validateFindingsArtifact(artifact()), artifact());
+		for (const invalid of [
+			artifact({ findings: [{ ...artifact().findings[0]!, severity: "P3" as "P2" }] }),
+			artifact({ findings: [{ ...artifact().findings[0]!, body: " " }] }),
+			artifact({ findings: [{ ...artifact().findings[0]!, fix: "" }] }),
+			artifact({ findings: [{ ...artifact().findings[0]!, path: "../secret" }] }),
+			artifact({ findings: [{ ...artifact().findings[0]!, id: "x" }] }),
+		]) {
+			assert.throws(() => validateFindingsArtifact(invalid), ReviewPublisherError);
+		}
+	});
+
+	it("rejects duplicate ids, unknown fields, and empty finding sets", () => {
+		const duplicate = artifact({ findings: [artifact().findings[0]!, artifact().findings[0]!] });
+		assert.throws(() => validateFindingsArtifact(duplicate), /duplicate finding id/);
+		assert.throws(() => validateFindingsArtifact({ ...artifact(), extra: true }), /unknown fields/);
+		assert.throws(() => validateFindingsArtifact(artifact({ findings: [] })), /non-empty array/);
+	});
+
+	it("validates side-specific diff anchors and fails closed on missing patches", () => {
+		const finding = artifact().findings[0]!;
+		assert.doesNotThrow(() => validateDiffAnchors([finding], [{ filename: finding.path, patch: "@@ -1 +1,2 @@\n old\n+new" }]));
+		assert.throws(() => validateDiffAnchors([{ ...finding, side: "LEFT" }], [{ filename: finding.path, patch: "@@ -1 +1,2 @@\n old\n+new" }]), /does not anchor/);
+		assert.throws(() => validateDiffAnchors([finding], [{ filename: finding.path }]), /no complete reviewable patch/);
+	});
+});
+
+describe("GitHub PR review publisher", () => {
+	it("publishes with maximum GitHub owner/repository lengths using bounded real-filesystem names", async () => {
+		await withArtifact(async (root, path) => {
+			const repository = `${"o".repeat(39)}/${"r".repeat(100)}`;
+			await writeFile(path, JSON.stringify(artifact({ repository })));
+			const gh = mockGh({ repository });
+			const result = await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, cwd: root, gh: gh.run });
+			assert.equal(result.mode, "publish");
+			if (result.mode !== "publish") throw new Error("expected publish receipt");
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+			const guard = (await guards(root))[0];
+			const guardFilename = basename(String(guard?.guard_path));
+			const receiptFilename = basename(result.receipt_path);
+			assert.match(guardFilename, /^guard-[0-9a-f]{64}\.json$/);
+			assert.match(receiptFilename, /^receipt-[0-9a-f]{64}\.json$/);
+			assert.ok(guardFilename.length <= 96);
+			assert.ok(receiptFilename.length <= 96);
+			assert.equal(guard?.host, "github.com");
+			assert.equal(guard?.repository, repository);
+			assert.equal(guard?.reviewed_head_sha, SHA);
+			assert.match(String(guard?.artifact_sha256), /^[0-9a-f]{64}$/);
+			assert.equal(result.host, "github.com");
+			assert.equal(result.repository, repository);
+			assert.equal(result.head_sha, SHA);
+			assert.match(result.artifact_sha256, /^[0-9a-f]{64}$/);
+		});
+	});
+
+	it("does not misclassify an overlong guard-path filesystem error as an existing guard", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			const base = createDefaultReviewReceiptFileOps();
+			const fileOps: ReviewReceiptFileOps = {
+				...base,
+				async open(value, flags, mode) {
+					if (value.includes("/guards/") && flags === "wx") throw Object.assign(new Error("name too long"), { code: "ENAMETOOLONG" });
+					return base.open(value, flags, mode);
+				},
+			};
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, cwd: root, gh: gh.run, receiptFileOps: fileOps }),
+				(error: unknown) => error instanceof ReviewPublisherError && error.code === "publish_guard_reservation_failed" && /ENAMETOOLONG/.test(error.message),
+			);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 0);
+		});
+	});
+
+	it("supports win32 dry-run but rejects publish before any local or external write", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			let fileOpCalls = 0;
+			const base = createDefaultReviewReceiptFileOps();
+			const fileOps: ReviewReceiptFileOps = {
+				...base,
+				mkdir: async (value) => { fileOpCalls += 1; await base.mkdir(value); },
+			};
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, platform: "win32", cwd: root, gh: gh.run, receiptFileOps: fileOps }),
+				/publish_unsupported_platform.*win32.*dry-run remains supported/,
+			);
+			assert.equal(gh.calls.length, 0);
+			assert.equal(fileOpCalls, 0);
+			assert.deepEqual(await readdir(root), ["findings.json"]);
+			const proposal = await publishGithubPrReview({ artifactPath: path, pullRequest: 7, platform: "win32", cwd: root, gh: gh.run, receiptFileOps: fileOps });
+			assert.equal(proposal.mode, "dry-run");
+			assert.equal(fileOpCalls, 0);
+		});
+	});
+
+	it("defaults to read-only dry-run, preflights identity/head/anchors, and performs zero writes", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			const result = await publishGithubPrReview({ artifactPath: path, pullRequest: 7, cwd: root, gh: gh.run });
+			assert.equal(result.mode, "dry-run");
+			assert.equal(result.head_sha, SHA);
+			assert.deepEqual(result.finding_ids, ["G007-P1-001"]);
+			assert.equal(result.request.event, "REQUEST_CHANGES");
+			assert.equal(result.request.commit_id, SHA);
+			assert.equal(gh.calls.some((call) => call.args.includes("POST")), false);
+			assert.deepEqual(await readdir(root), ["findings.json"]);
+		});
+	});
+
+	it("publishes exactly one REST create-review request and persists an auditable receipt", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			const receiptPath = join(root, "receipt.json");
+			const result = await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run });
+			assert.equal(result.mode, "publish");
+			assert.equal(result.review_id, 99);
+			assert.equal(result.submission_count, 1);
+			assert.equal(result.comment_count, 1);
+			const writes = gh.calls.filter((call) => call.args.includes("POST"));
+			assert.equal(writes.length, 1);
+			assert.deepEqual(writes[0]?.args, ["api", "--hostname", "github.com", "-X", "POST", `repos/${REPO}/pulls/7/reviews`, "--input", "-"]);
+			assert.doesNotMatch(writes[0]?.args.join(" ") ?? "", /comments|issues/);
+			const payload = JSON.parse(writes[0]?.input ?? "{}") as { event?: string; commit_id?: string; comments?: unknown[] };
+			assert.equal(payload.event, "REQUEST_CHANGES");
+			assert.equal(payload.commit_id, SHA);
+			assert.equal(payload.comments?.length, 1);
+			assert.deepEqual(gh.calls.map((call) => call.args.join(" ")), [
+				"auth status --hostname github.com",
+				`api --hostname github.com repos/${REPO}`,
+				`api --hostname github.com repos/${REPO}/pulls/7`,
+				`api --hostname github.com repos/${REPO}/pulls/7/files --paginate --slurp`,
+				`api --hostname github.com repos/${REPO}/pulls/7`,
+				`api --hostname github.com -X POST repos/${REPO}/pulls/7/reviews --input -`,
+				`api --hostname github.com repos/${REPO}/pulls/7`,
+				`api --hostname github.com repos/${REPO}/pulls/7/reviews/${REVIEW_ID}`,
+				`api --hostname github.com repos/${REPO}/pulls/7/reviews/${REVIEW_ID}/comments --paginate --slurp`,
+			]);
+			assert.deepEqual(JSON.parse(await readFile(receiptPath, "utf8")), result);
+		});
+	});
+
+	it("keeps the default receipt separate from the canonical guard", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			const result = await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, cwd: root, gh: gh.run });
+			assert.equal(result.mode, "publish");
+			assert.match(result.receipt_path, /\.omx\/reviews\/receipts\/receipt-[0-9a-f]{64}\.json$/);
+			assert.equal((await guards(root))[0]?.guard_path === result.receipt_path, false);
+			assert.deepEqual(JSON.parse(await readFile(result.receipt_path, "utf8")), result);
+		});
+	});
+
+	it("pins every REST read and write to github.com even when GH_HOST names an enterprise host", async () => {
+		await withArtifact(async (root, path) => {
+			const previousHost = process.env.GH_HOST;
+			process.env.GH_HOST = "ghe.example.invalid";
+			try {
+				const gh = mockGh();
+				await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "receipt.json"), cwd: root, gh: gh.run });
+				const apiCalls = gh.calls.filter((call) => call.args[0] === "api");
+				assert.ok(apiCalls.length > 0);
+				assert.ok(apiCalls.every((call) => call.args[1] === "--hostname" && call.args[2] === "github.com"));
+				assert.equal(apiCalls.filter((call) => call.args.includes("POST") && call.args[2] !== "github.com").length, 0);
+			} finally {
+				if (previousHost === undefined) delete process.env.GH_HOST;
+				else process.env.GH_HOST = previousHost;
+			}
+		});
+	});
+
+	it("uses one canonical guard across distinct receipt paths for the same artifact", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "first.json"), cwd: root, gh: gh.run });
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "second.json"), cwd: root, gh: gh.run }),
+				/publish_guard_exists.*publication was not attempted/,
+			);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+			const storedGuards = await guards(root);
+			assert.equal(storedGuards.length, 1);
+			assert.equal(storedGuards[0]?.status, "final");
+		});
+	});
+
+	it("keys canonical guards by artifact hash", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "first.json"), cwd: root, gh: gh.run });
+			await writeFile(path, `${JSON.stringify(artifact())} `);
+			await publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "second.json"), cwd: root, gh: gh.run });
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 2);
+			const storedGuards = await guards(root);
+			assert.equal(storedGuards.length, 2);
+			assert.notEqual(storedGuards[0]?.artifact_sha256, storedGuards[1]?.artifact_sha256);
+		});
+	});
+
+	it("keeps a pre-submit pending guard when receipt reservation fails and blocks an alternate receipt", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh();
+			const occupiedReceipt = join(root, "occupied.json");
+			await writeFile(occupiedReceipt, "occupied\n");
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: occupiedReceipt, cwd: root, gh: gh.run }),
+				/receipt_reservation_failed/,
+			);
+			const storedGuards = await guards(root);
+			assert.equal(storedGuards.length, 1);
+			assert.equal(storedGuards[0]?.status, "pending");
+			assert.equal(storedGuards[0]?.phase, "pre_submit_receipt_reservation_failed");
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "alternate.json"), cwd: root, gh: gh.run }),
+				/publish_guard_exists/,
+			);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 0);
+		});
+	});
+
+	it("keeps an ambiguous guard after stored verification fails and blocks an alternate receipt", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh({ storedReview: storedReview({ body: "wrong" }) });
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "first.json"), cwd: root, gh: gh.run }),
+				/publish_ambiguous_response/,
+			);
+			const ambiguousGuard = (await guards(root))[0];
+			assert.equal(ambiguousGuard?.status, "ambiguous");
+			assert.equal(ambiguousGuard?.review_id, REVIEW_ID);
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "alternate.json"), cwd: root, gh: gh.run }),
+				/publish_guard_exists/,
+			);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+		});
+	});
+
+	it("re-reads the head after diff validation and refuses to create a receipt or submit when it moved", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh({ pullRequests: [pullRequest(), pullRequest(MOVED_SHA)] });
+			const receiptPath = join(root, "receipt.json");
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run }),
+				/stale_head.*pre-submit head verification.*current head b{40}/,
+			);
+			assert.equal(gh.calls.some((call) => call.args.includes("POST")), false);
+			assert.deepEqual(await readdir(root), ["findings.json"]);
+		});
+	});
+
+	it("persists a truthful stale receipt and throws when the PR head moves after verified submission", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh({
+				pullRequests: [pullRequest(), pullRequest(), pullRequest(MOVED_SHA)],
+				storedComments: [[storedComment({ line: null, original_line: 2, commit_id: MOVED_SHA, original_commit_id: SHA })]],
+			});
+			const receiptPath = join(root, "receipt.json");
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run }),
+				/post_submit_stale_head.*review 99 was submitted.*current head is b{40}/,
+			);
+			const receipt = JSON.parse(await readFile(receiptPath, "utf8")) as Record<string, unknown>;
+			assert.deepEqual(receipt, {
+				mode: "publish-stale",
+				host: "github.com",
+				repository: REPO,
+				pull_request: 7,
+				reviewed_head_sha: SHA,
+				current_head_sha: MOVED_SHA,
+				artifact_sha256: receipt.artifact_sha256,
+				finding_ids: ["G007-P1-001"],
+				review_id: REVIEW_ID,
+				review_url: `https://github.com/${REPO}/pull/7#pullrequestreview-${REVIEW_ID}`,
+				review_state: "CHANGES_REQUESTED",
+				submission_count: 1,
+				comment_count: 1,
+				receipt_path: receiptPath,
+				status: "review_submitted_but_pr_head_moved",
+			});
+			assert.match(String(receipt.artifact_sha256), /^[0-9a-f]{64}$/);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+			assert.equal((await guards(root))[0]?.status, "stale");
+			const retryGh = mockGh();
+			await assert.rejects(
+				() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, "alternate-stale.json"), cwd: root, gh: retryGh.run }),
+				/publish_guard_exists/,
+			);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length + retryGh.calls.filter((call) => call.args.includes("POST")).length, 1);
+		});
+	});
+
+	it("fails closed on ambiguous original coordinates after a post-submit head move", async () => {
+		await withArtifact(async (root, path) => {
+			const scenarios = [
+				storedComment({ line: null, original_line: null, commit_id: MOVED_SHA, original_commit_id: SHA }),
+				storedComment({ line: null, original_line: 2, commit_id: MOVED_SHA, original_commit_id: MOVED_SHA }),
+				storedComment({ line: null, original_line: 2, side: null, commit_id: MOVED_SHA, original_commit_id: SHA }),
+				storedComment({ line: null, original_line: 2, commit_id: "not-a-sha", original_commit_id: SHA }),
+			];
+			for (const [index, comment] of scenarios.entries()) {
+				await writeFile(path, `${JSON.stringify(artifact())}${" ".repeat(index + 1)}`);
+				const receiptPath = join(root, `ambiguous-stale-${index}.json`);
+				const gh = mockGh({ pullRequests: [pullRequest(), pullRequest(), pullRequest(MOVED_SHA)], storedComments: [[comment]] });
+				await assert.rejects(() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run }), /publish_ambiguous_response/);
+				assert.equal((JSON.parse(await readFile(receiptPath, "utf8")) as { mode?: string }).mode, "publish-pending");
+				assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+			}
+		});
+	});
+
+	it("keeps a recoverable pending or explicit ambiguity guard for every finalization fault", async () => {
+		await withArtifact(async (root, path) => {
+			for (const [index, fault] of (["open", "write", "fsync", "rename", "directory-fsync"] as const).entries()) {
+				const receiptPath = join(root, `finalization-${fault}.json`);
+				await writeFile(path, `${JSON.stringify(artifact())}${" ".repeat(index + 1)}`);
+				const gh = mockGh();
+				await assert.rejects(
+					() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run, receiptFileOps: faultingReceiptFileOps(fault, receiptPath) }),
+					/receipt_finalization_failed/,
+					fault,
+				);
+				const canonical = JSON.parse(await readFile(receiptPath, "utf8")) as { mode?: string };
+				assert.equal(canonical.mode, fault === "directory-fsync" ? "publish" : "publish-pending", fault);
+				assert.equal((JSON.parse(await readFile(`${receiptPath}.ambiguous`, "utf8")) as { mode?: string }).mode, "publish-ambiguous", fault);
+				const canonicalGuard = (await guards(root)).find((guard) => guard.receipt_path === receiptPath);
+				assert.equal(canonicalGuard?.status, "final", fault);
+				assert.equal(canonicalGuard?.review_id, REVIEW_ID, fault);
+				assert.equal((await readdir(root)).some((name) => name.startsWith(`finalization-${fault}.json.tmp.`)), false, fault);
+				assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1, fault);
+			}
+		});
+	});
+
+	it("fails closed for repo, permission, PR state, and moved-head preflight", async () => {
+		await withArtifact(async (root, path) => {
+			const scenarios = [
+				{ match: `api repos/${REPO}`, response: { full_name: "other/repo", permissions: { push: true } }, error: /repository_mismatch/ },
+				{ match: `api repos/${REPO}`, response: { full_name: REPO, permissions: { push: false } }, error: /permission_denied/ },
+				{ match: `api repos/${REPO}/pulls/7`, response: { state: "closed", head: { sha: SHA }, base: { repo: { full_name: REPO } } }, error: /pull_request_not_open/ },
+				{ match: `api repos/${REPO}/pulls/7`, response: { state: "open", head: { sha: "b".repeat(40) }, base: { repo: { full_name: REPO } } }, error: /stale_head/ },
+			];
+			for (const scenario of scenarios) {
+				const gh = mockGh();
+				const base = gh.run;
+				gh.run = (args, input) => normalizedGhKey(args) === scenario.match
+					? (gh.calls.push({ args, input }), { status: 0, stdout: JSON.stringify(scenario.response), stderr: "" })
+					: base(args, input);
+				await assert.rejects(() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, cwd: root, gh: gh.run }), scenario.error);
+				assert.equal(gh.calls.some((call) => call.args.includes("POST")), false);
+			}
+		});
+	});
+
+	it("never retries 403, 422, rate-limit, or ambiguous write failures", async () => {
+		await withArtifact(async (root, path) => {
+			for (const [index, failure] of [
+				{ result: { status: 1, stdout: "", stderr: "HTTP 403 Forbidden" }, code: /publish_permission_denied/ },
+				{ result: { status: 1, stdout: "", stderr: "HTTP 422 Validation Failed" }, code: /publish_validation_failed/ },
+				{ result: { status: 1, stdout: "", stderr: "secondary rate limit" }, code: /publish_rate_limited/ },
+				{ result: { status: -1, stdout: "", stderr: "socket closed" }, code: /publish_ambiguous_failure/ },
+			].entries()) {
+				await writeFile(path, `${JSON.stringify(artifact())}${" ".repeat(index + 1)}`);
+				const gh = mockGh({ publishResult: failure.result });
+				await assert.rejects(() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath: join(root, `failure-${index}.json`), cwd: root, gh: gh.run }), failure.code);
+				assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+			}
+		});
+	});
+
+	it("does not retry an ambiguous successful response without a review receipt identity", async () => {
+		await withArtifact(async (root, path) => {
+			const gh = mockGh({ publishResult: { status: 0, stdout: "{}", stderr: "" } });
+			await assert.rejects(() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, cwd: root, gh: gh.run }), /publish_ambiguous_response/);
+			assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1);
+		});
+	});
+
+	it("preserves the pending receipt and never retries for every stored-review identity mismatch", async () => {
+		await withArtifact(async (root, path) => {
+			const scenarios: Array<{ name: string; review?: unknown; readFailures?: Record<string, GhResult> }> = [
+				{ name: "missing review", readFailures: { [`api repos/${REPO}/pulls/7/reviews/${REVIEW_ID}`]: { status: 1, stdout: "", stderr: "HTTP 404 Not Found" } } },
+				{ name: "wrong id", review: storedReview({ id: 100 }) },
+				{ name: "foreign API URL", review: storedReview({ url: `https://api.github.com/repos/other/repo/pulls/7/reviews/${REVIEW_ID}` }) },
+				{ name: "foreign PR URL", review: storedReview({ pull_request_url: `https://api.github.com/repos/other/repo/pulls/7` }) },
+				{ name: "foreign HTML URL", review: storedReview({ html_url: `https://github.com/other/repo/pull/7#pullrequestreview-${REVIEW_ID}` }) },
+				{ name: "wrong head", review: storedReview({ commit_id: MOVED_SHA }) },
+				{ name: "approved state", review: storedReview({ state: "APPROVED" }) },
+				{ name: "wrong body", review: storedReview({ body: "different summary" }) },
+			];
+			for (const [index, scenario] of scenarios.entries()) {
+				await writeFile(path, `${JSON.stringify(artifact())}${" ".repeat(index + 1)}`);
+				const receiptPath = join(root, `review-mismatch-${index}.json`);
+				const gh = mockGh({ storedReview: scenario.review, readFailures: scenario.readFailures });
+				await assert.rejects(
+					() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run }),
+					/publish_ambiguous_response/,
+					scenario.name,
+				);
+				assert.equal((JSON.parse(await readFile(receiptPath, "utf8")) as { mode?: string }).mode, "publish-pending", scenario.name);
+				assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1, scenario.name);
+			}
+		});
+	});
+
+	it("preserves the pending receipt for every stored-comment count and identity mismatch", async () => {
+		await withArtifact(async (root, path) => {
+			const scenarios: Array<{ name: string; comments?: unknown; readFailures?: Record<string, GhResult> }> = [
+				{ name: "missing comments", readFailures: { [`api repos/${REPO}/pulls/7/reviews/${REVIEW_ID}/comments --paginate --slurp`]: { status: 1, stdout: "", stderr: "HTTP 404 Not Found" } } },
+				{ name: "wrong count", comments: [[]] },
+				{ name: "wrong review id", comments: [[storedComment({ pull_request_review_id: 100 })]] },
+				{ name: "foreign PR URL", comments: [[storedComment({ pull_request_url: `https://api.github.com/repos/other/repo/pulls/7` })]] },
+				{ name: "wrong head", comments: [[storedComment({ commit_id: MOVED_SHA })]] },
+				{ name: "wrong path", comments: [[storedComment({ path: "src/other.ts" })]] },
+				{ name: "wrong line", comments: [[storedComment({ line: 3 })]] },
+				{ name: "wrong side", comments: [[storedComment({ side: "LEFT" })]] },
+				{ name: "wrong body", comments: [[storedComment({ body: "different finding" })]] },
+			];
+			for (const [index, scenario] of scenarios.entries()) {
+				await writeFile(path, `${JSON.stringify(artifact())}${" ".repeat(index + 1)}`);
+				const receiptPath = join(root, `comment-mismatch-${index}.json`);
+				const gh = mockGh({ storedComments: scenario.comments, readFailures: scenario.readFailures });
+				await assert.rejects(
+					() => publishGithubPrReview({ artifactPath: path, pullRequest: 7, publish: true, receiptPath, cwd: root, gh: gh.run }),
+					/publish_ambiguous_response/,
+					scenario.name,
+				);
+				assert.equal((JSON.parse(await readFile(receiptPath, "utf8")) as { mode?: string }).mode, "publish-pending", scenario.name);
+				assert.equal(gh.calls.filter((call) => call.args.includes("POST")).length, 1, scenario.name);
+			}
+		});
+	});
+});
+
+describe("external mutation guard", () => {
+	it("classifies default and --dry-run as read-only and requires explicit --publish for external write", () => {
+		const base = ["--github-pr", "7", "--findings", "findings.json"];
+		assert.equal(classifyCodeReviewExternalMutationArgs(base), "read-only");
+		assert.equal(classifyCodeReviewExternalMutationArgs([...base, "--dry-run"]), "read-only");
+		assert.equal(classifyCodeReviewExternalMutationArgs([...base, "--publish"]), "external-write");
+		assert.equal(classifyCodeReviewExternalMutationArgs([...base, "--publish", "--dry-run"]), "invalid");
+		assert.equal(classifyCodeReviewExternalMutationArgs([...base, "--receipt", "receipt.json"]), "invalid");
+		assert.equal(classifyCodeReviewExternalMutationArgs(["--publish"]), "invalid");
+	});
+});

--- a/src/github-pr-review/guard.ts
+++ b/src/github-pr-review/guard.ts
@@ -1,0 +1,33 @@
+export type CodeReviewExternalMutationClass = "read-only" | "external-write" | "invalid";
+
+/**
+ * Classify only the exact public code-review publisher grammar. Invalid or
+ * unfamiliar forms fail closed instead of borrowing read-only treatment.
+ */
+export function classifyCodeReviewExternalMutationArgs(
+	args: readonly string[],
+): CodeReviewExternalMutationClass {
+	const valueOptions = new Set(["--github-pr", "--findings", "--repo", "--head", "--receipt"]);
+	const seen = new Set<string>();
+	let publish = false;
+	let dryRun = false;
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index] ?? "";
+		if (arg === "--publish" || arg === "--dry-run") {
+			if (seen.has(arg)) return "invalid";
+			seen.add(arg);
+			publish ||= arg === "--publish";
+			dryRun ||= arg === "--dry-run";
+			continue;
+		}
+		if (!valueOptions.has(arg) || seen.has(arg)) return "invalid";
+		const value = args[index + 1] ?? "";
+		if (!value || value.startsWith("--") || /[\0\r\n]/.test(value)) return "invalid";
+		seen.add(arg);
+		index += 1;
+	}
+	if (publish && dryRun) return "invalid";
+	if (!seen.has("--github-pr") || !seen.has("--findings")) return "invalid";
+	if (!publish && seen.has("--receipt")) return "invalid";
+	return publish ? "external-write" : "read-only";
+}

--- a/src/github-pr-review/publisher.ts
+++ b/src/github-pr-review/publisher.ts
@@ -1,0 +1,765 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm, type FileHandle } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export const GITHUB_PR_REVIEW_SCHEMA_VERSION = 1;
+
+export type ReviewSeverity = "P0" | "P1" | "P2";
+export type ReviewSide = "LEFT" | "RIGHT";
+
+export interface ReviewFinding {
+	id: string;
+	severity: ReviewSeverity;
+	body: string;
+	fix: string;
+	path: string;
+	line: number;
+	side: ReviewSide;
+}
+
+export interface ReviewFindingsArtifact {
+	schema_version: 1;
+	repository: string;
+	pull_request: number;
+	reviewed_head_sha: string;
+	findings: ReviewFinding[];
+}
+
+export interface GhResult {
+	status: number;
+	stdout: string;
+	stderr: string;
+}
+
+export type GhRunner = (args: readonly string[], input?: string) => GhResult;
+
+export interface ReviewPublisherOptions {
+	artifactPath: string;
+	pullRequest: number;
+	repository?: string;
+	reviewedHeadSha?: string;
+	publish?: boolean;
+	receiptPath?: string;
+	cwd?: string;
+	gh?: GhRunner;
+	receiptFileOps?: ReviewReceiptFileOps;
+	platform?: NodeJS.Platform;
+}
+
+interface PullRequestResponse {
+	state?: string;
+	head?: { sha?: string };
+	base?: { repo?: { full_name?: string } };
+}
+
+interface RepositoryResponse {
+	full_name?: string;
+	permissions?: { admin?: boolean; maintain?: boolean; push?: boolean };
+}
+
+interface PullFileResponse {
+	filename?: string;
+	patch?: string;
+}
+
+interface ReviewResponse {
+	id?: number;
+	url?: string;
+	html_url?: string;
+	pull_request_url?: string;
+	commit_id?: string;
+	body?: string;
+	state?: string;
+}
+
+interface ReviewCommentResponse {
+	id?: number;
+	pull_request_review_id?: number;
+	pull_request_url?: string;
+	commit_id?: string;
+	path?: string;
+	line?: number | null;
+	original_line?: number | null;
+	side?: string | null;
+	original_side?: string | null;
+	original_commit_id?: string;
+	body?: string;
+}
+
+export interface ReviewReceiptFileHandle {
+	writeFile(data: string): Promise<void>;
+	sync(): Promise<void>;
+	close(): Promise<void>;
+}
+
+export interface ReviewReceiptFileOps {
+	mkdir(path: string): Promise<void>;
+	open(path: string, flags: "r" | "wx", mode?: number): Promise<ReviewReceiptFileHandle>;
+	rename(from: string, to: string): Promise<void>;
+	rm(path: string): Promise<void>;
+	syncDirectory(path: string): Promise<void>;
+	token(): string;
+}
+
+export interface ReviewProposal {
+	mode: "dry-run";
+	repository: string;
+	pull_request: number;
+	head_sha: string;
+	artifact_sha256: string;
+	finding_ids: string[];
+	request: ReviewRequestPayload;
+}
+
+export interface ReviewReceipt {
+	mode: "publish";
+	host: "github.com";
+	repository: string;
+	pull_request: number;
+	head_sha: string;
+	artifact_sha256: string;
+	finding_ids: string[];
+	review_id: number;
+	review_url: string;
+	review_state: string;
+	submission_count: 1;
+	comment_count: number;
+	receipt_path: string;
+}
+
+export interface ReviewStaleReceipt {
+	mode: "publish-stale";
+	host: "github.com";
+	repository: string;
+	pull_request: number;
+	reviewed_head_sha: string;
+	current_head_sha: string;
+	artifact_sha256: string;
+	finding_ids: string[];
+	review_id: number;
+	review_url: string;
+	review_state: "CHANGES_REQUESTED";
+	submission_count: 1;
+	comment_count: number;
+	receipt_path: string;
+	status: "review_submitted_but_pr_head_moved";
+}
+
+export interface ReviewRequestPayload {
+	commit_id: string;
+	event: "REQUEST_CHANGES";
+	body: string;
+	comments: Array<{
+		path: string;
+		line: number;
+		side: ReviewSide;
+		body: string;
+	}>;
+}
+
+export class ReviewPublisherError extends Error {
+	constructor(
+		public readonly code: string,
+		message: string,
+	) {
+		super(`${code}: ${message}`);
+		this.name = "ReviewPublisherError";
+	}
+}
+
+async function syncDirectory(path: string): Promise<void> {
+	const handle = await open(path, "r");
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+export function createDefaultReviewReceiptFileOps(): ReviewReceiptFileOps {
+	return {
+		mkdir: (path) => mkdir(path, { recursive: true }).then(() => undefined),
+		open: (path, flags, mode) => open(path, flags, mode) as Promise<FileHandle>,
+		rename,
+		rm: (path) => rm(path, { force: true }),
+		syncDirectory,
+		token: randomUUID,
+	};
+}
+
+const GITHUB_HOST = "github.com";
+
+function ghApiArgs(...args: string[]): string[] {
+	return ["api", "--hostname", GITHUB_HOST, ...args];
+}
+
+export function defaultGhRunner(args: readonly string[], input?: string): GhResult {
+	const result = spawnSync("gh", [...args], {
+		encoding: "utf8",
+		input,
+		stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+	});
+	if (result.error) {
+		return { status: -1, stdout: result.stdout ?? "", stderr: result.error.message };
+	}
+	return {
+		status: result.status ?? -1,
+		stdout: result.stdout ?? "",
+		stderr: result.stderr ?? "",
+	};
+}
+
+function fail(code: string, message: string): never {
+	throw new ReviewPublisherError(code, message);
+}
+
+function parseJson<T>(value: string, label: string): T {
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fail("invalid_gh_response", `${label} returned invalid JSON`);
+	}
+}
+
+function parsePostSubmitJson<T>(value: string, label: string): T {
+	try {
+		return JSON.parse(value) as T;
+	} catch {
+		return fail("publish_ambiguous_response", `${label} returned invalid JSON after submission; submission was not retried`);
+	}
+}
+
+function runRead(gh: GhRunner, args: readonly string[], label: string): string {
+	const result = gh(args);
+	if (result.status !== 0) {
+		fail("preflight_failed", `${label}: ${result.stderr.trim() || `gh exited ${result.status}`}`);
+	}
+	return result.stdout;
+}
+
+function runPostSubmitRead(gh: GhRunner, args: readonly string[], label: string): string {
+	const result = gh(args);
+	if (result.status !== 0) {
+		fail("publish_ambiguous_response", `${label} failed after submission: ${result.stderr.trim() || `gh exited ${result.status}`}; submission was not retried`);
+	}
+	return result.stdout;
+}
+
+function assertExactKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void {
+	const extras = Object.keys(value).filter((key) => !allowed.includes(key));
+	if (extras.length > 0) fail("invalid_artifact", `${label} contains unknown fields: ${extras.join(", ")}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validRepository(value: string): boolean {
+	return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value);
+}
+
+function validPath(value: string): boolean {
+	return value.length > 0
+		&& !value.startsWith("/")
+		&& !value.startsWith("../")
+		&& !value.includes("\\")
+		&& !value.split("/").includes("..");
+}
+
+export function validateFindingsArtifact(value: unknown): ReviewFindingsArtifact {
+	if (!isRecord(value)) fail("invalid_artifact", "artifact must be an object");
+	assertExactKeys(value, ["schema_version", "repository", "pull_request", "reviewed_head_sha", "findings"], "artifact");
+	if (value.schema_version !== GITHUB_PR_REVIEW_SCHEMA_VERSION) fail("invalid_artifact", "schema_version must be 1");
+	if (typeof value.repository !== "string" || !validRepository(value.repository)) fail("invalid_artifact", "repository must be owner/name");
+	if (!Number.isSafeInteger(value.pull_request) || Number(value.pull_request) <= 0) fail("invalid_artifact", "pull_request must be a positive integer");
+	if (typeof value.reviewed_head_sha !== "string" || !/^[0-9a-f]{40}$/.test(value.reviewed_head_sha)) fail("invalid_artifact", "reviewed_head_sha must be a lowercase 40-character SHA");
+	if (!Array.isArray(value.findings) || value.findings.length === 0) fail("invalid_artifact", "findings must be a non-empty array");
+
+	const ids = new Set<string>();
+	const findings = value.findings.map((candidate, index): ReviewFinding => {
+		if (!isRecord(candidate)) fail("invalid_artifact", `finding ${index} must be an object`);
+		assertExactKeys(candidate, ["id", "severity", "body", "fix", "path", "line", "side"], `finding ${index}`);
+		if (typeof candidate.id !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._-]{1,127}$/.test(candidate.id)) fail("invalid_artifact", `finding ${index} has an invalid stable id`);
+		if (ids.has(candidate.id)) fail("invalid_artifact", `duplicate finding id ${candidate.id}`);
+		ids.add(candidate.id);
+		if (candidate.severity !== "P0" && candidate.severity !== "P1" && candidate.severity !== "P2") fail("invalid_artifact", `${candidate.id} severity must be P0, P1, or P2`);
+		if (typeof candidate.body !== "string" || candidate.body.trim().length === 0) fail("invalid_artifact", `${candidate.id} body must be actionable and non-empty`);
+		if (typeof candidate.fix !== "string" || candidate.fix.trim().length === 0) fail("invalid_artifact", `${candidate.id} fix must be actionable and non-empty`);
+		if (typeof candidate.path !== "string" || !validPath(candidate.path)) fail("invalid_artifact", `${candidate.id} path must be PR-relative`);
+		if (!Number.isSafeInteger(candidate.line) || Number(candidate.line) <= 0) fail("invalid_artifact", `${candidate.id} line must be a positive integer`);
+		if (candidate.side !== "LEFT" && candidate.side !== "RIGHT") fail("invalid_artifact", `${candidate.id} side must be LEFT or RIGHT`);
+		return candidate as unknown as ReviewFinding;
+	});
+
+	return {
+		schema_version: 1,
+		repository: value.repository,
+		pull_request: Number(value.pull_request),
+		reviewed_head_sha: value.reviewed_head_sha,
+		findings,
+	};
+}
+
+function patchAnchors(patch: string): Set<string> {
+	const anchors = new Set<string>();
+	let oldLine = 0;
+	let newLine = 0;
+	for (const rawLine of patch.split("\n")) {
+		const header = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(rawLine);
+		if (header) {
+			oldLine = Number(header[1]);
+			newLine = Number(header[2]);
+			continue;
+		}
+		if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {
+			anchors.add(`RIGHT:${newLine}`);
+			newLine += 1;
+		} else if (rawLine.startsWith("-") && !rawLine.startsWith("---")) {
+			anchors.add(`LEFT:${oldLine}`);
+			oldLine += 1;
+		} else if (rawLine.startsWith(" ")) {
+			anchors.add(`LEFT:${oldLine}`);
+			anchors.add(`RIGHT:${newLine}`);
+			oldLine += 1;
+			newLine += 1;
+		}
+	}
+	return anchors;
+}
+
+export function validateDiffAnchors(findings: readonly ReviewFinding[], files: readonly PullFileResponse[]): void {
+	const patches = new Map(files.map((file) => [file.filename, file.patch]));
+	for (const finding of findings) {
+		const patch = patches.get(finding.path);
+		if (typeof patch !== "string" || patch.length === 0) fail("invalid_anchor", `${finding.id} path has no complete reviewable patch`);
+		if (!patchAnchors(patch).has(`${finding.side}:${finding.line}`)) fail("invalid_anchor", `${finding.id} does not anchor to ${finding.path}:${finding.line}:${finding.side}`);
+	}
+}
+
+function buildRequest(artifact: ReviewFindingsArtifact): ReviewRequestPayload {
+	const ids = artifact.findings.map((finding) => finding.id);
+	return {
+		commit_id: artifact.reviewed_head_sha,
+		event: "REQUEST_CHANGES",
+		body: `Requested changes for ${ids.length} actionable finding${ids.length === 1 ? "" : "s"}: ${ids.join(", ")}`,
+		comments: artifact.findings.map((finding) => ({
+			path: finding.path,
+			line: finding.line,
+			side: finding.side,
+			body: `**${finding.severity} ${finding.id}**\n\n${finding.body.trim()}\n\n**Required fix:** ${finding.fix.trim()}`,
+		})),
+	};
+}
+
+function assertCurrentHead(
+	gh: GhRunner,
+	artifact: ReviewFindingsArtifact,
+	label: string,
+): PullRequestResponse {
+	const pr = parseJson<PullRequestResponse>(
+		runRead(gh, ghApiArgs(`repos/${artifact.repository}/pulls/${artifact.pull_request}`), label),
+		label,
+	);
+	if (pr.base?.repo?.full_name !== artifact.repository) fail("repository_mismatch", `${label} resolved a foreign base repository`);
+	if (pr.state !== "open") fail("pull_request_not_open", `${label} found pull request state ${pr.state ?? "unknown"}`);
+	if (pr.head?.sha !== artifact.reviewed_head_sha) fail("stale_head", `${label} found current head ${pr.head?.sha ?? "unknown"}`);
+	return pr;
+}
+
+function expectedApiRoot(repository: string): string {
+	return `https://api.github.com/repos/${repository}`;
+}
+
+function expectedReviewUrl(repository: string, pullRequest: number, reviewId: number): string {
+	return `${expectedApiRoot(repository)}/pulls/${pullRequest}/reviews/${reviewId}`;
+}
+
+function expectedPullRequestUrl(repository: string, pullRequest: number): string {
+	return `${expectedApiRoot(repository)}/pulls/${pullRequest}`;
+}
+
+function expectedReviewHtmlUrl(repository: string, pullRequest: number, reviewId: number): string {
+	return `https://github.com/${repository}/pull/${pullRequest}#pullrequestreview-${reviewId}`;
+}
+
+function validSha(value: unknown): value is string {
+	return typeof value === "string" && /^[0-9a-f]{40}$/.test(value);
+}
+
+function requestedCommentSignature(comment: ReviewRequestPayload["comments"][number]): string {
+	return JSON.stringify([comment.path, comment.line, comment.side, comment.body]);
+}
+
+function storedCommentSignature(comment: ReviewCommentResponse, headMoved: boolean): string | undefined {
+	if (typeof comment.path !== "string" || typeof comment.body !== "string") return undefined;
+	if (!headMoved) {
+		if (!Number.isSafeInteger(comment.line) || (comment.side !== "LEFT" && comment.side !== "RIGHT")) return undefined;
+		return JSON.stringify([comment.path, comment.line, comment.side, comment.body]);
+	}
+	const originalSide = comment.original_side ?? comment.side;
+	if (!Number.isSafeInteger(comment.original_line) || (originalSide !== "LEFT" && originalSide !== "RIGHT")) return undefined;
+	return JSON.stringify([comment.path, comment.original_line, originalSide, comment.body]);
+}
+
+function verifyStoredReview(
+	gh: GhRunner,
+	artifact: ReviewFindingsArtifact,
+	request: ReviewRequestPayload,
+	reviewId: number,
+	headMoved: boolean,
+): { review: Required<Pick<ReviewResponse, "id" | "html_url" | "state">>; commentCount: number } {
+	const reviewRoute = `repos/${artifact.repository}/pulls/${artifact.pull_request}/reviews/${reviewId}`;
+	const review = parsePostSubmitJson<ReviewResponse>(runPostSubmitRead(gh, ghApiArgs(reviewRoute), "stored review verification"), "stored review verification");
+	const expectedReviewApiUrl = expectedReviewUrl(artifact.repository, artifact.pull_request, reviewId);
+	if (
+		review.id !== reviewId
+		|| review.url !== expectedReviewApiUrl
+		|| review.pull_request_url !== expectedPullRequestUrl(artifact.repository, artifact.pull_request)
+		|| review.html_url !== expectedReviewHtmlUrl(artifact.repository, artifact.pull_request, reviewId)
+		|| review.commit_id !== artifact.reviewed_head_sha
+		|| review.state !== "CHANGES_REQUESTED"
+		|| review.body !== request.body
+	) {
+		fail("publish_ambiguous_response", "stored review identity, head, state, body, or canonical URLs did not match the submitted review; submission was not retried");
+	}
+
+	const pagedComments = parsePostSubmitJson<ReviewCommentResponse[][]>(
+		runPostSubmitRead(gh, ghApiArgs(`${reviewRoute}/comments`, "--paginate", "--slurp"), "stored review comments verification"),
+		"stored review comments verification",
+	);
+	if (!Array.isArray(pagedComments) || pagedComments.some((page) => !Array.isArray(page))) {
+		fail("publish_ambiguous_response", "stored review comments response was not a paginated array; submission was not retried");
+	}
+	const comments = pagedComments.flat();
+	const expectedCommentSignatures = request.comments.map(requestedCommentSignature).sort();
+	const observedCommentSignatures = comments.map((comment) => storedCommentSignature(comment, headMoved)).sort();
+	const commentsMatch = comments.length === request.comments.length
+		&& comments.every((comment) => Number.isSafeInteger(comment.id)
+			&& Number(comment.id) > 0
+			&& comment.pull_request_review_id === reviewId
+			&& comment.pull_request_url === expectedPullRequestUrl(artifact.repository, artifact.pull_request)
+			&& (headMoved
+				? comment.original_commit_id === artifact.reviewed_head_sha && validSha(comment.commit_id)
+				: comment.commit_id === artifact.reviewed_head_sha))
+		&& observedCommentSignatures.every((signature) => signature !== undefined)
+		&& JSON.stringify(observedCommentSignatures) === JSON.stringify(expectedCommentSignatures);
+	if (!commentsMatch) {
+		fail("publish_ambiguous_response", "stored inline comments did not exactly match the submitted count, review identity, head, paths, lines, sides, and bodies; submission was not retried");
+	}
+
+	return {
+		review: {
+			id: reviewId,
+			html_url: review.html_url,
+			state: "CHANGES_REQUESTED",
+		},
+		commentCount: comments.length,
+	};
+}
+
+function receiptJson(value: unknown): string {
+	return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+async function writeExclusiveDurable(path: string, contents: string, fileOps: ReviewReceiptFileOps): Promise<void> {
+	const parent = dirname(path);
+	let created = false;
+	let handle: ReviewReceiptFileHandle | undefined;
+	try {
+		handle = await fileOps.open(path, "wx", 0o600);
+		created = true;
+		await handle.writeFile(contents);
+		await handle.sync();
+		await handle.close();
+		handle = undefined;
+		await fileOps.syncDirectory(parent);
+	} catch (error) {
+		if (handle) await handle.close().catch(() => undefined);
+		if (created) await fileOps.rm(path).catch(() => undefined);
+		throw error;
+	}
+}
+
+async function reservePendingReceipt(receiptPath: string, pending: unknown, fileOps: ReviewReceiptFileOps): Promise<void> {
+	await fileOps.mkdir(dirname(receiptPath));
+	try {
+		await writeExclusiveDurable(receiptPath, receiptJson(pending), fileOps);
+	} catch (error) {
+		throw new ReviewPublisherError("receipt_reservation_failed", error instanceof Error ? error.message : String(error));
+	}
+}
+
+async function reserveCanonicalGuard(guardPath: string, pending: unknown, fileOps: ReviewReceiptFileOps): Promise<void> {
+	try {
+		await fileOps.mkdir(dirname(guardPath));
+		await writeExclusiveDurable(guardPath, receiptJson(pending), fileOps);
+	} catch (error) {
+		const errorCode = isRecord(error) && typeof error.code === "string" ? error.code : undefined;
+		const errorPath = isRecord(error) && typeof error.path === "string" ? error.path : undefined;
+		if (errorCode === "EEXIST" && errorPath === guardPath) {
+			throw new ReviewPublisherError("publish_guard_exists", `${guardPath} is already reserved; publication was not attempted`);
+		}
+		throw new ReviewPublisherError("publish_guard_reservation_failed", `${guardPath} could not be reserved: ${errorCode ? `${errorCode}: ` : ""}${error instanceof Error ? error.message : String(error)}; publication was not attempted`);
+	}
+}
+
+async function replaceDurable(path: string, value: unknown, fileOps: ReviewReceiptFileOps, code: string): Promise<void> {
+	const parent = dirname(path);
+	const tempPath = `${path}.tmp.${fileOps.token()}`;
+	try {
+		await writeExclusiveDurable(tempPath, receiptJson(value), fileOps);
+		await fileOps.rename(tempPath, path);
+		await fileOps.syncDirectory(parent);
+	} catch (error) {
+		await fileOps.rm(tempPath).catch(() => undefined);
+		throw new ReviewPublisherError(code, `${error instanceof Error ? error.message : String(error)}; prior durable state was preserved`);
+	}
+}
+
+async function finalizeReceipt(receiptPath: string, finalReceipt: unknown, fileOps: ReviewReceiptFileOps): Promise<void> {
+	const parent = dirname(receiptPath);
+	const guardPath = `${receiptPath}.ambiguous`;
+	const tempPath = `${receiptPath}.tmp.${fileOps.token()}`;
+	const guard = {
+		mode: "publish-ambiguous",
+		status: "receipt_finalization_in_progress",
+		receipt_path: receiptPath,
+	};
+	try {
+		await writeExclusiveDurable(guardPath, receiptJson(guard), fileOps);
+		await writeExclusiveDurable(tempPath, receiptJson(finalReceipt), fileOps);
+		await fileOps.rename(tempPath, receiptPath);
+		await fileOps.syncDirectory(parent);
+		await fileOps.rm(guardPath);
+	} catch (error) {
+		await fileOps.rm(tempPath).catch(() => undefined);
+		throw new ReviewPublisherError("receipt_finalization_failed", `${error instanceof Error ? error.message : String(error)}; pending receipt or durable ambiguity guard was preserved`);
+	}
+}
+
+function classifyPublishFailure(result: GhResult): ReviewPublisherError {
+	const detail = result.stderr.trim() || result.stdout.trim() || `gh exited ${result.status}`;
+	if (/403|forbidden|resource not accessible/i.test(detail)) return new ReviewPublisherError("publish_permission_denied", detail);
+	if (/422|unprocessable|validation failed/i.test(detail)) return new ReviewPublisherError("publish_validation_failed", detail);
+	if (/429|rate.?limit|secondary rate/i.test(detail)) return new ReviewPublisherError("publish_rate_limited", detail);
+	return new ReviewPublisherError("publish_ambiguous_failure", `${detail}; submission was not retried`);
+}
+
+export function reviewPublicationStateFilename(
+	kind: "guard" | "receipt",
+	artifact: Pick<ReviewFindingsArtifact, "repository" | "pull_request" | "reviewed_head_sha">,
+	artifactSha256: string,
+): string {
+	const identity = JSON.stringify({
+		host: GITHUB_HOST,
+		repository: artifact.repository,
+		pull_request: artifact.pull_request,
+		reviewed_head_sha: artifact.reviewed_head_sha,
+		artifact_sha256: artifactSha256,
+	});
+	const digest = createHash("sha256").update(`omx-github-pr-review-${kind}\0`).update(identity).digest("hex");
+	return `${kind}-${digest}.json`;
+}
+
+function receiptDefaultPath(cwd: string, artifact: ReviewFindingsArtifact, artifactSha256: string): string {
+	return join(cwd, ".omx", "reviews", "receipts", reviewPublicationStateFilename("receipt", artifact, artifactSha256));
+}
+
+function canonicalGuardPath(cwd: string, artifact: ReviewFindingsArtifact, artifactSha256: string): string {
+	return join(cwd, ".omx", "reviews", "guards", reviewPublicationStateFilename("guard", artifact, artifactSha256));
+}
+
+export async function publishGithubPrReview(options: ReviewPublisherOptions): Promise<ReviewProposal | ReviewReceipt> {
+	if (options.publish && (options.platform ?? process.platform) === "win32") {
+		fail("publish_unsupported_platform", "--publish is unavailable on win32 because crash-durable guard and receipt semantics are not guaranteed; dry-run remains supported");
+	}
+	const artifactBytes = await readFile(options.artifactPath, "utf8");
+	let artifactJson: unknown;
+	try {
+		artifactJson = JSON.parse(artifactBytes);
+	} catch {
+		fail("invalid_artifact", "findings artifact is not valid JSON");
+	}
+	const artifact = validateFindingsArtifact(artifactJson);
+	if (options.pullRequest !== artifact.pull_request) fail("identity_mismatch", "--github-pr does not match artifact pull_request");
+	if (options.repository && options.repository !== artifact.repository) fail("identity_mismatch", "--repo does not match artifact repository");
+	if (options.reviewedHeadSha && options.reviewedHeadSha !== artifact.reviewed_head_sha) fail("identity_mismatch", "--head does not match artifact reviewed_head_sha");
+
+	const gh = options.gh ?? defaultGhRunner;
+	runRead(gh, ["auth", "status", "--hostname", "github.com"], "gh authentication");
+	const repo = parseJson<RepositoryResponse>(runRead(gh, ghApiArgs(`repos/${artifact.repository}`), "repository preflight"), "repository preflight");
+	if (repo.full_name !== artifact.repository) fail("repository_mismatch", `resolved repository is ${repo.full_name ?? "unknown"}`);
+	if (!(repo.permissions?.admin || repo.permissions?.maintain || repo.permissions?.push)) fail("permission_denied", "authenticated user lacks write/maintain/admin permission");
+
+	assertCurrentHead(gh, artifact, "pull request preflight");
+
+	const pagedFiles = parseJson<PullFileResponse[][]>(runRead(gh, ghApiArgs(`repos/${artifact.repository}/pulls/${artifact.pull_request}/files`, "--paginate", "--slurp"), "pull request diff preflight"), "pull request diff preflight");
+	if (!Array.isArray(pagedFiles) || pagedFiles.some((page) => !Array.isArray(page))) fail("invalid_gh_response", "pull request files response must be paginated arrays");
+	validateDiffAnchors(artifact.findings, pagedFiles.flat());
+	assertCurrentHead(gh, artifact, "pre-submit head verification");
+
+	const artifactSha256 = createHash("sha256").update(artifactBytes).digest("hex");
+	const request = buildRequest(artifact);
+	const findingIds = artifact.findings.map((finding) => finding.id);
+	if (!options.publish) {
+		return {
+			mode: "dry-run",
+			repository: artifact.repository,
+			pull_request: artifact.pull_request,
+			head_sha: artifact.reviewed_head_sha,
+			artifact_sha256: artifactSha256,
+			finding_ids: findingIds,
+			request,
+		};
+	}
+
+	const cwd = options.cwd ?? process.cwd();
+	const receiptPath = options.receiptPath ?? receiptDefaultPath(cwd, artifact, artifactSha256);
+	const guardPath = canonicalGuardPath(cwd, artifact, artifactSha256);
+	const fileOps = options.receiptFileOps ?? createDefaultReviewReceiptFileOps();
+	const guardBase = {
+		mode: "publish-guard",
+		host: GITHUB_HOST,
+		repository: artifact.repository,
+		pull_request: artifact.pull_request,
+		reviewed_head_sha: artifact.reviewed_head_sha,
+		artifact_sha256: artifactSha256,
+		finding_ids: findingIds,
+		guard_path: guardPath,
+		receipt_path: receiptPath,
+	};
+	await reserveCanonicalGuard(guardPath, {
+		...guardBase,
+		status: "pending",
+		phase: "pre_submit_reserved",
+		submission_count: 0,
+	}, fileOps);
+	try {
+		await reservePendingReceipt(receiptPath, {
+			mode: "publish-pending",
+			host: GITHUB_HOST,
+			repository: artifact.repository,
+			pull_request: artifact.pull_request,
+			head_sha: artifact.reviewed_head_sha,
+			artifact_sha256: artifactSha256,
+			finding_ids: findingIds,
+			guard_path: guardPath,
+		}, fileOps);
+	} catch (error) {
+		await replaceDurable(guardPath, {
+			...guardBase,
+			status: "pending",
+			phase: "pre_submit_receipt_reservation_failed",
+			submission_count: 0,
+		}, fileOps, "publish_guard_finalization_failed").catch(() => undefined);
+		throw error;
+	}
+
+	await replaceDurable(guardPath, {
+		...guardBase,
+		status: "ambiguous",
+		phase: "submission_in_progress",
+		submission_count: "unknown",
+	}, fileOps, "publish_guard_finalization_failed");
+
+	let reviewId: number | undefined;
+	let guardFinalized = false;
+	try {
+		const result = gh(
+			ghApiArgs("-X", "POST", `repos/${artifact.repository}/pulls/${artifact.pull_request}/reviews`, "--input", "-"),
+			JSON.stringify(request),
+		);
+		if (result.status !== 0) throw classifyPublishFailure(result);
+		const response = parsePostSubmitJson<ReviewResponse>(result.stdout, "create review");
+		if (!Number.isSafeInteger(response.id) || Number(response.id) <= 0) {
+			fail("publish_ambiguous_response", "create review succeeded without a positive numeric review id; submission was not retried");
+		}
+		reviewId = response.id as number;
+		const postSubmitPr = parsePostSubmitJson<PullRequestResponse>(
+			runPostSubmitRead(gh, ghApiArgs(`repos/${artifact.repository}/pulls/${artifact.pull_request}`), "post-submit head verification"),
+			"post-submit head verification",
+		);
+		if (postSubmitPr.base?.repo?.full_name !== artifact.repository || postSubmitPr.state !== "open") {
+			fail("publish_ambiguous_response", "post-submit head verification resolved a foreign or non-open pull request");
+		}
+		const currentHeadSha = postSubmitPr.head?.sha;
+		if (typeof currentHeadSha !== "string" || !/^[0-9a-f]{40}$/.test(currentHeadSha)) {
+			fail("publish_ambiguous_response", "post-submit head verification returned no valid current head SHA");
+		}
+		const headMoved = currentHeadSha !== artifact.reviewed_head_sha;
+		const verified = verifyStoredReview(gh, artifact, request, reviewId, headMoved);
+		if (headMoved) {
+			const staleReceipt: ReviewStaleReceipt = {
+				mode: "publish-stale",
+				host: GITHUB_HOST,
+				repository: artifact.repository,
+				pull_request: artifact.pull_request,
+				reviewed_head_sha: artifact.reviewed_head_sha,
+				current_head_sha: currentHeadSha,
+				artifact_sha256: artifactSha256,
+				finding_ids: findingIds,
+				review_id: verified.review.id,
+				review_url: verified.review.html_url,
+				review_state: "CHANGES_REQUESTED",
+				submission_count: 1,
+				comment_count: verified.commentCount,
+				receipt_path: receiptPath,
+				status: "review_submitted_but_pr_head_moved",
+			};
+			await replaceDurable(guardPath, {
+				...guardBase,
+				status: "stale",
+				current_head_sha: currentHeadSha,
+				review_id: verified.review.id,
+				review_url: verified.review.html_url,
+				review_state: "CHANGES_REQUESTED",
+				submission_count: 1,
+				comment_count: verified.commentCount,
+			}, fileOps, "publish_guard_finalization_failed");
+			guardFinalized = true;
+			await finalizeReceipt(receiptPath, staleReceipt, fileOps);
+			fail("post_submit_stale_head", `review ${reviewId} was submitted to ${artifact.reviewed_head_sha}, but current head is ${currentHeadSha}; submission was not retried`);
+		}
+		const receipt: ReviewReceipt = {
+			mode: "publish",
+			host: GITHUB_HOST,
+			repository: artifact.repository,
+			pull_request: artifact.pull_request,
+			head_sha: artifact.reviewed_head_sha,
+			artifact_sha256: artifactSha256,
+			finding_ids: findingIds,
+			review_id: verified.review.id,
+			review_url: verified.review.html_url,
+			review_state: verified.review.state,
+			submission_count: 1,
+			comment_count: verified.commentCount,
+			receipt_path: receiptPath,
+		};
+		await replaceDurable(guardPath, {
+			...guardBase,
+			status: "final",
+			current_head_sha: currentHeadSha,
+			review_id: verified.review.id,
+			review_url: verified.review.html_url,
+			review_state: verified.review.state,
+			submission_count: 1,
+			comment_count: verified.commentCount,
+		}, fileOps, "publish_guard_finalization_failed");
+		guardFinalized = true;
+		await finalizeReceipt(receiptPath, receipt, fileOps);
+		return receipt;
+	} catch (error) {
+		if (!guardFinalized) {
+			await replaceDurable(guardPath, {
+				...guardBase,
+				status: "ambiguous",
+				phase: "post_submit_verification_or_finalization_failed",
+				submission_count: "unknown",
+				...(reviewId === undefined ? {} : { review_id: reviewId }),
+				error_code: error instanceof ReviewPublisherError ? error.code : "unknown_error",
+			}, fileOps, "publish_guard_finalization_failed").catch(() => undefined);
+		}
+		throw error;
+	}
+}

--- a/src/hooks/__tests__/code-review-skill-contract.test.ts
+++ b/src/hooks/__tests__/code-review-skill-contract.test.ts
@@ -68,6 +68,42 @@ describe('code-review skill contract', () => {
     assert.match(codeReviewSkill, /Plain `code-review` itself remains read-only and does \*\*not\*\* promise auto-fix/i);
   });
 
+  it('keeps publication explicit, fail-closed, and outside Autopilot/pipeline review', () => {
+    assert.match(codeReviewSkill, /Plain `\$code-review` is local and read-only/i);
+    assert.match(codeReviewSkill, /Autopilot and pipeline review phases also remain read-only/i);
+    assert.match(codeReviewSkill, /omx code-review --github-pr <number> --findings <artifact\.json>/i);
+    assert.match(codeReviewSkill, /--publish/i);
+    assert.match(codeReviewSkill, /exact current head SHA/i);
+    assert.match(codeReviewSkill, /rejects the entire set/i);
+    assert.match(codeReviewSkill, /exactly one REST create-review request/i);
+    assert.match(codeReviewSkill, /never falls back to timeline comments/i);
+    assert.match(codeReviewSkill, /never retries an ambiguous write failure/i);
+    assert.match(codeReviewSkill, /never resolves threads/i);
+		assert.match(codeReviewSkill, /re-reads the PR immediately before any receipt or review write/i);
+		assert.match(codeReviewSkill, /reads the stored review and its paginated review-comments endpoint/i);
+		assert.match(codeReviewSkill, /Every `gh api` read and write includes `--hostname github\.com`/i);
+		assert.match(codeReviewSkill, /Immediately after validating that ID, the command re-reads the current PR head/i);
+		assert.match(codeReviewSkill, /original_commit_id/i);
+		assert.match(codeReviewSkill, /original_line/i);
+		assert.match(codeReviewSkill, /canonical guard is durably finalized as ambiguous/i);
+		assert.match(codeReviewSkill, /atomic rename, directory fsync/i);
+		assert.match(codeReviewSkill, /publish_unsupported_platform/i);
+		assert.match(codeReviewSkill, /crash durability is not claimed on Windows/i);
+		assert.match(codeReviewSkill, /canonical guard under `<cwd>\/\.omx\/reviews\/guards\/`/i);
+		assert.match(codeReviewSkill, /guard-<64 lowercase hex>\.json/i);
+		assert.match(codeReviewSkill, /complete canonical identity/i);
+		assert.match(codeReviewSkill, /separate guard and receipt domains/i);
+		assert.match(codeReviewSkill, /retains the full readable identity and artifact hash/i);
+		assert.match(codeReviewSkill, /ENAMETOOLONG.*publish_guard_reservation_failed/i);
+		assert.match(codeReviewSkill, /custom receipt changes only the separate destination receipt/i);
+		assert.match(codeReviewSkill, /Any existing pending, ambiguous, final, or stale guard blocks publication/i);
+		assert.match(codeReviewSkill, /canonical guard already contains final, stale, or conservative ambiguous evidence/i);
+		assert.match(codeReviewSkill, /publish_ambiguous_response/i);
+		assert.match(codeReviewSkill, /mode: "publish-stale"/i);
+		assert.match(codeReviewSkill, /post_submit_stale_head/i);
+		assert.match(codeReviewSkill, /observed stored count/i);
+  });
+
   it('keeps the sample output consistent with a WATCH and COMMENT outcome', () => {
     const totalIssues = codeReviewSkill.match(/Total Issues: (\d+)/i);
     const criticalCount = codeReviewSkill.match(/CRITICAL \((\d+)\)/i);

--- a/src/pipeline/stages/code-review.ts
+++ b/src/pipeline/stages/code-review.ts
@@ -85,5 +85,5 @@ export function createCodeReviewStage(options: CodeReviewStageOptions = {}): Pip
 }
 
 export function buildCodeReviewInstruction(task: string): string {
-  return `$code-review ${JSON.stringify(task)}`;
+  return `$code-review ${JSON.stringify(task)}\nThis pipeline review stage is read-only. Do not publish GitHub comments or reviews implicitly.`;
 }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -14172,6 +14172,10 @@ exit 0
 				await assertAllowed("omx ralplan --help", "omx ralplan --help");
 				await assertAllowed("omx state read --mode ralplan --json", "omx state read --mode ralplan --json");
 				await assertAllowed("omx state get-status --mode ralplan --json", "omx state get-status --mode ralplan --json");
+				await assertAllowed("code-review default preflight stays read-only", "omx code-review --github-pr 7 --findings findings.json");
+				await assertAllowed("code-review explicit dry-run stays read-only", "omx code-review --github-pr 7 --findings findings.json --dry-run");
+				await assertBlocked("code-review publish crosses the external-write approval boundary", "omx code-review --github-pr 7 --findings findings.json --publish");
+				await assertBlocked("invalid code-review grammar fails closed", "omx code-review --github-pr 7 --findings findings.json --receipt receipt.json");
 				await assertBlocked("invalid state status spelling stays blocked", "omx state status --mode ralplan --json");
 				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
 

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -155,6 +155,7 @@ import {
   resolveNativeSubagentSupportStatus,
   type NativeSubagentUnsupportedReason,
 } from "../leader/contract.js";
+import { classifyCodeReviewExternalMutationArgs } from "../github-pr-review/guard.js";
 import { readRunState } from "../runtime/run-state.js";
 import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../ralph/completion-audit.js";
 import {
@@ -10024,6 +10025,7 @@ const OMX_NESTED_HELP_COMMANDS = new Set([
   "auth",
   "capabilities",
   "cleanup",
+  "code-review",
   "deepinit",
   "explore",
   "hooks",
@@ -10082,6 +10084,7 @@ function omxOrGjcReadOnlyShapeMatches(command: string): boolean {
   if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
   if (args[0] === "state" && ["read", "get-status", "status"].includes(args[1] ?? "")) return true;
   if (args[0] === "sparkshell") return true;
+  if (args[0] === "code-review") return true;
   return args[0] === "cleanup" && args.includes("--dry-run");
 }
 
@@ -10107,6 +10110,9 @@ function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
   if (args[0] === "state" && OMX_STATE_READ_ONLY_OPERATIONS.has(args[1] ?? "")) {
     return stateReadTrailingArgsAreSafe(args.slice(2));
   }
+  if (args[0] === "code-review") {
+    return classifyCodeReviewExternalMutationArgs(args.slice(1)) === "read-only";
+  }
   return isAllowedOmxCleanupDryRunCommand(command);
 }
 
@@ -10127,6 +10133,9 @@ function isAllowedTrustedAbsoluteOmxReadOnlyCommand(command: string, cwd: string
   if (args.length === 1 && (args[0] === "--help" || args[0] === "-h" || args[0] === "--version" || args[0] === "-v")) return true;
   if (args.length === 1 && (args[0] === "help" || args[0] === "status" || args[0] === "version")) return true;
   if (isAllowedOmxNestedHelpForm(args)) return true;
+  if (args[0] === "code-review") {
+    return classifyCodeReviewExternalMutationArgs(args.slice(1)) === "read-only";
+  }
   return args.length === 3
     && args[0] === "ultragoal"
     && args[1] === "status"
@@ -12675,6 +12684,9 @@ function omxCliInvocationHasMutationIntent(words: string[], commandIndex: number
   const subcommand = operands[1] ?? "";
   if (!commandName || ["help", "read", "status", "version"].includes(commandName)) return false;
   if (commandName === "state" && ["read", "get-status"].includes(subcommand)) return false;
+  if (commandName === "code-review") {
+    return classifyCodeReviewExternalMutationArgs(boundedWords.slice(1).map(shellWordLiteral)) !== "read-only";
+  }
   if (["deep-interview", "ralplan", "ralph", "team", "ultragoal"].includes(commandName) && ["read", "status"].includes(subcommand)) return false;
   return true;
 }


### PR DESCRIPTION
## Summary
- add native TypeScript `omx code-review` with read-only preflight by default and an explicit `--publish` external-write boundary
- require exact structured P0/P1/P2 findings, repository/PR/head identity, and side-specific diff anchors
- submit exactly one REST `REQUEST_CHANGES` review pinned by `commit_id`; never retry, fall back to timeline comments, or resolve threads
- keep plain, Autopilot, and pipeline review lanes read-only and enforce the boundary in the native hook guard
- update the canonical skill, generated plugin mirror, CLI help, and README

## Platform and host boundary
- dry-run remains supported on Windows
- explicit win32 publication fails before artifact access, runner calls, guard/receipt creation, or POST; crash durability is not claimed on Windows
- every `gh api` read and POST is pinned to `--hostname github.com`

## Canonical idempotency guard
- reserve an exclusive, fsynced canonical guard under `.omx/reviews/guards/`, keyed by the complete host/repository/PR/reviewed-head/artifact-hash identity
- derive guard and default-receipt names as domain-separated fixed 64-hex SHA-256 digests (`guard-<hex>.json` / `receipt-<hex>.json`), while retaining full readable identity in JSON
- prove maximum GitHub owner/repository lengths on the real filesystem with 75- and 77-character filename components and one mocked POST
- keep `--receipt` solely as a separate destination; the default receipt lives under `.omx/reviews/receipts/`
- pending, ambiguous, final, and stale guards all block an alternate receipt path; distinct artifact hashes receive distinct guards
- preserve a durable non-submitted pending state when destination receipt reservation fails
- transition the guard to submission-in-progress before POST, then durably finalize it as ambiguous, final, or stale before finalizing the destination receipt
- ensure a custom/default receipt finalization fault still leaves canonical review evidence that prevents duplicate publication

## Stored-review and head-race guarantees
- re-read the PR head after diff validation, immediately before any receipt or review write
- after the single POST returns a numeric review ID, read the current PR head before validating stored comment coordinates
- require exact stored review API/web identity, reviewed commit, `CHANGES_REQUESTED` state, summary body, observed count, and comment identity/path/body
- for an unchanged head, require current commit/line/side coordinates; for a moved head, require original commit/line/side coordinates, including GitHub's null current-line stale shape
- persist verified moved-head evidence as stale and raise `post_submit_stale_head`; ambiguous stored evidence finalizes the canonical guard as ambiguous and is never retried

## Validation
Completed on `2b39a058d97f1c7b937ed9564fba4158019e39c6`:
- `npm run sync:plugin` — pass
- `npm run verify:plugin-bundle` — pass
- `npm run lint` — pass (794 files)
- `npm run check:no-unused` — pass
- `npx tsc --noEmit` — pass
- `npm run build` — pass
- publisher + skill-contract + pipeline tests — pass (109/109; publisher 25/25, including bounded-name collision separation, maximum owner/repository real-FS publication, `ENAMETOOLONG` classification, win32 zero-write rejection, alternate receipts, every guard state, and receipt-finalization faults)
- exact native hook regression `issue #3314 permits ralplan planning read-only discovery without relaxing write guards` — pass (1/1)
- `git diff --check` — pass

## Existing upstream baseline failures
A prior full `npm test` run reported 5/408 failing files. These are not claimed green and were reproduced from an archived build of upstream `dev` at `0b064c2292e0d17553b11d3cb7946982fa108d00`:
- three setup files (`setup-prompts-overwrite`, `setup-refresh`, `setup-skills-overwrite`): 26 failing subtests because the live HOME plugin cache selects plugin mode while legacy-layout tests expect project `.codex` prompts/skills; isolated empty `CODEX_HOME` gives 56/56
- `team/__tests__/scaling.test`: one failure because live HOME config resolves `test-engineer` to `gpt-5.6-terra` while the test asserts Sol; isolated empty `CODEX_HOME` gives 119/119
- `scripts/__tests__/codex-native-hook.test`: two existing failures, `treats installed custom native agent roles as typed lanes for prompt submit` and `allows session-scoped omx cancel under active ralplan without weakening state guards`; both named tests also fail on archived upstream `dev`

No real GitHub review publication was exercised by validation; all publisher tests use mocked `gh` responses.

Document-refresh: updated README, CLI help, and canonical code-review skill.
