### PR TITLE
fix(smoke): scrub ambient session environment

### DIFF
--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1234,7 +1234,17 @@ function buildPackedProbeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessE
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const key of Object.keys(env)) {
     const upper = key.toUpperCase();
-    if (upper === 'NODE_OPTIONS' || upper.startsWith('OMX_') || upper.startsWith('CODEX_')) {
+    if (
+      upper === 'NODE_OPTIONS'
+      || upper === 'BASH_ENV'
+      || upper === 'ENV'
+      || upper === 'ZDOTDIR'
+      || upper.startsWith('OMX_')
+      || upper.startsWith('CODEX_')
+      || upper.startsWith('GJC_')
+      || upper === 'TMUX'
+      || upper === 'TMUX_PANE'
+    ) {
       delete env[key];
     }
   }

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -1238,7 +1238,11 @@ function buildPackedProbeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessE
       delete env[key];
     }
   }
-  return { ...env, ...overrides };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+  return env;
 }
 
 export interface PackedInstallNpmFile {
@@ -2458,13 +2462,15 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       [realpathSync(hookScript)],
       { cwd: smokeCwd, env, input: JSON.stringify(payload) },
     );
-    const hookEnv = {
-      ...process.env,
+    const hookEnv = buildPackedProbeEnv({
+      BASH_ENV: undefined,
+      ENV: undefined,
+      ZDOTDIR: undefined,
       OMX_NATIVE_HOOK_DOCTOR_SMOKE: '1',
       OMX_ROOT: hookRoot,
       OMX_SOURCE_CWD: smokeCwd,
       OMX_STARTUP_CWD: smokeCwd,
-    };
+    });
     const officialTeamRootPayload = {
       hook_event_name: 'PreToolUse',
       cwd: smokeCwd,
@@ -2788,9 +2794,9 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
     })).length !== 0) {
       throw new Error('packed main-root bounded quoted heredoc metadata control should be allowed');
     }
-    if (Object.keys(runActorProbeResult('main-root', 'zsh fast startup control', 'Bash', {
+    if (Object.keys(runActorProbe('main-root', 'zsh fast startup control', 'Bash', {
       command: `zsh -f -c ':'`,
-    }, { BASH_ENV: undefined, ENV: undefined, ZDOTDIR: undefined }).output).length !== 0) {
+    })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');


### PR DESCRIPTION
Bounded fixture repair for issue #3303 and Release smoke failure 30653123438. The packaged hook probe environment now scrubs inherited BASH_ENV, ENV, ZDOTDIR, GJC_*, TMUX, TMUX_PANE, OMX_*, CODEX_*, and NODE_OPTIONS before applying explicit probe overrides. Product trust logic and hostile startup tests are unchanged.

Local build, no-unused, lint, and diff checks pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*