### PR TITLE
release: promote zsh probe env removal

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2788,9 +2788,9 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
     })).length !== 0) {
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
-    if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
+    if (Object.keys(runActorProbeResult('main-root', 'zsh fast startup control', 'Bash', {
       command: `zsh -f -c ':'`,
-    }, { BASH_ENV: '', ENV: '', ZDOTDIR: '' })).length !== 0) {
+    }, { BASH_ENV: undefined, ENV: undefined, ZDOTDIR: undefined }).output).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
Promote exact green dev head 229d5dc4fd82aa87e274ddf22dbe197987f2778e after PR #3393 and terminal-green post-merge dev CI. This is the smoke-only zsh startup environment repair for failed Release run 30648708842.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*