### PR TITLE
test(hooks): cover clean-PATH Deep-interview state writes

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -17144,8 +17144,7 @@ exit 0
 
 			const previousPath = process.env.PATH;
 			try {
-				// Keep only the active Node runtime plus system directories; omit workspace shims and ambient PATH entries.
-				process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
+				process.env.PATH = "/usr/bin:/bin";
 				const cleanPathCanonicalStateWrite = await preToolUse(
 					{
 						hook_event_name: "PreToolUse",
@@ -17154,7 +17153,7 @@ exit 0
 						tool_name: "Bash",
 						tool_use_id: "tool-di-clean-path-canonical-state-write",
 						tool_input: {
-							command: `env FOO=bar node dist/cli/omx.js state write --input ${safeStateWriteInput} --json`,
+							command: `env FOO=bar ${JSON.stringify(process.execPath)} dist/cli/omx.js state write --input ${safeStateWriteInput} --json`,
 						},
 					},
 					{ cwd },

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -17142,6 +17142,59 @@ exit 0
 				);
 			}
 
+			const previousPath = process.env.PATH;
+			try {
+				process.env.PATH = "/usr/bin:/bin";
+				const cleanPathCanonicalStateWrite = await preToolUse(
+					{
+						hook_event_name: "PreToolUse",
+						cwd,
+						session_id: "sess-di-artifact",
+						tool_name: "Bash",
+						tool_use_id: "tool-di-clean-path-canonical-state-write",
+						tool_input: {
+							command: `env FOO=bar node dist/cli/omx.js state write --input ${safeStateWriteInput} --json`,
+						},
+					},
+					{ cwd },
+				);
+				assert.equal(cleanPathCanonicalStateWrite.outputJson, null, "canonical clean-PATH state write should reach backend validation");
+				const cleanPathReadOnlyInspection = await preToolUse(
+					{
+						hook_event_name: "PreToolUse",
+						cwd,
+						session_id: "sess-di-artifact",
+						tool_name: "Bash",
+						tool_use_id: "tool-di-clean-path-read-only-inspection",
+						tool_input: {
+							command: "sed -n '1,20p' src/runtime.ts; perl -ne 'print if $. < 3' src/runtime.ts",
+						},
+					},
+					{ cwd },
+				);
+				assert.equal(cleanPathReadOnlyInspection.outputJson, null, "sed/perl inspection should remain read-only under clean PATH");
+				for (const [toolUseId, command] of [
+					["tool-di-clean-path-sed-mutation", "sed -Ei 's/old/new/' src/runtime.ts"],
+					["tool-di-clean-path-perl-mutation", "perl -0pi -e 's/old/new/' src/runtime.ts"],
+				] as const) {
+					const cleanPathMutation = await preToolUse(
+						{
+							hook_event_name: "PreToolUse",
+							cwd,
+							session_id: "sess-di-artifact",
+							tool_name: "Bash",
+							tool_use_id: toolUseId,
+							tool_input: { command },
+						},
+						{ cwd },
+					);
+					assert.equal(cleanPathMutation.outputJson?.decision, "block", command);
+				}
+			} finally {
+				if (previousPath === undefined) delete process.env.PATH;
+				else process.env.PATH = previousPath;
+			}
+
 			const safeArtifactInputFile = join(
 				cwd,
 				".omx",

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -17144,7 +17144,8 @@ exit 0
 
 			const previousPath = process.env.PATH;
 			try {
-				process.env.PATH = "/usr/bin:/bin";
+				// Keep only the active Node runtime plus system directories; omit workspace shims and ambient PATH entries.
+				process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
 				const cleanPathCanonicalStateWrite = await preToolUse(
 					{
 						hook_event_name: "PreToolUse",


### PR DESCRIPTION
## Summary
- add an exact clean-system-PATH regression for the canonical authenticated leader Deep-interview state-write command
- independently assert sed/perl read-only inspection remains allowed while sed/perl in-place mutations remain denied
- preserve existing backend validation and fail-closed deny boundaries

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

Closes #3400

No merge, release, publish, or workflow changes are included. Adversarial review is required before any merge.