### PR TITLE
fix(windows): unblock lifecycle builds and native-hook setup

### DIFF
--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -3,6 +3,7 @@ import { constants } from "fs";
 import { copyFile, link, open, lstat, mkdir, readFile, rm, type FileHandle } from "fs/promises";
 import { dirname, isAbsolute, join, relative, sep } from "path";
 import {
+	syncDirectoryHandle,
 	syncRegularFile,
 	type RegularFileSyncOutcome,
 } from "../utils/file-durability.js";
@@ -48,10 +49,10 @@ function processIsAlive(pid: number): boolean {
 	}
 }
 
-async function fsyncDirectory(path: string): Promise<void> {
+async function fsyncDirectory(path: string, platform: NodeJS.Platform): Promise<void> {
 	const handle = await open(path, "r");
 	try {
-		await handle.sync();
+		await syncDirectoryHandle(handle, platform);
 	} finally {
 		await handle.close();
 	}
@@ -63,7 +64,7 @@ export function createNativeHookClaimJournalDurability(
 	return {
 		platform,
 		syncRegularFile: (handle) => syncRegularFile(handle, platform),
-		syncDirectory: fsyncDirectory,
+		syncDirectory: (path) => fsyncDirectory(path, platform),
 	};
 }
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -689,7 +689,14 @@ function nativeHookTransactionTopologyEqual(
 ): boolean {
 	return left.kind === "absent" || right.kind === "absent"
 		? left.kind === right.kind
-		: left.mode === right.mode;
+		: nativeHookTransactionModesEqual(left.mode, right.mode);
+}
+
+function nativeHookTransactionModesEqual(left: number, right: number): boolean {
+	if (process.platform !== "win32") return left === right;
+	// Windows only preserves the writable/read-only distinction for chmod modes.
+	// For example, a requested 0600 file is reported by lstat as 0666.
+	return Boolean(left & 0o222) === Boolean(right & 0o222);
 }
 
 function isMissingPathError(error: unknown): boolean {

--- a/src/scripts/__tests__/prepare-build.test.ts
+++ b/src/scripts/__tests__/prepare-build.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+test('prepare-build launches the lifecycle npm CLI through Node', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'omx-prepare-build-'));
+  const receiptPath = join(cwd, 'npm-receipt.json');
+  const npmCliPath = join(cwd, 'npm-cli.js');
+  const prepareBuildPath = join(process.cwd(), 'src', 'scripts', 'prepare-build.js');
+  const tscShim = join(
+    cwd,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsc.cmd' : 'tsc',
+  );
+
+  try {
+    mkdirSync(dirname(tscShim), { recursive: true });
+    writeFileSync(tscShim, 'fixture');
+    writeFileSync(
+      npmCliPath,
+      "import { writeFileSync } from 'node:fs';\n"
+        + "writeFileSync(process.env.OMX_PREPARE_RECEIPT, JSON.stringify({ argv: process.argv.slice(2) }));\n",
+    );
+
+    const result = spawnSync(process.execPath, [prepareBuildPath], {
+      cwd,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        npm_config_json: 'false',
+        npm_execpath: npmCliPath,
+        OMX_PREPARE_RECEIPT: receiptPath,
+      },
+    });
+
+    assert.equal(result.status, 0, `stderr=${result.stderr} stdout=${result.stdout}`);
+    assert.deepEqual(JSON.parse(readFileSync(receiptPath, 'utf-8')), {
+      argv: ['run', 'build'],
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/src/scripts/prepare-build.js
+++ b/src/scripts/prepare-build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { existsSync, rmSync } from 'node:fs';
-import { delimiter, join } from 'node:path';
+import { existsSync, realpathSync, rmSync } from 'node:fs';
+import { delimiter, dirname, isAbsolute, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const requiredDistFiles = [
@@ -12,14 +12,39 @@ if (requiredDistFiles.every((file) => existsSync(file))) {
   process.exit(0);
 }
 
-const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const tscBin = process.platform === 'win32'
   ? join(process.cwd(), 'node_modules', '.bin', 'tsc.cmd')
   : join(process.cwd(), 'node_modules', '.bin', 'tsc');
 const nodeModulesDir = join(process.cwd(), 'node_modules');
 
+function resolveNpmCommand() {
+  const candidates = [
+    process.env.npm_execpath,
+    process.platform === 'win32'
+      ? join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')
+      : undefined,
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (!isAbsolute(candidate)) continue;
+    try {
+      return {
+        command: realpathSync(process.execPath),
+        commandArgs: [realpathSync(candidate)],
+      };
+    } catch {
+      // Try the next trusted lifecycle/runtime-relative npm CLI candidate.
+    }
+  }
+  if (process.platform !== 'win32') {
+    return { command: 'npm', commandArgs: [] };
+  }
+  throw new Error('omx prepare: unable to resolve the npm CLI from npm_execpath or the Node runtime');
+}
+
+const npmCommand = resolveNpmCommand();
+
 function runNpm(args, env = process.env) {
-  return spawnSync(npmBin, args, {
+  return spawnSync(npmCommand.command, [...npmCommand.commandArgs, ...args], {
     cwd: process.cwd(),
     stdio: process.env.npm_config_json === 'true' ? ['inherit', 'ignore', 'inherit'] : 'inherit',
     env,
@@ -66,11 +91,7 @@ const pathWithLocalBins = [
   process.env.PATH ?? '',
 ].filter(Boolean).join(delimiter);
 
-const buildResult = spawnSync(npmBin, ['run', 'build'], {
-  cwd: process.cwd(),
-  stdio: process.env.npm_config_json === 'true' ? ['inherit', 'ignore', 'inherit'] : 'inherit',
-  env: { ...process.env, PATH: pathWithLocalBins },
-});
+const buildResult = runNpm(['run', 'build'], { ...process.env, PATH: pathWithLocalBins });
 exitOnFailure(buildResult, 'npm build');
 
 if (shouldCleanupBootstrappedDependencies) {

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import {
 	emitDegradedDurabilityWarning,
 	recordRegularFileSyncOutcome,
+	syncDirectoryHandle,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
 } from "../file-durability.js";
@@ -22,6 +23,29 @@ test("regular-file sync returns the Windows EPERM durability outcome", async () 
 test("regular-file sync returns synced after a successful sync", async () => {
 	assert.equal(await syncRegularFile({ sync: async () => {} }, "win32"), "synced");
 });
+
+test("directory sync tolerates Windows EPERM", async () => {
+	await assert.doesNotReject(
+		syncDirectoryHandle({ sync: async () => { throw errno("EPERM"); } }, "win32"),
+	);
+});
+
+test("directory sync succeeds when fsync is supported", async () => {
+	await assert.doesNotReject(syncDirectoryHandle({ sync: async () => {} }, "linux"));
+});
+
+for (const { description, platform, failure } of [
+	{ description: "Linux EPERM", platform: "linux", failure: errno("EPERM") },
+	{ description: "Windows EACCES", platform: "win32", failure: errno("EACCES") },
+	{ description: "Windows message-only EPERM", platform: "win32", failure: new Error("EPERM") },
+] as const) {
+	test(`directory sync preserves fatal error identity for ${description}`, async () => {
+		await assert.rejects(
+			syncDirectoryHandle({ sync: async () => { throw failure; } }, platform),
+			(error: unknown) => error === failure,
+		);
+	});
+}
 
 for (const { description, platform, failure } of [
 	{ description: "Linux string EPERM", platform: "linux", failure: errno("EPERM") },

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -13,7 +13,7 @@ export interface RegularFileDurabilityTracker {
 	degraded: boolean;
 }
 
-function isUnsupportedWindowsRegularFileSync(
+function isUnsupportedWindowsSync(
 	error: unknown,
 	platform: NodeJS.Platform,
 ): boolean {
@@ -38,8 +38,23 @@ export async function syncRegularFile(
 		await handle.sync();
 		return "synced";
 	} catch (error) {
-		if (!isUnsupportedWindowsRegularFileSync(error, platform)) throw error;
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
 		return "unsupported-windows-eperm";
+	}
+}
+
+/**
+ * Windows does not support fsync for directory handles and reports EPERM.
+ * Preserve every other platform/error pair as fatal.
+ */
+export async function syncDirectoryHandle(
+	handle: Pick<FileHandle, "sync">,
+	platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+	try {
+		await handle.sync();
+	} catch (error) {
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
 	}
 }
 


### PR DESCRIPTION
## Summary

Windows source installs and updates were blocked in sequence by three POSIX assumptions: direct `npm.cmd` spawning returned `EINVAL`, directory-handle `fsync` returned `EPERM`, and fresh native-hook files requested as `0600` were reported by NTFS as `0666` and rejected as concurrent mutations.

## Changes

- Resolve the lifecycle-provided npm CLI to an absolute path and launch it through the current Node executable, with a Windows runtime-relative npm CLI fallback.
- Tolerate only structured `code === "EPERM"` from directory `fsync` on Windows; every other platform/error pair remains fatal.
- Compare native-hook modes on Windows by the writable/read-only distinction that Node and NTFS can represent, while keeping exact POSIX mode checks on other hosts.
- Add focused regression coverage for lifecycle npm invocation and Windows directory durability boundaries.

## Validation

- [x] `npm ci`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] `npm run prepack`
- [x] Focused tests: prepare-build 1/1, file-durability 13/13, native-hook claim journal 8/8, fresh Windows native-hook setup 1/1
- [x] Real Windows `omx setup --scope user --legacy`
- [x] `omx doctor`: 16 passed, 3 non-blocking warnings, 0 failed
- [ ] `npm test` — the unmodified `upstream/dev` baseline reproduces the same Windows failures in `package-bin-contract.test.js`, `setup-install-mode.test.js`, and `update.test.js`; `ask.test.js` also uses POSIX advisor stubs and is not a safe Windows full-suite gate. The changed-file and real setup paths above pass.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — not needed; this is an internal portability repair with no operator contract change
- [x] Backward-compatibility impact considered — POSIX behavior and non-EPERM failures remain unchanged

## Review

Independent OMX review completed:
- code-reviewer: APPROVE, 0 Critical/High/Medium/Low findings
- architect: WATCH, no merge blocker; only broader directory-only durability observability and optional fallback-branch coverage remain outside this focused repair
- code-simplifier: no-change; current diff is already the smallest clear boundary