### PR TITLE
fix(hooks): allow ultragoal create-goals force (#3397)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -13870,6 +13870,7 @@ exit 0
 				await assertAllowed("omx auth nested help", "omx auth --help");
 				await assertBlocked("invalid state status spelling stays blocked", "omx state status --mode=deep-interview --json");
 
+
 				// #3314: sparkshell-wrapped read-only discovery must not be misclassified as a write.
 				await assertAllowed("sparkshell wrapped git status", "omx sparkshell -- git status --short --branch");
 				await assertAllowed("sparkshell nested help", "omx sparkshell --help");
@@ -33216,6 +33217,56 @@ PY`,
               { cwd },
             );
 
+            const assertCommandAllowed = async (command: string) => {
+              const commandResult = await dispatchCodexNativeHook(
+                {
+                  hook_event_name: "PreToolUse",
+                  cwd,
+                  session_id: sessionId,
+                  thread_id: leaderThreadId,
+                  agent_id: leaderThreadId,
+                  tool_name: "Bash",
+                  tool_use_id: `tool-3397-${Math.random()}`,
+                  tool_input: { command },
+                },
+                { cwd },
+              );
+              assert.equal(commandResult.outputJson, null, command);
+            };
+            const assertCommandBlocked = async (command: string) => {
+              const commandResult = await dispatchCodexNativeHook(
+                {
+                  hook_event_name: "PreToolUse",
+                  cwd,
+                  session_id: sessionId,
+                  thread_id: leaderThreadId,
+                  agent_id: leaderThreadId,
+                  tool_name: "Bash",
+                  tool_use_id: `tool-3397-${Math.random()}`,
+                  tool_input: { command },
+                },
+                { cwd },
+              );
+              assert.equal(commandResult.outputJson?.decision, "block", command);
+            };
+            await symlink(join(trustedPath.split(":", 1)[0] ?? "", "omx"), join(trustedPath.split(":", 1)[0] ?? "", "gjc"));
+            await assertCommandAllowed("gjc ultragoal create --brief 'Issue 3397' --force --json");
+            await assertCommandAllowed(
+              "omx ultragoal create-goals --brief 'Issue 3397' --goal 'Fix::Correct parser' --goal 'Verify::Run regressions' --codex-goal-mode aggregate --force --json",
+            );
+            for (const command of [
+              "omx ultragoal create-goals --brief 'Issue 3397' --force --force --json",
+              "omx ultragoal create-goals --brief 'Issue 3397' --force --unknown --json",
+              "omx ultragoal create-goals --brief-file brief.md --force --json",
+              "omx ultragoal create-goals --from-stdin --force --json",
+              "omx ultragoal create-goals 'Issue 3397' --force --json",
+              "omx ultragoal create-goals --brief \"$(printf Issue3397)\" --force --json",
+              "omx ultragoal create-goals --brief 'Issue 3397' --force --json > metadata.json",
+              "omx ultragoal create-goals --brief 'Issue 3397' --force --json && printf done",
+              "env NODE_OPTIONS=--require=./payload.cjs omx ultragoal create-goals --brief 'Issue 3397' --force --json",
+            ]) {
+              await assertCommandBlocked(command);
+            }
             assert.equal(result.outputJson, null);
           } finally {
             if (inheritedPath === undefined) delete process.env.PATH;

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -33255,6 +33255,7 @@ PY`,
               "omx ultragoal create-goals --brief 'Issue 3397' --goal 'Fix::Correct parser' --goal 'Verify::Run regressions' --codex-goal-mode aggregate --force --json",
             );
             for (const command of [
+              "omx ultragoal create-goals --brief 'Issue 3397' --json",
               "omx ultragoal create-goals --brief 'Issue 3397' --force --force --json",
               "omx ultragoal create-goals --brief 'Issue 3397' --force --unknown --json",
               "omx ultragoal create-goals --brief-file brief.md --force --json",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -16656,9 +16656,13 @@ function hasExactConductorOrchestrationOptionSchema(commandName: string, words: 
   const args = collectConductorInvocationWords(words, commandIndex);
   const command = shellWordLiteral(args[0] ?? "");
   const subcommand = shellWordLiteral(args[1] ?? "");
+  const isUltragoalCreate = command === "ultragoal" && (subcommand === "create" || subcommand === "create-goals");
   let permitted: Set<string>;
   let required: Set<string>;
-  if (command === "ultragoal" && subcommand === "steer") {
+  if (isUltragoalCreate) {
+    permitted = new Set(["--brief", "--goal", "--codex-goal-mode", "--force", "--json"]);
+    required = new Set(["--brief"]);
+  } else if (command === "ultragoal" && subcommand === "steer") {
     permitted = new Set(["--kind", "--target-goal-id", "--evidence", "--rationale", "--json"]);
     required = new Set(["--kind", "--target-goal-id", "--evidence", "--rationale"]);
   } else if (command === "ultragoal" && subcommand === "checkpoint") {
@@ -16677,13 +16681,15 @@ function hasExactConductorOrchestrationOptionSchema(commandName: string, words: 
     const raw = args[index] ?? "";
     const option = shellWordLiteral(raw);
     if (!option || !option.startsWith("--") || option === "--" || !conductorOrchestrationWordIsStatic(raw)) return false;
-    if (option === "--json") {
+    if (option === "--json" || (isUltragoalCreate && option === "--force")) {
       if (!permitted.has(option) || seen.has(option)) return false;
       seen.set(option, "");
       continue;
     }
     const name = option.split("=", 1)[0] ?? "";
-    if (!permitted.has(name) || seen.has(name)) return false;
+    if (!permitted.has(name)) return false;
+    const repeated = isUltragoalCreate && name === "--goal";
+    if (!repeated && seen.has(name)) return false;
     const rawValue = option.startsWith(`${name}=`) ? option.slice(name.length + 1) : args[index + 1] ?? "";
     const value = shellWordLiteral(rawValue);
     if (!value || !conductorOrchestrationWordIsStatic(rawValue) || shellWordMayProduceWgetOptions(value)) return false;
@@ -16691,6 +16697,10 @@ function hasExactConductorOrchestrationOptionSchema(commandName: string, words: 
     seen.set(name, value);
   }
   if (![...required].every((option) => seen.has(option))) return false;
+  if (isUltragoalCreate) {
+    const mode = seen.get("--codex-goal-mode");
+    return mode === undefined || new Set(["aggregate", "per-story"]).has(mode);
+  }
   const status = seen.get("--status");
   return status === undefined || new Set(["complete", "blocked", "failed", "in_progress"]).has(status);
 }
@@ -20390,6 +20400,15 @@ function isExactConductorMetadataRoot(cwd: string, target: string): boolean {
 }
 
   const shellMutations = extractConductorBashMutations(normalizedCommand, cwd, policyCwd);
+  if (
+    splitShellCommandSegments(normalizedCommand).length > 1
+    && shellMutations.some((mutation) => mutation.mainRootStructuredOrchestrationMutation)
+  ) {
+    return {
+      allowed: false,
+      blockedDetail: "Bash compound command cannot combine a Main-root Conductor orchestration mutation with another shell segment",
+    };
+  }
   if (shellMutations.length > 0) {
     for (const mutation of shellMutations) {
       if (mutation.mainRootStructuredStateWrite || mutation.mainRootStructuredOrchestrationMutation) continue;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -16661,7 +16661,7 @@ function hasExactConductorOrchestrationOptionSchema(commandName: string, words: 
   let required: Set<string>;
   if (isUltragoalCreate) {
     permitted = new Set(["--brief", "--goal", "--codex-goal-mode", "--force", "--json"]);
-    required = new Set(["--brief"]);
+    required = new Set(["--brief", "--force"]);
   } else if (command === "ultragoal" && subcommand === "steer") {
     permitted = new Set(["--kind", "--target-goal-id", "--evidence", "--rationale", "--json"]);
     required = new Set(["--kind", "--target-goal-id", "--evidence", "--rationale"]);


### PR DESCRIPTION
Status: implemented and verified in the dedicated issue worktree.

Evidence:
- Corrected `src/scripts/codex-native-hook.ts` so trusted same-session Main-root leader `omx`/`gjc` Ultragoal `create`/`create-goals` accepts one literal `--force` with literal `--brief`, repeated literal `--goal`, optional `--codex-goal-mode`, and optional `--json`.
- Preserved denial of duplicates, unknown options, `--brief-file`, `--from-stdin`, positional input, dynamic expansions, redirects/chaining, unsafe wrappers, impostor executables, child/descendant callers, mismatched identity, and unrelated writes.
- Added focused regressions in `src/scripts/__tests__/codex-native-hook.test.ts`.
- Worktree: `/mnt/offloading/Workspace/oh-my-codex-issue-3397-native-ultragoal-metadata`
- Branch: `fix/issue-3397-create-goals-force`, tracking `origin/dev`.
- Verification passed: `npm run build`; focused native hook test (640/640); `npm run lint`; `npm run check:no-unused`; `git diff --check`.
- Ultragoal final-aggregate receipt: `7e045aaa531630a7eb069b88c32c264bf5e113d6d6cbbc05de43b15b2a49c3e2`.
- RALPLAN pending approval artifact: `.gjc/_session-019fbc37-4011-7000-b016-4e5b031b7032/plans/ralplan/ralplan-3397/pending-approval.md`.
- No PR exists for this head; this issue comment is the single terminal GitHub receipt. No merge, release, publication, or workflow-run alteration was performed.
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
