### PR TITLE
fix(team): harden worker provenance and startup

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -249,7 +249,7 @@ TASK_ID=$(echo "$CREATE_JSON" | jq -r '.data.task.id')
 CLAIM_JSON=$(omx team api claim-task --input "{\"team_name\":\"e2e-team-demo\",\"task_id\":\"$TASK_ID\",\"worker\":\"worker-1\",\"expected_version\":1}" --json)
 CLAIM_TOKEN=$(echo "$CLAIM_JSON" | jq -r '.data.claimToken')
 
-omx team api transition-task-status --input "{\"team_name\":\"e2e-team-demo\",\"task_id\":\"$TASK_ID\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"$CLAIM_TOKEN\"}" --json
+omx team api transition-task-status --input "{\"team_name\":\"e2e-team-demo\",\"task_id\":\"$TASK_ID\",\"worker\":\"worker-1\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"$CLAIM_TOKEN\"}" --json
 ```
 
 ### 7.2 Mailbox/message flow
@@ -350,7 +350,7 @@ CLAIM_JSON=$(omx team api claim-task --input "{\"team_name\":\"$TEAM_NAME\",\"ta
 CLAIM_TOKEN=$(echo "$CLAIM_JSON" | jq -r '.data.claimToken')
 
 echo "[5/8] transition task -> completed"
-omx team api transition-task-status --input "{\"team_name\":\"$TEAM_NAME\",\"task_id\":\"$TASK_ID\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"$CLAIM_TOKEN\"}" --json
+omx team api transition-task-status --input "{\"team_name\":\"$TEAM_NAME\",\"task_id\":\"$TASK_ID\",\"worker\":\"worker-1\",\"from\":\"in_progress\",\"to\":\"completed\",\"claim_token\":\"$CLAIM_TOKEN\"}" --json
 
 echo "[6/8] mailbox flow"
 omx team api send-message --input "{\"team_name\":\"$TEAM_NAME\",\"from_worker\":\"leader-fixed\",\"to_worker\":\"worker-1\",\"body\":\"ACK one-shot\"}" --json

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -108,9 +108,11 @@ current worker pane recorded under the strictly resolved Team state root. Each
 launch receives a random run-scoped worker capability; only its digest and its
 Team, worker, leader-session, leader-cwd, worker-cwd, shared-state-root, and Team
 lifecycle bindings are persisted in worker identity/config/manifest metadata.
-The worker's first authoritative `SessionStart` binds its actual native Codex
-session ID exactly once. Later writes require that bound ID plus the capability,
-pane, paths, and metadata to agree. The shared `OMX_TEAM_STATE_ROOT` remains
+The worker's first authoritative hook event binds its actual native Codex
+session ID exactly once in a worker-scoped `native-session-binding.json` record;
+the hook does not rewrite leader-owned Team config or manifest records. Later
+writes require that bound ID plus the capability, pane, paths, and metadata to
+agree. The shared `OMX_TEAM_STATE_ROOT` remains
 leader-owned and does not require a detached worker to impersonate the leader
 cwd. Validated standalone worker API calls are limited to the current Team and
 worker; cross-Team payloads, protected workflow state, arbitrary state trees,

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -51,7 +51,7 @@ Setup-owned trust state is limited to those generated wrapper identities; user h
 | wiki startup context | `SessionStart` | `session-start` | native | Wiki session-start context can append a compact `omx_wiki/` summary when wiki pages exist; startup writes stay config-gated |
 | `keyword-detector` | `UserPromptSubmit` | `keyword-detector` | native | Persists skill activation state and can add prompt-side developer context for top-level prompts; native subagent prompt text is treated as delegated task text, so literal workflow keywords inside a child prompt do not activate nested workflow state; `$ralph` prompt routing seeds workflow state only and does not launch `omx ralph --prd ...` |
 | ultragoal bounded steering | `UserPromptSubmit` | `ultragoal` artifacts | native | Only explicit structured directives such as `OMX_ULTRAGOAL_STEER: { ... }`, `omx.ultragoal.steer: { ... }`, or `omx ultragoal steer: { ... }` are parsed; accepted/rejected/deduped attempts route through `steerUltragoal`, append `.omx/ultragoal/ledger.jsonl`, and add advisory context without changing keyword precedence |
-| `pre-tool-use` | `PreToolUse` | `pre-tool-use` | native-partial | Native behavior cautions on Bash `rm -rf dist`, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present only when explicitly opted in with `OMX_LORE_COMMIT_GUARD=1`, emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence, and blocks `close_agent` / parallel close cleanup before it starts when a fresh native subagent capacity blocker was recorded |
+| `pre-tool-use` | `PreToolUse` | `pre-tool-use` | native-partial | Native behavior cautions on Bash `rm -rf dist`, structurally classifies direct OMX subcommands instead of matching quoted prompt/search text, binds Team workers to their launched runtime capability and actual native session, blocks inspectable inline `git commit` commands until Lore-format structure + the required `Co-authored-by: OmX <omx@oh-my-codex.dev>` trailer are present only when explicitly opted in with `OMX_LORE_COMMIT_GUARD=1`, emits non-blocking document-refresh warnings for mapped staged commit changes that lack rule-scoped docs/spec refresh evidence, and blocks `close_agent` / parallel close cleanup before it starts when a fresh native subagent capacity blocker was recorded |
 | native `PreToolUse` stdout schema | `PreToolUse` | CLI stdout | native | Codex CLI 0.141.0 accepts only `systemMessage` for `PreToolUse`; the native CLI writer strips internal `decision`, `reason`, `stopReason`, `continue`, and `hookSpecificOutput` fields before stdout while preserving richer internal dispatch results for tests and non-stdout callers. |
 | `post-tool-use` | `PostToolUse` | `post-tool-use` | native-partial | Built-in Bash behavior covers command-not-found / permission-denied / missing-path guidance only from stderr or non-zero Bash results, ignores failure-looking strings from successful source/log reads, keeps MCP transport-death guidance scoped to MCP-like tool calls, and records a short-lived `.omx/state/native-subagent-capacity-blocker.json` when native subagent spawn/collab output reports `agent thread limit reached`; document-refresh commit warnings use PreToolUse advisory output, with PostToolUse reserved as a future fallback if Codex advisory semantics change |
 | Ralph/persistence stop handling | `Stop` | `stop` | native-partial | Native adapter uses the documented native Stop continuation contract (`decision: "block"` + `reason`) for active Ralph runs, emits a single JSON object on Stop stdout even for no-op Stop decisions, emits deterministic JSON continuation output if Stop dispatch fails before normal handling, no-ops immediately when the selected session pointer belongs to a foreign cwd or the Stop session is unmatched, and bounds other unusable session-pointer authorization failures to one diagnostic block per Stop replay chain so active Stop-hook replays no-op instead of looping forever |
@@ -104,9 +104,25 @@ raw-command matching.
 Official Team worker roots may omit both `agent_id` and legacy `thread_id`.
 After Main-root exclusion, OMX preserves their established exemption only when
 the Team environment agrees with the durable worker identity, Team config, and
-current worker pane recorded under the strictly resolved Team state root. A
-leader native-session match wins before this check, and a payload with any named
-unknown or foreign identity cannot borrow the Team exemption.
+current worker pane recorded under the strictly resolved Team state root. Each
+launch receives a random run-scoped worker capability; only its digest and its
+Team, worker, leader-session, leader-cwd, worker-cwd, shared-state-root, and Team
+lifecycle bindings are persisted in worker identity/config/manifest metadata.
+The worker's first authoritative `SessionStart` binds its actual native Codex
+session ID exactly once. Later writes require that bound ID plus the capability,
+pane, paths, and metadata to agree. The shared `OMX_TEAM_STATE_ROOT` remains
+leader-owned and does not require a detached worker to impersonate the leader
+cwd. Validated standalone worker API calls are limited to the current Team and
+worker; cross-Team payloads, protected workflow state, arbitrary state trees,
+shell compounds, dynamic input, and capability/session rebinding fail closed.
+A leader native-session match wins before this check, and a payload with any
+named unknown or foreign identity cannot borrow the Team exemption.
+
+Outside tmux, direct `omx team ...` and `node .../omx.js team ...` executable
+forms remain blocked with launch guidance. Classification is command-structural:
+quoted arguments, search patterns, heredoc bodies, and an `omx --tmux ...`
+bootstrap prompt may mention the same words without being treated as a direct
+Team invocation. The same structural rule applies to the native HUD guard.
 
 Known read-only MCP compatibility tools are governed by an explicit name contract,
 not a read-looking prefix heuristic. The audited contract covers filesystem/state

--- a/docs/interop-team-mutation-contract.md
+++ b/docs/interop-team-mutation-contract.md
@@ -20,7 +20,7 @@ Direct writes to `.omx/state/team/...` are unsupported and may violate runtime i
 2. Claim with optimistic version:
    - `omx team api claim-task --json`
 3. Transition terminal state with claim token:
-   - `omx team api transition-task-status --json` (`in_progress -> completed|failed`)
+   - `omx team api transition-task-status --json` (`in_progress -> completed|failed`, with `worker` matching the claim owner)
 4. Use `omx team api release-task-claim --json` only for rollback/requeue-to-pending flows.
 
 ## Legacy MCP -> CLI migration table

--- a/plugins/oh-my-codex/skills/team/SKILL.md
+++ b/plugins/oh-my-codex/skills/team/SKILL.md
@@ -324,7 +324,7 @@ Examples:
 ```bash
 omx team api send-message --input '{"team_name":"my-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json
 omx team api claim-task --input '{"team_name":"my-team","task_id":"1","worker":"worker-1"}' --json
-omx team api transition-task-status --input '{"team_name":"my-team","task_id":"1","from":"in_progress","to":"completed","claim_token":"<token>"}' --json
+omx team api transition-task-status --input '{"team_name":"my-team","task_id":"1","worker":"worker-1","from":"in_progress","to":"completed","claim_token":"<token>"}' --json
 ```
 
 `--json` responses include stable metadata for automation:

--- a/plugins/oh-my-codex/skills/worker/SKILL.md
+++ b/plugins/oh-my-codex/skills/worker/SKILL.md
@@ -64,7 +64,7 @@ omx team api send-message --input "{\"team_name\":\"<teamName>\",\"from_worker\"
    - Never use legacy `tasks/{id}.json` wording.
 6. Claim the task (do NOT start work without a claim) using claim-safe lifecycle CLI interop (`omx team api claim-task --json`).
 7. Do the work.
-8. Complete/fail the task via lifecycle transition CLI interop (`omx team api transition-task-status --json`) from `in_progress` to `completed` or `failed`.
+8. Complete/fail the task via lifecycle transition CLI interop (`omx team api transition-task-status --json`) from `in_progress` to `completed` or `failed`; include your own worker name in the `worker` field.
    - Do NOT directly write lifecycle fields (`status`, `owner`, `result`, `error`) in task files.
 9. Use `omx team api release-task-claim --json` only for rollback/requeue to `pending` (not for completion).
 10. Update your worker status:

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -324,7 +324,7 @@ Examples:
 ```bash
 omx team api send-message --input '{"team_name":"my-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json
 omx team api claim-task --input '{"team_name":"my-team","task_id":"1","worker":"worker-1"}' --json
