### PR TITLE
fix(hooks): silence identity-indeterminate Stop

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -30029,6 +30029,11 @@ PY`,
           },
         },
       });
+      const ralphStatePath = join(stateDir, "sessions", "sess-dead", "ralph-state.json");
+      const skillStatePath = join(stateDir, "skill-active-state.json");
+      const ralphStateBefore = await readFile(ralphStatePath, "utf-8");
+      const skillStateBefore = await readFile(skillStatePath, "utf-8");
+
       const nativeStopStateBefore = await readFile(nativeStopStatePath, "utf-8");
       const payload = {
         hook_event_name: "Stop" as const,
@@ -30047,11 +30052,12 @@ PY`,
       );
 
       assert.equal(first.omxEventName, "stop");
-      assert.equal(first.outputJson?.decision, "block");
-      assert.equal(first.outputJson?.stopReason, "session_pointer_unusable");
+      assert.equal(first.outputJson, null);
       assert.equal(replay.omxEventName, "stop");
       assert.equal(replay.outputJson, null);
       assert.equal(await readFile(nativeStopStatePath, "utf-8"), nativeStopStateBefore);
+      assert.equal(await readFile(ralphStatePath, "utf-8"), ralphStateBefore);
+      assert.equal(await readFile(skillStatePath, "utf-8"), skillStateBefore);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -23225,10 +23225,11 @@ export async function dispatchCodexNativeHook(
       const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
       const pointerCannotAuthorizeThisCwd = pointer.status === "foreign-cwd";
       const unmatchedStopSession = failure.stopReason === "session_scope_unmatched";
-      // An unmatched payload or foreign-cwd pointer cannot authorize continuation.
-      // Return no output so Codex cannot reinterpret an authorization diagnostic as
-      // a new action request. Other unusable pointers retain their bounded replay behavior.
-      if (pointerCannotAuthorizeThisCwd || unmatchedStopSession || stopHookActive) {
+      // An unmatched payload, foreign-cwd pointer, or identity-indeterminate pointer
+      // cannot authorize continuation. Return no output so Codex cannot reinterpret an
+      // authorization diagnostic as a new action request. Other unusable pointers retain
+      // their bounded replay behavior.
+      if (pointerCannotAuthorizeThisCwd || pointer.status === "identity-indeterminate" || unmatchedStopSession || stopHookActive) {
         outputJson = null;
       } else {
         outputJson = {


### PR DESCRIPTION
## Summary
- neutralize the first Stop response for `identity-indeterminate` session pointers so the diagnostic cannot become a repeated Codex App model turn
- preserve fail-closed behavior and leave malformed-pointer and authorization branches unchanged
- assert repeated Stop dispatch leaves native Stop, Ralph, and active-skill state untouched

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/codex-native-hook.test.js` (641 passed)
- `npm run check:no-unused`
- `npm run lint`
- `git diff --check`

Resolves #3420