### PR TITLE
fix(team): bind worker hook provenance

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -51,7 +51,7 @@ Setup-owned trust state is limited to those generated wrapper identities; user h
 | wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `omx_wiki/` summary when wiki pages exist; startup writes stay config-gated |
 | `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context for top-level prompts; native subagent prompt text is treated as delegated task text, so literal workflow keywords inside a child prompt do not activate nested workflow state; `$ralph` prompt routing seeds workflow state only and does not launch `omx ralph --prd ...` |
 | ultragoal bounded steering | `UserPromptSubmit` | `ultragoal` artifacts | native | Only explicit structured directives such as `OMX_ULTRAGOAL_STEER: { ... }`, `omx.ultragoal.steer: { ... }`, or `omx ultragoal steer: { ... }` are parsed; accepted/rejected/deduped attempts route through `steerUltragoal`, append `.omx/ultragoal/ledger.jsonl`, and add advisory context without changing keyword precedence |
-| `pre-tool-use` | `PreToolUse` | `pre-tool-use` | native-partial | Native behavior cautions on Bash `rm -rf dist`, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present only when explicitly opted in with `OMX_LORE_COMMIT_GUARD=1`, emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence, and blocks `close_agent` / parallel close cleanup before it starts when a fresh native subagent capacity blocker was recorded |
+| `pre-tool-use` | `PreToolUse` | `pre-tool-use` | native-partial | Native behavior cautions on Bash `rm -rf dist`, structurally classifies direct OMX subcommands instead of matching quoted prompt/search text, binds Team workers to their launched runtime capability and actual native session, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present only when explicitly opted in with `OMX_LORE_COMMIT_GUARD=1`, emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence, and blocks `close_agent` / parallel close cleanup before it starts when a fresh native subagent capacity blocker was recorded |
 | native `PreToolUse` stdout schema | `PreToolUse` | CLI stdout | native | Codex CLI 0.141.0 accepts only `systemMessage` for `PreToolUse`; the native CLI writer strips internal `decision`, `reason`, `stopReason`, `continue`, and `hookSpecificOutput` fields before stdout while preserving richer internal dispatch results for tests and non-stdout callers. |
 | `post-tool-use` | `PostToolUse` | `post-tool-use` | native-partial | Built-in Bash behavior covers command-not-found / permission-denied / missing-path guidance only from stderr or non-zero Bash results, ignores failure-looking strings from successful source/log reads, keeps MCP transport-death guidance scoped to MCP-like tool calls, and records a short-lived `.omx/state/native-subagent-capacity-blocker.json` when native subagent spawn/collab output reports `agent thread limit reached`; document-refresh commit warnings use PreToolUse advisory output, with PostToolUse reserved as a future fallback if Codex advisory semantics change |
 | Ralph/persistence stop handling | `Stop` | `stop` | native-partial | Native adapter uses the documented native Stop continuation contract (`decision: "block"` + `reason`) for active Ralph runs, emits a single JSON object on Stop stdout even for no-op Stop decisions, emits deterministic JSON continuation output if Stop dispatch fails before normal handling, no-ops immediately when the selected session pointer belongs to a foreign cwd or the Stop session is unmatched, and bounds other unusable session-pointer authorization failures to one diagnostic block per Stop replay chain so active Stop-hook replays no-op instead of looping forever |
@@ -104,9 +104,25 @@ raw-command matching.
 Official Team worker roots may omit both `agent_id` and legacy `thread_id`.
 After Main-root exclusion, OMX preserves their established exemption only when
 the Team environment agrees with the durable worker identity, Team config, and
-current worker pane recorded under the strictly resolved Team state root. A
-leader native-session match wins before this check, and a payload with any named
-unknown or foreign identity cannot borrow the Team exemption.
+current worker pane recorded under the strictly resolved Team state root. Each
+launch receives a random run-scoped worker capability; only its digest and its
+Team, worker, leader-session, leader-cwd, worker-cwd, shared-state-root, and Team
+lifecycle bindings are persisted in worker identity/config/manifest metadata.
+The worker's first authoritative `SessionStart` binds its actual native Codex
+session ID exactly once. Later writes require that bound ID plus the capability,
+pane, paths, and metadata to agree. The shared `OMX_TEAM_STATE_ROOT` remains
+leader-owned and does not require a detached worker to impersonate the leader
+cwd. Validated standalone worker API calls are limited to the current Team and
+worker; cross-Team payloads, protected workflow state, arbitrary state trees,
+shell compounds, dynamic input, and capability/session rebinding fail closed.
+A leader native-session match wins before this check, and a payload with any
+named unknown or foreign identity cannot borrow the Team exemption.
+
+Outside tmux, direct `omx team ...` and `node .../omx.js team ...` executable
+forms remain blocked with launch guidance. Classification is command-structural:
+quoted arguments, search patterns, heredoc bodies, and an `omx --tmux ...`
+bootstrap prompt may mention the same words without being treated as a direct
+Team invocation. The same structural rule applies to the native HUD guard.
 
 Known read-only MCP compatibility tools are governed by an explicit name contract,
 not a read-looking prefix heuristic. The audited contract covers filesystem/state

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -67,6 +67,7 @@ import {
 import { getBaseStateDir } from "../../state/paths.js";
 import { maybeNudgeLeaderForAllowedWorkerStop } from "../notify-hook/team-worker-stop.js";
 import { MAX_NATIVE_STDIN_JSON_BYTES } from "../hook-payload-guard.js";
+import { digestTeamWorkerCapabilityToken } from "../../team/worker-capability.js";
 
 
 const ARGUMENT_PRODUCING_RUNTIME_DENIAL_COMMANDS = [
@@ -436,6 +437,7 @@ async function configureAuthoritativeTeamWorker(
   cwd: string,
   teamName: string,
   workerPaneId = "%10",
+  workerCwd = cwd,
 ): Promise<void> {
   const stateRoot = join(cwd, ".omx", "state");
   await initTeamState(teamName, "session pointer ownership regression", "executor", 1, cwd, undefined, {
@@ -445,6 +447,10 @@ async function configureAuthoritativeTeamWorker(
     leaderPaneId: "%42",
     workerPaneIds: { "worker-1": workerPaneId },
   });
+  const initialConfig = JSON.parse(
+    await readFile(join(stateRoot, "team", teamName, "config.json"), "utf-8"),
+  ) as { created_at: string };
+  const issuedAt = "2026-08-02T00:00:00.000Z";
   for (const fileName of ["config.json", "manifest.v2.json"]) {
     const filePath = join(stateRoot, "team", teamName, fileName);
     const state = JSON.parse(await readFile(filePath, "utf-8")) as {
@@ -456,9 +462,23 @@ async function configureAuthoritativeTeamWorker(
     state.leader_cwd = cwd;
     state.workers = (state.workers ?? []).map((worker) => ({
       ...worker,
-      working_dir: cwd,
-      worktree_path: cwd,
+      working_dir: workerCwd,
+      worktree_path: workerCwd,
       team_state_root: stateRoot,
+      leader_cwd: cwd,
+      leader_session_id: "leader-session",
+      runtime_capability: {
+        version: 1,
+        team_name: teamName,
+        worker_name: "worker-1",
+        leader_session_id: "leader-session",
+        leader_cwd: cwd,
+        team_state_root: stateRoot,
+        worker_cwd: workerCwd,
+        team_created_at: initialConfig.created_at,
+        issued_at: issuedAt,
+        token_sha256: "c0b1ad20af38abb877cad30cab710e23733c63e6a8a38a6132ccb6264e78f50a",
+      },
     }));
     await writeJson(filePath, state);
   }
@@ -467,9 +487,23 @@ async function configureAuthoritativeTeamWorker(
     index: 1,
     role: "executor",
     pane_id: workerPaneId,
-    working_dir: cwd,
-    worktree_path: cwd,
+    working_dir: workerCwd,
+    worktree_path: workerCwd,
     team_state_root: stateRoot,
+    leader_cwd: cwd,
+    leader_session_id: "leader-session",
+    runtime_capability: {
+      version: 1,
+      team_name: teamName,
+      worker_name: "worker-1",
+      leader_session_id: "leader-session",
+      leader_cwd: cwd,
+      team_state_root: stateRoot,
+      worker_cwd: workerCwd,
+      team_created_at: initialConfig.created_at,
+      issued_at: issuedAt,
+      token_sha256: "c0b1ad20af38abb877cad30cab710e23733c63e6a8a38a6132ccb6264e78f50a",
+    },
   });
   process.env.TMUX = "1";
   process.env.TMUX_PANE = workerPaneId;
@@ -477,6 +511,7 @@ async function configureAuthoritativeTeamWorker(
   process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
   process.env.OMX_TEAM_STATE_ROOT = stateRoot;
   process.env.OMX_TEAM_LEADER_CWD = cwd;
+  process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
   process.env.OMX_SESSION_ID = "leader-session";
 }
 
@@ -763,6 +798,7 @@ const DEFAULT_AUTO_NUDGE_RESPONSE =
 const TEAM_ENV_KEYS = [
   "OMX_TEAM_WORKER",
   "OMX_TEAM_INTERNAL_WORKER",
+  "OMX_TEAM_WORKER_CAPABILITY",
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
   "OMX_TEAM_MODE",
@@ -5692,6 +5728,218 @@ PY`,
       assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), leaderPointerBefore);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds a registered Team worker native session before authorizing worker writes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-native-binding-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await writeSessionStart(cwd, "leader-session", {
+        nativeSessionId: "leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(cwd, "binding-team");
+      await writeSessionSkillActiveState(stateDir, "leader-session", "team", "team-exec");
+      await writeJson(join(stateDir, "sessions", "leader-session", "team-state.json"), {
+        active: true,
+        mode: "team",
+        current_phase: "team-exec",
+        team_name: "binding-team",
+        session_id: "leader-session",
+        workingDirectory: cwd,
+      });
+      const pointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-native-binding",
+      }, { cwd, sessionOwnerPid: process.pid });
+
+      const identityPath = join(stateDir, "team", "binding-team", "workers", "worker-1", "identity.json");
+      const boundIdentity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
+      assert.equal(boundIdentity.native_session_id, "worker-native-binding");
+      for (const fileName of ["config.json", "manifest.v2.json"]) {
+        const teamMetadata = JSON.parse(await readFile(
+          join(stateDir, "team", "binding-team", fileName),
+          "utf-8",
+        )) as { workers?: Array<{ name?: string; native_session_id?: string }> };
+        assert.equal(
+          teamMetadata.workers?.find((worker) => worker.name === "worker-1")?.native_session_id,
+          "worker-native-binding",
+          fileName,
+        );
+      }
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+
+      const sourceWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Edit",
+        tool_use_id: "tool-worker-native-binding-source",
+        tool_input: { file_path: "src/worker-owned.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(sourceWrite.outputJson, null);
+
+      const teamApiWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Bash",
+        tool_use_id: "tool-worker-native-binding-api",
+        tool_input: {
+          command: `omx team api send-message --input '{"team_name":"binding-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json`,
+        },
+      }, { cwd });
+      assert.equal(teamApiWrite.outputJson, null);
+
+      for (const [toolUseId, command] of [
+        ["claim", `omx team api claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`],
+        ["transition", `omx team api transition-task-status --input '{"team_name":"binding-team","task_id":"1","from":"in_progress","to":"completed","claim_token":"claim-token","result":"done"}' --json`],
+        ["mailbox", `omx team api mailbox-mark-delivered --input '{"team_name":"binding-team","worker":"worker-1","message_id":"message-1"}' --json`],
+      ] as const) {
+        const teamControlPlaneWrite = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "worker-native-binding",
+          tool_name: "Bash",
+          tool_use_id: `tool-worker-native-binding-${toolUseId}`,
+          tool_input: { command },
+        }, { cwd });
+        assert.equal(teamControlPlaneWrite.outputJson, null, toolUseId);
+      }
+
+      const crossTeamApiWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Bash",
+        tool_use_id: "tool-worker-native-binding-cross-team-api",
+        tool_input: {
+          command: `omx team api claim-task --input '{"team_name":"foreign-team","task_id":"1","worker":"worker-1"}' --json`,
+        },
+      }, { cwd });
+      assert.equal(crossTeamApiWrite.outputJson?.decision, "block");
+
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "wrong-worker-capability-token";
+      const wrongCapabilityWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Edit",
+        tool_use_id: "tool-worker-wrong-capability-source",
+        tool_input: { file_path: "src/wrong-capability.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(wrongCapabilityWrite.outputJson?.decision, "block");
+      assert.match(String(wrongCapabilityWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "forged-worker-native",
+      }, { cwd, sessionOwnerPid: process.pid });
+      const reboundIdentity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
+      assert.equal(reboundIdentity.native_session_id, "worker-native-binding");
+
+      const forgedWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "forged-worker-native",
+        tool_name: "Edit",
+        tool_use_id: "tool-forged-worker-native-source",
+        tool_input: { file_path: "src/forged.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(forgedWrite.outputJson?.decision, "block");
+      assert.match(String(forgedWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("waits for transactional startup metadata before binding a fast worker SessionStart", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-startup-race-"));
+    try {
+      const teamName = "startup-race-team";
+      const stateRoot = join(cwd, ".omx", "state");
+      process.env.TMUX = "1";
+      process.env.TMUX_PANE = "%10";
+      process.env.OMX_TEAM_INTERNAL_WORKER = `${teamName}/worker-1`;
+      process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
+      process.env.OMX_TEAM_STATE_ROOT = stateRoot;
+      process.env.OMX_TEAM_LEADER_CWD = cwd;
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
+      process.env.OMX_SESSION_ID = "leader-session";
+
+      const materialized = (async () => {
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 75));
+        await configureAuthoritativeTeamWorker(cwd, teamName);
+      })();
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-native-startup-race",
+      }, { cwd, sessionOwnerPid: process.pid });
+      await materialized;
+
+      const identity = JSON.parse(await readFile(
+        join(stateRoot, "team", teamName, "workers", "worker-1", "identity.json"),
+        "utf-8",
+      )) as { native_session_id?: string };
+      assert.equal(identity.native_session_id, "worker-native-startup-race");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds a registered detached-worktree worker and rejects an unregistered sibling checkout", async () => {
+    const leaderCwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-detached-binding-"));
+    try {
+      const workerCwd = join(leaderCwd, "registered-worker-checkout");
+      const foreignCwd = join(leaderCwd, "unregistered-worker-checkout");
+      await mkdir(workerCwd, { recursive: true });
+      await mkdir(foreignCwd, { recursive: true });
+      await writeSessionStart(leaderCwd, "leader-session", {
+        nativeSessionId: "leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(leaderCwd, "detached-binding-team", "%10", workerCwd);
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd: workerCwd,
+        session_id: "detached-worker-native",
+      }, { cwd: workerCwd, sessionOwnerPid: process.pid });
+
+      const registeredWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd: workerCwd,
+        session_id: "detached-worker-native",
+        tool_name: "Edit",
+        tool_input: { file_path: "src/registered.ts", old_string: "a", new_string: "b" },
+      }, { cwd: workerCwd });
+      assert.equal(registeredWrite.outputJson, null);
+
+      const foreignWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd: foreignCwd,
+        session_id: "detached-worker-native",
+        tool_name: "Edit",
+        tool_input: { file_path: "src/foreign.ts", old_string: "a", new_string: "b" },
+      }, { cwd: foreignCwd });
+      assert.equal(foreignWrite.outputJson?.decision, "block");
+      assert.match(String(foreignWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
+
+      const identity = JSON.parse(await readFile(
+        join(leaderCwd, ".omx", "state", "team", "detached-binding-team", "workers", "worker-1", "identity.json"),
+        "utf-8",
+      )) as { native_session_id?: string; worktree_path?: string };
+      assert.equal(identity.native_session_id, "detached-worker-native");
+      assert.equal(identity.worktree_path, workerCwd);
+    } finally {
+      await rm(leaderCwd, { recursive: true, force: true });
     }
   });
 
