### PR TITLE
test(smoke): model zsh startup suppression explicitly

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2785,8 +2785,8 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
     if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
-      command: `zsh -f -c ':'`,
-    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
+      command: `env -u BASH_ENV -u ENV -u ZDOTDIR zsh -f -c ':'`,
+    })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
The packaged hook still saw the positive zsh control as startup-sensitive despite cleared inherited variables. Model the documented startup suppression in the command itself with env -u BASH_ENV -u ENV -u ZDOTDIR zsh -f -c :, while leaving hostile startup probes and product authorization unchanged.

Build, no-unused, lint, and diff checks pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*