### PR TITLE
fix(test): provide Darwin launch fixture PTY

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -2712,16 +2712,20 @@ exit 0
           // Simulate a user tmux config that would retain the dead leader pane.
           fixture.run(['set-option', '-g', 'remain-on-exit', remainOnExit]);
           const envPrefix = [
-            `HOME=${JSON.stringify(home)}`,
-            `PATH=${JSON.stringify(bin)}:$PATH`,
-            'OMX_AUTO_UPDATE=0',
-            'OMX_NOTIFY_FALLBACK=0',
-            'OMX_HOOK_DERIVED_SIGNALS=0',
-            'TERM=xterm-256color',
-          ].map((kv) => `export ${kv}`).join('; ');
-          const ptyCommand = buildPtyScriptCommand(
-            `${envPrefix}; cd ${JSON.stringify(wd)} && exec ${JSON.stringify(process.execPath)} ${JSON.stringify(omxBin)} --tmux ${JSON.stringify('e2e prompt')}`,
-          );
+            'unset TMUX TMUX_PANE',
+            `export HOME=${JSON.stringify(home)}`,
+            `export PATH=${JSON.stringify(bin)}:$PATH`,
+            'export OMX_AUTO_UPDATE=0',
+            'export OMX_NOTIFY_FALLBACK=0',
+            'export OMX_HOOK_DERIVED_SIGNALS=0',
+            'export TERM=xterm-256color',
+          ].join('; ');
+          const command = `${envPrefix}; cd ${JSON.stringify(wd)} && exec ${JSON.stringify(process.execPath)} ${JSON.stringify(omxBin)} --tmux ${JSON.stringify('e2e prompt')}`;
+          if (process.platform === 'darwin') {
+            const result = fixture.runPtyResult(command);
+            return { status: result.status, output: `${result.stdout}\n${result.stderr}\n${result.error}` };
+          }
+          const ptyCommand = buildPtyScriptCommand(command);
           const result = spawnSync(
             ptyCommand.executable,
             ptyCommand.args,

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -303,21 +303,23 @@ describe('runPtyResult failure contracts', () => {
     assert.equal(calls.at(-1)?.[0], 'kill-pane');
   });
 
-  it('surfaces capture failure without losing the child status', () => {
+  it('rejects capture failure from status alone without losing the child status', () => {
     const { result } = runWithDisplayState('1 7', {
-      'capture-pane': { status: 1, stdout: '', stderr: 'capture failed', error: 'capture failed' },
+      'capture-pane': { status: 1, stdout: '', stderr: 'capture status only', error: '' },
     });
     assert.equal(result.status, 7);
-    assert.match(result.error, /capture failed/);
-    assert.equal(result.stderr, 'capture failed');
+    assert.match(result.error, /capture-pane failed with status 1/);
+    assert.match(result.error, /capture status only/);
+    assert.equal(result.stderr, 'capture status only');
   });
 
-  it('surfaces cleanup failure after a successful child exit', () => {
+  it('rejects cleanup failure from status alone after a successful child exit', () => {
     const { result } = runWithDisplayState('1 0', {
-      'kill-pane': { status: 1, stdout: '', stderr: 'cleanup failed', error: 'cleanup failed' },
+      'kill-pane': { status: 1, stdout: '', stderr: 'cleanup status only', error: '' },
     });
     assert.equal(result.status, 0);
-    assert.match(result.error, /cleanup failed/);
-    assert.equal(result.stderr, 'cleanup failed');
+    assert.match(result.error, /kill-pane failed with status 1/);
+    assert.match(result.error, /cleanup status only/);
+    assert.equal(result.stderr, 'cleanup status only');
   });
 });

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, type TestContext } from 'node:test';
-import { buildPtyScriptCommand, isRealTmuxAvailable, tmuxSessionExists, withTempTmuxSession } from './tmux-test-fixture.js';
+import { buildPtyScriptCommand, isRealTmuxAvailable, runPtyResult, tmuxSessionExists, withTempTmuxSession } from './tmux-test-fixture.js';
 
 function skipUnlessTmux(t: TestContext): void {
   if (!isRealTmuxAvailable()) {
@@ -260,5 +260,64 @@ describe('buildPtyScriptCommand', () => {
       ? { executable: 'script', args: ['-q', '/dev/null', '/bin/sh', '-c', 'echo hi'] }
       : { executable: 'script', args: ['-q', '-e', '-c', 'echo hi', '/dev/null'] };
     assert.deepEqual(result, expected);
+  });
+});
+
+describe('runPtyResult failure contracts', () => {
+  function runWithDisplayState(
+    displayState: string,
+    resultOverrides: Record<string, { status: number | null; stdout: string; stderr: string; error: string }> = {},
+  ): { result: ReturnType<typeof runPtyResult>; calls: string[][] } {
+    const calls: string[][] = [];
+    const result = runPtyResult('echo hi', {
+      platform: 'darwin',
+      syntheticServer: true,
+      sessionName: 'omx-test-fixture',
+      pollLimit: 1,
+      sleep: () => undefined,
+      run: (args) => {
+        calls.push(args);
+        if (args[0] === 'new-window') return '%99';
+        if (args[0] === 'display-message') return displayState;
+        return '';
+      },
+      runResult: (args) => {
+        calls.push(args);
+        return resultOverrides[args[0]] ?? { status: 0, stdout: '', stderr: '', error: '' };
+      },
+    });
+    return { result, calls };
+  }
+
+  it('reports malformed pane status and still attempts capture and cleanup', () => {
+    const { result, calls } = runWithDisplayState('1 malformed');
+    assert.equal(result.status, null);
+    assert.match(result.error, /PTY command did not exit: 1 malformed/);
+    assert.deepEqual(calls.slice(-2).map(([command]) => command), ['capture-pane', 'kill-pane']);
+  });
+
+  it('reports missing pane status after the bounded poll and still cleans up', () => {
+    const { result, calls } = runWithDisplayState('');
+    assert.equal(result.status, null);
+    assert.match(result.error, /PTY command did not exit/);
+    assert.equal(calls.at(-1)?.[0], 'kill-pane');
+  });
+
+  it('surfaces capture failure without losing the child status', () => {
+    const { result } = runWithDisplayState('1 7', {
+      'capture-pane': { status: 1, stdout: '', stderr: 'capture failed', error: 'capture failed' },
+    });
+    assert.equal(result.status, 7);
+    assert.match(result.error, /capture failed/);
+    assert.equal(result.stderr, 'capture failed');
+  });
+
+  it('surfaces cleanup failure after a successful child exit', () => {
+    const { result } = runWithDisplayState('1 0', {
+      'kill-pane': { status: 1, stdout: '', stderr: 'cleanup failed', error: 'cleanup failed' },
+    });
+    assert.equal(result.status, 0);
+    assert.match(result.error, /cleanup failed/);
+    assert.equal(result.stderr, 'cleanup failed');
   });
 });

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -200,6 +200,76 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+export interface PtyCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error: string;
+}
+
+interface PtyCommandRunner {
+  run: (args: string[]) => string;
+  runResult: (args: string[]) => { status: number | null; stdout: string; stderr: string; error: string };
+  sleep?: () => void;
+}
+
+export function runPtyResult(
+  command: string,
+  options: PtyCommandRunner & {
+    platform?: NodeJS.Platform;
+    syntheticServer?: boolean;
+    sessionName: string;
+    pollLimit?: number;
+  },
+): PtyCommandResult {
+  if ((options.platform ?? process.platform) !== 'darwin') {
+    throw new Error('runPtyResult is only supported on Darwin');
+  }
+  if (options.syntheticServer !== true) {
+    throw new Error('runPtyResult requires a private synthetic tmux server');
+  }
+  options.run(['set-option', '-g', 'remain-on-exit', 'on']);
+  const ptyCommand = buildPtyScriptCommand(command, 'darwin');
+  const paneId = options.run([
+    'new-window',
+    '-d',
+    '-P',
+    '-F',
+    '#{pane_id}',
+    '-t',
+    options.sessionName,
+    ...[ptyCommand.executable, ...ptyCommand.args].map(shellQuote),
+  ]);
+  let status: number | null = null;
+  let state = '';
+  for (let attempt = 0; attempt < (options.pollLimit ?? 240); attempt += 1) {
+    state = options.run(['display-message', '-p', '-t', paneId, '#{pane_dead} #{pane_exit_status}']);
+    const [dead, exitStatus] = state.split(/\s+/, 2);
+    if (dead === '1') {
+      status = /^-?\d+$/.test(exitStatus ?? '') ? Number(exitStatus) : null;
+      break;
+    }
+    options.sleep?.();
+  }
+  const outputResult = options.runResult(['capture-pane', '-p', '-t', paneId, '-S', '-']);
+  const cleanupResult = options.runResult(['kill-pane', '-t', paneId]);
+  const errors = [outputResult.error, cleanupResult.error].filter(Boolean).join('; ');
+  if (status === null) {
+    return {
+      status: null,
+      stdout: outputResult.stdout,
+      stderr: outputResult.stderr || cleanupResult.stderr,
+      error: [`PTY command did not exit: ${state}`, errors].filter(Boolean).join('; '),
+    };
+  }
+  return {
+    status,
+    stdout: outputResult.stdout,
+    stderr: outputResult.stderr || cleanupResult.stderr,
+    error: errors,
+  };
+}
+
 export async function withTempTmuxSession<T>(
   optionsOrFn: TempTmuxSessionOptions | ((fixture: TempTmuxSessionFixture) => Promise<T> | T),
   maybeFn?: (fixture: TempTmuxSessionFixture) => Promise<T> | T,
@@ -241,53 +311,14 @@ export async function withTempTmuxSession<T>(
     runTmux(['set-environment', '-g', 'PATH', `${directory}${delimiter}${process.env.PATH ?? ''}`], tmuxOptions);
     return shimPath;
   };
-  const runPtyResult = (command: string): { status: number | null; stdout: string; stderr: string; error: string } => {
-    if (process.platform !== 'darwin') {
-      throw new Error('runPtyResult is only supported on Darwin');
-    }
-    if (serverKind !== 'synthetic') {
-      throw new Error('runPtyResult requires a private synthetic tmux server');
-    }
-    runTmux(['set-option', '-g', 'remain-on-exit', 'on'], tmuxOptions);
-    const ptyCommand = buildPtyScriptCommand(command, 'darwin');
-    const paneId = runTmux([
-      'new-window',
-      '-d',
-      '-P',
-      '-F',
-      '#{pane_id}',
-      '-t',
-      sessionName,
-      ...[ptyCommand.executable, ...ptyCommand.args].map(shellQuote),
-    ], tmuxOptions);
-    let status: number | null = null;
-    let state = '';
-    for (let attempt = 0; attempt < 240; attempt += 1) {
-      state = runTmux(['display-message', '-p', '-t', paneId, '#{pane_dead} #{pane_exit_status}'], tmuxOptions);
-      const [dead, exitStatus] = state.split(/\s+/, 2);
-      if (dead === '1') {
-        status = /^-?\d+$/.test(exitStatus ?? '') ? Number(exitStatus) : null;
-        break;
-      }
-      spawnSync('sleep', ['0.05'], { stdio: 'ignore' });
-    }
-    const outputResult = runTmuxResult(['capture-pane', '-p', '-t', paneId, '-S', '-'], tmuxOptions);
-    const cleanupResult = runTmuxResult(['kill-pane', '-t', paneId], tmuxOptions);
-    if (status === null) {
-      return {
-        status: null,
-        stdout: outputResult.stdout,
-        stderr: outputResult.stderr || cleanupResult.stderr,
-        error: `PTY command did not exit: ${state}`,
-      };
-    }
-    return {
-      status,
-      stdout: outputResult.stdout,
-      stderr: outputResult.stderr || cleanupResult.stderr,
-      error: outputResult.error || cleanupResult.error,
-    };
-  };
+  const runPtyCommandResult = (command: string): PtyCommandResult => runPtyResult(command, {
+    platform: process.platform,
+    syntheticServer: serverKind === 'synthetic',
+    sessionName,
+    run: (args) => runTmux(args, tmuxOptions),
+    runResult: (args) => runTmuxResult(args, tmuxOptions),
+    sleep: () => spawnSync('sleep', ['0.05'], { stdio: 'ignore' }),
+  });
   const triggerClientResize = (
     targetSession: string,
     geometry: { rows?: number; cols?: number } = {},
@@ -381,7 +412,7 @@ export async function withTempTmuxSession<T>(
     sessionExists: (targetSessionName = sessionName) => tmuxSessionExists(targetSessionName, serverName || undefined),
     run: (args) => runTmux(args, tmuxOptions),
     runResult: (args) => runTmuxResult(args, tmuxOptions),
-    runPtyResult,
+    runPtyResult: runPtyCommandResult,
     createPathShim,
     triggerClientResize,
     serverLogPath,

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -26,6 +26,7 @@ export interface TempTmuxSessionFixture {
   sessionExists: (targetSessionName?: string) => boolean;
   run: (args: string[]) => string;
   runResult: (args: string[]) => { status: number | null; stdout: string; stderr: string; error: string };
+  runPtyResult: (command: string) => { status: number | null; stdout: string; stderr: string; error: string };
   createPathShim: (directory: string, commandLogPath?: string) => Promise<string>;
   triggerClientResize: (
     targetSession: string,
@@ -240,6 +241,53 @@ export async function withTempTmuxSession<T>(
     runTmux(['set-environment', '-g', 'PATH', `${directory}${delimiter}${process.env.PATH ?? ''}`], tmuxOptions);
     return shimPath;
   };
+  const runPtyResult = (command: string): { status: number | null; stdout: string; stderr: string; error: string } => {
+    if (process.platform !== 'darwin') {
+      throw new Error('runPtyResult is only supported on Darwin');
+    }
+    if (serverKind !== 'synthetic') {
+      throw new Error('runPtyResult requires a private synthetic tmux server');
+    }
+    runTmux(['set-option', '-g', 'remain-on-exit', 'on'], tmuxOptions);
+    const ptyCommand = buildPtyScriptCommand(command, 'darwin');
+    const paneId = runTmux([
+      'new-window',
+      '-d',
+      '-P',
+      '-F',
+      '#{pane_id}',
+      '-t',
+      sessionName,
+      ...[ptyCommand.executable, ...ptyCommand.args].map(shellQuote),
+    ], tmuxOptions);
+    let status: number | null = null;
+    let state = '';
+    for (let attempt = 0; attempt < 240; attempt += 1) {
+      state = runTmux(['display-message', '-p', '-t', paneId, '#{pane_dead} #{pane_exit_status}'], tmuxOptions);
+      const [dead, exitStatus] = state.split(/\s+/, 2);
+      if (dead === '1') {
+        status = /^-?\d+$/.test(exitStatus ?? '') ? Number(exitStatus) : null;
+        break;
+      }
+      spawnSync('sleep', ['0.05'], { stdio: 'ignore' });
+    }
+    const outputResult = runTmuxResult(['capture-pane', '-p', '-t', paneId, '-S', '-'], tmuxOptions);
+    const cleanupResult = runTmuxResult(['kill-pane', '-t', paneId], tmuxOptions);
+    if (status === null) {
+      return {
+        status: null,
+        stdout: outputResult.stdout,
+        stderr: outputResult.stderr || cleanupResult.stderr,
+        error: `PTY command did not exit: ${state}`,
+      };
+    }
+    return {
+      status,
+      stdout: outputResult.stdout,
+      stderr: outputResult.stderr || cleanupResult.stderr,
+      error: outputResult.error || cleanupResult.error,
+    };
+  };
   const triggerClientResize = (
     targetSession: string,
     geometry: { rows?: number; cols?: number } = {},
@@ -333,6 +381,7 @@ export async function withTempTmuxSession<T>(
     sessionExists: (targetSessionName = sessionName) => tmuxSessionExists(targetSessionName, serverName || undefined),
     run: (args) => runTmux(args, tmuxOptions),
     runResult: (args) => runTmuxResult(args, tmuxOptions),
+    runPtyResult,
     createPathShim,
     triggerClientResize,
     serverLogPath,

--- a/src/team/__tests__/tmux-test-fixture.ts
+++ b/src/team/__tests__/tmux-test-fixture.ts
@@ -213,6 +213,18 @@ interface PtyCommandRunner {
   sleep?: () => void;
 }
 
+function ptyRunnerFailure(
+  label: string,
+  result: { status: number | null; stderr: string; error: string },
+): string {
+  if (result.status === 0 && result.error === '') return '';
+  const detail = result.error || result.stderr;
+  if (result.status !== 0) {
+    return `${label} failed with status ${String(result.status)}${detail === '' ? '' : `: ${detail}`}`;
+  }
+  return `${label} failed${detail === '' ? '' : `: ${detail}`}`;
+}
+
 export function runPtyResult(
   command: string,
   options: PtyCommandRunner & {
@@ -253,7 +265,7 @@ export function runPtyResult(
   }
   const outputResult = options.runResult(['capture-pane', '-p', '-t', paneId, '-S', '-']);
   const cleanupResult = options.runResult(['kill-pane', '-t', paneId]);
-  const errors = [outputResult.error, cleanupResult.error].filter(Boolean).join('; ');
+  const errors = [ptyRunnerFailure('capture-pane', outputResult), ptyRunnerFailure('kill-pane', cleanupResult)].filter(Boolean).join('; ');
   if (status === null) {
     return {
       status: null,


### PR DESCRIPTION
## Summary
- run Darwin launch-fallback fixture commands inside the existing private tmux PTY
- preserve Linux util-linux script(1) argv and exact child-status assertions
- retain fixture cleanup and hostile/negative contracts

Closes #3398

## Verification
- npm run build
- npm run check:no-unused
- npm run lint
- node dist/scripts/run-test-files.js dist/team/__tests__/tmux-test-fixture.test.js
- node dist/scripts/run-test-files.js dist/cli/__tests__/launch-fallback.test.js
- git diff --check

macOS execution requires a Darwin host; Linux focused coverage passed in this worktree.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*