### PR TITLE
test(smoke): remove startup env keys from zsh probe

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2788,9 +2788,9 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
     })).length !== 0) {
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
-    if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
+    if (Object.keys(runActorProbeResult('main-root', 'zsh fast startup control', 'Bash', {
       command: `zsh -f -c ':'`,
-    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
+    }, { BASH_ENV: undefined, ENV: undefined, ZDOTDIR: undefined }).output).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
The previous fixture passed empty strings, which still counts as configured startup environment in the hook inspection. The positive zsh -f probe now passes undefined values through the normalized helper so BASH_ENV/ENV/ZDOTDIR are actually absent. Hostile startup probes and product trust logic remain unchanged.

Build, no-unused, lint, and diff checks pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*