### PR TITLE
release: promote explicit zsh startup env repair

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2789,8 +2789,8 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
     if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
-      command: `env -u BASH_ENV -u ENV -u ZDOTDIR zsh -f -c ':'`,
-    })).length !== 0) {
+      command: `zsh -f -c ':'`,
+    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
Promote exact green dev head e271cc594c3e7de95114d4a26738af4d25b7d9d6 after PR #3391 and terminal-green post-merge dev CI 30646280630. Smoke-only zsh startup environment repair for failed Release run 30643424124.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*