### PR TITLE
fix(team): explain foreign tmux pane topology

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -5660,7 +5660,17 @@ esac
 
           assert.throws(
             () => createTeamSession('Owned HUD Startup', 1, cwd),
-            /tmux window topology changed before layout mutation/,
+            (error: unknown) => {
+              assert.ok(error instanceof Error);
+              assert.match(error.message, /tmux window topology changed before layout mutation/);
+              assert.match(error.message, /target=shared:0/);
+              assert.match(error.message, /expected=\[%1,%2\]/);
+              assert.match(error.message, /actual=\[%1,%2,%7,%8\]/);
+              assert.match(error.message, /unexpected=\[%7,%8\]/);
+              assert.match(error.message, /missing=\[\]/);
+              assert.match(error.message, /isolated tmux window with no host-owned foreign panes/);
+              return true;
+            },
           );
 
           const tmuxLog = await readFile(logPath, 'utf-8');

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -775,6 +775,20 @@ function requireLiveTeamOwnedPaneSync(
   return requireLiveExactPaneSync(target, expectedPanePid);
 }
 
+function frozenWindowTopologyError(
+  teamTarget: string,
+  expectedPaneIds: ReadonlySet<string>,
+  actualPaneIds: ReadonlySet<string>,
+): Error {
+  const expected = [...expectedPaneIds].sort();
+  const actual = [...actualPaneIds].sort();
+  const unexpected = actual.filter((paneId) => !expectedPaneIds.has(paneId));
+  const missing = expected.filter((paneId) => !actualPaneIds.has(paneId));
+  return new Error(
+    `tmux window topology changed before layout mutation: target=${teamTarget}; expected=[${expected.join(',')}]; actual=[${actual.join(',')}]; unexpected=[${unexpected.join(',')}]; missing=[${missing.join(',')}]. Team requires an isolated tmux window with no host-owned foreign panes`,
+  );
+}
+
 function requireFrozenWindowTopologySync(
   teamTarget: string,
   expectedPanePids: ReadonlyMap<string, number>,
@@ -786,7 +800,7 @@ function requireFrozenWindowTopologySync(
   const actualPaneIds = new Set(topology.panes.map((pane) => pane.paneId));
   if (actualPaneIds.size !== expectedPanePids.size
     || [...expectedPanePids.keys()].some((paneId) => !actualPaneIds.has(paneId))) {
-    throw new Error('tmux window topology changed before layout mutation');
+    throw frozenWindowTopologyError(teamTarget, new Set(expectedPanePids.keys()), actualPaneIds);
   }
 
   for (const [paneId, expectedPanePid] of expectedPanePids) {
@@ -815,7 +829,7 @@ function requireFrozenWindowTopologySync(
   const finalPaneIds = new Set(finalTopology.panes.map((pane) => pane.paneId));
   if (finalPaneIds.size !== expectedPanePids.size
     || [...expectedPanePids.keys()].some((paneId) => !finalPaneIds.has(paneId))) {
-    throw new Error('tmux window topology changed before layout mutation');
+    throw frozenWindowTopologyError(teamTarget, new Set(expectedPanePids.keys()), finalPaneIds);
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve the existing fail-closed frozen-window topology guard
- report the target plus expected, actual, unexpected, and missing pane IDs
- give actionable isolated-window remediation without classifying foreign panes as Team-owned
- strengthen the intentional unowned-neighbor regression to prove diagnostics and zero partial tmux mutation

## Reproduction
Current `origin/dev` reproduces issue #3433 with the existing `rejects an unowned pane in startup topology before any window-wide mutation` fixture: the shared window contains `%1,%2,%7,%8`, while Team owns only `%1,%2`, and startup rejects before mutation.

## Safety boundaries
- foreign panes remain host-owned
- worker/HUD ownership proofs are unchanged
- `requireFrozenWindowTopologySync()` call ordering is unchanged
- standalone tmux and existing unowned/mutating topology protections remain intact
- no broad arbitrary-topology acceptance

## Verification
- `npm run build`
- focused foreign-neighbor and later-owner-check regressions: 2 passed
- relevant tmux/guard/fixture suites: 327 passed across the selected files (290 + 19 + 18)
- full `dist/team/__tests__` suite: all 40 files passed
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

Closes #3433

Signed-off-by: GJC <gjc@openai.com>