-omx team api transition-task-status --input '{"team_name":"my-team","task_id":"1","from":"in_progress","to":"completed","claim_token":"<token>"}' --json
+omx team api transition-task-status --input '{"team_name":"my-team","task_id":"1","worker":"worker-1","from":"in_progress","to":"completed","claim_token":"<token>"}' --json
 ```
 
 `--json` responses include stable metadata for automation:

--- a/skills/worker/SKILL.md
+++ b/skills/worker/SKILL.md
@@ -64,7 +64,7 @@ omx team api send-message --input "{\"team_name\":\"<teamName>\",\"from_worker\"
    - Never use legacy `tasks/{id}.json` wording.
 6. Claim the task (do NOT start work without a claim) using claim-safe lifecycle CLI interop (`omx team api claim-task --json`).
 7. Do the work.
-8. Complete/fail the task via lifecycle transition CLI interop (`omx team api transition-task-status --json`) from `in_progress` to `completed` or `failed`.
+8. Complete/fail the task via lifecycle transition CLI interop (`omx team api transition-task-status --json`) from `in_progress` to `completed` or `failed`; include your own worker name in the `worker` field.
    - Do NOT directly write lifecycle fields (`status`, `owner`, `result`, `error`) in task files.
 9. Use `omx team api release-task-claim --json` only for rollback/requeue to `pending` (not for completion).
 10. Update your worker status:

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -1943,6 +1943,19 @@ describe('teamCommand api', () => {
     }
   });
 
+  it('documents worker as optional for public transition callers', async () => {
+    const logs: string[] = [];
+    const originalLog = console.log;
+    try {
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '));
+      await teamCommand(['api', 'transition-task-status', '--help']);
+      assert.equal(logs.length, 1);
+      assert.match(logs[0] ?? '', /Optional input fields:\s+- worker\s+- result\s+- error/);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   it('prints operation-specific help for omx team api <operation> help alias', async () => {
     const logs: string[] = [];
     const originalLog = console.log;
@@ -2334,6 +2347,7 @@ describe('teamCommand api', () => {
         JSON.stringify({
           team_name: 'lifecycle-team',
           task_id: taskId,
+          worker: 'worker-1',
           from: 'in_progress',
           to: 'completed',
           claim_token: claimToken,

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -361,7 +361,7 @@ const TEAM_API_OPERATION_OPTIONAL_FIELDS: Partial<Record<TeamApiOperation, strin
   'update-task': ['subject', 'description', 'blocked_by', 'requires_code_change'],
   'claim-task': ['expected_version'],
   'cleanup': ['force', 'confirm_issues'],
-  'transition-task-status': ['result', 'error'],
+  'transition-task-status': ['worker', 'result', 'error'],
   'read-shutdown-ack': ['min_updated_at'],
   'write-worker-identity': [
     'assigned_tasks', 'pid', 'pane_id', 'working_dir',

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -275,6 +275,18 @@ describe('HUD pane ownership helpers', () => {
     });
   });
 
+  it('reads ownership from tmux 3.7b whole-command quoting with a receipt comment', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%3\tnode\t"exec env OMX_SESSION_ID='%0' OMX_TMUX_HUD_OWNER=1 ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%0' '/node' '/omx.js' hud --watch # omx_source_receipt"`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: '%0',
+      leaderPaneId: '%0',
+    });
+    assert.equal(hudPaneMatchesOwner(pane!, { leaderPaneId: '%0' }), true);
+  });
+
   it('splits tmux octal-escaped control separators from live list-panes output', () => {
     const escapedSeparator = '\\037';
     const panes = parseTmuxPaneSnapshot(

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -311,6 +311,19 @@ function lexPosixWords(command: string): string[] | null {
   return words;
 }
 
+function normalizeTmuxRenderedStartCommand(command: string): string {
+  const trimmed = command.trim();
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) return trimmed;
+  const renderedWords = lexPosixWords(trimmed);
+  if (renderedWords?.length !== 1) return trimmed;
+  const unwrapped = renderedWords[0]!.trim();
+  return /^(?:exec\s+)?env(?:\s|$)/.test(unwrapped) ? unwrapped : trimmed;
+}
+
+function hudOwnerMetadataCommand(pane: TmuxPaneSnapshot): string {
+  return normalizeTmuxRenderedStartCommand(pane.startCommand);
+}
+
 function parsePosixHudEnvAssignments(command: string): PosixHudEnvAssignments {
   const values = new Map<string, string[]>();
   const attempted = HUD_OWNER_ENV_KEYS.some((key) => command.includes(key));
@@ -490,7 +503,7 @@ function hasAmbiguousHudOwnerMetadata(command: string): boolean {
 }
 
 export function readHudPaneOwner(pane: TmuxPaneSnapshot): HudPaneOwner {
-  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  const command = hudOwnerMetadataCommand(pane);
   const rawLeaderPaneId = parseHudEnvAssignment(command, OMX_TMUX_HUD_LEADER_PANE_ENV);
   if (
     hasAmbiguousHudOwnerMetadata(command)
@@ -505,12 +518,12 @@ export function readHudPaneOwner(pane: TmuxPaneSnapshot): HudPaneOwner {
 }
 
 function hasHudPaneOwnerMetadata(pane: TmuxPaneSnapshot): boolean {
-  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  const command = hudOwnerMetadataCommand(pane);
   return hasHudOwnerMetadataAttempt(command) && !hasAmbiguousHudOwnerMetadata(command);
 }
 
 export function hasValidHudOwnerMarker(pane: TmuxPaneSnapshot): boolean {
-  const command = `${pane.startCommand} ${pane.currentCommand}`;
+  const command = hudOwnerMetadataCommand(pane);
   if (hasAmbiguousHudOwnerMetadata(command)) return false;
   return parseHudEnvAssignment(command, OMX_TMUX_HUD_OWNER_ENV) === '1';
 }
@@ -565,7 +578,7 @@ export function hudPaneMatchesOwner(pane: TmuxPaneSnapshot, owner: HudPaneOwner 
   const wantsSession = wantedSessionIds.length > 0;
   const wantsLeaderPane = wantedLeaderPaneId !== null;
   if (!wantsSession && !wantsLeaderPane) return true;
-  if (hasAmbiguousHudOwnerMetadata(`${pane.startCommand} ${pane.currentCommand}`)) return false;
+  if (hasAmbiguousHudOwnerMetadata(hudOwnerMetadataCommand(pane))) return false;
 
   const paneOwner = readHudPaneOwner(pane);
   const sessionMatches = wantsSession && wantedSessionIds.includes(paneOwner.sessionId ?? '');

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -67,6 +67,7 @@ import {
 import { getBaseStateDir } from "../../state/paths.js";
 import { maybeNudgeLeaderForAllowedWorkerStop } from "../notify-hook/team-worker-stop.js";
 import { MAX_NATIVE_STDIN_JSON_BYTES } from "../hook-payload-guard.js";
+import { digestTeamWorkerCapabilityToken } from "../../team/worker-capability.js";
 
 
 const ARGUMENT_PRODUCING_RUNTIME_DENIAL_COMMANDS = [
@@ -436,6 +437,7 @@ async function configureAuthoritativeTeamWorker(
   cwd: string,
   teamName: string,
   workerPaneId = "%10",
+  workerCwd = cwd,
 ): Promise<void> {
   const stateRoot = join(cwd, ".omx", "state");
   await initTeamState(teamName, "session pointer ownership regression", "executor", 1, cwd, undefined, {
@@ -445,6 +447,10 @@ async function configureAuthoritativeTeamWorker(
     leaderPaneId: "%42",
     workerPaneIds: { "worker-1": workerPaneId },
   });
+  const initialConfig = JSON.parse(
+    await readFile(join(stateRoot, "team", teamName, "config.json"), "utf-8"),
+  ) as { created_at: string };
+  const issuedAt = "2026-08-02T00:00:00.000Z";
   for (const fileName of ["config.json", "manifest.v2.json"]) {
     const filePath = join(stateRoot, "team", teamName, fileName);
     const state = JSON.parse(await readFile(filePath, "utf-8")) as {
@@ -456,9 +462,23 @@ async function configureAuthoritativeTeamWorker(
     state.leader_cwd = cwd;
     state.workers = (state.workers ?? []).map((worker) => ({
       ...worker,
-      working_dir: cwd,
-      worktree_path: cwd,
+      working_dir: workerCwd,
+      worktree_path: workerCwd,
       team_state_root: stateRoot,
+      leader_cwd: cwd,
+      leader_session_id: "leader-session",
+      runtime_capability: {
+        version: 1,
+        team_name: teamName,
+        worker_name: "worker-1",
+        leader_session_id: "leader-session",
+        leader_cwd: cwd,
+        team_state_root: stateRoot,
+        worker_cwd: workerCwd,
+        team_created_at: initialConfig.created_at,
+        issued_at: issuedAt,
+        token_sha256: "c0b1ad20af38abb877cad30cab710e23733c63e6a8a38a6132ccb6264e78f50a",
+      },
     }));
     await writeJson(filePath, state);
   }
@@ -467,9 +487,23 @@ async function configureAuthoritativeTeamWorker(
     index: 1,
     role: "executor",
     pane_id: workerPaneId,
-    working_dir: cwd,
-    worktree_path: cwd,
+    working_dir: workerCwd,
+    worktree_path: workerCwd,
     team_state_root: stateRoot,
+    leader_cwd: cwd,
+    leader_session_id: "leader-session",
+    runtime_capability: {
+      version: 1,
+      team_name: teamName,
+      worker_name: "worker-1",
+      leader_session_id: "leader-session",
+      leader_cwd: cwd,
+      team_state_root: stateRoot,
+      worker_cwd: workerCwd,
+      team_created_at: initialConfig.created_at,
+      issued_at: issuedAt,
+      token_sha256: "c0b1ad20af38abb877cad30cab710e23733c63e6a8a38a6132ccb6264e78f50a",
+    },
   });
   process.env.TMUX = "1";
   process.env.TMUX_PANE = workerPaneId;
@@ -477,6 +511,7 @@ async function configureAuthoritativeTeamWorker(
   process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
   process.env.OMX_TEAM_STATE_ROOT = stateRoot;
   process.env.OMX_TEAM_LEADER_CWD = cwd;
+  process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
   process.env.OMX_SESSION_ID = "leader-session";
 }
 
@@ -763,6 +798,7 @@ const DEFAULT_AUTO_NUDGE_RESPONSE =
 const TEAM_ENV_KEYS = [
   "OMX_TEAM_WORKER",
   "OMX_TEAM_INTERNAL_WORKER",
+  "OMX_TEAM_WORKER_CAPABILITY",
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
   "OMX_TEAM_MODE",
@@ -5692,6 +5728,218 @@ PY`,
       assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), leaderPointerBefore);
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds a registered Team worker native session before authorizing worker writes", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-native-binding-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      await writeSessionStart(cwd, "leader-session", {
+        nativeSessionId: "leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(cwd, "binding-team");
+      await writeSessionSkillActiveState(stateDir, "leader-session", "team", "team-exec");
+      await writeJson(join(stateDir, "sessions", "leader-session", "team-state.json"), {
+        active: true,
+        mode: "team",
+        current_phase: "team-exec",
+        team_name: "binding-team",
+        session_id: "leader-session",
+        workingDirectory: cwd,
+      });
+      const pointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-native-binding",
+      }, { cwd, sessionOwnerPid: process.pid });
+
+      const identityPath = join(stateDir, "team", "binding-team", "workers", "worker-1", "identity.json");
+      const boundIdentity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
+      assert.equal(boundIdentity.native_session_id, "worker-native-binding");
+      for (const fileName of ["config.json", "manifest.v2.json"]) {
+        const teamMetadata = JSON.parse(await readFile(
+          join(stateDir, "team", "binding-team", fileName),
+          "utf-8",
+        )) as { workers?: Array<{ name?: string; native_session_id?: string }> };
+        assert.equal(
+          teamMetadata.workers?.find((worker) => worker.name === "worker-1")?.native_session_id,
+          "worker-native-binding",
+          fileName,
+        );
+      }
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+
+      const sourceWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Edit",
+        tool_use_id: "tool-worker-native-binding-source",
+        tool_input: { file_path: "src/worker-owned.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(sourceWrite.outputJson, null);
+
+      const teamApiWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Bash",
+        tool_use_id: "tool-worker-native-binding-api",
+        tool_input: {
+          command: `omx team api send-message --input '{"team_name":"binding-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json`,
+        },
+      }, { cwd });
+      assert.equal(teamApiWrite.outputJson, null);
+
+      for (const [toolUseId, command] of [
+        ["claim", `omx team api claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`],
+        ["transition", `omx team api transition-task-status --input '{"team_name":"binding-team","task_id":"1","from":"in_progress","to":"completed","claim_token":"claim-token","result":"done"}' --json`],
+        ["mailbox", `omx team api mailbox-mark-delivered --input '{"team_name":"binding-team","worker":"worker-1","message_id":"message-1"}' --json`],
+      ] as const) {
+        const teamControlPlaneWrite = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: "worker-native-binding",
+          tool_name: "Bash",
+          tool_use_id: `tool-worker-native-binding-${toolUseId}`,
+          tool_input: { command },
+        }, { cwd });
+        assert.equal(teamControlPlaneWrite.outputJson, null, toolUseId);
+      }
+
+      const crossTeamApiWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Bash",
+        tool_use_id: "tool-worker-native-binding-cross-team-api",
+        tool_input: {
+          command: `omx team api claim-task --input '{"team_name":"foreign-team","task_id":"1","worker":"worker-1"}' --json`,
+        },
+      }, { cwd });
+      assert.equal(crossTeamApiWrite.outputJson?.decision, "block");
+
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "wrong-worker-capability-token";
+      const wrongCapabilityWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Edit",
+        tool_use_id: "tool-worker-wrong-capability-source",
+        tool_input: { file_path: "src/wrong-capability.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(wrongCapabilityWrite.outputJson?.decision, "block");
+      assert.match(String(wrongCapabilityWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "forged-worker-native",
+      }, { cwd, sessionOwnerPid: process.pid });
+      const reboundIdentity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
+      assert.equal(reboundIdentity.native_session_id, "worker-native-binding");
+
+      const forgedWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "forged-worker-native",
+        tool_name: "Edit",
+        tool_use_id: "tool-forged-worker-native-source",
+        tool_input: { file_path: "src/forged.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(forgedWrite.outputJson?.decision, "block");
+      assert.match(String(forgedWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("waits for transactional startup metadata before binding a fast worker SessionStart", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-startup-race-"));
+    try {
+      const teamName = "startup-race-team";
+      const stateRoot = join(cwd, ".omx", "state");
+      process.env.TMUX = "1";
+      process.env.TMUX_PANE = "%10";
+      process.env.OMX_TEAM_INTERNAL_WORKER = `${teamName}/worker-1`;
+      process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
+      process.env.OMX_TEAM_STATE_ROOT = stateRoot;
+      process.env.OMX_TEAM_LEADER_CWD = cwd;
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
+      process.env.OMX_SESSION_ID = "leader-session";
+
+      const materialized = (async () => {
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 75));
+        await configureAuthoritativeTeamWorker(cwd, teamName);
+      })();
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-native-startup-race",
+      }, { cwd, sessionOwnerPid: process.pid });
+      await materialized;
+
+      const identity = JSON.parse(await readFile(
+        join(stateRoot, "team", teamName, "workers", "worker-1", "identity.json"),
+        "utf-8",
+      )) as { native_session_id?: string };
+      assert.equal(identity.native_session_id, "worker-native-startup-race");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds a registered detached-worktree worker and rejects an unregistered sibling checkout", async () => {
+    const leaderCwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-detached-binding-"));
+    try {
+      const workerCwd = join(leaderCwd, "registered-worker-checkout");
+      const foreignCwd = join(leaderCwd, "unregistered-worker-checkout");
+      await mkdir(workerCwd, { recursive: true });
+      await mkdir(foreignCwd, { recursive: true });
+      await writeSessionStart(leaderCwd, "leader-session", {
+        nativeSessionId: "leader-native",
+        pid: process.pid,
+      });
+      await configureAuthoritativeTeamWorker(leaderCwd, "detached-binding-team", "%10", workerCwd);
+
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd: workerCwd,
+        session_id: "detached-worker-native",
+      }, { cwd: workerCwd, sessionOwnerPid: process.pid });
+
+      const registeredWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd: workerCwd,
+        session_id: "detached-worker-native",
+        tool_name: "Edit",
+        tool_input: { file_path: "src/registered.ts", old_string: "a", new_string: "b" },
+      }, { cwd: workerCwd });
+      assert.equal(registeredWrite.outputJson, null);
+
+      const foreignWrite = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd: foreignCwd,
+        session_id: "detached-worker-native",
+        tool_name: "Edit",
+        tool_input: { file_path: "src/foreign.ts", old_string: "a", new_string: "b" },
+      }, { cwd: foreignCwd });
+      assert.equal(foreignWrite.outputJson?.decision, "block");
+      assert.match(String(foreignWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
+
+      const identity = JSON.parse(await readFile(
+        join(leaderCwd, ".omx", "state", "team", "detached-binding-team", "workers", "worker-1", "identity.json"),
+        "utf-8",
+      )) as { native_session_id?: string; worktree_path?: string };
+      assert.equal(identity.native_session_id, "detached-worker-native");
+      assert.equal(identity.worktree_path, workerCwd);
+    } finally {
+      await rm(leaderCwd, { recursive: true, force: true });
     }
   });
 
@@ -13075,6 +13323,56 @@ exit 0
 		}
 	});
 
+	it("allows an outside-tmux bootstrap when prompt text mentions the Team subcommand", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-native-hook-pretool-team-bootstrap-"),
+		);
+		try {
+			const result = await dispatchCodexNativeHook(
+				{
+					hook_event_name: "PreToolUse",
+					cwd,
+					source: "codex-app",
+					session_id: "sess-team-bootstrap",
+					tool_name: "Bash",
+					tool_use_id: "tool-team-bootstrap",
+					tool_input: {
+						command: `omx --tmux "After startup run omx team status durable-team"`,
+					},
+				},
+				{ cwd },
+			);
+
+			assert.equal(result.outputJson, null);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not classify read-only search text as a Team invocation", async () => {
+		const cwd = await mkdtemp(
+			join(tmpdir(), "omx-native-hook-pretool-team-search-text-"),
+		);
+		try {
+			const result = await dispatchCodexNativeHook(
+				{
+					hook_event_name: "PreToolUse",
+					cwd,
+					source: "codex-app",
+					session_id: "sess-team-search-text",
+					tool_name: "Bash",
+					tool_use_id: "tool-team-search-text",
+					tool_input: { command: `rg -n "omx team" src` },
+				},
+				{ cwd },
+			);
+
+			assert.equal(result.outputJson, null);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves direct CLI outside-tmux omx team Bash behavior", async () => {
 		const cwd = await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-team-cli-outside-"),
@@ -14774,21 +15072,41 @@ exit 0
 				stateRoot: process.env.OMX_TEAM_STATE_ROOT,
 				leaderCwd: process.env.OMX_TEAM_LEADER_CWD,
 				pane: process.env.TMUX_PANE,
+				capability: process.env.OMX_TEAM_WORKER_CAPABILITY,
 			};
 			try {
 				const teamName = "deep-state-guard";
 				const workerName = "worker-1";
 				const workerPane = "%77";
+				const workerCapabilityToken = "deep-state-guard-worker-1-capability";
+				const teamCreatedAt = "2026-08-02T00:00:00.000Z";
 				const teamRoot = join(stateDir, "team", teamName);
+				const workerCapability = (name: string, workerCwd: string, token: string) => ({
+					version: 1 as const,
+					team_name: teamName,
+					worker_name: name,
+					leader_session_id: "sess-di-artifact",
+					leader_cwd: cwd,
+					team_state_root: stateDir,
+					worker_cwd: workerCwd,
+					team_created_at: teamCreatedAt,
+					issued_at: teamCreatedAt,
+					token_sha256: digestTeamWorkerCapabilityToken(token),
+				});
 				await mkdir(join(teamRoot, "workers", workerName), { recursive: true });
 				await writeJson(join(teamRoot, "workers", workerName, "identity.json"), {
 					name: workerName,
 					team_state_root: stateDir,
 					pane_id: workerPane,
 					working_dir: cwd,
+					leader_cwd: cwd,
+					leader_session_id: "sess-di-artifact",
+					native_session_id: "sess-di-artifact",
+					runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken),
 				});
 				const teamAuthority = {
 					name: teamName,
+					created_at: teamCreatedAt,
 					leader_pane_id: "%1",
 					leader_cwd: cwd,
 					team_state_root: stateDir,
@@ -14797,6 +15115,10 @@ exit 0
 						pane_id: workerPane,
 						working_dir: cwd,
 						team_state_root: stateDir,
+						leader_cwd: cwd,
+						leader_session_id: "sess-di-artifact",
+						native_session_id: "sess-di-artifact",
+						runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken),
 					}],
 				};
 				await writeJson(join(teamRoot, "manifest.v2.json"), teamAuthority);
@@ -14806,6 +15128,7 @@ exit 0
 				process.env.OMX_TEAM_STATE_ROOT = stateDir;
 				process.env.OMX_TEAM_LEADER_CWD = cwd;
 				process.env.TMUX_PANE = workerPane;
+				process.env.OMX_TEAM_WORKER_CAPABILITY = workerCapabilityToken;
 				for (const [toolName, toolInput] of [
 					["mcp__omx_state__state_clear", { mode: "deep-interview" }],
 					["mcp__omx_state__state_write", { mode: "deep-interview", active: false, session_id: "sess-di-artifact", workingDirectory: cwd }],
@@ -14912,7 +15235,7 @@ exit 0
 					tool_input: { file_path: "src/runtime.ts", content: "export {};\n" },
 				}, { cwd });
 				assert.equal(canonicalIdentitylessLeader.outputJson?.decision, "block");