@@ -13075,6 +13323,56 @@ exit 0
 		}
 	});
 
+	it("allows an outside-tmux bootstrap when prompt text mentions the Team subcommand", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-native-hook-pretool-team-bootstrap-"),
+		);
+		try {
+			const result = await dispatchCodexNativeHook(
+				{
+					hook_event_name: "PreToolUse",
+					cwd,
+					source: "codex-app",
+					session_id: "sess-team-bootstrap",
+					tool_name: "Bash",
+					tool_use_id: "tool-team-bootstrap",
+					tool_input: {
+						command: `omx --tmux "After startup run omx team status durable-team"`,
+					},
+				},
+				{ cwd },
+			);
+
+			assert.equal(result.outputJson, null);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not classify read-only search text as a Team invocation", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-native-hook-pretool-team-search-text-"),
+		);
+		try {
+			const result = await dispatchCodexNativeHook(
+				{
+					hook_event_name: "PreToolUse",
+					cwd,
+					source: "codex-app",
+					session_id: "sess-team-search-text",
+					tool_name: "Bash",
+					tool_use_id: "tool-team-search-text",
+					tool_input: { command: `rg -n "omx team" src` },
+				},
+				{ cwd },
+			);
+
+			assert.equal(result.outputJson, null);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves direct CLI outside-tmux omx team Bash behavior", async () => {
 		const cwd = await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-team-cli-outside-"),
@@ -14774,21 +15072,41 @@ exit 0
 				stateRoot: process.env.OMX_TEAM_STATE_ROOT,
 				leaderCwd: process.env.OMX_TEAM_LEADER_CWD,
 				pane: process.env.TMUX_PANE,
+				capability: process.env.OMX_TEAM_WORKER_CAPABILITY,
 			};
 			try {
 				const teamName = "deep-state-guard";
 				const workerName = "worker-1";
 				const workerPane = "%77";
+				const workerCapabilityToken = "deep-state-guard-worker-1-capability";
+				const teamCreatedAt = "2026-08-02T00:00:00.000Z";
 				const teamRoot = join(stateDir, "team", teamName);
+				const workerCapability = (name: string, workerCwd: string, token: string) => ({
+					version: 1 as const,
+					team_name: teamName,
+					worker_name: name,
+					leader_session_id: "sess-di-artifact",
+					leader_cwd: cwd,
+					team_state_root: stateDir,
+					worker_cwd: workerCwd,
+					team_created_at: teamCreatedAt,
+					issued_at: teamCreatedAt,
+					token_sha256: digestTeamWorkerCapabilityToken(token),
+				});
 				await mkdir(join(teamRoot, "workers", workerName), { recursive: true });
 				await writeJson(join(teamRoot, "workers", workerName, "identity.json"), {
 					name: workerName,
 					team_state_root: stateDir,
 					pane_id: workerPane,
 					working_dir: cwd,
+					leader_cwd: cwd,
+					leader_session_id: "sess-di-artifact",
+					native_session_id: "sess-di-artifact",
+					runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken),
 				});
 				const teamAuthority = {
 					name: teamName,
+					created_at: teamCreatedAt,
 					leader_pane_id: "%1",
 					leader_cwd: cwd,
 					team_state_root: stateDir,
@@ -14797,6 +15115,10 @@ exit 0
 						pane_id: workerPane,
 						working_dir: cwd,
 						team_state_root: stateDir,
+						leader_cwd: cwd,
+						leader_session_id: "sess-di-artifact",
+						native_session_id: "sess-di-artifact",
+						runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken),
 					}],
 				};
 				await writeJson(join(teamRoot, "manifest.v2.json"), teamAuthority);
