### PR TITLE
test(smoke): isolate zsh startup probe environment

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2786,7 +2786,7 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
     }
     if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
       command: `zsh -f -c ':'`,
-    })).length !== 0) {
+    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
The tagged release reached the documented zsh -f startup-control probe and the packaged hook returned an empty envelope because the smoke child inherited startup environment. Run this exact positive control with BASH_ENV, ENV, and ZDOTDIR explicitly empty; hostile startup probes remain unchanged and fail closed.

Build, no-unused, lint, and diff checks pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*