### PR TITLE
fix(runtime): use full Darwin process info buffer

### DIFF
--- a/crates/omx-runtime/src/main.rs
+++ b/crates/omx-runtime/src/main.rs
@@ -413,65 +413,21 @@ fn read_linux_cmdline(pid: u32) -> Option<String> {
 // Darwin: proc_pidinfo with PROC_PIDTBSDINFO for pbi_start_tvsec/pbi_start_tvusec
 #[cfg(target_os = "macos")]
 fn process_identity(pid: u32) -> Result<ProcessIdentityResult, ProcessIdentityError> {
-    use std::ffi::c_int;
-
-    extern "C" {
-        fn proc_pidinfo(
-            pid: c_int,
-            flavor: c_int,
-            arg: u64,
-            buffer: *mut std::ffi::c_void,
-            buffersize: c_int,
-        ) -> c_int;
-    }
-
-    const PROC_PIDTBSDINFO: c_int = 3;
-    const PROC_PIDTBSDINFO_SIZE: c_int = std::mem::size_of::<ProcTaskBsdInfo>() as c_int;
-
-    // struct proc_bsdinfo (from libproc.h / proc_info.h):
-    //   pbi_name: [c_char; 16] (COMMLEN = 16)
-    //   pbi_pid: i32
-    //   pbi_ppid: i32
-    //   pbi_uid: uid_t (u32)
-    //   pbi_gid: gid_t (u32)
-    //   pbi_ruid: uid_t
-    //   pbi_rgid: gid_t
-    //   pbi_svuid: uid_t
-    //   pbi_svgid: gid_t
-    //   pbi_rfu: u32
-    //   pbi_flags: u32
-    //   pbi_start_tvsec: u64   ← birth seconds since epoch
-    //   pbi_start_tvusec: u64  ← birth microseconds
-    //   ... remaining fields not needed
-    #[repr(C)]
-    struct ProcTaskBsdInfo {
-        pbi_name: [std::ffi::c_char; 16],
-        pbi_pid: i32,
-        pbi_ppid: i32,
-        pbi_uid: u32,
-        pbi_gid: u32,
-        pbi_ruid: u32,
-        pbi_rgid: u32,
-        pbi_svuid: u32,
-        pbi_svgid: u32,
-        pbi_rfu: u32,
-        pbi_flags: u32,
-        pbi_start_tvsec: u64,
-        pbi_start_tvusec: u64,
-    }
-
-    let mut buf: ProcTaskBsdInfo = unsafe { std::mem::zeroed() };
-    let ret = unsafe {
-        proc_pidinfo(
-            pid as c_int,
-            PROC_PIDTBSDINFO,
+    // Use libc's maintained Darwin ABI definition instead of a partial local
+    // prefix. PROC_PIDTBSDINFO requires a full proc_bsdinfo-sized buffer.
+    let mut process_info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let buffer_size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    let bytes_read = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
             0,
-            &mut buf as *mut _ as *mut std::ffi::c_void,
-            PROC_PIDTBSDINFO_SIZE,
+            &mut process_info as *mut _ as *mut libc::c_void,
+            buffer_size,
         )
     };
 
-    if ret <= 0 {
+    if bytes_read <= 0 {
         let errno_val = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
         return match errno_val {
             libc::EPERM | libc::EACCES => Err(ProcessIdentityError::Denied),
@@ -482,11 +438,19 @@ fn process_identity(pid: u32) -> Result<ProcessIdentityResult, ProcessIdentityEr
             ))),
         };
     }
+    if bytes_read != buffer_size {
+        return Err(ProcessIdentityError::Error(format!(
+            "proc_pidinfo(PROC_PIDTBSDINFO) returned {bytes_read} bytes; expected {buffer_size}"
+        )));
+    }
 
     // Birth is exact decimal string: seconds.microseconds since Unix epoch.
     // Two processes started in the same second will differ in microseconds
     // unless they genuinely started at the same microsecond instant.