@@ -14806,6 +15128,7 @@ exit 0
 				process.env.OMX_TEAM_STATE_ROOT = stateDir;
 				process.env.OMX_TEAM_LEADER_CWD = cwd;
 				process.env.TMUX_PANE = workerPane;
+				process.env.OMX_TEAM_WORKER_CAPABILITY = workerCapabilityToken;
 				for (const [toolName, toolInput] of [
 					["mcp__omx_state__state_clear", { mode: "deep-interview" }],
 					["mcp__omx_state__state_write", { mode: "deep-interview", active: false, session_id: "sess-di-artifact", workingDirectory: cwd }],
@@ -14912,7 +15235,7 @@ exit 0
 					tool_input: { file_path: "src/runtime.ts", content: "export {};\n" },
 				}, { cwd });
 				assert.equal(canonicalIdentitylessLeader.outputJson?.decision, "block");
-				assert.match(String(canonicalIdentitylessLeader.outputJson?.reason ?? ""), /Deep-interview is active/);
+				assert.match(String(canonicalIdentitylessLeader.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
 
 				process.env.TMUX_PANE = "%foreign";
 				const mismatchedPaneWrite = await dispatchCodexNativeHook({
@@ -14924,12 +15247,12 @@ exit 0
 					tool_input: { file_path: "src/runtime.ts", content: "export {};\n" },
 				}, { cwd });
 				assert.equal(mismatchedPaneWrite.outputJson?.decision, "block");
-				assert.match(String(mismatchedPaneWrite.outputJson?.reason ?? ""), /OWNER_CONFIRMATION_REQUIRED/);
+				assert.match(String(mismatchedPaneWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
 				process.env.TMUX_PANE = workerPane;
 
 				for (const [name, path, invalidValue, restoreValue] of [
 					["config pane mismatch", join(teamRoot, "config.json"), { ...teamAuthority, workers: [{ ...teamAuthority.workers[0], pane_id: "%foreign" }] }, teamAuthority],
-					["identity root mismatch", join(teamRoot, "workers", workerName, "identity.json"), { name: workerName, pane_id: workerPane, team_state_root: join(cwd, "foreign-state"), working_dir: cwd }, { name: workerName, pane_id: workerPane, team_state_root: stateDir, working_dir: cwd }],
+					["identity root mismatch", join(teamRoot, "workers", workerName, "identity.json"), { name: workerName, pane_id: workerPane, team_state_root: join(cwd, "foreign-state"), working_dir: cwd, leader_cwd: cwd, leader_session_id: "sess-di-artifact", native_session_id: "sess-di-artifact", runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken) }, { name: workerName, pane_id: workerPane, team_state_root: stateDir, working_dir: cwd, leader_cwd: cwd, leader_session_id: "sess-di-artifact", native_session_id: "sess-di-artifact", runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken) }],
 					["config worktree mismatch", join(teamRoot, "config.json"), { ...teamAuthority, workers: [{ ...teamAuthority.workers[0], worktree_path: join(cwd, "foreign-worktree") }] }, teamAuthority],
 				] as const) {
 					await writeJson(path, invalidValue);
@@ -14948,6 +15271,7 @@ exit 0
 				const detachedWorkerName = "worker-2";
 				const detachedWorkerPane = "%78";
 				const detachedWorkerCwd = join(cwd, "worker-checkout");
+				const detachedWorkerCapabilityToken = "deep-state-guard-worker-2-capability";
 				await mkdir(join(teamRoot, "workers", detachedWorkerName), { recursive: true });
 				await mkdir(detachedWorkerCwd, { recursive: true });
 				await writeJson(join(teamRoot, "workers", detachedWorkerName, "identity.json"), {
@@ -14955,6 +15279,10 @@ exit 0
 					pane_id: detachedWorkerPane,
 					team_state_root: stateDir,
 					working_dir: detachedWorkerCwd,
+					leader_cwd: cwd,
+					leader_session_id: "sess-di-artifact",
+					native_session_id: "sess-di-artifact",
+					runtime_capability: workerCapability(detachedWorkerName, detachedWorkerCwd, detachedWorkerCapabilityToken),
 				});
 				const detachedAuthority = {
 					...teamAuthority,
@@ -14964,6 +15292,10 @@ exit 0
 						team_state_root: stateDir,
 						worktree_path: detachedWorkerCwd,
 						working_dir: detachedWorkerCwd,
+						leader_cwd: cwd,
+						leader_session_id: "sess-di-artifact",
+						native_session_id: "sess-di-artifact",
+						runtime_capability: workerCapability(detachedWorkerName, detachedWorkerCwd, detachedWorkerCapabilityToken),
 					}],
 				};
 				await writeJson(join(teamRoot, "config.json"), detachedAuthority);
@@ -14971,6 +15303,7 @@ exit 0
 				process.env.OMX_TEAM_WORKER = `deep-display/${detachedWorkerName}`;
 				process.env.OMX_TEAM_INTERNAL_WORKER = `${teamName}/${detachedWorkerName}`;
 				process.env.TMUX_PANE = detachedWorkerPane;
+				process.env.OMX_TEAM_WORKER_CAPABILITY = detachedWorkerCapabilityToken;
 				const detachedWorkerProductWrite = await dispatchCodexNativeHook({
 					hook_event_name: "PreToolUse",
 					cwd: detachedWorkerCwd,
@@ -15048,6 +15381,7 @@ exit 0
 					OMX_TEAM_INTERNAL_WORKER: previousTeamEnv.internalWorker,
 					OMX_TEAM_STATE_ROOT: previousTeamEnv.stateRoot,
 					OMX_TEAM_LEADER_CWD: previousTeamEnv.leaderCwd,
+					OMX_TEAM_WORKER_CAPABILITY: previousTeamEnv.capability,
 					TMUX_PANE: previousTeamEnv.pane,
 				})) {
 					if (value === undefined) delete process.env[key];

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -71,9 +71,16 @@ import {
   readTeamConfig,
   readTeamManifestV2,
   readTeamPhase,
+  saveTeamConfig,
+  writeWorkerIdentity,
   writeTeamLeaderAttention,
   writeTeamPhase,
+  type WorkerInfo,
 } from "../team/state.js";
+import {
+  capabilityTokenMatches,
+  TEAM_WORKER_CAPABILITY_ENV,
+} from "../team/worker-capability.js";
 import { parseTeamNoticeLedgerPrompt, reconcileTeamNoticeLedger } from "../team/notice-ledger.js";
 import {
   canonicalizeComparablePath,
@@ -2939,7 +2946,10 @@ function hasRawTeamWorkerDeclaration(): boolean {
     || safeString(process.env.OMX_TEAM_WORKER).trim() !== "";
 }
 
-async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> {
+async function hasAuthoritativeTeamWorkerContext(
+  cwd: string,
+  expectedNativeSessionId = "",
+): Promise<boolean> {
   const workerContext = readTeamWorkerEnvironment();
   if (!workerContext) return false;
 
@@ -2979,6 +2989,35 @@ async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> 
   if (safeString(identity.pane_id).trim() !== currentPaneId) return false;
   if (!pathMatches(identity.team_state_root, canonicalStateRoot)) return false;
   if (!pathMatches(identity.worktree_path ?? identity.working_dir, canonicalCwd)) return false;
+  const capabilityToken = safeString(process.env[TEAM_WORKER_CAPABILITY_ENV]).trim();
+  if (!capabilityToken) return false;
+  const capabilityMatches = (record: Record<string, unknown>): boolean => {
+    const capability = safeObject(record.runtime_capability);
+    if (Number(capability.version) !== 1) return false;
+    if (safeString(capability.team_name).trim() !== workerContext.teamName) return false;
+    if (safeString(capability.worker_name).trim() !== workerContext.workerName) return false;
+    if (safeString(capability.leader_session_id).trim() === "") return false;
+    if (safeString(capability.leader_session_id).trim() !== safeString(record.leader_session_id).trim()) return false;
+    if (safeString(capability.team_created_at).trim() !== safeString(config.created_at).trim()) return false;
+    if (safeString(capability.team_created_at).trim() !== safeString(manifest.created_at).trim()) return false;
+    if (!pathMatches(capability.team_state_root, canonicalStateRoot)) return false;
+    if (!pathMatches(capability.worker_cwd, canonicalCwd)) return false;
+    if (!pathMatches(capability.leader_cwd, canonicalLeaderCwd)) return false;
+    return capabilityTokenMatches(capabilityToken, safeString(capability.token_sha256));
+  };
+  if (![identity, manifestWorker, configWorker].every(capabilityMatches)) return false;
+  const identityCapability = safeObject(identity.runtime_capability);
+  for (const worker of [identity, manifestWorker, configWorker]) {
+    if (safeString(worker.leader_session_id).trim() !== safeString(identityCapability.leader_session_id).trim()) return false;
+    if (!pathMatches(worker.leader_cwd, canonicalLeaderCwd)) return false;
+  }
+  const expectedSession = normalizeSessionId(expectedNativeSessionId);
+  if (expectedNativeSessionId && !expectedSession) return false;
+  if (expectedSession) {
+    for (const worker of [identity, manifestWorker, configWorker]) {
+      if (normalizeSessionId(safeString(worker.native_session_id)) !== expectedSession) return false;
+    }
+  }
   for (const state of [manifest, config]) {
     if (safeString(state.name).trim() !== workerContext.teamName) return false;
     if (safeString(state.leader_pane_id).trim() === currentPaneId) return false;
@@ -2996,6 +3035,56 @@ async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> 
     if (worktreePath && !pathMatches(worktreePath, canonicalCwd)) return false;
   }
   return true;
+}
+
+async function bindAuthoritativeTeamWorkerNativeSession(
+  cwd: string,
+  nativeSessionId: string,
+): Promise<boolean> {
+  const normalizedSessionId = normalizeSessionId(nativeSessionId);
+  const workerContext = readTeamWorkerEnvironment();
+  if (!normalizedSessionId || !workerContext) return false;
+  if (!safeString(process.env[TEAM_WORKER_CAPABILITY_ENV]).trim()) return false;
+  if (!safeString(process.env.TMUX_PANE).trim()) return false;
+  let startupMetadataReady = false;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (await hasAuthoritativeTeamWorkerContext(cwd)) {
+      startupMetadataReady = true;
+      break;
+    }
+    if (attempt < 39) await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  if (!startupMetadataReady) return false;
+
+  const stateRoot = await resolveWorkerTeamStateRootPath(cwd, workerContext, process.env).catch(() => null);
+  if (!stateRoot) return false;
+  const identityPath = join(stateRoot, "team", workerContext.teamName, "workers", workerContext.workerName, "identity.json");
+  const identity = await readJsonIfExists(identityPath);
+  if (!identity) return false;
+  const config = await readTeamConfig(workerContext.teamName, cwd).catch(() => null);
+  const configWorker = config?.workers.find((worker) => worker.name === workerContext.workerName);
+  if (!config || !configWorker) return false;
+  const existingSessionIds = [identity.native_session_id, configWorker.native_session_id]
+    .map((value) => normalizeSessionId(safeString(value)))
+    .filter(Boolean);
+  if (existingSessionIds.some((value) => value !== normalizedSessionId)) return false;
+  try {
+    if (normalizeSessionId(safeString(configWorker.native_session_id)) !== normalizedSessionId) {
+      configWorker.native_session_id = normalizedSessionId;
+      await saveTeamConfig(config, cwd);
+    }
+    if (normalizeSessionId(safeString(identity.native_session_id)) !== normalizedSessionId) {
+      await writeWorkerIdentity(
+        workerContext.teamName,
+        workerContext.workerName,
+        { ...identity, native_session_id: normalizedSessionId } as unknown as WorkerInfo,
+        cwd,
+      );
+    }
+  } catch {
+    return false;
+  }
+  return await hasAuthoritativeTeamWorkerContext(cwd, normalizedSessionId);
 }
 
 async function resolveTeamStateDirForWorkerContext(
@@ -3847,6 +3936,7 @@ async function resolvePreToolUseSessionBinding(
   stateDir: string,
   payload: CodexHookPayload,
   allowSharedTeamRoot = false,
+  authorizedWorkerNativeSessionId = "",
 ): Promise<PreToolUseSessionBinding> {
   const currentSession = allowSharedTeamRoot
     ? await readRootSessionStateFromStateDir(stateDir).catch(() => null)
@@ -3855,6 +3945,11 @@ async function resolvePreToolUseSessionBinding(
   const aliases = payloadAliasValues(payload, ["session_id", "sessionId"]);
   const knownAliases = sessionPointerAliases(currentSession);
   const nativeIdentityAliases = sessionNativeIdentityAliases(currentSession);
+  const workerNativeSessionId = normalizeSessionId(authorizedWorkerNativeSessionId);
+  if (workerNativeSessionId) {
+    knownAliases.add(workerNativeSessionId);
+    nativeIdentityAliases.add(workerNativeSessionId);
+  }
   return {
     canonicalSessionId,
     payloadSessionAliases: knownAliases,
@@ -10614,6 +10709,87 @@ function buildPlanningStateScopeDeny(modeLabel: string, phase: string): Record<s
   };
 }
 
+const TEAM_WORKER_MUTATING_API_OPERATIONS = new Set([
+  "send-message",
+  "broadcast",
+  "mailbox-mark-delivered",
+  "mailbox-mark-notified",
+  "claim-task",
+  "transition-task-status",
+  "release-task-claim",
+  "update-worker-heartbeat",
+]);
+
+function parseAuthorizedTeamWorkerApiCommand(command: string): {
+  operation: string;
+  input: Record<string, unknown>;
+} | null {
+  if (!command.trim() || /[$`\r\n]/.test(command)) return null;
+  const segments = splitShellCommandSegments(stripHeredocBodiesForCommandScan(command));
+  if (segments.length !== 1 || segments[0]?.trim() !== command.trim()) return null;
+  const rawWords = tokenizeShellWords(segments[0] ?? "");
+  const words = rawWords.map((word) => shellWordLiteral(word));
+  if (words.some((word) => word === null)) return null;
+  const literalWords = words as string[];
+  const commandIndex = findWrappedCommandPositionIndex(rawWords, 0);
+  if (commandIndex === null) return null;
+  const executable = basename(literalWords[commandIndex] ?? "").toLowerCase();
+  let subcommandIndex = commandIndex + 1;
+  if (executable === "node" || executable === "node.exe") {
+    if (basename(literalWords[subcommandIndex] ?? "").toLowerCase() !== "omx.js") return null;
+    subcommandIndex += 1;
+  } else if (executable !== "omx" && executable !== "omx.js") {
+    return null;
+  }
+  if (literalWords[subcommandIndex] !== "team" || literalWords[subcommandIndex + 1] !== "api") return null;
+  const operation = literalWords[subcommandIndex + 2] ?? "";
+  if (!TEAM_WORKER_MUTATING_API_OPERATIONS.has(operation)) return null;
+
+  let input: Record<string, unknown> = {};
+  for (let index = subcommandIndex + 3; index < literalWords.length; index += 1) {
+    const word = literalWords[index] ?? "";
+    if (word === "--json") continue;
+    let rawInput = "";
+    if (word === "--input") {
+      rawInput = literalWords[index + 1] ?? "";
+      index += 1;
+    } else if (word.startsWith("--input=")) {
+      rawInput = word.slice("--input=".length);
+    } else {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(rawInput) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      input = parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  return { operation, input };
+}
+
+function isAuthorizedTeamWorkerApiCommand(command: string): boolean {
+  const workerContext = readTeamWorkerEnvironment();
+  const parsed = parseAuthorizedTeamWorkerApiCommand(command);
+  if (!workerContext || !parsed) return false;
+  const teamName = safeString(parsed.input.team_name).trim();
+  if (teamName && teamName !== workerContext.teamName) return false;
+  const fromWorker = safeString(parsed.input.from_worker).trim();
+  if (fromWorker && fromWorker !== workerContext.workerName) return false;
+  const worker = safeString(parsed.input.worker).trim();
+  if (worker && worker !== workerContext.workerName) return false;
+  if ((parsed.operation === "send-message" || parsed.operation === "broadcast") && fromWorker !== workerContext.workerName) return false;
+  if ([
+    "mailbox-mark-delivered",
+    "mailbox-mark-notified",
+    "claim-task",
+    "release-task-claim",
+    "update-worker-heartbeat",
+  ].includes(parsed.operation) && worker !== workerContext.workerName) return false;
+  return teamName === "" || teamName === workerContext.teamName;
+}
+
 function teamWorkerMutationTargetsProtectedWorkflowState(
   payload: CodexHookPayload,
   toolName: string,
@@ -10631,6 +10807,7 @@ function teamWorkerMutationTargetsProtectedWorkflowState(
   if (toolName === "mcp__omx_state__state_clear" || toolName === "mcp__omx_state__state_write") return true;
   if (mutationTransport === "unknown" || mutationTransport === "state" || mutationTransport === "goal-lifecycle") return true;
   if (toolName === "Bash") {
+    if (isAuthorizedTeamWorkerApiCommand(command)) return false;
     if (collectOmxStateCommandOperations(command, "write").length > 0
       || findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
     let effectiveCwd = cwd;
@@ -11108,7 +11285,7 @@ async function resolvePreToolUseWriteActor(
   if (payloadHasOwnerIdentityClaim(payload)) return "native-child";
   if (!payloadAgentId && isTypedAgentRolePayload(payload, cwd)) return "native-child";
   if (payloadAgentId || payloadThreadId) return "native-child";
-  return (await hasAuthoritativeTeamWorkerContext(cwd)) ? "team-worker" : "native-child";
+  return (await hasAuthoritativeTeamWorkerContext(cwd, payloadSessionId)) ? "team-worker" : "native-child";
 }
 
 function isActiveConductorModeState(state: Record<string, unknown> | null, mode: string, sessionId: string): boolean {
@@ -22430,7 +22607,11 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const authoritativeTeamWorker = declaredTeamWorker && await hasAuthoritativeTeamWorkerContext(cwd);
+  const authoritativeTeamWorker = declaredTeamWorker
+    && candidateWorkerPayloadSessionId !== ""
+    && (hookEventName === "SessionStart"
+      ? await bindAuthoritativeTeamWorkerNativeSession(cwd, candidateWorkerPayloadSessionId)
+      : await hasAuthoritativeTeamWorkerContext(cwd, candidateWorkerPayloadSessionId));
   const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
     && candidateWorkerPayloadSessionId
     && (!pointer.state || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, pointer.state))
@@ -22966,20 +23147,22 @@ export async function dispatchCodexNativeHook(
       };
     }
   } else if (hookEventName === "PreToolUse") {
-    const identitylessTeamWorkerContext = !readPayloadAgentId(payload)
+    const payloadSessionId = readPayloadSessionId(payload);
+    const identitylessTeamWorkerPayload = !readPayloadAgentId(payload)
       && !safeString(payload.agentId).trim()
       && !safeString(payload.threadId).trim()
       && !readPayloadThreadId(payload)
       && !payloadHasOwnerIdentityClaim(payload)
-      && !hasSubagentThreadSpawnProvenance(payload)
-      && await hasAuthoritativeTeamWorkerContext(cwd);
+      && !hasSubagentThreadSpawnProvenance(payload);
+    const identitylessTeamWorkerContext = identitylessTeamWorkerPayload
+      && await hasAuthoritativeTeamWorkerContext(cwd, payloadSessionId);
     const sessionBinding = await resolvePreToolUseSessionBinding(
       policyCwd,
       stateDir,
       payload,
       identitylessTeamWorkerContext,
+      identitylessTeamWorkerContext ? payloadSessionId : "",
     );
-    const payloadSessionId = readPayloadSessionId(payload);
     const rootPointerConflict = await readLiveRootSessionPointerConflict(stateDir, payloadSessionId);
     const mutationTransport = classifyPreToolUseMutationTransport(
       payload,
@@ -23032,7 +23215,18 @@ export async function dispatchCodexNativeHook(
       });
       if (directCancel.kind !== "not-direct-cancel") outputJson = directCancel.output;
     }
-    if (!outputJson && !policyRoot.valid && policyRoot.statePresent && mutationTransport !== "read-only") {
+    if (
+      !outputJson
+      && declaredTeamWorker
+      && identitylessTeamWorkerPayload
+      && !identitylessTeamWorkerContext
+      && mutationTransport !== "read-only"
+    ) {
+      outputJson = buildConductorSessionProvenanceDeny(
+        { mode: "team", phase: "active" },
+        "the declared Team worker does not match its bound native session capability",
+      );
+    } else if (!outputJson && !policyRoot.valid && policyRoot.statePresent && mutationTransport !== "read-only") {
       outputJson = buildConductorSessionProvenanceDeny(
         { mode: "conductor", phase: "active" },
         "the selected workflow state root has no usable canonical session cwd",

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1168,10 +1168,11 @@ function removeHereDocBodies(command: string): string {
   return retained.join("\n");
 }
 
-function commandInvokesOmxQuestion(command: string): boolean {
+function commandInvokesOmxSubcommand(command: string, subcommand: string): boolean {
   const tokens = tokenizeShellCommandWithBoundaries(removeHereDocBodies(command))
     ?.map((token) => ({ ...token, value: token.value.toLowerCase() }))
     ?? [];
+  const normalizedSubcommand = subcommand.toLowerCase();
 
   for (let commandStart = 0; commandStart < tokens.length; commandStart = nextCommandStart(tokens, commandStart)) {
     const commandEnd = nextCommandStart(tokens, commandStart);
@@ -1207,15 +1208,19 @@ function commandInvokesOmxQuestion(command: string): boolean {
 
     const rawToken = tokens[index]?.value || "";
     const token = rawToken.replace(/\\/g, "/").split("/").pop() || "";
-    if ((token === "omx" || token === "omx.js") && tokens[index + 1]?.value === "question") return true;
+    if ((token === "omx" || token === "omx.js") && tokens[index + 1]?.value === normalizedSubcommand) return true;
     if (
       (token === "node" || token === "node.exe")
       && /(?:^|\/)omx\.js$/.test(tokens[index + 1]?.value || "")
-      && tokens[index + 2]?.value === "question"
+      && tokens[index + 2]?.value === normalizedSubcommand
     ) return true;
   }
 
   return false;
+}
+
+function commandInvokesOmxQuestion(command: string): boolean {
+  return commandInvokesOmxSubcommand(command, "question");
 }
 
 function isQuestionReturnPaneAssignment(token: string): boolean {
@@ -1261,25 +1266,11 @@ function commandHasQuestionReturnPane(command: string): boolean {
 }
 
 function commandInvokesOmxTeam(command: string): boolean {
-  const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
-  for (let index = 0; index < tokens.length; index += 1) {
-    const rawToken = tokens[index] || '';
-    const token = rawToken.replace(/\\/g, '/').split('/').pop() || '';
-    if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'team') return true;
-    if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'team') return true;
-  }
-  return /\bomx\s+team\b/i.test(command) || /\bomx\.js['"]?\s+team\b/i.test(command);
+  return commandInvokesOmxSubcommand(command, "team");
 }
 
 function commandInvokesOmxHud(command: string): boolean {
-  const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
-  for (let index = 0; index < tokens.length; index += 1) {
-    const rawToken = tokens[index] || '';
-    const token = rawToken.replace(/\\/g, '/').split('/').pop() || '';
-    if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'hud') return true;
-    if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'hud') return true;
-  }
-  return /\bomx\s+hud\b/i.test(command) || /\bomx\.js['"]?\s+hud\b/i.test(command);
+  return commandInvokesOmxSubcommand(command, "hud");
 }
 
 function buildNativeOmxHudPreToolUseEnforcementOutput(

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6147,6 +6147,7 @@ fs.writeFileSync(path.join(logDir, 'env.json'), JSON.stringify({
   cwd: process.cwd(),
   teamStateRoot: process.env.OMX_TEAM_STATE_ROOT || '',
   worker: process.env.OMX_TEAM_WORKER || '',
+  workerCapability: process.env.OMX_TEAM_WORKER_CAPABILITY || '',
 }));
 process.stdin.on('data', (chunk) => {
   fs.appendFileSync(path.join(logDir, 'stdin.log'), chunk.toString());
@@ -6208,10 +6209,32 @@ process.on('SIGTERM', () => process.exit(0));
         cwd: string;
         teamStateRoot: string;
         worker: string;
+        workerCapability: string;
       };
       assert.equal(envLog.cwd, workerPath);
       assert.equal(envLog.teamStateRoot, join(repo, '.omx', 'state'));
       assert.equal(envLog.worker, 'team-detached-worktree-paths/worker-1');
+      assert.match(envLog.workerCapability, /^[A-Za-z0-9_-]{40,}$/);
+      const workerIdentity = JSON.parse(await readFile(
+        join(repo, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'identity.json'),
+        'utf-8',
+      )) as {
+        leader_cwd?: string;
+        leader_session_id?: string;
+        runtime_capability?: {
+          team_name?: string;
+          worker_name?: string;
+          worker_cwd?: string;
+          token_sha256?: string;
+        };
+      };
+      assert.equal(workerIdentity.leader_cwd, repo);
+      assert.ok(workerIdentity.leader_session_id);
+      assert.equal(workerIdentity.runtime_capability?.team_name, runtime.teamName);
+      assert.equal(workerIdentity.runtime_capability?.worker_name, 'worker-1');
+      assert.equal(workerIdentity.runtime_capability?.worker_cwd, workerPath);
+      assert.match(workerIdentity.runtime_capability?.token_sha256 ?? '', /^[a-f0-9]{64}$/);
+      assert.equal(workerIdentity.runtime_capability?.token_sha256?.includes(envLog.workerCapability), false);
       const rootAgents = await readFile(join(workerPath, 'AGENTS.md'), 'utf-8');
       assert.match(rootAgents, /Team Worker Runtime Instructions/);
       assert.match(rootAgents, new RegExp(`Inbox path: .*${runtime.teamName}/workers/worker-1/inbox\\.md`));

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -954,8 +954,19 @@ exit 0
       assert.equal(createdTask?.role, 'writer');
       assert.equal(createdTask?.owner, 'worker-2');
 
-      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'identity.json'), 'utf-8')) as { role?: string };
+      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'identity.json'), 'utf-8')) as {
+        role?: string;
+        leader_cwd?: string;
+        leader_session_id?: string;
+        runtime_capability?: { team_name?: string; worker_name?: string; token_sha256?: string };
+      };
       assert.equal(workerIdentity.role, 'writer');
+      assert.equal(workerIdentity.leader_cwd, cwd);
+      assert.ok(workerIdentity.leader_session_id);
+      assert.equal(workerIdentity.runtime_capability?.team_name, 'scale-up-role');
+      assert.equal(workerIdentity.runtime_capability?.worker_name, 'worker-2');
+      assert.match(workerIdentity.runtime_capability?.token_sha256 ?? '', /^[a-f0-9]{64}$/);
+      assert.match(await readFile(workerStartupScriptPath(cwd, 'scale-up-role', 'worker-2'), 'utf-8'), /OMX_TEAM_WORKER_CAPABILITY/);
 
       const inbox = await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'inbox.md'), 'utf-8');
       assert.match(inbox, /Task 2/);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -48,6 +48,11 @@ import {
 import { readExactPaneProofSync, readExactPaneProofsSync, type ExactPaneProof } from './exact-pane.js';
 import { reconcileScaleDownCleanupDebt } from './scaling.js';
 import {
+  issueTeamWorkerRuntimeCapability,
+  TEAM_WORKER_CAPABILITY_ENV,
+  type TeamWorkerRuntimeCapability,
+} from './worker-capability.js';
+import {
   teamInit as initTeamState,
   DEFAULT_MAX_WORKERS,
   teamReadConfig as readTeamConfig,
@@ -3704,6 +3709,8 @@ export async function startTeam(
       workerLaunchArgs: readonly string[];
       workerCli: TeamWorkerCli;
       toolContext: ReturnType<typeof resolveWorktreeToolContext>;
+      capabilityToken: string;
+      runtimeCapability: TeamWorkerRuntimeCapability;
     }>;
 
     for (let i = 1; i <= workerCount; i++) {
@@ -3766,6 +3773,15 @@ export async function startTeam(
       );
       const trigger = triggerDirective.text;
       const initialPrompt = workerCli === 'gemini' ? trigger : undefined;
+      const issuedCapability = issueTeamWorkerRuntimeCapability({
+        teamName: sanitized,
+        workerName,
+        leaderSessionId,
+        leaderCwd,
+        teamStateRoot,
+        workerCwd: workerWorkspace.cwd,
+        teamCreatedAt: config.created_at,
+      });
       if (initialPrompt) {
         await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
       }
@@ -3783,6 +3799,8 @@ export async function startTeam(
         workerLaunchArgs,
         workerCli,
         toolContext,
+        capabilityToken: issuedCapability.token,
+        runtimeCapability: issuedCapability.metadata,
       });
     }
 
@@ -3792,6 +3810,7 @@ export async function startTeam(
         [TEAM_LEADER_CWD_ENV]: leaderCwd,
         [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
         OMX_TEAM_DISPLAY_NAME: displayName,
+        [TEAM_WORKER_CAPABILITY_ENV]: plan.capabilityToken,
         ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
         ...worktreeToolContextEnv(plan.toolContext),
       };
@@ -3834,6 +3853,9 @@ export async function startTeam(
         worktree_detached: workerWorkspace.worktreeDetached,
         worktree_created: workerWorkspace.worktreeCreated,
         team_state_root: teamStateRoot,
+        leader_cwd: leaderCwd,
+        leader_session_id: leaderSessionId,
+        runtime_capability: bootstrapPlan.runtimeCapability,
       };
 
       const persistedPanePid = config?.workers[workerIndex - 1]?.pid;
@@ -3865,6 +3887,9 @@ export async function startTeam(
         config.workers[workerIndex - 1].worktree_detached = workerWorkspace.worktreeDetached;
         config.workers[workerIndex - 1].worktree_created = workerWorkspace.worktreeCreated;
         config.workers[workerIndex - 1].team_state_root = teamStateRoot;
+        config.workers[workerIndex - 1].leader_cwd = leaderCwd;
+        config.workers[workerIndex - 1].leader_session_id = leaderSessionId;
+        config.workers[workerIndex - 1].runtime_capability = bootstrapPlan.runtimeCapability;
       }
 
       await writeWorkerIdentity(sanitized, bootstrapPlan.workerName, identity, leaderCwd);

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -77,6 +77,11 @@ import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
 import { resolveCodexHomeForLaunch } from '../cli/codex-home.js';
 import {
+  issueTeamWorkerRuntimeCapability,
+  TEAM_WORKER_CAPABILITY_ENV,
+  type IssuedTeamWorkerRuntimeCapability,
+} from './worker-capability.js';
+import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
   resolveAgentDefaultModel,
@@ -648,6 +653,9 @@ export async function scaleUp(
     let nextIndex = initialNextIndex;
     const sessionName = config.tmux_session;
     const manifest = await readTeamManifestV2(sanitized, leaderCwd);
+    const leaderSessionId = manifest?.leader?.session_id?.trim()
+      || env.OMX_SESSION_ID?.trim()
+      || config.tmux_session;
     const dispatchPolicy = normalizeTeamPolicy(manifest?.policy, {
       display_mode: manifest?.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
       worker_launch_mode: config.worker_launch_mode,
@@ -1104,6 +1112,7 @@ export async function scaleUp(
       let workerCwd = leaderCwd;
       let cmd: string;
       let rawRolePromptContent: string | null = null;
+      let issuedCapability: IssuedTeamWorkerRuntimeCapability | null = null;
       try {
         preparedWorkerDirectoryOwner.set(workerDirPath, workerName);
         await mkdir(workerDirPath, { recursive: true });
@@ -1168,10 +1177,20 @@ export async function scaleUp(
           : rolePromptContent
             ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, teamInstructionsPath, runtimeRole, rolePromptContent)
             : teamInstructionsPath;
+        issuedCapability = issueTeamWorkerRuntimeCapability({
+          teamName: sanitized,
+          workerName,
+          leaderSessionId,
+          leaderCwd,
+          teamStateRoot,
+          workerCwd,
+          teamCreatedAt: config.created_at,
+        });
         const extraEnv: Record<string, string> = {
           OMX_TEAM_STATE_ROOT: teamStateRoot,
           OMX_TEAM_LEADER_CWD: leaderCwd,
           OMX_MODEL_INSTRUCTIONS_FILE: instructionsFilePath,
+          [TEAM_WORKER_CAPABILITY_ENV]: issuedCapability.token,
           ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
         };
         if (workerWorkspace) {
@@ -1251,6 +1270,12 @@ export async function scaleUp(
         );
       }
       const paneId = createdPane.paneId;
+      if (!issuedCapability) {
+        return await rollbackScaleUp(
+          `scale_up_worker_capability_unavailable:${workerName}`,
+          { paneId, workerName, worktreePath: workerWorkspace?.worktreePath },
+        );
+      }
       const workerInfo: ScaleUpWorkerInfo = {
         name: workerName,
         index: workerIndex,
@@ -1268,6 +1293,9 @@ export async function scaleUp(
         worktree_detached: workerWorkspace ? workerWorkspace.detached : undefined,
         worktree_created: workerWorkspace ? workerWorkspace.created : undefined,
         team_state_root: teamStateRoot,
+        leader_cwd: leaderCwd,
+        leader_session_id: leaderSessionId,
+        runtime_capability: issuedCapability.metadata,
       };
 
 

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -66,6 +66,7 @@ import {
   type TeamEventType,
 } from './contracts.js';
 import type { TeamReminderIntent } from './reminder-intents.js';
+import type { TeamWorkerRuntimeCapability } from './worker-capability.js';
 import type { WorktreeMode } from './worktree.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { normalizeTeamTaskCoordinationPlanForStorage } from './coordination-protocol.js';
@@ -136,6 +137,10 @@ export interface WorkerInfo {
   worktree_detached?: boolean;
   worktree_created?: boolean;
   team_state_root?: string;
+  leader_cwd?: string;
+  leader_session_id?: string;
+  native_session_id?: string;
+  runtime_capability?: TeamWorkerRuntimeCapability;
 }
 
 export interface WorkerHeartbeat {

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -2,6 +2,7 @@ import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
 import type { TeamDispatchRequestStatus, TeamEventType, TeamTaskStatus } from '../contracts.js';
 import type { TeamReminderIntent } from '../reminder-intents.js';
 import type { WorktreeMode } from '../worktree.js';
+import type { TeamWorkerRuntimeCapability } from '../worker-capability.js';
 
 export interface StartupCleanupPane {
   pane_id: string;
@@ -48,6 +49,10 @@ export interface WorkerInfo {
   worktree_detached?: boolean;
   worktree_created?: boolean;
   team_state_root?: string;
+  leader_cwd?: string;
+  leader_session_id?: string;
+  native_session_id?: string;
+  runtime_capability?: TeamWorkerRuntimeCapability;
 }
 
 export interface WorkerHeartbeat {

--- a/src/team/worker-capability.ts
+++ b/src/team/worker-capability.ts
@@ -1,0 +1,61 @@
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+
+export const TEAM_WORKER_CAPABILITY_ENV = 'OMX_TEAM_WORKER_CAPABILITY';
+
+export interface TeamWorkerRuntimeCapability {
+  version: 1;
+  team_name: string;
+  worker_name: string;
+  leader_session_id: string;
+  leader_cwd: string;
+  team_state_root: string;
+  worker_cwd: string;
+  team_created_at: string;
+  issued_at: string;
+  token_sha256: string;
+}
+
+export interface IssuedTeamWorkerRuntimeCapability {
+  token: string;
+  metadata: TeamWorkerRuntimeCapability;
+}
+
+export function digestTeamWorkerCapabilityToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+export function issueTeamWorkerRuntimeCapability(input: {
+  teamName: string;
+  workerName: string;
+  leaderSessionId: string;
+  leaderCwd: string;
+  teamStateRoot: string;
+  workerCwd: string;
+  teamCreatedAt: string;
+}): IssuedTeamWorkerRuntimeCapability {
+  const token = randomBytes(32).toString('base64url');
+  return {
+    token,
+    metadata: {
+      version: 1,
+      team_name: input.teamName,
+      worker_name: input.workerName,
+      leader_session_id: input.leaderSessionId,
+      leader_cwd: input.leaderCwd,
+      team_state_root: input.teamStateRoot,
+      worker_cwd: input.workerCwd,
+      team_created_at: input.teamCreatedAt,
+      issued_at: new Date().toISOString(),
+      token_sha256: digestTeamWorkerCapabilityToken(token),
+    },
+  };
+}
+
+export function capabilityTokenMatches(token: string, expectedSha256: string): boolean {
+  const normalizedToken = token.trim();
+  const normalizedExpected = expectedSha256.trim().toLowerCase();
+  if (!normalizedToken || !/^[a-f0-9]{64}$/.test(normalizedExpected)) return false;
+  const actual = Buffer.from(digestTeamWorkerCapabilityToken(normalizedToken), 'hex');
+  const expected = Buffer.from(normalizedExpected, 'hex');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}


### PR DESCRIPTION
## Summary

Fix Team worker startup and native-hook provenance when workers run in registered detached worktrees, while keeping foreign worktrees and cross-Team state access denied.

This also changes the Codex App outside-tmux guard to classify the parsed executable/subcommand rather than matching arbitrary prompt or search text.

## Root cause

- Worker processes inherited the leader-owned `OMX_TEAM_STATE_ROOT`, but hook authorization resolved generic leader-session provenance before the registered Team worker identity. A detached worker cwd therefore appeared to be a foreign cwd.
- Worker launch metadata did not bind the worker's actual native Codex session ID, so inheriting or comparing only the leader session could not establish worker authority safely.
- Conductor treated validated Team task/mailbox/API commands as unresolved shell mutation targets.
- The outside-tmux guard scanned arbitrary command text, so quoted bootstrap prompts and read-only searches containing Team command words were misclassified as direct Team launches.

## Security boundary

- Each worker receives a random run-scoped capability token; only its SHA-256 digest is persisted.
- Authorization requires matching Team name, worker name, worker pane, registered cwd/worktree, leader cwd, shared Team state root, Team lifecycle timestamp, leader identity, capability digest, and the worker's bound native session ID across worker identity, config, and manifest metadata.
- The first authoritative worker `SessionStart` binds the actual native session ID once. Conflicting rebinding fails closed.
- Scoped worker control-plane access is limited to structurally parsed standalone Team API operations for that worker's current Team. Cross-Team requests, dynamic/compound shell commands, unrelated OMX state, and arbitrary source/state mutation remain blocked.
- The shared state root remains leader-owned; detached workers are not authorized by pretending their cwd is the leader cwd.

## Startup and rollback behavior

The existing transactional startup gates and rollback paths remain intact. Targeted tests verify missing startup evidence and ready-prompt timeouts roll back instead of leaving a shutdown gate. Capability metadata is issued before worker launch, and worker `SessionStart` waits for the bounded startup metadata handoff before binding.

## Regression matrix

| Surface | Hooks | Worktrees | Result |
| --- | --- | --- | --- |
| Native hook worker | on | leader cwd | session bind, source edit, ACK/API, claim, transition allowed |
| Native hook worker | on | registered detached cwd | distinct native session binds and writes are allowed |
| Native hook worker | on | unregistered cwd | provenance denied |
| Worker A targeting Team B | on | either | denied |
| App direct Team command | on | either | immediate actionable block |
| App `omx --tmux` bootstrap with Team words in prompt | on | worktree-ready | allowed |
| Side-session Stop | on | either | authoritative leader preserved; bounded no-op behavior retained |

## Verification

Passed from this branch:

- `npm run build`
- focused native-hook provenance/session-binding/control-plane tests, including registered leader cwd, registered detached worktree, unregistered foreign cwd, cross-Team denial, wrong capability, rebinding denial, startup race, structural command parsing, and Stop scoping
- targeted Team runtime startup rollback and detached-worktree tests
- targeted scale-up capability persistence tests
- duplicate pane/topology tests
- `npm run test:team:worker-runtime-identity:compiled`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- packed `oh-my-codex@0.20.4` candidate installed with scripts disabled in an isolated temporary directory; direct hook classification and capability-digest smoke passed; fixture removed afterward

No test worktrees or candidate processes remained after verification.

### Explicit validation gaps

- The full `npm test` suite is not green on the current `origin/dev` baseline. Among the observed failures, the issue #3138 owner assertion was reproduced unchanged in a clean detached `origin/dev` worktree; other baseline failures included agent-template expectations, unusable session-pointer auth fixtures, and detached-leader teardown timeouts. This PR does not claim those failures are fixed.
- A live Team orchestration smoke was intentionally not run because this repair session explicitly prohibited OMX agents/functions while Team is the subject under repair. The packed candidate was exercised directly instead. The PR remains draft until an authorized isolated live-Team smoke and separate read-only review can be performed.

## Compatibility

The incident was observed with OMX 0.20.3, Codex CLI 0.146.0, and tmux 3.7b. This branch is based on OMX source version 0.20.4 and preserves the leader-owned shared-state model while adding worker-native-session binding.

No globally installed package, user hook configuration, Updog repository, preserved Updog worktree, active tmux session, or package release was modified.
