### PR TITLE
test(smoke): pass explicit empty zsh startup env

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2789,8 +2789,8 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
     if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
-      command: `env -u BASH_ENV -u ENV -u ZDOTDIR zsh -f -c ':'`,
-    })).length !== 0) {
+      command: `zsh -f -c ':'`,
+    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
The packaged hook probe helper now deletes undefined env entries before spawn. Pass the exact empty BASH_ENV/ENV/ZDOTDIR values through the helper for the positive zsh -f startup-control contract, without adding env -u parsing to the product command classifier. Hostile startup probes and trust logic remain unchanged.

Build, no-unused, lint, and diff checks pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*