-				assert.match(String(canonicalIdentitylessLeader.outputJson?.reason ?? ""), /Deep-interview is active/);
+				assert.match(String(canonicalIdentitylessLeader.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
 
 				process.env.TMUX_PANE = "%foreign";
 				const mismatchedPaneWrite = await dispatchCodexNativeHook({
@@ -14924,12 +15247,12 @@ exit 0
 					tool_input: { file_path: "src/runtime.ts", content: "export {};\n" },
 				}, { cwd });
 				assert.equal(mismatchedPaneWrite.outputJson?.decision, "block");
-				assert.match(String(mismatchedPaneWrite.outputJson?.reason ?? ""), /OWNER_CONFIRMATION_REQUIRED/);
+				assert.match(String(mismatchedPaneWrite.outputJson?.reason ?? ""), /PROVENANCE_DENIED/);
 				process.env.TMUX_PANE = workerPane;
 
 				for (const [name, path, invalidValue, restoreValue] of [
 					["config pane mismatch", join(teamRoot, "config.json"), { ...teamAuthority, workers: [{ ...teamAuthority.workers[0], pane_id: "%foreign" }] }, teamAuthority],
-					["identity root mismatch", join(teamRoot, "workers", workerName, "identity.json"), { name: workerName, pane_id: workerPane, team_state_root: join(cwd, "foreign-state"), working_dir: cwd }, { name: workerName, pane_id: workerPane, team_state_root: stateDir, working_dir: cwd }],
+					["identity root mismatch", join(teamRoot, "workers", workerName, "identity.json"), { name: workerName, pane_id: workerPane, team_state_root: join(cwd, "foreign-state"), working_dir: cwd, leader_cwd: cwd, leader_session_id: "sess-di-artifact", native_session_id: "sess-di-artifact", runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken) }, { name: workerName, pane_id: workerPane, team_state_root: stateDir, working_dir: cwd, leader_cwd: cwd, leader_session_id: "sess-di-artifact", native_session_id: "sess-di-artifact", runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken) }],
 					["config worktree mismatch", join(teamRoot, "config.json"), { ...teamAuthority, workers: [{ ...teamAuthority.workers[0], worktree_path: join(cwd, "foreign-worktree") }] }, teamAuthority],
 				] as const) {
 					await writeJson(path, invalidValue);
@@ -14948,6 +15271,7 @@ exit 0
 				const detachedWorkerName = "worker-2";
 				const detachedWorkerPane = "%78";
 				const detachedWorkerCwd = join(cwd, "worker-checkout");
+				const detachedWorkerCapabilityToken = "deep-state-guard-worker-2-capability";
 				await mkdir(join(teamRoot, "workers", detachedWorkerName), { recursive: true });
 				await mkdir(detachedWorkerCwd, { recursive: true });
 				await writeJson(join(teamRoot, "workers", detachedWorkerName, "identity.json"), {
@@ -14955,6 +15279,10 @@ exit 0
 					pane_id: detachedWorkerPane,
 					team_state_root: stateDir,
 					working_dir: detachedWorkerCwd,
+					leader_cwd: cwd,
+					leader_session_id: "sess-di-artifact",
+					native_session_id: "sess-di-artifact",
+					runtime_capability: workerCapability(detachedWorkerName, detachedWorkerCwd, detachedWorkerCapabilityToken),
 				});
 				const detachedAuthority = {
 					...teamAuthority,
@@ -14964,6 +15292,10 @@ exit 0
 						team_state_root: stateDir,
 						worktree_path: detachedWorkerCwd,
 						working_dir: detachedWorkerCwd,
+						leader_cwd: cwd,
+						leader_session_id: "sess-di-artifact",
+						native_session_id: "sess-di-artifact",
+						runtime_capability: workerCapability(detachedWorkerName, detachedWorkerCwd, detachedWorkerCapabilityToken),
 					}],
 				};
 				await writeJson(join(teamRoot, "config.json"), detachedAuthority);
@@ -14971,6 +15303,7 @@ exit 0
 				process.env.OMX_TEAM_WORKER = `deep-display/${detachedWorkerName}`;
 				process.env.OMX_TEAM_INTERNAL_WORKER = `${teamName}/${detachedWorkerName}`;
 				process.env.TMUX_PANE = detachedWorkerPane;
+				process.env.OMX_TEAM_WORKER_CAPABILITY = detachedWorkerCapabilityToken;
 				const detachedWorkerProductWrite = await dispatchCodexNativeHook({
 					hook_event_name: "PreToolUse",
 					cwd: detachedWorkerCwd,
@@ -15048,6 +15381,7 @@ exit 0
 					OMX_TEAM_INTERNAL_WORKER: previousTeamEnv.internalWorker,
 					OMX_TEAM_STATE_ROOT: previousTeamEnv.stateRoot,
 					OMX_TEAM_LEADER_CWD: previousTeamEnv.leaderCwd,
+					OMX_TEAM_WORKER_CAPABILITY: previousTeamEnv.capability,
 					TMUX_PANE: previousTeamEnv.pane,
 				})) {
 					if (value === undefined) delete process.env[key];

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -15,7 +15,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { buildManagedCodexHooksConfig } from "../../config/codex-hooks.js";
 import { DOCUMENT_REFRESH_EXEMPTION_PREFIX } from "../../document-refresh/enforcer.js";
@@ -69,6 +69,7 @@ import { maybeNudgeLeaderForAllowedWorkerStop } from "../notify-hook/team-worker
 import { MAX_NATIVE_STDIN_JSON_BYTES } from "../hook-payload-guard.js";
 import { digestTeamWorkerCapabilityToken } from "../../team/worker-capability.js";
 
+const TEST_OMX_ENTRY_PATH = fileURLToPath(new URL("../../cli/omx.js", import.meta.url));
 
 const ARGUMENT_PRODUCING_RUNTIME_DENIAL_COMMANDS = [
   ["node-xargs-wrapper-read", `printf x | xargs node -e "require('fs').readFileSync('src/victim.ts','utf8')"`],
@@ -512,6 +513,7 @@ async function configureAuthoritativeTeamWorker(
   process.env.OMX_TEAM_STATE_ROOT = stateRoot;
   process.env.OMX_TEAM_LEADER_CWD = cwd;
   process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
+  process.env.OMX_ENTRY_PATH = TEST_OMX_ENTRY_PATH;
   process.env.OMX_SESSION_ID = "leader-session";
 }
 
@@ -799,6 +801,7 @@ const TEAM_ENV_KEYS = [
   "OMX_TEAM_WORKER",
   "OMX_TEAM_INTERNAL_WORKER",
   "OMX_TEAM_WORKER_CAPABILITY",
+  "OMX_ENTRY_PATH",
   "OMX_TEAM_STATE_ROOT",
   "OMX_TEAM_LEADER_CWD",
   "OMX_TEAM_MODE",
@@ -5740,6 +5743,8 @@ PY`,
         pid: process.pid,
       });
       await configureAuthoritativeTeamWorker(cwd, "binding-team");
+      const configBefore = await readFile(join(stateDir, "team", "binding-team", "config.json"), "utf-8");
+      const teamApiPrefix = `${JSON.stringify(process.execPath)} ${JSON.stringify(TEST_OMX_ENTRY_PATH)} team api`;
       await writeSessionSkillActiveState(stateDir, "leader-session", "team", "team-exec");
       await writeJson(join(stateDir, "sessions", "leader-session", "team-state.json"), {
         active: true,
@@ -5758,19 +5763,10 @@ PY`,
       }, { cwd, sessionOwnerPid: process.pid });
 
       const identityPath = join(stateDir, "team", "binding-team", "workers", "worker-1", "identity.json");
-      const boundIdentity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
-      assert.equal(boundIdentity.native_session_id, "worker-native-binding");
-      for (const fileName of ["config.json", "manifest.v2.json"]) {
-        const teamMetadata = JSON.parse(await readFile(
-          join(stateDir, "team", "binding-team", fileName),
-          "utf-8",
-        )) as { workers?: Array<{ name?: string; native_session_id?: string }> };
-        assert.equal(
-          teamMetadata.workers?.find((worker) => worker.name === "worker-1")?.native_session_id,
-          "worker-native-binding",
-          fileName,
-        );
-      }
+      const bindingPath = join(dirname(identityPath), "native-session-binding.json");
+      const boundSession = JSON.parse(await readFile(bindingPath, "utf-8")) as Record<string, unknown>;
+      assert.equal(boundSession.native_session_id, "worker-native-binding");
+      assert.equal(await readFile(join(stateDir, "team", "binding-team", "config.json"), "utf-8"), configBefore);
       assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
 
       const sourceWrite = await dispatchCodexNativeHook({
@@ -5790,15 +5786,15 @@ PY`,
         tool_name: "Bash",
         tool_use_id: "tool-worker-native-binding-api",
         tool_input: {
-          command: `omx team api send-message --input '{"team_name":"binding-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json`,
+          command: `${teamApiPrefix} send-message --input '{"team_name":"binding-team","from_worker":"worker-1","to_worker":"leader-fixed","body":"ACK"}' --json`,
         },
       }, { cwd });
       assert.equal(teamApiWrite.outputJson, null);
 
       for (const [toolUseId, command] of [
-        ["claim", `omx team api claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`],
-        ["transition", `omx team api transition-task-status --input '{"team_name":"binding-team","task_id":"1","from":"in_progress","to":"completed","claim_token":"claim-token","result":"done"}' --json`],
-        ["mailbox", `omx team api mailbox-mark-delivered --input '{"team_name":"binding-team","worker":"worker-1","message_id":"message-1"}' --json`],
+        ["claim", `${teamApiPrefix} claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`],
+        ["transition", `${teamApiPrefix} transition-task-status --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1","from":"in_progress","to":"completed","claim_token":"claim-token","result":"done"}' --json`],
+        ["mailbox", `${teamApiPrefix} mailbox-mark-delivered --input '{"team_name":"binding-team","worker":"worker-1","message_id":"message-1"}' --json`],
       ] as const) {
         const teamControlPlaneWrite = await dispatchCodexNativeHook({
           hook_event_name: "PreToolUse",
@@ -5810,6 +5806,67 @@ PY`,
         }, { cwd });
         assert.equal(teamControlPlaneWrite.outputJson, null, toolUseId);
       }
+			const trustedBinDir = join(cwd, "trusted-bin");
+			await mkdir(trustedBinDir, { recursive: true });
+			await symlink(TEST_OMX_ENTRY_PATH, join(trustedBinDir, "omx"));
+
+			for (const [name, mutateEnvironment, command] of [
+				[
+					"inline NODE_OPTIONS",
+					() => () => {},
+					`NODE_OPTIONS=--require=./payload.cjs ${teamApiPrefix} claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`,
+				],
+				[
+					"inherited NODE_OPTIONS",
+					() => {
+						const previous = process.env.NODE_OPTIONS;
+						process.env.NODE_OPTIONS = "--require=./payload.cjs";
+						return () => previous === undefined ? delete process.env.NODE_OPTIONS : (process.env.NODE_OPTIONS = previous);
+					},
+					`${teamApiPrefix} claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`,
+				],
+				[
+					"inherited node function",
+					() => {
+						const key = "BASH_FUNC_node%%";
+						const previous = process.env[key];
+						process.env[key] = "() { printf owned > src/pwned.ts; }";
+						return () => previous === undefined ? delete process.env[key] : (process.env[key] = previous);
+					},
+					`${teamApiPrefix} claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`,
+				],
+				[
+					"inherited omx function",
+					() => {
+						const key = "BASH_FUNC_omx%%";
+						const previousFunction = process.env[key];
+						const previousPath = process.env.PATH;
+						process.env[key] = "() { printf owned > src/pwned.ts; }";
+						process.env.PATH = `${trustedBinDir}:${previousPath ?? ""}`;
+						return () => {
+							if (previousFunction === undefined) delete process.env[key];
+							else process.env[key] = previousFunction;
+							if (previousPath === undefined) delete process.env.PATH;
+							else process.env.PATH = previousPath;
+						};
+					},
+					`omx team api claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`,
+				],
+			] as const) {
+				const restore = mutateEnvironment();
+				try {
+					const poisonedTeamApiWrite = await dispatchCodexNativeHook({
+						hook_event_name: "PreToolUse",
+						cwd,
+						session_id: "worker-native-binding",
+						tool_name: "Bash",
+						tool_input: { command },
+					}, { cwd });
+					assert.equal(poisonedTeamApiWrite.outputJson?.decision, "block", name);
+				} finally {
+					restore();
+				}
+			}
 
       const crossTeamApiWrite = await dispatchCodexNativeHook({
         hook_event_name: "PreToolUse",
@@ -5818,10 +5875,34 @@ PY`,
         tool_name: "Bash",
         tool_use_id: "tool-worker-native-binding-cross-team-api",
         tool_input: {
-          command: `omx team api claim-task --input '{"team_name":"foreign-team","task_id":"1","worker":"worker-1"}' --json`,
+          command: `${teamApiPrefix} claim-task --input '{"team_name":"foreign-team","task_id":"1","worker":"worker-1"}' --json`,
         },
       }, { cwd });
       assert.equal(crossTeamApiWrite.outputJson?.decision, "block");
+
+      const crossWorkerTransition = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Bash",
+        tool_input: {
+          command: `${teamApiPrefix} transition-task-status --input '{"team_name":"binding-team","task_id":"1","worker":"worker-2","from":"in_progress","to":"completed","claim_token":"claim-token"}' --json`,
+        },
+      }, { cwd });
+      assert.equal(crossWorkerTransition.outputJson?.decision, "block");
+
+      const untrustedEntryPath = join(cwd, "omx.js");
+      await writeFile(untrustedEntryPath, "process.exit(0);\n", "utf8");
+      const untrustedOmxExecutable = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-binding",
+        tool_name: "Bash",
+        tool_input: {
+          command: `${JSON.stringify(process.execPath)} ${JSON.stringify(untrustedEntryPath)} team api claim-task --input '{"team_name":"binding-team","task_id":"1","worker":"worker-1"}' --json`,
+        },
+      }, { cwd });
+      assert.equal(untrustedOmxExecutable.outputJson?.decision, "block");
 
       process.env.OMX_TEAM_WORKER_CAPABILITY = "wrong-worker-capability-token";
       const wrongCapabilityWrite = await dispatchCodexNativeHook({
@@ -5841,8 +5922,8 @@ PY`,
         cwd,
         session_id: "forged-worker-native",
       }, { cwd, sessionOwnerPid: process.pid });
-      const reboundIdentity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
-      assert.equal(reboundIdentity.native_session_id, "worker-native-binding");
+      const reboundSession = JSON.parse(await readFile(bindingPath, "utf-8")) as Record<string, unknown>;
+      assert.equal(reboundSession.native_session_id, "worker-native-binding");
 
       const forgedWrite = await dispatchCodexNativeHook({
         hook_event_name: "PreToolUse",
@@ -5884,11 +5965,63 @@ PY`,
       }, { cwd, sessionOwnerPid: process.pid });
       await materialized;
 
