### PR TITLE
release: promote zsh smoke fixture repair

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2786,7 +2786,7 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
     }
     if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
       command: `zsh -f -c ':'`,
-    })).length !== 0) {
+    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
Promote exact green dev head 19e7af568d3dee59d0074b105812a036c0c9ac3d after PR #3385 and terminal green post-merge dev CI 30631338499. This is the smoke-only zsh startup fixture repair for failed Release run 30629284026.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*