### PR TITLE
fix(version): fall back from invalid revision override

### DIFF
--- a/src/utils/__tests__/version.test.ts
+++ b/src/utils/__tests__/version.test.ts
@@ -41,6 +41,25 @@ describe('resolveOmxDisplayVersionSync', () => {
     });
   });
 
+  it('falls back to OMX_GIT_REVISION when OMX_VERSION_REVISION is invalid', async () => {
+    await withVersionFixture(async ({ packageRoot, stampPath }) => {
+      await writeFile(stampPath, JSON.stringify({
+        installed_version: '0.18.8',
+        setup_completed_version: '0.18.8',
+        install_channel: 'dev',
+      }, null, 2));
+
+      assert.equal(resolveOmxDisplayVersionSync({
+        packageRoot,
+        stampPath,
+        env: {
+          OMX_VERSION_REVISION: 'not-a-revision',
+          OMX_GIT_REVISION: 'abcdef1234567890',
+        },
+      }), 'v0.18.8-dev-abcdef123456');
+    });
+  });
+
 
 
   it('uses a dev base version from the install stamp when package.json lags the release baseline', async () => {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -69,7 +69,8 @@ export function resolveOmxDisplayVersionSync(options: {
   if (!version) return null;
 
   const env = options.env ?? process.env;
-  const explicitRevision = shortRevision(env.OMX_VERSION_REVISION || env.OMX_GIT_REVISION);
+  const explicitRevision = shortRevision(env.OMX_VERSION_REVISION)
+    ?? shortRevision(env.OMX_GIT_REVISION);
   const stamp = readInstallVersionMetadata(options.stampPath);
   const stampVersion = typeof stamp?.setup_completed_version === 'string'
     ? stripLeadingV(stamp.setup_completed_version)


### PR DESCRIPTION
## Summary

Development-version rendering accepts `OMX_VERSION_REVISION` and the legacy `OMX_GIT_REVISION` fallback. A non-empty but invalid primary value currently prevents a valid fallback revision from being considered, so the displayed version loses its commit suffix.

## Changes

- Validate each revision source independently and fall back to `OMX_GIT_REVISION` when the primary override is invalid.
- Add a regression test covering an invalid primary value with a valid fallback SHA.

## Validation

- [x] `npm run build`
- [ ] `npm test` (not run; the scoped utility suite was used)
- [ ] `omx doctor` (not applicable; setup/config behavior is unchanged)
- [x] `npm run lint`
- [x] `node dist/scripts/run-test-files.js dist/utils/__tests__` — 111 tests passed

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs reviewed; no update is needed for this internal fallback correction
- [x] Backward-compatibility impact considered