-      const identity = JSON.parse(await readFile(
-        join(stateRoot, "team", teamName, "workers", "worker-1", "identity.json"),
+      const binding = JSON.parse(await readFile(
+        join(stateRoot, "team", teamName, "workers", "worker-1", "native-session-binding.json"),
         "utf-8",
       )) as { native_session_id?: string };
-      assert.equal(identity.native_session_id, "worker-native-startup-race");
+      assert.equal(binding.native_session_id, "worker-native-startup-race");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("binds on the next hook event when metadata arrives after the SessionStart window", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-team-worker-late-metadata-"));
+    try {
+      const teamName = "late-metadata-team";
+      const stateRoot = join(cwd, ".omx", "state");
+      process.env.TMUX = "1";
+      process.env.TMUX_PANE = "%10";
+      process.env.OMX_TEAM_INTERNAL_WORKER = `${teamName}/worker-1`;
+      process.env.OMX_TEAM_WORKER = `${teamName}/worker-1`;
+      process.env.OMX_TEAM_STATE_ROOT = stateRoot;
+      process.env.OMX_TEAM_LEADER_CWD = cwd;
+      process.env.OMX_TEAM_WORKER_CAPABILITY = "test-worker-capability-token";
+      process.env.OMX_SESSION_ID = "leader-session";
+
+      const materialized = (async () => {
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 1_100));
+        await configureAuthoritativeTeamWorker(cwd, teamName);
+      })();
+      await dispatchCodexNativeHook({
+        hook_event_name: "SessionStart",
+        cwd,
+        session_id: "worker-native-late-metadata",
+      }, { cwd, sessionOwnerPid: process.pid });
+      assert.equal(existsSync(join(
+        stateRoot,
+        "team",
+        teamName,
+        "workers",
+        "worker-1",
+        "native-session-binding.json",
+      )), false);
+
+      await materialized;
+      const writeAfterMetadata = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: "worker-native-late-metadata",
+        tool_name: "Edit",
+        tool_input: { file_path: "src/late-metadata.ts", old_string: "a", new_string: "b" },
+      }, { cwd });
+      assert.equal(writeAfterMetadata.outputJson, null);
+
+      const binding = JSON.parse(await readFile(
+        join(stateRoot, "team", teamName, "workers", "worker-1", "native-session-binding.json"),
+        "utf-8",
+      )) as { native_session_id?: string };
+      assert.equal(binding.native_session_id, "worker-native-late-metadata");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -5935,8 +6068,12 @@ PY`,
       const identity = JSON.parse(await readFile(
         join(leaderCwd, ".omx", "state", "team", "detached-binding-team", "workers", "worker-1", "identity.json"),
         "utf-8",
-      )) as { native_session_id?: string; worktree_path?: string };
-      assert.equal(identity.native_session_id, "detached-worker-native");
+      )) as { worktree_path?: string };
+      const binding = JSON.parse(await readFile(
+        join(leaderCwd, ".omx", "state", "team", "detached-binding-team", "workers", "worker-1", "native-session-binding.json"),
+        "utf-8",
+      )) as { native_session_id?: string };
+      assert.equal(binding.native_session_id, "detached-worker-native");
       assert.equal(identity.worktree_path, workerCwd);
     } finally {
       await rm(leaderCwd, { recursive: true, force: true });
@@ -13373,6 +13510,54 @@ exit 0
 		}
 	});
 
+	it("blocks structurally wrapped direct Team invocations outside tmux", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-team-wrappers-"));
+		try {
+			for (const [name, command] of [
+				["command", "command omx team status durable-team"],
+				["exec", "exec omx team status durable-team"],
+				["nohup", "nohup omx team status durable-team"],
+				["timeout", "timeout 5s omx team status durable-team"],
+				["nice", "nice -n 5 omx team status durable-team"],
+				["stdbuf", "stdbuf -o0 omx team status durable-team"],
+			] as const) {
+				const result = await dispatchCodexNativeHook({
+					hook_event_name: "PreToolUse",
+					cwd,
+					source: "codex-app",
+					session_id: `sess-team-wrapper-${name}`,
+					tool_name: "Bash",
+					tool_input: { command },
+				}, { cwd });
+				assert.equal(result.outputJson?.decision, "block", name);
+			}
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("blocks nice/stdbuf wrapped HUD invocations outside tmux", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-pretool-hud-wrappers-"));
+		try {
+			for (const [name, command] of [
+				["nice", "nice -n 5 omx hud"],
+				["stdbuf", "stdbuf -e0 omx hud"],
+			] as const) {
+				const result = await dispatchCodexNativeHook({
+					hook_event_name: "PreToolUse",
+					cwd,
+					source: "codex-app",
+					session_id: `sess-hud-wrapper-${name}`,
+					tool_name: "Bash",
+					tool_input: { command },
+				}, { cwd });
+				assert.equal(result.outputJson?.decision, "block", name);
+			}
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
 	it("preserves direct CLI outside-tmux omx team Bash behavior", async () => {
 		const cwd = await mkdtemp(
 			join(tmpdir(), "omx-native-hook-pretool-team-cli-outside-"),
@@ -15104,10 +15289,11 @@ exit 0
 					native_session_id: "sess-di-artifact",
 					runtime_capability: workerCapability(workerName, cwd, workerCapabilityToken),
 				});
-				const teamAuthority = {
-					name: teamName,
-					created_at: teamCreatedAt,
-					leader_pane_id: "%1",
+					const teamAuthority = {
+						name: teamName,
+						created_at: teamCreatedAt,
+						leader: { session_id: "sess-di-artifact" },
+						leader_pane_id: "%1",
 					leader_cwd: cwd,
 					team_state_root: stateDir,
 					workers: [{

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -71,9 +71,16 @@ import {
   readTeamConfig,
   readTeamManifestV2,
   readTeamPhase,
+  saveTeamConfig,
+  writeWorkerIdentity,
   writeTeamLeaderAttention,
   writeTeamPhase,
+  type WorkerInfo,
 } from "../team/state.js";
+import {
+  capabilityTokenMatches,
+  TEAM_WORKER_CAPABILITY_ENV,
+} from "../team/worker-capability.js";
 import { parseTeamNoticeLedgerPrompt, reconcileTeamNoticeLedger } from "../team/notice-ledger.js";
 import {
   canonicalizeComparablePath,
@@ -2939,7 +2946,10 @@ function hasRawTeamWorkerDeclaration(): boolean {
     || safeString(process.env.OMX_TEAM_WORKER).trim() !== "";
 }
 
-async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> {
+async function hasAuthoritativeTeamWorkerContext(
+  cwd: string,
+  expectedNativeSessionId = "",
+): Promise<boolean> {
   const workerContext = readTeamWorkerEnvironment();
   if (!workerContext) return false;
 
@@ -2979,6 +2989,35 @@ async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> 
   if (safeString(identity.pane_id).trim() !== currentPaneId) return false;
   if (!pathMatches(identity.team_state_root, canonicalStateRoot)) return false;
   if (!pathMatches(identity.worktree_path ?? identity.working_dir, canonicalCwd)) return false;
+  const capabilityToken = safeString(process.env[TEAM_WORKER_CAPABILITY_ENV]).trim();
+  if (!capabilityToken) return false;
+  const capabilityMatches = (record: Record<string, unknown>): boolean => {
+    const capability = safeObject(record.runtime_capability);
+    if (Number(capability.version) !== 1) return false;
+    if (safeString(capability.team_name).trim() !== workerContext.teamName) return false;
+    if (safeString(capability.worker_name).trim() !== workerContext.workerName) return false;
+    if (safeString(capability.leader_session_id).trim() === "") return false;
+    if (safeString(capability.leader_session_id).trim() !== safeString(record.leader_session_id).trim()) return false;
+    if (safeString(capability.team_created_at).trim() !== safeString(config.created_at).trim()) return false;
+    if (safeString(capability.team_created_at).trim() !== safeString(manifest.created_at).trim()) return false;
+    if (!pathMatches(capability.team_state_root, canonicalStateRoot)) return false;
+    if (!pathMatches(capability.worker_cwd, canonicalCwd)) return false;
+    if (!pathMatches(capability.leader_cwd, canonicalLeaderCwd)) return false;
+    return capabilityTokenMatches(capabilityToken, safeString(capability.token_sha256));
+  };
+  if (![identity, manifestWorker, configWorker].every(capabilityMatches)) return false;
+  const identityCapability = safeObject(identity.runtime_capability);
+  for (const worker of [identity, manifestWorker, configWorker]) {
+    if (safeString(worker.leader_session_id).trim() !== safeString(identityCapability.leader_session_id).trim()) return false;
+    if (!pathMatches(worker.leader_cwd, canonicalLeaderCwd)) return false;
+  }
+  const expectedSession = normalizeSessionId(expectedNativeSessionId);
+  if (expectedNativeSessionId && !expectedSession) return false;
+  if (expectedSession) {
+    for (const worker of [identity, manifestWorker, configWorker]) {
+      if (normalizeSessionId(safeString(worker.native_session_id)) !== expectedSession) return false;
+    }
+  }
   for (const state of [manifest, config]) {
     if (safeString(state.name).trim() !== workerContext.teamName) return false;
     if (safeString(state.leader_pane_id).trim() === currentPaneId) return false;
@@ -2996,6 +3035,56 @@ async function hasAuthoritativeTeamWorkerContext(cwd: string): Promise<boolean> 
     if (worktreePath && !pathMatches(worktreePath, canonicalCwd)) return false;
   }
   return true;
+}
+
+async function bindAuthoritativeTeamWorkerNativeSession(
+  cwd: string,
+  nativeSessionId: string,
+): Promise<boolean> {
+  const normalizedSessionId = normalizeSessionId(nativeSessionId);
+  const workerContext = readTeamWorkerEnvironment();
+  if (!normalizedSessionId || !workerContext) return false;
+  if (!safeString(process.env[TEAM_WORKER_CAPABILITY_ENV]).trim()) return false;
+  if (!safeString(process.env.TMUX_PANE).trim()) return false;
+  let startupMetadataReady = false;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (await hasAuthoritativeTeamWorkerContext(cwd)) {
+      startupMetadataReady = true;
+      break;
+    }
+    if (attempt < 39) await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  if (!startupMetadataReady) return false;
+
+  const stateRoot = await resolveWorkerTeamStateRootPath(cwd, workerContext, process.env).catch(() => null);
+  if (!stateRoot) return false;
+  const identityPath = join(stateRoot, "team", workerContext.teamName, "workers", workerContext.workerName, "identity.json");
+  const identity = await readJsonIfExists(identityPath);
+  if (!identity) return false;
+  const config = await readTeamConfig(workerContext.teamName, cwd).catch(() => null);
+  const configWorker = config?.workers.find((worker) => worker.name === workerContext.workerName);
+  if (!config || !configWorker) return false;
+  const existingSessionIds = [identity.native_session_id, configWorker.native_session_id]
+    .map((value) => normalizeSessionId(safeString(value)))
+    .filter(Boolean);
+  if (existingSessionIds.some((value) => value !== normalizedSessionId)) return false;
+  try {
+    if (normalizeSessionId(safeString(configWorker.native_session_id)) !== normalizedSessionId) {
+      configWorker.native_session_id = normalizedSessionId;
+      await saveTeamConfig(config, cwd);
+    }
+    if (normalizeSessionId(safeString(identity.native_session_id)) !== normalizedSessionId) {
+      await writeWorkerIdentity(
+        workerContext.teamName,
+        workerContext.workerName,
+        { ...identity, native_session_id: normalizedSessionId } as unknown as WorkerInfo,
+        cwd,
+      );
+    }
+  } catch {
+    return false;
+  }
+  return await hasAuthoritativeTeamWorkerContext(cwd, normalizedSessionId);
 }
 
 async function resolveTeamStateDirForWorkerContext(
@@ -3847,6 +3936,7 @@ async function resolvePreToolUseSessionBinding(
   stateDir: string,
   payload: CodexHookPayload,
   allowSharedTeamRoot = false,
+  authorizedWorkerNativeSessionId = "",
 ): Promise<PreToolUseSessionBinding> {
   const currentSession = allowSharedTeamRoot
     ? await readRootSessionStateFromStateDir(stateDir).catch(() => null)
@@ -3855,6 +3945,11 @@ async function resolvePreToolUseSessionBinding(
   const aliases = payloadAliasValues(payload, ["session_id", "sessionId"]);
   const knownAliases = sessionPointerAliases(currentSession);
   const nativeIdentityAliases = sessionNativeIdentityAliases(currentSession);
+  const workerNativeSessionId = normalizeSessionId(authorizedWorkerNativeSessionId);
+  if (workerNativeSessionId) {
+    knownAliases.add(workerNativeSessionId);
+    nativeIdentityAliases.add(workerNativeSessionId);
+  }
   return {
     canonicalSessionId,
     payloadSessionAliases: knownAliases,
@@ -10614,6 +10709,87 @@ function buildPlanningStateScopeDeny(modeLabel: string, phase: string): Record<s
   };
 }
 
+const TEAM_WORKER_MUTATING_API_OPERATIONS = new Set([
+  "send-message",
+  "broadcast",
+  "mailbox-mark-delivered",
+  "mailbox-mark-notified",
+  "claim-task",
+  "transition-task-status",
+  "release-task-claim",
+  "update-worker-heartbeat",
+]);
+
+function parseAuthorizedTeamWorkerApiCommand(command: string): {
+  operation: string;
+  input: Record<string, unknown>;
+} | null {
+  if (!command.trim() || /[$`\r\n]/.test(command)) return null;
+  const segments = splitShellCommandSegments(stripHeredocBodiesForCommandScan(command));
+  if (segments.length !== 1 || segments[0]?.trim() !== command.trim()) return null;
+  const rawWords = tokenizeShellWords(segments[0] ?? "");
+  const words = rawWords.map((word) => shellWordLiteral(word));
+  if (words.some((word) => word === null)) return null;
+  const literalWords = words as string[];
+  const commandIndex = findWrappedCommandPositionIndex(rawWords, 0);
+  if (commandIndex === null) return null;
+  const executable = basename(literalWords[commandIndex] ?? "").toLowerCase();
+  let subcommandIndex = commandIndex + 1;
+  if (executable === "node" || executable === "node.exe") {
+    if (basename(literalWords[subcommandIndex] ?? "").toLowerCase() !== "omx.js") return null;
+    subcommandIndex += 1;
+  } else if (executable !== "omx" && executable !== "omx.js") {
+    return null;
+  }
+  if (literalWords[subcommandIndex] !== "team" || literalWords[subcommandIndex + 1] !== "api") return null;
+  const operation = literalWords[subcommandIndex + 2] ?? "";
+  if (!TEAM_WORKER_MUTATING_API_OPERATIONS.has(operation)) return null;
+
+  let input: Record<string, unknown> = {};
+  for (let index = subcommandIndex + 3; index < literalWords.length; index += 1) {
+    const word = literalWords[index] ?? "";
+    if (word === "--json") continue;
+    let rawInput = "";
+    if (word === "--input") {
+      rawInput = literalWords[index + 1] ?? "";
+      index += 1;
+    } else if (word.startsWith("--input=")) {
+      rawInput = word.slice("--input=".length);
+    } else {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(rawInput) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+      input = parsed as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  return { operation, input };
+}
+
+function isAuthorizedTeamWorkerApiCommand(command: string): boolean {
+  const workerContext = readTeamWorkerEnvironment();
+  const parsed = parseAuthorizedTeamWorkerApiCommand(command);
+  if (!workerContext || !parsed) return false;
+  const teamName = safeString(parsed.input.team_name).trim();
+  if (teamName && teamName !== workerContext.teamName) return false;
+  const fromWorker = safeString(parsed.input.from_worker).trim();
+  if (fromWorker && fromWorker !== workerContext.workerName) return false;
+  const worker = safeString(parsed.input.worker).trim();
+  if (worker && worker !== workerContext.workerName) return false;
+  if ((parsed.operation === "send-message" || parsed.operation === "broadcast") && fromWorker !== workerContext.workerName) return false;
+  if ([
+    "mailbox-mark-delivered",
+    "mailbox-mark-notified",
+    "claim-task",
+    "release-task-claim",
+    "update-worker-heartbeat",
+  ].includes(parsed.operation) && worker !== workerContext.workerName) return false;
+  return teamName === "" || teamName === workerContext.teamName;
+}
+
 function teamWorkerMutationTargetsProtectedWorkflowState(
   payload: CodexHookPayload,
   toolName: string,
@@ -10631,6 +10807,7 @@ function teamWorkerMutationTargetsProtectedWorkflowState(
   if (toolName === "mcp__omx_state__state_clear" || toolName === "mcp__omx_state__state_write") return true;
   if (mutationTransport === "unknown" || mutationTransport === "state" || mutationTransport === "goal-lifecycle") return true;
   if (toolName === "Bash") {
+    if (isAuthorizedTeamWorkerApiCommand(command)) return false;
     if (collectOmxStateCommandOperations(command, "write").length > 0
       || findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
     let effectiveCwd = cwd;
@@ -11108,7 +11285,7 @@ async function resolvePreToolUseWriteActor(
   if (payloadHasOwnerIdentityClaim(payload)) return "native-child";
   if (!payloadAgentId && isTypedAgentRolePayload(payload, cwd)) return "native-child";
   if (payloadAgentId || payloadThreadId) return "native-child";
-  return (await hasAuthoritativeTeamWorkerContext(cwd)) ? "team-worker" : "native-child";
+  return (await hasAuthoritativeTeamWorkerContext(cwd, payloadSessionId)) ? "team-worker" : "native-child";
 }
 
 function isActiveConductorModeState(state: Record<string, unknown> | null, mode: string, sessionId: string): boolean {
@@ -22430,7 +22607,11 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const authoritativeTeamWorker = declaredTeamWorker && await hasAuthoritativeTeamWorkerContext(cwd);
+  const authoritativeTeamWorker = declaredTeamWorker
+    && candidateWorkerPayloadSessionId !== ""
+    && (hookEventName === "SessionStart"
+      ? await bindAuthoritativeTeamWorkerNativeSession(cwd, candidateWorkerPayloadSessionId)
+      : await hasAuthoritativeTeamWorkerContext(cwd, candidateWorkerPayloadSessionId));
   const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
     && candidateWorkerPayloadSessionId
     && (!pointer.state || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, pointer.state))
@@ -22966,20 +23147,22 @@ export async function dispatchCodexNativeHook(
       };
     }
   } else if (hookEventName === "PreToolUse") {
-    const identitylessTeamWorkerContext = !readPayloadAgentId(payload)
+    const payloadSessionId = readPayloadSessionId(payload);
+    const identitylessTeamWorkerPayload = !readPayloadAgentId(payload)
       && !safeString(payload.agentId).trim()
       && !safeString(payload.threadId).trim()
       && !readPayloadThreadId(payload)
       && !payloadHasOwnerIdentityClaim(payload)
-      && !hasSubagentThreadSpawnProvenance(payload)
-      && await hasAuthoritativeTeamWorkerContext(cwd);
+      && !hasSubagentThreadSpawnProvenance(payload);
+    const identitylessTeamWorkerContext = identitylessTeamWorkerPayload
+      && await hasAuthoritativeTeamWorkerContext(cwd, payloadSessionId);
     const sessionBinding = await resolvePreToolUseSessionBinding(
       policyCwd,
       stateDir,
       payload,
       identitylessTeamWorkerContext,
+      identitylessTeamWorkerContext ? payloadSessionId : "",
     );
-    const payloadSessionId = readPayloadSessionId(payload);
     const rootPointerConflict = await readLiveRootSessionPointerConflict(stateDir, payloadSessionId);
     const mutationTransport = classifyPreToolUseMutationTransport(
       payload,
@@ -23032,7 +23215,18 @@ export async function dispatchCodexNativeHook(
       });
       if (directCancel.kind !== "not-direct-cancel") outputJson = directCancel.output;
     }
-    if (!outputJson && !policyRoot.valid && policyRoot.statePresent && mutationTransport !== "read-only") {
+    if (
+      !outputJson
+      && declaredTeamWorker
+      && identitylessTeamWorkerPayload
+      && !identitylessTeamWorkerContext
+      && mutationTransport !== "read-only"
+    ) {
+      outputJson = buildConductorSessionProvenanceDeny(
+        { mode: "team", phase: "active" },
+        "the declared Team worker does not match its bound native session capability",
+      );
+    } else if (!outputJson && !policyRoot.valid && policyRoot.statePresent && mutationTransport !== "read-only") {
       outputJson = buildConductorSessionProvenanceDeny(
         { mode: "conductor", phase: "active" },
         "the selected workflow state root has no usable canonical session cwd",

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -71,20 +71,20 @@ import {
   readTeamConfig,
   readTeamManifestV2,
   readTeamPhase,
-  saveTeamConfig,
-  writeWorkerIdentity,
   writeTeamLeaderAttention,
   writeTeamPhase,
-  type WorkerInfo,
 } from "../team/state.js";
 import {
+  bindTeamWorkerNativeSession,
   capabilityTokenMatches,
+  readTeamWorkerNativeSessionBinding,
   TEAM_WORKER_CAPABILITY_ENV,
 } from "../team/worker-capability.js";
 import { parseTeamNoticeLedgerPrompt, reconcileTeamNoticeLedger } from "../team/notice-ledger.js";
 import {
   canonicalizeComparablePath,
   omxNotepadPath,
+  resolveOmxCliEntryPath,
   resolveProjectMemoryPath,
   sameFilePath,
 } from "../utils/paths.js";
@@ -3007,6 +3007,8 @@ async function hasAuthoritativeTeamWorkerContext(
   };
   if (![identity, manifestWorker, configWorker].every(capabilityMatches)) return false;
   const identityCapability = safeObject(identity.runtime_capability);
+  const leader = safeObject(manifest.leader);
+  if (safeString(leader.session_id).trim() !== safeString(identityCapability.leader_session_id).trim()) return false;
   for (const worker of [identity, manifestWorker, configWorker]) {
     if (safeString(worker.leader_session_id).trim() !== safeString(identityCapability.leader_session_id).trim()) return false;
     if (!pathMatches(worker.leader_cwd, canonicalLeaderCwd)) return false;
@@ -3014,9 +3016,19 @@ async function hasAuthoritativeTeamWorkerContext(
   const expectedSession = normalizeSessionId(expectedNativeSessionId);
   if (expectedNativeSessionId && !expectedSession) return false;
   if (expectedSession) {
-    for (const worker of [identity, manifestWorker, configWorker]) {
-      if (normalizeSessionId(safeString(worker.native_session_id)) !== expectedSession) return false;
-    }
+    const binding = await readTeamWorkerNativeSessionBinding(
+      canonicalStateRoot,
+      workerContext.teamName,
+      workerContext.workerName,
+    );
+    if (!binding) return false;
+    if (binding.team_name !== workerContext.teamName || binding.worker_name !== workerContext.workerName) return false;
+    if (normalizeSessionId(binding.native_session_id) !== expectedSession) return false;
+    if (binding.leader_session_id !== safeString(identityCapability.leader_session_id).trim()) return false;
+    if (binding.team_created_at !== safeString(config.created_at).trim()) return false;
+    if (binding.capability_sha256 !== safeString(identityCapability.token_sha256).trim()) return false;
+    if (!pathMatches(binding.team_state_root, canonicalStateRoot)) return false;
+    if (!pathMatches(binding.worker_cwd, canonicalCwd)) return false;
   }
   for (const state of [manifest, config]) {
     if (safeString(state.name).trim() !== workerContext.teamName) return false;
@@ -3034,6 +3046,8 @@ async function hasAuthoritativeTeamWorkerContext(
     if (workingDir && !pathMatches(workingDir, canonicalCwd)) return false;
     if (worktreePath && !pathMatches(worktreePath, canonicalCwd)) return false;
   }
+  const teamPhase = await readTeamPhase(workerContext.teamName, cwd).catch(() => null);
+  if (teamPhase && ["complete", "failed", "cancelled"].includes(safeString(teamPhase.current_phase).trim())) return false;
   return true;
 }
 
@@ -3061,26 +3075,20 @@ async function bindAuthoritativeTeamWorkerNativeSession(
   const identityPath = join(stateRoot, "team", workerContext.teamName, "workers", workerContext.workerName, "identity.json");
   const identity = await readJsonIfExists(identityPath);
   if (!identity) return false;
-  const config = await readTeamConfig(workerContext.teamName, cwd).catch(() => null);
-  const configWorker = config?.workers.find((worker) => worker.name === workerContext.workerName);
-  if (!config || !configWorker) return false;
-  const existingSessionIds = [identity.native_session_id, configWorker.native_session_id]
-    .map((value) => normalizeSessionId(safeString(value)))
-    .filter(Boolean);
-  if (existingSessionIds.some((value) => value !== normalizedSessionId)) return false;
+  const capability = safeObject(identity.runtime_capability);
   try {
-    if (normalizeSessionId(safeString(configWorker.native_session_id)) !== normalizedSessionId) {
-      configWorker.native_session_id = normalizedSessionId;
-      await saveTeamConfig(config, cwd);
-    }
-    if (normalizeSessionId(safeString(identity.native_session_id)) !== normalizedSessionId) {
-      await writeWorkerIdentity(
-        workerContext.teamName,
-        workerContext.workerName,
-        { ...identity, native_session_id: normalizedSessionId } as unknown as WorkerInfo,
-        cwd,
-      );
-    }
+    await bindTeamWorkerNativeSession(stateRoot, {
+      version: 1,
+      team_name: workerContext.teamName,
+      worker_name: workerContext.workerName,
+      native_session_id: normalizedSessionId,
+      leader_session_id: safeString(capability.leader_session_id).trim(),
+      team_created_at: safeString(capability.team_created_at).trim(),
+      worker_cwd: safeString(capability.worker_cwd).trim(),
+      team_state_root: safeString(capability.team_state_root).trim(),
+      capability_sha256: safeString(capability.token_sha256).trim(),
+      bound_at: new Date().toISOString(),
+    });
   } catch {
     return false;
   }
@@ -10720,7 +10728,47 @@ const TEAM_WORKER_MUTATING_API_OPERATIONS = new Set([
   "update-worker-heartbeat",
 ]);
 
-function parseAuthorizedTeamWorkerApiCommand(command: string): {
+function resolveLiteralExecutablePath(executable: string, cwd: string): string | null {
+  if (!executable) return null;
+  if (executable.includes("/") || executable.includes("\\")) {
+    return isAbsolute(executable) ? executable : resolve(cwd, executable);
+  }
+  for (const directory of safeString(process.env.PATH).split(delimiter)) {
+    if (!directory) continue;
+    const candidate = join(directory, executable);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function trustedTeamApiSubcommandIndex(
+  command: string,
+  literalWords: string[],
+  commandIndex: number,
+  cwd: string,
+): number | null {
+  if (literalWords.slice(0, commandIndex).some(isEnvironmentAssignmentWord)) return null;
+  if (commandHasUnsafeDynamicLoaderEnvironment(command) || commandHasUnsafeLeadingRuntimeEnvironment(command)) return null;
+  const unsafeInheritedNames = [...OMX_GJC_TRUSTED_CONTEXT_UNSAFE_INHERITED_ENV_NAMES, ...CONDUCTOR_NODE_OUTPUT_ENVIRONMENT_NAMES];
+  if (unsafeInheritedNames.some((name) => safeString(process.env[name]).trim() !== "")) return null;
+  const trustedEntry = resolveOmxCliEntryPath({ cwd, env: process.env });
+  if (!trustedEntry) return null;
+  const executableWord = literalWords[commandIndex] ?? "";
+  const executable = basename(executableWord).toLowerCase();
+  const executableName = executable.replace(/\.exe$/i, "");
+  if (safeString(process.env[`BASH_FUNC_${executableName}%%`]).trim() !== "") return null;
+  if (executable === "node" || executable === "node.exe") {
+    const nodePath = resolveLiteralExecutablePath(executableWord, cwd);
+    const targetPath = resolveLiteralExecutablePath(literalWords[commandIndex + 1] ?? "", cwd);
+    if (!nodePath || !targetPath || !sameFilePath(nodePath, process.execPath) || !sameFilePath(targetPath, trustedEntry)) return null;
+    return commandIndex + 2;
+  }
+  if (executable !== "omx" && executable !== "omx.js") return null;
+  const invokedPath = resolveLiteralExecutablePath(executableWord, cwd);
+  return invokedPath && sameFilePath(invokedPath, trustedEntry) ? commandIndex + 1 : null;
+}
+
+function parseAuthorizedTeamWorkerApiCommand(command: string, cwd: string): {
   operation: string;
   input: Record<string, unknown>;
 } | null {
@@ -10733,14 +10781,8 @@ function parseAuthorizedTeamWorkerApiCommand(command: string): {
   const literalWords = words as string[];
   const commandIndex = findWrappedCommandPositionIndex(rawWords, 0);
   if (commandIndex === null) return null;
-  const executable = basename(literalWords[commandIndex] ?? "").toLowerCase();
-  let subcommandIndex = commandIndex + 1;
-  if (executable === "node" || executable === "node.exe") {
-    if (basename(literalWords[subcommandIndex] ?? "").toLowerCase() !== "omx.js") return null;
-    subcommandIndex += 1;
-  } else if (executable !== "omx" && executable !== "omx.js") {
-    return null;
-  }
+  const subcommandIndex = trustedTeamApiSubcommandIndex(command, literalWords, commandIndex, cwd);
+  if (subcommandIndex === null) return null;
   if (literalWords[subcommandIndex] !== "team" || literalWords[subcommandIndex + 1] !== "api") return null;
   const operation = literalWords[subcommandIndex + 2] ?? "";
   if (!TEAM_WORKER_MUTATING_API_OPERATIONS.has(operation)) return null;
@@ -10769,9 +10811,9 @@ function parseAuthorizedTeamWorkerApiCommand(command: string): {
   return { operation, input };
 }
 
-function isAuthorizedTeamWorkerApiCommand(command: string): boolean {
+function isAuthorizedTeamWorkerApiCommand(command: string, cwd: string): boolean {
   const workerContext = readTeamWorkerEnvironment();
-  const parsed = parseAuthorizedTeamWorkerApiCommand(command);
+  const parsed = parseAuthorizedTeamWorkerApiCommand(command, cwd);
   if (!workerContext || !parsed) return false;
   const teamName = safeString(parsed.input.team_name).trim();
   if (teamName && teamName !== workerContext.teamName) return false;
@@ -10784,6 +10826,7 @@ function isAuthorizedTeamWorkerApiCommand(command: string): boolean {
     "mailbox-mark-delivered",
     "mailbox-mark-notified",
     "claim-task",
+    "transition-task-status",
     "release-task-claim",
     "update-worker-heartbeat",
   ].includes(parsed.operation) && worker !== workerContext.workerName) return false;
@@ -10807,7 +10850,7 @@ function teamWorkerMutationTargetsProtectedWorkflowState(
   if (toolName === "mcp__omx_state__state_clear" || toolName === "mcp__omx_state__state_write") return true;
   if (mutationTransport === "unknown" || mutationTransport === "state" || mutationTransport === "goal-lifecycle") return true;
   if (toolName === "Bash") {
-    if (isAuthorizedTeamWorkerApiCommand(command)) return false;
+    if (isAuthorizedTeamWorkerApiCommand(command, cwd)) return false;
     if (collectOmxStateCommandOperations(command, "write").length > 0
       || findUnquotedOmxStateCommandIndexes(command, "clear").length > 0) return true;
     let effectiveCwd = cwd;
@@ -22609,9 +22652,8 @@ export async function dispatchCodexNativeHook(
   let isSubagentSessionStart = false;
   const authoritativeTeamWorker = declaredTeamWorker
     && candidateWorkerPayloadSessionId !== ""
-    && (hookEventName === "SessionStart"
-      ? await bindAuthoritativeTeamWorkerNativeSession(cwd, candidateWorkerPayloadSessionId)
-      : await hasAuthoritativeTeamWorkerContext(cwd, candidateWorkerPayloadSessionId));
+    && (await hasAuthoritativeTeamWorkerContext(cwd, candidateWorkerPayloadSessionId)
+      || await bindAuthoritativeTeamWorkerNativeSession(cwd, candidateWorkerPayloadSessionId));
   const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
     && candidateWorkerPayloadSessionId
     && (!pointer.state || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, pointer.state))

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1177,34 +1177,88 @@ function commandInvokesOmxSubcommand(command: string, subcommand: string): boole
   for (let commandStart = 0; commandStart < tokens.length; commandStart = nextCommandStart(tokens, commandStart)) {
     const commandEnd = nextCommandStart(tokens, commandStart);
     let index = commandStart;
-
-    while (index < commandEnd && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) {
-      index += 1;
-    }
-
-    while (index < commandEnd && isEnvExecutableToken(tokens[index]?.value ?? "")) {
-      index += 1;
-      while (index < commandEnd) {
-        const token = tokens[index]?.value ?? "";
-        if (token === "--") {
+    let wrapperRejected = false;
+    for (let unwrapCount = 0; unwrapCount < 8 && index < commandEnd; unwrapCount += 1) {
+      while (index < commandEnd && isInlineShellEnvAssignment(tokens[index]?.value ?? "")) index += 1;
+      const wrapper = shellCommandBasename(tokens[index]?.value ?? "");
+      if (wrapper === "env") {
+        index += 1;
+        while (index < commandEnd) {
+          const token = tokens[index]?.value ?? "";
+          if (token === "--") { index += 1; break; }
+          if (isInlineShellEnvAssignment(token) || token === "-i" || token === "--ignore-environment" || token.startsWith("--unset=")) {
+            index += 1;
+            continue;
+          }
+          if (token.startsWith("-")) { index += envOptionConsumesNextValue(token) ? 2 : 1; continue; }
+          break;
+        }
+        continue;
+      }
+      if (wrapper === "command") {
+        index += 1;
+        if (["-v", "-V"].includes(tokens[index]?.value ?? "")) { wrapperRejected = true; break; }
+        while (["-p", "--"].includes(tokens[index]?.value ?? "")) index += 1;
+        continue;
+      }
+      if (["builtin", "nohup", "setsid"].includes(wrapper)) {
+        index += 1;
+        while ((tokens[index]?.value ?? "").startsWith("-")) index += 1;
+        continue;
+      }
+      if (wrapper === "exec") {
+        index += 1;
+        while (index < commandEnd) {
+          const token = tokens[index]?.value ?? "";
+          if (token === "--") { index += 1; break; }
+          if (token === "-a") { index += 2; continue; }
+          if (token === "-c" || token === "-l") { index += 1; continue; }
+          break;
+        }
+        continue;
+      }
+      if (wrapper === "time") {
+        index += 1;
+        while (["-p", "--"].includes(tokens[index]?.value ?? "")) index += 1;
+        continue;
+      }
+      if (wrapper === "timeout") {
+        index += 1;
+        while (index < commandEnd) {
+          const token = tokens[index]?.value ?? "";
+          if (token === "--") { index += 1; break; }
+          if (token === "-k" || token === "--kill-after" || token === "-s" || token === "--signal") { index += 2; continue; }
+          if (token.startsWith("-")) { index += 1; continue; }
           index += 1;
           break;
         }
-        if (isInlineShellEnvAssignment(token)) {
-          index += 1;
-          continue;
-        }
-        if (token === "-i" || token === "--ignore-environment" || token.startsWith("--unset=")) {
-          index += 1;
-          continue;
-        }
-        if (token.startsWith("-")) {
-          index += envOptionConsumesNextValue(token) ? 2 : 1;
-          continue;
-        }
-        break;
+        continue;
       }
+      if (wrapper === "nice") {
+        index += 1;
+        while (index < commandEnd) {
+          const token = tokens[index]?.value ?? "";
+          if (token === "--") { index += 1; break; }
+          if (token === "-n" || token === "--adjustment") { index += 2; continue; }
+          if (/^-(?:n)?\d+$/.test(token) || token.startsWith("--adjustment=")) { index += 1; continue; }
+          break;
+        }
+        continue;
+      }
+      if (wrapper === "stdbuf") {
+        index += 1;
+        while (index < commandEnd) {
+          const token = tokens[index]?.value ?? "";
+          if (token === "--") { index += 1; break; }
+          if (["-i", "-o", "-e", "--input", "--output", "--error"].includes(token)) { index += 2; continue; }
+          if (/^-[ioe].+/.test(token) || /^--(?:input|output|error)=/.test(token)) { index += 1; continue; }
+          break;
+        }
+        continue;
+      }
+      break;
     }
+    if (wrapperRejected) continue;
 
     const rawToken = tokens[index]?.value || "";
     const token = rawToken.replace(/\\/g, "/").split("/").pop() || "";

--- a/src/scripts/codex-native-pre-post.ts
+++ b/src/scripts/codex-native-pre-post.ts
@@ -1168,10 +1168,11 @@ function removeHereDocBodies(command: string): string {
   return retained.join("\n");
 }
 
-function commandInvokesOmxQuestion(command: string): boolean {
+function commandInvokesOmxSubcommand(command: string, subcommand: string): boolean {
   const tokens = tokenizeShellCommandWithBoundaries(removeHereDocBodies(command))
     ?.map((token) => ({ ...token, value: token.value.toLowerCase() }))
     ?? [];
+  const normalizedSubcommand = subcommand.toLowerCase();
 
   for (let commandStart = 0; commandStart < tokens.length; commandStart = nextCommandStart(tokens, commandStart)) {
     const commandEnd = nextCommandStart(tokens, commandStart);
@@ -1207,15 +1208,19 @@ function commandInvokesOmxQuestion(command: string): boolean {
 
     const rawToken = tokens[index]?.value || "";
     const token = rawToken.replace(/\\/g, "/").split("/").pop() || "";
-    if ((token === "omx" || token === "omx.js") && tokens[index + 1]?.value === "question") return true;
+    if ((token === "omx" || token === "omx.js") && tokens[index + 1]?.value === normalizedSubcommand) return true;
     if (
       (token === "node" || token === "node.exe")
       && /(?:^|\/)omx\.js$/.test(tokens[index + 1]?.value || "")
-      && tokens[index + 2]?.value === "question"
+      && tokens[index + 2]?.value === normalizedSubcommand
     ) return true;
   }
 
   return false;
+}
+
+function commandInvokesOmxQuestion(command: string): boolean {
+  return commandInvokesOmxSubcommand(command, "question");
 }
 
 function isQuestionReturnPaneAssignment(token: string): boolean {
@@ -1261,25 +1266,11 @@ function commandHasQuestionReturnPane(command: string): boolean {
 }
 
 function commandInvokesOmxTeam(command: string): boolean {
-  const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
-  for (let index = 0; index < tokens.length; index += 1) {
-    const rawToken = tokens[index] || '';
-    const token = rawToken.replace(/\\/g, '/').split('/').pop() || '';
-    if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'team') return true;
-    if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'team') return true;
-  }
-  return /\bomx\s+team\b/i.test(command) || /\bomx\.js['"]?\s+team\b/i.test(command);
+  return commandInvokesOmxSubcommand(command, "team");
 }
 
 function commandInvokesOmxHud(command: string): boolean {
-  const tokens = tokenizeShellCommand(command)?.map((token) => token.toLowerCase()) ?? [];
-  for (let index = 0; index < tokens.length; index += 1) {
-    const rawToken = tokens[index] || '';
-    const token = rawToken.replace(/\\/g, '/').split('/').pop() || '';
-    if ((token === 'omx' || token === 'omx.js') && tokens[index + 1] === 'hud') return true;
-    if ((token === 'node' || token === 'node.exe') && /(?:^|\/)omx\.js$/.test(tokens[index + 1] || '') && tokens[index + 2] === 'hud') return true;
-  }
-  return /\bomx\s+hud\b/i.test(command) || /\bomx\.js['"]?\s+hud\b/i.test(command);
+  return commandInvokesOmxSubcommand(command, "hud");
 }
 
 function buildNativeOmxHudPreToolUseEnforcementOutput(

--- a/src/scripts/demo-claude-workers.sh
+++ b/src/scripts/demo-claude-workers.sh
@@ -164,8 +164,9 @@ for i in $(seq 1 "$WORKER_COUNT"); do
     TRANSITION_INPUT="$(jq -nc \
       --arg team "$TEAM_NAME" \
       --arg task "$TASK_ID" \
+      --arg worker "$WORKER_NAME" \
       --arg token "$CLAIM_TOKEN" \
-      '{team_name:$team,task_id:$task,from:"in_progress",to:"completed",claim_token:$token}')"
+      '{team_name:$team,task_id:$task,worker:$worker,from:"in_progress",to:"completed",claim_token:$token}')"
     omx team api transition-task-status --input "$TRANSITION_INPUT" --json >/dev/null
     echo "  $WORKER_NAME completed task $TASK_ID"
   fi

--- a/src/scripts/demo-team-e2e.sh
+++ b/src/scripts/demo-team-e2e.sh
@@ -148,8 +148,9 @@ echo "[5/8] transition task -> completed"
 TRANSITION_INPUT="$(jq -nc \
   --arg team "$TEAM_NAME" \
   --arg task "$TASK_ID" \
+  --arg worker "worker-1" \
   --arg token "$CLAIM_TOKEN" \
-  '{team_name:$team,task_id:$task,from:"in_progress",to:"completed",claim_token:$token}')"
+  '{team_name:$team,task_id:$task,worker:$worker,from:"in_progress",to:"completed",claim_token:$token}')"
 omx team api transition-task-status --input "$TRANSITION_INPUT" --json >/dev/null
 
 echo "[6/8] mailbox flow"

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -1231,10 +1231,34 @@ describe('executeTeamApiOperation: transition-task-status', () => {
 
   it('rejects invalid status values', async () => {
     const result = await executeTeamApiOperation('transition-task-status', {
-      team_name: 'x', task_id: '1', from: 'invalid', to: 'completed', claim_token: 'tok',
+      team_name: 'x', task_id: '1', worker: 'worker-1', from: 'invalid', to: 'completed', claim_token: 'tok',
     }, '/tmp');
     assert.equal(result.ok, false);
     if (!result.ok) assert.match(result.error.message, /valid task statuses/);
+  });
+
+  it('preserves legacy caller compatibility when worker is omitted', async () => {
+    const { cwd, cleanup } = await setupTeam('transition-legacy-caller');
+    try {
+      const task = await createTask('transition-legacy-caller', { subject: 'legacy', description: 'd', status: 'pending' }, cwd);
+      const claim = await executeTeamApiOperation('claim-task', {
+        team_name: 'transition-legacy-caller', task_id: task.id, worker: 'worker-1',
+      }, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) return;
+
+      const transition = await executeTeamApiOperation('transition-task-status', {
+        team_name: 'transition-legacy-caller',
+        task_id: task.id,
+        from: 'in_progress',
+        to: 'completed',
+        claim_token: String(claim.data.claimToken),
+      }, cwd);
+      assert.equal(transition.ok, true);
+      if (transition.ok) assert.equal(transition.data.ok, true);
+    } finally {
+      await cleanup();
+    }
   });
 
   it('persists optional result and error payloads', async () => {
@@ -1252,6 +1276,7 @@ describe('executeTeamApiOperation: transition-task-status', () => {
       const completedTransition = await executeTeamApiOperation('transition-task-status', {
         team_name: 'transition-payload',
         task_id: completedTask.id,
+        worker: 'worker-1',
         from: 'in_progress',
         to: 'completed',
         claim_token: completedClaimToken,
@@ -1275,6 +1300,7 @@ describe('executeTeamApiOperation: transition-task-status', () => {
       const failedTransition = await executeTeamApiOperation('transition-task-status', {
         team_name: 'transition-payload',
         task_id: failedTask.id,
+        worker: 'worker-1',
         from: 'in_progress',
         to: 'failed',
         claim_token: failedClaimToken,
@@ -1290,15 +1316,44 @@ describe('executeTeamApiOperation: transition-task-status', () => {
     }
   });
 
+  it('rejects a transition when the declared worker does not own the claim', async () => {
+    const { cwd, cleanup } = await setupTeam('transition-worker-binding');
+    try {
+      const task = await createTask('transition-worker-binding', { subject: 'owned', description: 'd', status: 'pending' }, cwd);
+      const claim = await executeTeamApiOperation('claim-task', {
+        team_name: 'transition-worker-binding', task_id: task.id, worker: 'worker-1',
+      }, cwd);
+      assert.equal(claim.ok, true);
+      if (!claim.ok) return;
+
+      const transition = await executeTeamApiOperation('transition-task-status', {
+        team_name: 'transition-worker-binding',
+        task_id: task.id,
+        worker: 'worker-2',
+        from: 'in_progress',
+        to: 'completed',
+        claim_token: String(claim.data.claimToken),
+      }, cwd);
+      assert.equal(transition.ok, true);
+      if (transition.ok) assert.equal(transition.data.error, 'claim_conflict');
+
+      const reread = await readTask('transition-worker-binding', task.id, cwd);
+      assert.equal(reread?.status, 'in_progress');
+      assert.equal(reread?.owner, 'worker-1');
+    } finally {
+      await cleanup();
+    }
+  });
+
   it('rejects non-string result and error payloads', async () => {
     const badResult = await executeTeamApiOperation('transition-task-status', {
-      team_name: 'x', task_id: '1', from: 'in_progress', to: 'completed', claim_token: 'tok', result: true,
+      team_name: 'x', task_id: '1', worker: 'worker-1', from: 'in_progress', to: 'completed', claim_token: 'tok', result: true,
     }, '/tmp');
     assert.equal(badResult.ok, false);
     if (!badResult.ok) assert.match(badResult.error.message, /result must be a string/);
 
     const badError = await executeTeamApiOperation('transition-task-status', {
-      team_name: 'x', task_id: '1', from: 'in_progress', to: 'failed', claim_token: 'tok', error: 42,
+      team_name: 'x', task_id: '1', worker: 'worker-1', from: 'in_progress', to: 'failed', claim_token: 'tok', error: 42,
     }, '/tmp');
     assert.equal(badError.ok, false);
     if (!badError.ok) assert.match(badError.error.message, /error must be a string/);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -6147,6 +6147,7 @@ fs.writeFileSync(path.join(logDir, 'env.json'), JSON.stringify({
   cwd: process.cwd(),
   teamStateRoot: process.env.OMX_TEAM_STATE_ROOT || '',
   worker: process.env.OMX_TEAM_WORKER || '',
+  workerCapability: process.env.OMX_TEAM_WORKER_CAPABILITY || '',
 }));
 process.stdin.on('data', (chunk) => {
   fs.appendFileSync(path.join(logDir, 'stdin.log'), chunk.toString());
@@ -6208,10 +6209,32 @@ process.on('SIGTERM', () => process.exit(0));
         cwd: string;
         teamStateRoot: string;
         worker: string;
+        workerCapability: string;
       };
       assert.equal(envLog.cwd, workerPath);
       assert.equal(envLog.teamStateRoot, join(repo, '.omx', 'state'));
       assert.equal(envLog.worker, 'team-detached-worktree-paths/worker-1');
+      assert.match(envLog.workerCapability, /^[A-Za-z0-9_-]{40,}$/);
+      const workerIdentity = JSON.parse(await readFile(
+        join(repo, '.omx', 'state', 'team', runtime.teamName, 'workers', 'worker-1', 'identity.json'),
+        'utf-8',
+      )) as {
+        leader_cwd?: string;
+        leader_session_id?: string;
+        runtime_capability?: {
+          team_name?: string;
+          worker_name?: string;
+          worker_cwd?: string;
+          token_sha256?: string;
+        };
+      };
+      assert.equal(workerIdentity.leader_cwd, repo);
+      assert.ok(workerIdentity.leader_session_id);
+      assert.equal(workerIdentity.runtime_capability?.team_name, runtime.teamName);
+      assert.equal(workerIdentity.runtime_capability?.worker_name, 'worker-1');
+      assert.equal(workerIdentity.runtime_capability?.worker_cwd, workerPath);
+      assert.match(workerIdentity.runtime_capability?.token_sha256 ?? '', /^[a-f0-9]{64}$/);
+      assert.equal(workerIdentity.runtime_capability?.token_sha256?.includes(envLog.workerCapability), false);
       const rootAgents = await readFile(join(workerPath, 'AGENTS.md'), 'utf-8');
       assert.match(rootAgents, /Team Worker Runtime Instructions/);
       assert.match(rootAgents, new RegExp(`Inbox path: .*${runtime.teamName}/workers/worker-1/inbox\\.md`));

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -11857,6 +11857,78 @@ esac
     }
   });
 
+  it('shutdownTeam preserves a restored standalone HUD after debt finalization', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-restored-hud-finalized-'));
+    const teamName = 'team-restored-hud-finalized';
+    try {
+      await withMockTmuxFixture(
+        {
+          dirPrefix: 'omx-runtime-shutdown-restored-hud-finalized-bin-',
+          tmuxScript: (tmuxLogPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${tmuxLogPath}"
+case "$1" in
+  -V)
+    echo "tmux 3.7b"
+    ;;
+  list-panes)
+    case "$*" in
+      *"-a -F #{pane_id}"*)
+        printf "%%11\t0\t2000000011\n%%12\t0\t2000000012\n"
+        if [ ! -f "${tmuxLogPath}.killed-%13" ]; then printf "%%13\t0\t2000000013\n"; fi
+        ;;
+      *"-F #{pane_dead} #{pane_pid}"*) exit 1 ;;
+      *"-t leader:0 -F #{pane_id}"*"#{pane_current_command}"*)
+        printf "%%11\\tzsh\\tzsh\\n%%12\\tnode\\t\\\"exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE='%%11' node /tmp/bin/omx.js hud --watch # omx_source_receipt\\\"\\n%%13\\tcodex\\tenv OMX_TEAM_INTERNAL_WORKER=team-restored-hud-finalized/worker-1 codex\\n"
+        ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  show-option)
+    case "$*" in
+      *"-p -t %11 @omx_team_pane_owner_id"*|*"-p -t %13 @omx_team_pane_owner_id"*)
+        echo "team:team-restored-hud-finalized"
+        ;;
+      *"-p -t %12 @omx_team_pane_owner_id"*) exit 1 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  kill-pane)
+    : > "${tmuxLogPath}.killed-$3"
+    ;;
+  resize-pane|select-pane|run-shell) ;;
+  *) ;;
+esac
+`,
+        },
+        async ({ tmuxLogPath }) => {
+          await initTeamState(teamName, 'finalized restored HUD retry test', 'executor', 1, cwd);
+          const config = await readTeamConfig(teamName, cwd);
+          assert.ok(config);
+          if (!config) return;
+          config.tmux_session = 'leader:0';
+          config.tmux_pane_owner_id = 'team:team-restored-hud-finalized';
+          config.leader_pane_id = '%11';
+          config.leader_pane_pid = 2000000011;
+          config.hud_pane_id = '%12';
+          config.hud_pane_pid = 2000000012;
+          config.workers[0]!.pane_id = '%13';
+          config.workers[0]!.pid = 2000000013;
+          await saveTeamConfig(config, cwd);
+
+          await shutdownTeam(teamName, cwd, { force: true });
+
+          const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
+          assert.doesNotMatch(tmuxLog, /kill-pane -t %12/);
+          assert.match(tmuxLog, /kill-pane -t %13/);
+          assert.doesNotMatch(tmuxLog, /split-window/);
+        },
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('shutdownTeam preserves leader exclusion while tearing down the hud pane', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-exclusions-'));
     try {

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -954,8 +954,19 @@ exit 0
       assert.equal(createdTask?.role, 'writer');
       assert.equal(createdTask?.owner, 'worker-2');
 
-      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'identity.json'), 'utf-8')) as { role?: string };
+      const workerIdentity = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'identity.json'), 'utf-8')) as {
+        role?: string;
+        leader_cwd?: string;
+        leader_session_id?: string;
+        runtime_capability?: { team_name?: string; worker_name?: string; token_sha256?: string };
+      };
       assert.equal(workerIdentity.role, 'writer');
+      assert.equal(workerIdentity.leader_cwd, cwd);
+      assert.ok(workerIdentity.leader_session_id);
+      assert.equal(workerIdentity.runtime_capability?.team_name, 'scale-up-role');
+      assert.equal(workerIdentity.runtime_capability?.worker_name, 'worker-2');
+      assert.match(workerIdentity.runtime_capability?.token_sha256 ?? '', /^[a-f0-9]{64}$/);
+      assert.match(await readFile(workerStartupScriptPath(cwd, 'scale-up-role', 'worker-2'), 'utf-8'), /OMX_TEAM_WORKER_CAPABILITY/);
 
       const inbox = await readFile(join(cwd, '.omx', 'state', 'team', 'scale-up-role', 'workers', 'worker-2', 'inbox.md'), 'utf-8');
       assert.match(inbox, /Task 2/);

--- a/src/team/__tests__/tmux-test-fixture.test.ts
+++ b/src/team/__tests__/tmux-test-fixture.test.ts
@@ -5,6 +5,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, type TestContext } from 'node:test';
 import { buildPtyScriptCommand, isRealTmuxAvailable, runPtyResult, tmuxSessionExists, withTempTmuxSession } from './tmux-test-fixture.js';
+import {
+  buildSourceAuthorizedEffectCommand,
+  buildSplitWindowReceiptFormat,
+  parseSplitWindowPaneId,
+} from '../tmux-session.js';
 
 function skipUnlessTmux(t: TestContext): void {
   if (!isRealTmuxAvailable()) {
@@ -38,6 +43,41 @@ function uniqueAmbientSessionName(): string {
 }
 
 describe('withTempTmuxSession', () => {
+  it('executes source-authorized Team transactions on the private real tmux server', async (t) => {
+    skipUnlessTmux(t);
+    await withTempTmuxSession(async (fixture) => {
+      const receipt = 'source-authority-receipt';
+      const output = fixture.run([
+        'if-shell', '-F', '-t', fixture.leaderPaneId, '#{==:#{pane_dead},0}',
+        buildSourceAuthorizedEffectCommand(
+          `set-option -p -t ${fixture.leaderPaneId} @omx_source_authority_test tagged`,
+          receipt,
+        ),
+        "display-message -p ''",
+      ]);
+      assert.equal(output, receipt);
+      assert.equal(
+        fixture.run(['show-option', '-qv', '-p', '-t', fixture.leaderPaneId, '@omx_source_authority_test']),
+        'tagged',
+      );
+    });
+  });
+
+  it('returns a parseable pane and receipt from a guarded split on the private real tmux server', async (t) => {
+    skipUnlessTmux(t);
+    await withTempTmuxSession(async (fixture) => {
+      const receipt = 'split-receipt';
+      const output = fixture.run([
+        'if-shell', '-F', '-t', fixture.leaderPaneId, '#{==:#{pane_dead},0}',
+        `split-window -h -t ${fixture.leaderPaneId} -d -P -F '${buildSplitWindowReceiptFormat(receipt)}' 'sleep 60 # ${receipt}'`,
+        "display-message -p ''",
+      ]);
+      const paneId = parseSplitWindowPaneId(output, receipt);
+      assert.match(paneId ?? '', /^%\d+$/);
+      assert.notEqual(paneId, fixture.leaderPaneId);
+    });
+  });
+
   it('provides isolated tmux env and cleans up on success', async (t) => {
     skipUnlessTmux(t);
     const ambientTmux = process.env.TMUX;

--- a/src/team/__tests__/worker-capability.test.ts
+++ b/src/team/__tests__/worker-capability.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  bindTeamWorkerNativeSession,
+  teamWorkerNativeSessionBindingPath,
+  type TeamWorkerNativeSessionBinding,
+} from '../worker-capability.js';
+
+describe('Team worker native session binding', () => {
+  it('does not recreate a worker directory removed by rollback', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'omx-worker-binding-rollback-'));
+    const binding: TeamWorkerNativeSessionBinding = {
+      version: 1,
+      team_name: 'rollback-team',
+      worker_name: 'worker-1',
+      native_session_id: 'worker-native',
+      leader_session_id: 'leader-native',
+      team_created_at: new Date().toISOString(),
+      worker_cwd: stateRoot,
+      team_state_root: stateRoot,
+      capability_sha256: 'capability',
+      bound_at: new Date().toISOString(),
+    };
+    const bindingPath = teamWorkerNativeSessionBindingPath(stateRoot, binding.team_name, binding.worker_name);
+    const workerDir = dirname(bindingPath);
+    await mkdir(workerDir, { recursive: true });
+    await rm(workerDir, { recursive: true });
+
+    try {
+      const result = await bindTeamWorkerNativeSession(stateRoot, binding);
+      assert.equal(result, null);
+      assert.equal(existsSync(workerDir), false);
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -851,6 +851,7 @@ export async function executeTeamApiOperation(
       case 'transition-task-status': {
         const teamName = String(opArgs.team_name || '').trim();
         const taskId = String(opArgs.task_id || '').trim();
+        const worker = String(opArgs.worker || '').trim();
         const from = String(opArgs.from || '').trim();
         const to = String(opArgs.to || '').trim();
         const claimToken = String(opArgs.claim_token || '').trim();
@@ -879,6 +880,7 @@ export async function executeTeamApiOperation(
           {
             result: typeof transitionResult === 'string' ? transitionResult : undefined,
             error: typeof transitionError === 'string' ? transitionError : undefined,
+            worker: worker || undefined,
           },
         );
         return { ok: true, operation, data: result as unknown as Record<string, unknown> };

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -48,6 +48,11 @@ import {
 import { readExactPaneProofSync, readExactPaneProofsSync, type ExactPaneProof } from './exact-pane.js';
 import { reconcileScaleDownCleanupDebt } from './scaling.js';
 import {
+  issueTeamWorkerRuntimeCapability,
+  TEAM_WORKER_CAPABILITY_ENV,
+  type TeamWorkerRuntimeCapability,
+} from './worker-capability.js';
+import {
   teamInit as initTeamState,
   DEFAULT_MAX_WORKERS,
   teamReadConfig as readTeamConfig,
@@ -3704,6 +3709,8 @@ export async function startTeam(
       workerLaunchArgs: readonly string[];
       workerCli: TeamWorkerCli;
       toolContext: ReturnType<typeof resolveWorktreeToolContext>;
+      capabilityToken: string;
+      runtimeCapability: TeamWorkerRuntimeCapability;
     }>;
 
     for (let i = 1; i <= workerCount; i++) {
@@ -3766,6 +3773,15 @@ export async function startTeam(
       );
       const trigger = triggerDirective.text;
       const initialPrompt = workerCli === 'gemini' ? trigger : undefined;
+      const issuedCapability = issueTeamWorkerRuntimeCapability({
+        teamName: sanitized,
+        workerName,
+        leaderSessionId,
+        leaderCwd,
+        teamStateRoot,
+        workerCwd: workerWorkspace.cwd,
+        teamCreatedAt: config.created_at,
+      });
       if (initialPrompt) {
         await writeWorkerInbox(sanitized, workerName, inbox, leaderCwd);
       }
@@ -3783,6 +3799,8 @@ export async function startTeam(
         workerLaunchArgs,
         workerCli,
         toolContext,
+        capabilityToken: issuedCapability.token,
+        runtimeCapability: issuedCapability.metadata,
       });
     }
 
@@ -3792,6 +3810,7 @@ export async function startTeam(
         [TEAM_LEADER_CWD_ENV]: leaderCwd,
         [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
         OMX_TEAM_DISPLAY_NAME: displayName,
+        [TEAM_WORKER_CAPABILITY_ENV]: plan.capabilityToken,
         ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
         ...worktreeToolContextEnv(plan.toolContext),
       };
@@ -3834,6 +3853,9 @@ export async function startTeam(
         worktree_detached: workerWorkspace.worktreeDetached,
         worktree_created: workerWorkspace.worktreeCreated,
         team_state_root: teamStateRoot,
+        leader_cwd: leaderCwd,
+        leader_session_id: leaderSessionId,
+        runtime_capability: bootstrapPlan.runtimeCapability,
       };
 
       const persistedPanePid = config?.workers[workerIndex - 1]?.pid;
@@ -3865,6 +3887,9 @@ export async function startTeam(
         config.workers[workerIndex - 1].worktree_detached = workerWorkspace.worktreeDetached;
         config.workers[workerIndex - 1].worktree_created = workerWorkspace.worktreeCreated;
         config.workers[workerIndex - 1].team_state_root = teamStateRoot;
+        config.workers[workerIndex - 1].leader_cwd = leaderCwd;
+        config.workers[workerIndex - 1].leader_session_id = leaderSessionId;
+        config.workers[workerIndex - 1].runtime_capability = bootstrapPlan.runtimeCapability;
       }
 
       await writeWorkerIdentity(sanitized, bootstrapPlan.workerName, identity, leaderCwd);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -637,17 +637,20 @@ function collectAuthorizedSharedSessionWorkerPaneIds(
 function isSharedSessionHudPaneReclaimable(params: {
   paneId: string;
   persistedHudPaneId: string | null;
-  leaderOwnedHudPaneIds: string[];
   teamPaneOwnerId: string;
   onOwnerReadError?: (paneId: string, error: string) => void;
 }): boolean {
-  const { paneId, persistedHudPaneId, leaderOwnedHudPaneIds, teamPaneOwnerId, onOwnerReadError } = params;
+  const { paneId, persistedHudPaneId, teamPaneOwnerId, onOwnerReadError } = params;
   const expectedOwnerId = teamPaneOwnerId.trim();
   if (!expectedOwnerId) return false;
   const owner = readPaneTeamOwnerTagResult(paneId);
   if (owner.status === 'value') return owner.value === expectedOwnerId;
   if (paneId !== persistedHudPaneId) return false;
-  if (owner.status === 'missing') return leaderOwnedHudPaneIds.includes(paneId);
+  // A restored standalone HUD deliberately retains only its leader-scoped HUD
+  // metadata, not the Team pane-owner tag. Once restoration debt is finalized,
+  // preserving that pane is safer than treating persisted config as authority
+  // to reclaim it on a retried shutdown.
+  if (owner.status === 'missing') return false;
   onOwnerReadError?.(paneId, owner.error);
   return false;
 }
@@ -5140,7 +5143,6 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
       ? sharedSessionTopology.hudPaneIds.filter((paneId) => isSharedSessionHudPaneReclaimable({
         paneId,
         persistedHudPaneId: hudPaneId,
-        leaderOwnedHudPaneIds: sharedSessionTopology.leaderOwnedHudPaneIds,
         teamPaneOwnerId: tmuxPaneOwnerId,
         onOwnerReadError: (candidateHudPaneId, error) => {
           warnOwnerReadError('HUD pane', candidateHudPaneId, error);

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -77,6 +77,11 @@ import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
 import { resolveCodexHomeForLaunch } from '../cli/codex-home.js';
 import {
+  issueTeamWorkerRuntimeCapability,
+  TEAM_WORKER_CAPABILITY_ENV,
+  type IssuedTeamWorkerRuntimeCapability,
+} from './worker-capability.js';
+import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
   resolveAgentDefaultModel,
@@ -648,6 +653,9 @@ export async function scaleUp(
     let nextIndex = initialNextIndex;
     const sessionName = config.tmux_session;
     const manifest = await readTeamManifestV2(sanitized, leaderCwd);
+    const leaderSessionId = manifest?.leader?.session_id?.trim()
+      || env.OMX_SESSION_ID?.trim()
+      || config.tmux_session;
     const dispatchPolicy = normalizeTeamPolicy(manifest?.policy, {
       display_mode: manifest?.policy?.display_mode === 'split_pane' ? 'split_pane' : 'auto',
       worker_launch_mode: config.worker_launch_mode,
@@ -1104,6 +1112,7 @@ export async function scaleUp(
       let workerCwd = leaderCwd;
       let cmd: string;
       let rawRolePromptContent: string | null = null;
+      let issuedCapability: IssuedTeamWorkerRuntimeCapability | null = null;
       try {
         preparedWorkerDirectoryOwner.set(workerDirPath, workerName);
         await mkdir(workerDirPath, { recursive: true });
@@ -1168,10 +1177,20 @@ export async function scaleUp(
           : rolePromptContent
             ? await writeWorkerRoleInstructionsFile(sanitized, workerName, leaderCwd, teamInstructionsPath, runtimeRole, rolePromptContent)
             : teamInstructionsPath;
+        issuedCapability = issueTeamWorkerRuntimeCapability({
+          teamName: sanitized,
+          workerName,
+          leaderSessionId,
+          leaderCwd,
+          teamStateRoot,
+          workerCwd,
+          teamCreatedAt: config.created_at,
+        });
         const extraEnv: Record<string, string> = {
           OMX_TEAM_STATE_ROOT: teamStateRoot,
           OMX_TEAM_LEADER_CWD: leaderCwd,
           OMX_MODEL_INSTRUCTIONS_FILE: instructionsFilePath,
+          [TEAM_WORKER_CAPABILITY_ENV]: issuedCapability.token,
           ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
         };
         if (workerWorkspace) {
@@ -1251,6 +1270,12 @@ export async function scaleUp(
         );
       }
       const paneId = createdPane.paneId;
+      if (!issuedCapability) {
+        return await rollbackScaleUp(
+          `scale_up_worker_capability_unavailable:${workerName}`,
+          { paneId, workerName, worktreePath: workerWorkspace?.worktreePath },
+        );
+      }
       const workerInfo: ScaleUpWorkerInfo = {
         name: workerName,
         index: workerIndex,
@@ -1268,6 +1293,9 @@ export async function scaleUp(
         worktree_detached: workerWorkspace ? workerWorkspace.detached : undefined,
         worktree_created: workerWorkspace ? workerWorkspace.created : undefined,
         team_state_root: teamStateRoot,
+        leader_cwd: leaderCwd,
+        leader_session_id: leaderSessionId,
+        runtime_capability: issuedCapability.metadata,
       };
 
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -193,7 +193,7 @@ function runScalePaneTransaction(
 ): boolean {
   const result = spawnSync('tmux', [
     'if-shell', '-F', '-t', pane.paneId, buildScalePaneAuthorityCondition(pane),
-    `${effect} \\; display-message -p ${quoteTmuxCommand(receipt)}`,
+    `${effect} ; display-message -p ${quoteTmuxCommand(receipt)}`,
     "display-message -p ''",
   ], { encoding: 'utf-8' });
   return result.status === 0 && hasExactScaleReceipt(result.stdout || '', receipt);
@@ -211,7 +211,7 @@ function tagScalePaneWithAuthority(pane: ScalePaneBirth, teamOwnerId: string): S
   const receipt = scaleTransactionReceipt();
   const result = spawnSync('tmux', [
     'if-shell', '-F', '-t', pane.paneId, condition,
-    `set-option -p -t ${pane.paneId} @omx_team_pane_owner_id ${quoteTmuxCommand(teamOwnerId)} \\; display-message -p ${quoteTmuxCommand(receipt)}`,
+    `set-option -p -t ${pane.paneId} @omx_team_pane_owner_id ${quoteTmuxCommand(teamOwnerId)} ; display-message -p ${quoteTmuxCommand(receipt)}`,
     "display-message -p ''",
   ], { encoding: 'utf-8' });
   if (result.status !== 0 || !hasExactScaleReceipt(result.stdout || '', receipt)) return null;
@@ -560,7 +560,7 @@ async function notifyWorkerPaneOutcome(
     };
     if (!runScalePaneTransaction(
       pane,
-      `send-keys -t ${paneId} -l ${quoteTmuxCommand(message)} \\; send-keys -t ${paneId} C-m`,
+      `send-keys -t ${paneId} -l ${quoteTmuxCommand(message)} ; send-keys -t ${paneId} C-m`,
     )) {
       throw new Error(`scale_up_final_send_authority_lost:${paneId}`);
     }
@@ -1316,6 +1316,13 @@ export async function scaleUp(
       await writeWorkerIdentity(sanitized, workerName, workerInfo, leaderCwd);
       throwIfScaleUpFailureInjected(env, 'identity');
 
+      addedWorkers.push(workerInfo);
+      config.workers.push(workerInfo);
+      config.worker_count = config.workers.length;
+      config.next_worker_index = nextIndex;
+      await saveTeamConfig(config, leaderCwd);
+      throwIfScaleUpFailureInjected(env, 'config');
+
 
       // Wait for worker readiness
       const readyTimeoutMs = resolveWorkerReadyTimeoutMs(env);
@@ -1468,13 +1475,6 @@ export async function scaleUp(
       }
       throwIfScaleUpFailureInjected(env, 'post-dispatch-rollback');
 
-      addedWorkers.push(workerInfo);
-      config.workers.push(workerInfo);
-      config.worker_count = config.workers.length;
-      config.next_worker_index = nextIndex;
-      throwIfScaleUpFailureInjected(env, 'config');
-
-      await saveTeamConfig(config, leaderCwd);
       throwIfScaleUpFailureInjected(env, 'finalization');
       } catch (error) {
         return await rollbackScaleUp(

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -139,7 +139,6 @@ export interface WorkerInfo {
   team_state_root?: string;
   leader_cwd?: string;
   leader_session_id?: string;
-  native_session_id?: string;
   runtime_capability?: TeamWorkerRuntimeCapability;
 }
 
@@ -1900,7 +1899,7 @@ export async function transitionTaskStatus(
   to: TeamTask['status'],
   claimToken: string,
   cwd: string,
-  terminalData?: { result?: string; error?: string },
+  terminalData?: { result?: string; error?: string; worker?: string },
 ): Promise<TransitionTaskResult> {
   return await withTeamTaskBarrier(teamName, cwd, async () => {
     await recoverTeamMembershipTaskTransaction(teamName, cwd);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -66,6 +66,7 @@ import {
   type TeamEventType,
 } from './contracts.js';
 import type { TeamReminderIntent } from './reminder-intents.js';
+import type { TeamWorkerRuntimeCapability } from './worker-capability.js';
 import type { WorktreeMode } from './worktree.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 import { normalizeTeamTaskCoordinationPlanForStorage } from './coordination-protocol.js';
@@ -136,6 +137,10 @@ export interface WorkerInfo {
   worktree_detached?: boolean;
   worktree_created?: boolean;
   team_state_root?: string;
+  leader_cwd?: string;
+  leader_session_id?: string;
+  native_session_id?: string;
+  runtime_capability?: TeamWorkerRuntimeCapability;
 }
 
 export interface WorkerHeartbeat {

--- a/src/team/state/tasks.ts
+++ b/src/team/state/tasks.ts
@@ -119,7 +119,7 @@ export async function claimTask(
 
 function extractDelegationComplianceEvidence(
   task: TeamTaskV2,
-  terminalData: { result?: string; error?: string } | undefined,
+  terminalData: { result?: string; error?: string; worker?: string } | undefined,
 ): TeamTaskDelegationComplianceEvidence | null {
   const plan = task.delegation;
   if (!plan || plan.mode === 'none') return null;
@@ -151,7 +151,7 @@ function requiresDelegationComplianceEvidence(task: TeamTaskV2): boolean {
 
 function extractCoordinationComplianceEvidence(
   task: TeamTaskV2,
-  terminalData: { result?: string; error?: string } | undefined,
+  terminalData: { result?: string; error?: string; worker?: string } | undefined,
 ): TeamTaskCoordinationComplianceEvidence | null {
   if (task.coordination?.mode !== 'coordinated') return null;
 
@@ -195,7 +195,7 @@ export async function transitionTaskStatus(
   from: TeamTaskStatus,
   to: TeamTaskStatus,
   claimToken: string,
-  terminalData: { result?: string; error?: string } | undefined,
+  terminalData: { result?: string; error?: string; worker?: string } | undefined,
   deps: TransitionDeps,
 ): Promise<TransitionTaskResult> {
   if (!deps.canTransitionTaskStatus(from, to)) return { ok: false, error: 'invalid_transition' };
@@ -210,6 +210,9 @@ export async function transitionTaskStatus(
     if (v.status !== from) return { ok: false as const, error: 'invalid_transition' as const };
 
     if (!v.owner || !v.claim || v.claim.owner !== v.owner || v.claim.token !== claimToken) {
+      return { ok: false as const, error: 'claim_conflict' as const };
+    }
+    if (terminalData?.worker && (v.owner !== terminalData.worker || v.claim.owner !== terminalData.worker)) {
       return { ok: false as const, error: 'claim_conflict' as const };
     }
     if (new Date(v.claim.leased_until) <= new Date()) return { ok: false as const, error: 'lease_expired' as const };

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -51,7 +51,6 @@ export interface WorkerInfo {
   team_state_root?: string;
   leader_cwd?: string;
   leader_session_id?: string;
-  native_session_id?: string;
   runtime_capability?: TeamWorkerRuntimeCapability;
 }
 

--- a/src/team/state/types.ts
+++ b/src/team/state/types.ts
@@ -2,6 +2,7 @@ import type { TeamPhase, TerminalPhase } from '../orchestrator.js';
 import type { TeamDispatchRequestStatus, TeamEventType, TeamTaskStatus } from '../contracts.js';
 import type { TeamReminderIntent } from '../reminder-intents.js';
 import type { WorktreeMode } from '../worktree.js';
+import type { TeamWorkerRuntimeCapability } from '../worker-capability.js';
 
 export interface StartupCleanupPane {
   pane_id: string;
@@ -48,6 +49,10 @@ export interface WorkerInfo {
   worktree_detached?: boolean;
   worktree_created?: boolean;
   team_state_root?: string;
+  leader_cwd?: string;
+  leader_session_id?: string;
+  native_session_id?: string;
+  runtime_capability?: TeamWorkerRuntimeCapability;
 }
 
 export interface WorkerHeartbeat {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -341,6 +341,14 @@ function sourceTransactionReceipt(): string {
   return `omx_source_${process.pid}_${Date.now()}_${randomBytes(16).toString('hex')}`;
 }
 
+export function buildSourceAuthorizedEffectCommand(effect: string, receipt: string): string {
+  return `${effect} ; display-message -p ${shellQuoteSingle(receipt)}`;
+}
+
+export function buildSplitWindowReceiptFormat(receipt: string): string {
+  return `#{pane_id}\t${receipt}`;
+}
+
 function bindSplitReceiptToPaneCommand(command: string, receipt: string): string {
   return `${command} # ${receipt}`;
 }
@@ -349,7 +357,7 @@ function bindSplitReceiptToPaneCommand(command: string, receipt: string): string
 function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: string, receipt: string = sourceTransactionReceipt()): string {
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    `${effect} \\; display-message -p ${shellQuoteSingle(receipt)}`,
+    buildSourceAuthorizedEffectCommand(effect, receipt),
     "display-message -p ''",
   ]);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);
@@ -374,7 +382,7 @@ function runSourceAuthorizedSplit(
   const effect = buildEffect(receipt);
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    effect.replace("-F '#{pane_id}'", `-F '#{pane_id}\\t${receipt}'`),
+    effect.replace("-F '#{pane_id}'", `-F '${buildSplitWindowReceiptFormat(receipt)}'`),
     "display-message -p ''",
   ], true);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);
@@ -2106,6 +2114,7 @@ function buildWorkerStartupScriptContent(
     `unset ${OMX_TMUX_HUD_OWNER_ENV} ${OMX_TMUX_HUD_LEADER_PANE_ENV}`,
     `cd ${shellQuoteSingle(translatePathForMsys(cwd))}`,
     envExports,
+    'rm -f -- "$0"',
     `exec ${shellQuoteSingle(launchSpec.shell)} -c ${shellQuoteSingle(`${rcPrefix}${pathPrefix}${cliInvocation}`)}`,
     '',
   ].filter((line) => line !== '').join('\n');

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -109,7 +109,7 @@ ${renderCodeGraphInstructions(options.toolContext)}
 5. Read task files from \`${options.teamStateRoot}/team/${options.teamName}/tasks/task-<id>.json\` using bare \`task_id\` values in APIs.
 6. Use claim-safe lifecycle APIs only:
    - \`omx team api claim-task --json\`
-   - \`omx team api transition-task-status --json\`
+   - \`omx team api transition-task-status --json\` with \`worker: "${options.workerName}"\`
    - \`omx team api release-task-claim --json\` only for rollback to pending
 7. Use mailbox delivery flow:
    - \`omx team api mailbox-list --input "{\"team_name\":\"${options.teamName}\",\"worker\":\"${options.workerName}\"}" --json\`
@@ -372,6 +372,7 @@ You are a team worker in team "${teamName}". Your identity and assigned tasks ar
    This ensures your changes are available for incremental integration into the leader branch.
 10. On completion/failure, use lifecycle transition APIs:
    - \`omx team api transition-task-status --json\` with from \`"in_progress"\` to \`"completed"\` or \`"failed"\`
+   - Always include \`worker: "<your-worker-name>"\`; the transition must match the claim owner
    - Include \`result\` (for completed) or \`error\` (for failed) in the transition patch
 11. Use \`omx team api release-task-claim --json\` only for rollback/requeue to \`pending\` (not for completion)
 12. Update your status: write {"state": "idle", "updated_at": "<current ISO timestamp>"} to <team_state_root>/team/${teamName}/workers/{your-name}/status.json
@@ -905,7 +906,7 @@ ${approvedContextSection}${workerGoalSection}
 9. After completing work, commit your changes before reporting completion:
    \`git add -A && git commit -m "task: <task-subject>"\`
    This ensures your changes are available for incremental integration into the leader branch.
-10. Complete/fail it via lifecycle transition API (\`omx team api transition-task-status --json\`) from \`"in_progress"\` to \`"completed"\` or \`"failed"\` (include \`result\`/\`error\`)
+10. Complete/fail it via lifecycle transition API (\`omx team api transition-task-status --json\`) from \`"in_progress"\` to \`"completed"\` or \`"failed"\` (include \`worker: "${workerName}"\` and \`result\`/\`error\`)
 11. Use \`omx team api release-task-claim --json\` only for rollback to \`pending\`
 12. Write \`{"state": "idle", "updated_at": "<current ISO timestamp>"}\` to \`${teamStateRoot}/team/${teamName}/workers/${workerName}/status.json\`
 13. Wait for the next instruction from the lead
@@ -1024,7 +1025,7 @@ ${workerGoalSection}
 5. After completing work, commit your changes before reporting completion:
    \`git add -A && git commit -m "task: <task-subject>"\`
    This ensures your changes are available for incremental integration into the leader branch.
-6. Complete/fail via lifecycle transition API (\`omx team api transition-task-status --json\`) from \`"in_progress"\` to \`"completed"\` or \`"failed"\` (include \`result\`/\`error\`)
+6. Complete/fail via lifecycle transition API (\`omx team api transition-task-status --json\`) from \`"in_progress"\` to \`"completed"\` or \`"failed"\` (include \`worker: "${workerName}"\` and \`result\`/\`error\`)
 7. Use \`omx team api release-task-claim --json\` only for rollback to \`pending\`
 8. Write \`{"state": "idle", "updated_at": "<current ISO timestamp>"}\` to your status file
 

--- a/src/team/worker-capability.ts
+++ b/src/team/worker-capability.ts
@@ -1,4 +1,6 @@
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import { link, open, readFile, unlink } from 'fs/promises';
+import { join } from 'path';
 
 export const TEAM_WORKER_CAPABILITY_ENV = 'OMX_TEAM_WORKER_CAPABILITY';
 
@@ -18,6 +20,70 @@ export interface TeamWorkerRuntimeCapability {
 export interface IssuedTeamWorkerRuntimeCapability {
   token: string;
   metadata: TeamWorkerRuntimeCapability;
+}
+
+export interface TeamWorkerNativeSessionBinding {
+  version: 1;
+  team_name: string;
+  worker_name: string;
+  native_session_id: string;
+  leader_session_id: string;
+  team_created_at: string;
+  worker_cwd: string;
+  team_state_root: string;
+  capability_sha256: string;
+  bound_at: string;
+}
+
+export function teamWorkerNativeSessionBindingPath(stateRoot: string, teamName: string, workerName: string): string {
+  return join(stateRoot, 'team', teamName, 'workers', workerName, 'native-session-binding.json');
+}
+
+export async function readTeamWorkerNativeSessionBinding(
+  stateRoot: string,
+  teamName: string,
+  workerName: string,
+): Promise<TeamWorkerNativeSessionBinding | null> {
+  try {
+    const parsed = JSON.parse(await readFile(
+      teamWorkerNativeSessionBindingPath(stateRoot, teamName, workerName),
+      'utf8',
+    )) as TeamWorkerNativeSessionBinding;
+    return parsed && parsed.version === 1 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function bindTeamWorkerNativeSession(
+  stateRoot: string,
+  binding: TeamWorkerNativeSessionBinding,
+): Promise<TeamWorkerNativeSessionBinding | null> {
+  const bindingPath = teamWorkerNativeSessionBindingPath(stateRoot, binding.team_name, binding.worker_name);
+  const temporaryPath = `${bindingPath}.tmp.${process.pid}.${randomBytes(8).toString('hex')}`;
+  let handle;
+  try {
+    handle = await open(temporaryPath, 'wx', 0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+  try {
+    await handle.writeFile(JSON.stringify(binding, null, 2), 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await link(temporaryPath, bindingPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return null;
+    if (code !== 'EEXIST') throw error;
+  } finally {
+    await unlink(temporaryPath).catch(() => {});
+  }
+  return await readTeamWorkerNativeSessionBinding(stateRoot, binding.team_name, binding.worker_name);
 }
 
 export function digestTeamWorkerCapabilityToken(token: string): string {

--- a/src/team/worker-capability.ts
+++ b/src/team/worker-capability.ts
@@ -1,0 +1,61 @@
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+
+export const TEAM_WORKER_CAPABILITY_ENV = 'OMX_TEAM_WORKER_CAPABILITY';
+
+export interface TeamWorkerRuntimeCapability {
+  version: 1;
+  team_name: string;
+  worker_name: string;
+  leader_session_id: string;
+  leader_cwd: string;
+  team_state_root: string;
+  worker_cwd: string;
+  team_created_at: string;
+  issued_at: string;
+  token_sha256: string;
+}
+
+export interface IssuedTeamWorkerRuntimeCapability {
+  token: string;
+  metadata: TeamWorkerRuntimeCapability;
+}
+
+export function digestTeamWorkerCapabilityToken(token: string): string {
+  return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+export function issueTeamWorkerRuntimeCapability(input: {
+  teamName: string;
+  workerName: string;
+  leaderSessionId: string;
+  leaderCwd: string;
+  teamStateRoot: string;
+  workerCwd: string;
+  teamCreatedAt: string;
+}): IssuedTeamWorkerRuntimeCapability {
+  const token = randomBytes(32).toString('base64url');
+  return {
+    token,
+    metadata: {
+      version: 1,
+      team_name: input.teamName,
+      worker_name: input.workerName,
+      leader_session_id: input.leaderSessionId,
+      leader_cwd: input.leaderCwd,
+      team_state_root: input.teamStateRoot,
+      worker_cwd: input.workerCwd,
+      team_created_at: input.teamCreatedAt,
+      issued_at: new Date().toISOString(),
+      token_sha256: digestTeamWorkerCapabilityToken(token),
+    },
+  };
+}
+
+export function capabilityTokenMatches(token: string, expectedSha256: string): boolean {
+  const normalizedToken = token.trim();
+  const normalizedExpected = expectedSha256.trim().toLowerCase();
+  if (!normalizedToken || !/^[a-f0-9]{64}$/.test(normalizedExpected)) return false;
+  const actual = Buffer.from(digestTeamWorkerCapabilityToken(normalizedToken), 'hex');
+  const expected = Buffer.from(normalizedExpected, 'hex');
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}


### PR DESCRIPTION
## Summary

Fix Team startup failures where hook-enabled workers in registered detached worktrees were rejected as foreign-cwd sessions, while preserving rejection of unregistered worktrees and cross-Team access.

This also fixes the related tmux 3.7b command-separator incompatibility, structurally classifies native/outside-tmux OMX commands, prevents unmatched Stop hooks from injecting synthetic conversation turns, and makes startup/shutdown cleanup resilient to HUD topology changes.

## Root cause

- Worker hook provenance was evaluated through leader-session cwd rules before registered Team worker identity was resolved.
- Workers shared the leader-owned `OMX_TEAM_STATE_ROOT`, but their real cwd was a registered detached worktree and their native Codex session ID differed from the leader.
- The Team control-plane exemption did not have a worker-scoped, runtime-backed identity proof.
- Native/outside-tmux blocking matched command text instead of the parsed executable/subcommand shape.
- tmux startup emitted an escaped command separator that tmux 3.7b parsed as an argument to `set-option`.
- An unmatched side-session Stop denial could be surfaced as a new user turn.

## Security boundary

- Native worker sessions bind atomically to a worker-scoped `native-session-binding.json`; leader-owned membership config is not mutated for binding.
- Authorization requires matching Team, worker, capability digest, leader identity/cwd, registered worker/worktree cwd, shared state root, pane, lifecycle phase, and bound native session ID.
- Registered detached worktrees are accepted; arbitrary foreign cwd and cross-Team/cross-worker mutations remain denied.
- Team API exemptions are limited to trusted OMX/Node entry paths and worker-bound operations. Inline environment assignments, inherited loader settings, `NODE_OPTIONS`, and `BASH_FUNC_node%%`/`BASH_FUNC_omx%%` poisoning fail closed.
- Public `transition-task-status` compatibility remains intact when `worker` is omitted; authenticated worker-hook invocations still require it to match the current worker.

## Startup, rollback, and tmux behavior

- Worker membership is persisted before dispatch/readiness checks, avoiding startup races.
- Binding never creates missing worker directories, so concurrent rollback/shutdown cannot recreate ghost Team state.
- Generated worker startup scripts self-delete before `exec`.
- tmux 3.7b receives a structural command separator and parseable pane/receipt output.
- HUD ownership handles tmux 3.7b whole-command quoting and preserves a restored standalone HUD during shutdown recovery.
- Failed startup remains rollback-safe and does not leave a pending-task shutdown gate.

## Regression matrix

| Surface | Hooks | Worktrees | Result |
| --- | --- | --- | --- |
| OMX tmux CLI | on | off | ACK, claim, transition, completion, shutdown covered |
| OMX tmux CLI | on | on | isolated real Team smoke passed |
| App/native outside tmux direct Team | on | either | immediate structural block |
| App bootstrap to OMX tmux leader | on | on | quoted prompt text containing `omx team` is allowed |

Additional regressions cover registered leader-cwd and detached-worktree workers, foreign worktree rejection, cross-Team and cross-worker denial, late metadata binding, API/mailbox/status operations through Conductor, loader/function poisoning, rollback cleanup, duplicate/topology conditions, tmux receipt parsing, and unmatched Stop no-op behavior.

## Isolated real-Team evidence

Built and packed this branch into a temporary installation and ran a private tmux server with hooks enabled and a detached worker worktree.

- Worker launch: `gpt-5.6-luna`, reasoning `max`.
- Native worker session bound separately from the leader session.
- Observed: startup -> ACK -> claim -> leader mailbox/status update -> completion -> graceful shutdown.
- No worker source diff was produced.
- Private tmux server was stopped; no registered test worktrees or processes remained; temporary roots were recoverably removed.
- A separate two-session Stop fixture preserved the authoritative leader and produced one silent `session_scope_unmatched` no-op with no synthetic user turn.

## Verification

Passed:

- Targeted worker provenance/native-hook tests (including detached worktree and poisoned runtime cases).
- Targeted Team API, lifecycle, rollback, HUD, tmux-session, and real private-tmux tests.
- Full `team.test.js`, `api-interop.test.js`, and worker binding tests.
- `npm run build`.
- `npm run lint` (792 files).
- `npm run check:no-unused`.
- Package prepack/native-agent/plugin-bundle verification in the isolated candidate flow.
- Independent security re-review: pass, no actionable findings.
- Independent architecture re-review: clear after wrapper, rollback, and compatibility fixes.

Known repository-suite gaps are called out rather than hidden: the full sequential suite was attempted but an unrelated detached-leader teardown fixture timed out waiting for a release report, and an existing issue-3138 owner-alias assertion also failed outside this diff. The affected fix slices and isolated real-Team smoke pass.

## Compatibility

Incident environment: OMX 0.20.3, Codex CLI 0.146.0, tmux 3.7b. This branch is based on OMX 0.20.4 development sources and specifically covers the observed Codex/tmux behavior without changing the global user installation or publishing a package.
