### PR TITLE
fix: exclude derived run-state from mode enumeration

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -73,6 +73,7 @@ import {
   getBaseStateDir,
   getBaseStateDirWithSource,
   getStateDir,
+  isModeStateFilename,
   listModeStateFilesWithScopePreference,
   resolveWritableStateScope,
   type ModeStateFileRef,
@@ -5587,7 +5588,7 @@ export async function cleanupPostLaunchModeStateFiles(
     preserveSkillActiveForReviewPendingAutopilot ||= preserveReviewPendingAutopilot;
 
     for (const file of files) {
-      if (!file.endsWith("-state.json") || file === "session.json") continue;
+      if (!isModeStateFilename(file)) continue;
       const path = join(stateDir, file);
       const mode = file.slice(0, -"-state.json".length);
       const result = await readPostLaunchModeStateFile(path, dependencies);
@@ -7584,7 +7585,7 @@ async function listHookVisibleRunDirStateRefs(cwd: string): Promise<ModeStateFil
     for (const dir of candidateDirs) {
       const files = await readdir(dir).catch(() => [] as string[]);
       for (const file of files) {
-        if (!file.endsWith("-state.json") || file === "session.json") continue;
+        if (!isModeStateFilename(file)) continue;
         const path = join(dir, file);
         if (seenPaths.has(path)) continue;
         seenPaths.add(path);
@@ -7666,7 +7667,7 @@ async function selectAuthorizedHookVisibleRunDirState(cwd: string): Promise<Auth
   const refs: ModeStateFileRef[] = [];
   const stateFiles = await readdir(sessionDir).catch(() => [] as string[]);
   for (const file of stateFiles) {
-    if (!file.endsWith("-state.json") || file === "session.json") continue;
+    if (!isModeStateFilename(file)) continue;
     const path = join(sessionDir, file);
     try {
       const fileStat = lstatSync(path);
@@ -7977,7 +7978,7 @@ async function cancelModes(
 
     const preferredRefs: ModeStateFileRef[] = writableScope.source === "root"
       ? (await readdir(writableScope.stateDir).catch(() => [] as string[]))
-        .filter((file) => file.endsWith("-state.json") && file !== "session.json")
+        .filter((file) => isModeStateFilename(file))
         .map((file) => ({
           mode: file.slice(0, -"-state.json".length),
           path: join(writableScope.stateDir, file),

--- a/src/mcp/__tests__/hermes-bridge.test.ts
+++ b/src/mcp/__tests__/hermes-bridge.test.ts
@@ -81,6 +81,25 @@ describe("Hermes MCP bridge core", () => {
     }
   });
 
+  it("excludes derived run-state.json while listing genuine session modes", async () => {
+    const cwd = await tempWorkspace("omx-hermes-derived-run-state-");
+    try {
+      const sessionDir = join(cwd, ".omx", "state", "sessions", "sess-derived");
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(sessionDir, "run-state.json"), JSON.stringify({ active: true, mode: "run" }));
+      await writeFile(join(sessionDir, "ralph-state.json"), JSON.stringify({ active: true, mode: "ralph" }));
+
+      const result = await hermesListSessions({ workingDirectory: cwd });
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(result.data?.sessions, [
+        { session_id: "sess-derived", active: false, source: "session_state_dir", modes: ["ralph"] },
+      ]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
 
   it("projects status without leaking raw internal mode state", async () => {
     const cwd = await tempWorkspace("omx-hermes-status-");

--- a/src/mcp/hermes-bridge.ts
+++ b/src/mcp/hermes-bridge.ts
@@ -15,6 +15,7 @@ import type { QuestionAnswerEntry, QuestionRecord } from "../question/types.js";
 import {
   getAllSessionScopedStateDirs,
   getBaseStateDir,
+  isModeStateFilename,
   listModeStateFilesWithScopePreference,
   resolveWorkingDirectoryForState,
   validateSessionId,
@@ -288,7 +289,7 @@ async function listModeNamesInStateDir(stateDir: string): Promise<string[]> {
   if (!existsSync(stateDir)) return [];
   const entries = await readdir(stateDir, { withFileTypes: true }).catch(() => []);
   return entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith("-state.json"))
+    .filter((entry) => entry.isFile() && isModeStateFilename(entry.name))
     .map((entry) => entry.name.slice(0, -"-state.json".length))
     .sort();
 }

--- a/src/mcp/state-paths.ts
+++ b/src/mcp/state-paths.ts
@@ -980,7 +980,7 @@ export async function getAllScopedStateDirs(workingDirectory?: string): Promise<
 }
 
 export function isModeStateFilename(filename: string): boolean {
-  return filename.endsWith(STATE_FILE_SUFFIX) && filename !== 'session.json';
+  return filename.endsWith(STATE_FILE_SUFFIX) && filename !== 'session.json' && filename !== 'run-state.json';
 }
 
 async function listModeStateFilesInDir(dir: string, scope: StateFileScope): Promise<ModeStateFileRef[]> {

--- a/src/scripts/__tests__/notify-tmux-injection.test.ts
+++ b/src/scripts/__tests__/notify-tmux-injection.test.ts
@@ -79,4 +79,23 @@ describe('notify-hook tmux injection canonical skill gating', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it('ignores derived run-state.json when scanning active mode states', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-notify-tmux-derived-run-state-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'sess-derived-run-state';
+      await mkdir(join(stateDir, 'sessions', sessionId), { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({ session_id: sessionId, cwd: wd }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'run-state.json'), JSON.stringify({ active: true, mode: 'run' }, null, 2));
+      await writeFile(join(stateDir, 'sessions', sessionId, 'ralph-state.json'), JSON.stringify({ active: true, mode: 'ralph' }, null, 2));
+
+      const visible = await readVisibleAllowedModes(wd, stateDir, {}, ['ralph', 'run']);
+
+      assert.equal(visible.preferredMode, null);
+      assert.equal(visible.canonicalPresent, false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/scripts/__tests__/notify-tmux-injection.test.ts
+++ b/src/scripts/__tests__/notify-tmux-injection.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { readVisibleAllowedModes } from '../notify-hook/tmux-injection.js';
+import { isNotifyModeStateFilename, readVisibleAllowedModes } from '../notify-hook/tmux-injection.js';
 
 describe('notify-hook tmux injection canonical skill gating', () => {
   it('reads canonical skill-active state from authoritative team state root', async () => {
@@ -97,5 +97,11 @@ describe('notify-hook tmux injection canonical skill gating', () => {
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
+  });
+
+  it('filters only derived run-state while retaining genuine state filenames', () => {
+    assert.equal(isNotifyModeStateFilename('run-state.json'), false);
+    assert.equal(isNotifyModeStateFilename('ralph-state.json'), true);
+    assert.equal(isNotifyModeStateFilename('tmux-hook-state.json'), false);
   });
 });

--- a/src/scripts/notify-hook/tmux-injection.ts
+++ b/src/scripts/notify-hook/tmux-injection.ts
@@ -37,6 +37,10 @@ import {
 } from '../tmux-hook-engine.js';
 import type { ResolvedPromptTurnContext } from '../../hooks/prompt-session-provenance.js';
 
+export function isNotifyModeStateFilename(file: string): boolean {
+  return file.endsWith('-state.json') && file !== 'tmux-hook-state.json' && file !== 'run-state.json';
+}
+
 function isHudPaneStartCommand(startCommand: any): boolean {
   return /\bomx\b.*\bhud\b.*--watch/i.test(safeString(startCommand));
 }
@@ -483,7 +487,7 @@ export async function handleTmuxInjection({ payload, cwd, stateDir, logsDir, con
 
       const files = await readdir(scopedDir).catch(() => []);
       for (const file of files) {
-        if (!file.endsWith('-state.json') || file === 'tmux-hook-state.json') continue;
+        if (!isNotifyModeStateFilename(file)) continue;
         const path = join(scopedDir, file);
         const parsed = JSON.parse(await readFile(path, 'utf-8'));
         if (parsed && parsed.active) {

--- a/src/state/__tests__/operations.test.ts
+++ b/src/state/__tests__/operations.test.ts
@@ -961,6 +961,27 @@ describe('state operations directory initialization', () => {
     }
   });
 
+  it('excludes derived run-state.json from active mode enumeration while preserving genuine mode state files', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-derived-run-state-'));
+    try {
+      const sessionId = 'sess-derived-run-state';
+      const sessionDir = join(wd, '.omx', 'state', 'sessions', sessionId);
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(wd, '.omx', 'state', 'session.json'), JSON.stringify({ session_id: sessionId }, null, 2));
+      await writeFile(join(sessionDir, 'run-state.json'), JSON.stringify({ active: true, mode: 'derived' }, null, 2));
+      await writeFile(join(sessionDir, 'autopilot-state.json'), JSON.stringify({ active: true, current_phase: 'executing' }, null, 2));
+
+      const response = await executeStateOperation('state_list_active', {
+        workingDirectory: wd,
+        session_id: sessionId,
+      });
+
+      assert.deepEqual(response.payload, { active_modes: ['autopilot'] });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not list a mode active when terminal canonical visibility contradicts an active detail state', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-state-ops-terminal-canonical-wins-'));
     try {
@@ -1809,7 +1830,7 @@ describe('state operations directory initialization', () => {
 
         const beforeList = await executeStateOperation('state_list_active', { workingDirectory: wd });
         const beforeTeam = await executeStateOperation('state_read', { workingDirectory: wd, mode: 'team' });
-        assert.deepEqual(beforeList.payload, { active_modes: ['run'] });
+        assert.deepEqual(beforeList.payload, { active_modes: [] });
         assert.deepEqual(beforeTeam.payload, teamState);
 
         const response = await executeStateOperation('state_write', {
@@ -1832,7 +1853,7 @@ describe('state operations directory initialization', () => {
           foreignSkillState,
         );
         const afterList = await executeStateOperation('state_list_active', { workingDirectory: wd });
-        assert.deepEqual(afterList.payload, { active_modes: ['deep-interview', 'run'] });
+        assert.deepEqual(afterList.payload, { active_modes: ['deep-interview'] });
       } finally {
         await rm(wd, { recursive: true, force: true });
       }

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -667,7 +667,7 @@ export async function listStateStatuses(
     if (!existsSync(stateDir)) continue;
     const files = await readdir(stateDir);
     for (const file of files) {
-      if (!file.endsWith('-state.json')) continue;
+      if (!file.endsWith('-state.json') || file === 'run-state.json') continue;
       const currentMode = file.replace('-state.json', '');
       if (!mode && currentMode === SKILL_ACTIVE_STATE_MODE) continue;
       if (mode && currentMode !== mode) continue;


### PR DESCRIPTION
## Summary
- fix #3418 by excluding exact derived `run-state.json` from mode-state enumeration across shared operations and CLI root/session/detached/post-launch paths
- preserve all other `*-state.json` files and contradictory-mode validation
- add focused regression coverage

## Verification
- `npm run build`
- focused operations and CLI suites: 107 passing
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*