### PR TITLE
release: promote explicit zsh smoke control

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2785,8 +2785,8 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
     if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
-      command: `zsh -f -c ':'`,
-    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
+      command: `env -u BASH_ENV -u ENV -u ZDOTDIR zsh -f -c ':'`,
+    })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
Promote exact green dev head b4bd6469f6e755a9fcfd5f357b9e5d2d57b7f270 after PR #3387 and terminal green post-merge dev CI 30635749253. This is the smoke-only zsh startup-control fixture repair for failed Release run 30633393462.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*