### PR TITLE
fix(hooks): allow trusted session lock inspect diagnostics (#3411)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -33332,6 +33332,113 @@ PY`,
       await rm(cwd, { recursive: true, force: true });
     }
   });
+  it("enforces the exact same-root session lock inspect grammar under ultragoal Conductor (#3411)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3411-lock-inspect-"));
+    const foreignCwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3411-foreign-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const sessionId = "sess-3411-lock-inspect";
+      const leaderThreadId = "thread-3411-lock-inspect";
+      await mkdir(join(cwd, ".git"), { recursive: true });
+      await writeNativeMappedSessionState(cwd, stateDir, sessionId, leaderThreadId, leaderThreadId);
+      await writeSessionSkillActiveState(stateDir, sessionId, "ultragoal", "planning");
+      await writeJson(join(stateDir, "sessions", sessionId, "ultragoal-state.json"), {
+        active: true,
+        mode: "ultragoal",
+        current_phase: "planning",
+        session_id: sessionId,
+        workingDirectory: cwd,
+      });
+
+      await withCleanAmbientNodeRuntimeEnvironment(async () => {
+        await withTrustedWorkspaceOmxCli(cwd, async (_omxCommand, trustedPath) => {
+          const runCommand = async (command: string, overrides: Record<string, unknown> = {}) => dispatchCodexNativeHook(
+            {
+              hook_event_name: "PreToolUse",
+              cwd,
+              session_id: sessionId,
+              thread_id: leaderThreadId,
+              agent_id: leaderThreadId,
+              tool_name: "Bash",
+              tool_use_id: `tool-3411-lock-inspect-${Math.random()}`,
+              tool_input: { command },
+              ...overrides,
+            },
+            { cwd },
+          );
+          const assertAllowed = async (command: string) => {
+            const result = await runCommand(command);
+            assert.equal(result.outputJson, null, `${command}: ${JSON.stringify(result)}`);
+          };
+          const assertBlocked = async (command: string, overrides?: Record<string, unknown>) => {
+            const result = await runCommand(command, overrides);
+            assert.equal(result.outputJson?.decision, "block", `${command} (policy cwd ${cwd}, foreign cwd ${foreignCwd}): ${JSON.stringify(result)}`);
+          };
+
+          const inheritedPath = process.env.PATH;
+          process.env.PATH = trustedPath;
+          try {
+            for (const command of [
+              "omx session lock inspect --json",
+              `omx session lock inspect --cwd ${cwd} --json`,
+              `omx session lock inspect --json --cwd=${cwd}`,
+              `omx session lock inspect --cwd=${cwd}`,
+            ]) await assertAllowed(command);
+
+            for (const command of [
+              `omx session lock inspect --cwd ${foreignCwd} --json`,
+              "omx session lock recover --json",
+              `omx session lock recover --cwd ${cwd} --json`,
+              "omx session lock inspect --unknown --json",
+              "omx session lock inspect --json --json",
+              `omx session lock inspect --cwd ${cwd} --cwd ${cwd} --json`,
+              "omx session lock inspect --cwd --json",
+              "omx session lock inspect --cwd= --json",
+              "omx session lock inspect positional --json",
+              "omx session lock inspect --cwd $(pwd) --json",
+              "omx session lock inspect --cwd `pwd` --json",
+              "omx session lock inspect --cwd $PWD --json",
+              "printf ready && omx session lock inspect --json",
+              "omx session lock inspect --json | cat",
+              "sh -c 'omx session lock inspect --json'",
+              "(omx session lock inspect --json)",
+            ]) await assertBlocked(command);
+
+            await assertBlocked(`omx session lock inspect --cwd ${cwd} --json`, {
+              session_id: "foreign-session",
+            });
+            await assertBlocked(`omx session lock inspect --cwd ${cwd} --json`, {
+              agent_id: "child-thread",
+              thread_id: "child-thread",
+            });
+
+            const attackerDir = await mkdtemp(join(tmpdir(), "omx-native-hook-3411-impostor-"));
+            try {
+              await writeFile(join(attackerDir, "omx"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+              process.env.PATH = `${attackerDir}:${trustedPath}`;
+              await assertBlocked("omx session lock inspect --json");
+            } finally {
+              await rm(attackerDir, { recursive: true, force: true });
+              process.env.PATH = trustedPath;
+            }
+
+            process.env.NODE_OPTIONS = "--require=./payload.cjs";
+            try {
+              await assertBlocked("omx session lock inspect --json");
+            } finally {
+              delete process.env.NODE_OPTIONS;
+            }
+          } finally {
+            if (inheritedPath === undefined) delete process.env.PATH;
+            else process.env.PATH = inheritedPath;
+          }
+        });
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(foreignCwd, { recursive: true, force: true });
+    }
+  });
   it("blocks an untrusted omx shim ahead of the trusted workspace CLI on PATH under ultragoal conductor planning (#3343)", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3343-untrusted-shim-"));
     try {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -5714,11 +5714,12 @@ function classifyPreToolUseMutationTransport(
     if (
       rawCommand === command
       && (isAllowedOmxReadOnlyCommand(command, cwd) || isAllowedGhReadOnlyCommand(command) || isAllowedVersionProbeCommand(command))
-    ) return "read-only";
+    ) return isAllowedOmxSessionLockInspectCommand(command, cwd) ? "bash" : "read-only";
     return rawCommand !== command
       || commandHasDeepInterviewWriteIntent(command, 0, cwd)
       || collectOmxStateCommandOperations(command, "write").length > 0
       || commandHasNestedCliMutationIntent(command)
+      || omxOrGjcReadOnlyShapeMatches(command)
       || classifyConductorExecutableRuntime(command, 0, cwd) !== null
       ? "bash"
       : "read-only";
@@ -10071,6 +10072,7 @@ function isAllowedOmxNestedHelpForm(args: readonly string[]): boolean {
 // untrusted binary, shell-function shadow, invalid state spelling, or unsafe
 // sparkshell mode.
 function omxOrGjcReadOnlyShapeMatches(command: string): boolean {
+  if (/^\s*(?:omx|gjc)\s+session\s+lock\s+(?:inspect|recover)(?:\s|$)/.test(command)) return true;
   if (!isSingleLiteralShellInvocation(command)) return false;
   const words = literalInvocationWords(command);
   const index = skipLiteralLeadingAssignments(words);
@@ -10082,7 +10084,48 @@ function omxOrGjcReadOnlyShapeMatches(command: string): boolean {
   if (args[0] === "help" || args[0] === "status" || args[0] === "version") return true;
   if (args[0] === "state" && ["read", "get-status", "status"].includes(args[1] ?? "")) return true;
   if (args[0] === "sparkshell") return true;
+  if (args[0] === "session" && args[1] === "lock" && (args[2] === "inspect" || args[2] === "recover")) return true;
   return args[0] === "cleanup" && args.includes("--dry-run");
+
+}
+
+function isAllowedOmxSessionLockInspectCommand(command: string, cwd: string): boolean {
+  if (!isSingleLiteralShellInvocation(command)) return false;
+  const words = literalInvocationWords(command);
+  const index = skipLiteralLeadingAssignments(words);
+  const commandName = commandNameFromShellWord(words[index] ?? "");
+  if (commandName !== "omx" && commandName !== "gjc") return false;
+  const args = words.slice(index + 1).filter(Boolean);
+  if (args[0] !== "session" || args[1] !== "lock" || args[2] !== "inspect") return false;
+
+  let sawJson = false;
+  let sawCwd = false;
+  for (let cursor = 3; cursor < args.length; cursor += 1) {
+    const arg = args[cursor] ?? "";
+    if (arg === "--json") {
+      if (sawJson) return false;
+      sawJson = true;
+      continue;
+    }
+    if (arg === "--cwd") {
+      if (sawCwd) return false;
+      const value = args[cursor + 1] ?? "";
+      if (!value || value.startsWith("-")) return false;
+      if (!sameFilePath(value, cwd)) return false;
+      sawCwd = true;
+      cursor += 1;
+      continue;
+    }
+    if (arg.startsWith("--cwd=")) {
+      if (sawCwd) return false;
+      const value = arg.slice("--cwd=".length);
+      if (!value || !sameFilePath(value, cwd)) return false;
+      sawCwd = true;
+      continue;
+    }
+    return false;
+  }
+  return true;
 }
 
 function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
@@ -10104,6 +10147,7 @@ function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
   if (args.length === 1 && (args[0] === "--help" || args[0] === "-h" || args[0] === "--version" || args[0] === "-v")) return true;
   if (args.length === 1 && (args[0] === "help" || args[0] === "status" || args[0] === "version")) return true;
   if (isAllowedOmxNestedHelpForm(args)) return true;
+  if (isAllowedOmxSessionLockInspectCommand(command, cwd)) return true;
   if (args[0] === "state" && OMX_STATE_READ_ONLY_OPERATIONS.has(args[1] ?? "")) {
     return stateReadTrailingArgsAreSafe(args.slice(2));
   }
@@ -20645,7 +20689,12 @@ export async function buildConductorPreToolUseWriteGuardOutput(
     } else if (mutationTransport !== "read-only") {
       const shellMutations = extractConductorBashMutations(command, cwd, policyCwd);
       const bashEvaluation = evaluateConductorBashWrite(cwd, command, 0, sessionId, policyCwd, rawCommand);
-      blocked = !bashEvaluation.allowed;
+      const recognizedOmxReadOnlyShape = omxOrGjcReadOnlyShapeMatches(command);
+      const trustedOmxReadOnly = isAllowedOmxReadOnlyCommand(command, policyCwd);
+      const trustedSessionLockInspect = trustedOmxReadOnly && isAllowedOmxSessionLockInspectCommand(command, policyCwd);
+      blocked = !trustedSessionLockInspect && (
+        !bashEvaluation.allowed || (recognizedOmxReadOnlyShape && !trustedOmxReadOnly)
+      );
       const canonicalStateCommand = canonicalizeOmxStateTransportCommand(command);
       const bashStateOperations = collectOmxStateCommandOperations(canonicalStateCommand, "write");
       if (bashStateOperations.length > 0) {


### PR DESCRIPTION
## Summary
- independently reproduced the active-Conductor denial for exact same-root trusted `omx session lock inspect`
- admit only the strict trusted inspect grammar while keeping recovery and malformed/untrusted forms denied
- add the exact grammar and adversarial regression matrix

## Verification
- `npm run build`
- focused native-hook test: 1 passed
- `npm run test:recent-bug-regressions`: 196 passed
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

Fixes #3411

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*