### PR TITLE
test: build runtime for #3407 binding regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true});\" && tsc && node -e \"require('fs').chmodSync('dist/cli/omx.js', 0o755)\"",
     "build:explore": "cargo build -p omx-explore-harness",
+    "build:runtime": "cargo build -p omx-runtime",
     "build:full": "npm run build && npm run build:explore:release && npm run build:sparkshell && npm run build:api",
     "build:explore:release": "node dist/scripts/build-explore-harness.js",
     "check:no-unused": "tsc -p tsconfig.no-unused.json",
@@ -27,8 +28,8 @@
     "test:team:cross-rebase-smoke:compiled": "node dist/scripts/run-test-files.js dist/team/__tests__/cross-rebase-smoke.test.js",
     "test:team:worker-runtime-identity": "npm run build && npm run test:team:worker-runtime-identity:compiled",
     "test:team:worker-runtime-identity:compiled": "node dist/scripts/run-test-files.js dist/team/__tests__/worker-runtime-identity.test.js",
-    "test:recent-bug-regressions": "npm run build && npm run test:recent-bug-regressions:compiled",
-    "test:recent-bug-regressions:compiled": "node dist/scripts/run-test-files.js dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/launch-fallback.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/hardening-e2e.test.js",
+    "test:recent-bug-regressions": "npm run build && npm run build:runtime && npm run test:recent-bug-regressions:compiled",
+    "test:recent-bug-regressions:compiled": "node dist/scripts/run-test-files.js dist/hooks/__tests__/keyword-detector.test.js dist/scripts/__tests__/codex-native-hook.test.js dist/cli/__tests__/launch-fallback.test.js dist/hooks/__tests__/session.test.js dist/team/__tests__/runtime.test.js dist/team/__tests__/hardening-e2e.test.js",
     "test:plugin-boundaries:compiled": "node dist/scripts/run-test-files.js dist/cli/__tests__/codex-plugin-layout.test.js dist/cli/__tests__/package-bin-contract.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js dist/catalog/__tests__/plugin-bundle-ssot.test.js",
     "test:node": "node dist/scripts/run-test-files.js dist",
     "test:node:cross-platform": "npm run test:node",


### PR DESCRIPTION
Closes #3407

## Summary
- build omx-runtime before the recent bug regression harness
- include session binding tests in that compiled regression command
- ensure clean invocation exercises v2 process identity evidence without weakening retained binding or stale/recycled PID validation

## Verification
- degraded runtime-absent case reproduced and remained fail-closed
- runtime-present case passed with target/debug/omx-runtime
- npm run test:recent-bug-regressions passed (196 tests)
- focused stale-dead, foreign/mismatched lineage, changed-incarnation, and recycled/native replacement denial tests passed

No merge, release, or publish performed.