### PR TITLE
test(smoke): use canonical identityless MCP denial probe

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2749,22 +2749,21 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       ),
       /Main-root Conductor mode is active/,
     );
-    const identitylessNativeOutput = parseNativeHookSmokeOutput(
-      'PreToolUse identityless native-session remote mutation',
-      String(invokeAuthorizationProbe({
-        hook_event_name: 'PreToolUse',
-        cwd: smokeCwd,
-        session_id: leaderAgentId,
-        tool_name: 'Bash',
-        tool_use_id: 'packed-install-identityless-native-session-remote-mutation',
-        tool_input: { command: 'PATH=/usr/bin:/bin gh issue create --title x --body y' },
-      }, childEnv).stdout),
+    requireNativeHookPermissionDeny(
+      'identityless native-session remote mutation',
+      parseNativeHookSmokeOutput(
+        'PreToolUse identityless native-session remote mutation',
+        String(invokeAuthorizationProbe({
+          hook_event_name: 'PreToolUse',
+          cwd: smokeCwd,
+          session_id: leaderAgentId,
+          tool_name: 'mcp__omx_wiki__wiki_delete',
+          tool_use_id: 'packed-install-identityless-native-session-remote-mutation',
+          tool_input: { path: 'src/session-bypass.ts' },
+        }, childEnv).stdout),
+      ),
+      /OWNER_CONFIRMATION_REQUIRED|Main-root Conductor mode is active/,
     );
-    const identitylessNativeHookOutput = identitylessNativeOutput.hookSpecificOutput as Record<string, unknown> | undefined;
-    const identitylessNativeReason = String(identitylessNativeHookOutput?.permissionDecisionReason ?? '').trim();
-    if (identitylessNativeHookOutput?.permissionDecision !== 'deny' || !identitylessNativeReason) {
-      throw new Error(`native hook identityless native-session remote mutation did not emit a canonical denial: ${JSON.stringify(identitylessNativeOutput)}`);
-    }
     if (Object.keys(runActorProbe('main-root', 'finite cp metadata leaf control', 'Bash', {
       command: 'cp .omx/state/payload .omx/handoffs/run-1/payload',
     })).length !== 0) {


### PR DESCRIPTION
The packaged release smoke showed the Bash remote mutation was not the canonical identityless native-session contract. Use the source-matching MCP mutation probe and require deny plus the accepted fail-closed reason variants. Same release-smoke repair lane; no product trust changes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*