-    let birth = format!("{}.{}", buf.pbi_start_tvsec, buf.pbi_start_tvusec);
+    let birth = format!(
+        "{}.{}",
+        process_info.pbi_start_tvsec, process_info.pbi_start_tvusec
+    );
 
     Ok(ProcessIdentityResult {
         platform: "darwin",

--- a/crates/omx-runtime/tests/execution.rs
+++ b/crates/omx-runtime/tests/execution.rs
@@ -590,7 +590,7 @@ mod fs_rename_no_replace_linux {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[test]
 fn process_identity_current_process_returns_identity() {
     let pid = std::process::id().to_string();
@@ -608,13 +608,37 @@ fn process_identity_current_process_returns_identity() {
     let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
 
     let platform = parsed["platform"].as_str().expect("platform string");
-    assert_eq!(platform, "linux");
+    let expected_platform = if cfg!(target_os = "macos") {
+        "darwin"
+    } else if cfg!(target_os = "windows") {
+        "win32"
+    } else {
+        "linux"
+    };
+    assert_eq!(platform, expected_platform);
     let birth = parsed["birth"].as_str().expect("birth string");
     assert!(!birth.is_empty(), "birth must not be empty");
-    assert!(
-        birth.chars().all(|character| character.is_ascii_digit()),
-        "birth must be a decimal string: {birth}"
-    );
+    if cfg!(target_os = "macos") {
+        let (seconds, microseconds) = birth
+            .split_once('.')
+            .expect("darwin birth must contain seconds.microseconds");
+        assert!(
+            !seconds.is_empty() && seconds.chars().all(|character| character.is_ascii_digit()),
+            "darwin birth seconds must be decimal: {birth}"
+        );
+        assert!(
+            !microseconds.is_empty()
+                && microseconds
+                    .chars()
+                    .all(|character| character.is_ascii_digit()),
+            "darwin birth microseconds must be decimal: {birth}"
+        );
+    } else {
+        assert!(
+            birth.chars().all(|character| character.is_ascii_digit()),
+            "birth must be a decimal string: {birth}"
+        );
+    }
     if let Some(cmdline) = parsed.get("cmdline") {
         assert!(cmdline.is_string(), "cmdline must be a string when present");
     }


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

The Darwin `process-identity` provider passed `proc_pidinfo(PROC_PIDTBSDINFO)` a truncated, incorrectly laid-out local structure. macOS rejects that undersized buffer with `ENOMEM` (`errno=12`), so v0.20.4 cannot record process identity and fail-closed Stop finalization reports `session_pointer_unusable`.

This follow-up uses libc's maintained Darwin ABI definition and adds target-native regression coverage so the macOS CI job executes the provider rather than only compiling it.

## Changes

- Replace the handwritten partial `ProcTaskBsdInfo` and local FFI declaration with `libc::proc_bsdinfo`, `libc::PROC_PIDTBSDINFO`, and `libc::proc_pidinfo`.
- Require `proc_pidinfo` to return the complete `proc_bsdinfo` byte count before reading the process birth fields.
- Run the current-process identity integration test on Linux, macOS, and Windows, with platform-specific birth-format checks.

## Validation

- [x] `npm run build`
- [ ] `npm test` — attempted on macOS; existing failures in the BSD `script` attached-launch fixture and Linux-oriented session/setup fixtures reproduce on clean `upstream/dev` without this patch.
- [x] `omx doctor` — isolated Codex plugin v0.20.4 setup: 20 passed, 0 warnings
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p omx-runtime --bin omx-runtime -- -D warnings`
- [x] `cargo test -p omx-runtime` — 19 passed
- [x] Isolated Codex/OMX smoke: `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"` returned the exact response, exited 0, and retained no session pointer

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — not needed; the process-identity schema and CLI contract are unchanged
- [x] Backward-compatibility impact considered — this restores the intended v0.20.4 Darwin provider contract

## Related

Follow-up to #3365 and #3362.
