### PR TITLE
fix(smoke): align packed autopilot terminal expectations

### DIFF
--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -14,6 +14,7 @@ import {
   assertInstalledRootReasoningRejection,
   assertInstalledTeamSkillContract,
   assertPackedInstallFileMetadata,
+  assertPackedRegressionWorkflowState,
   buildNativeHookSmokePayload,
   ensureRepoDependencies,
   hasUsableNodeModules,
@@ -44,6 +45,7 @@ import {
   resolveGitCommonDir,
   resolveReusableNodeModulesSource,
   validateHookStdout,
+  shouldPackedRegressionStopBlock,
   assertCodexBatchWriteResult,
   assertGeneratedTrustMatchesCodex,
   managedCodexHooksByEvent,
@@ -1044,11 +1046,37 @@ test('packed install smoke covers directive activation and terminal false-activa
     { name: 'percent-suffix', prompt: '$ralplan%docs', expectedSkill: null, expectedStopBlock: false },
     { name: 'fullwidth-percent-suffix', prompt: '$ralplan％docs', expectedSkill: null, expectedStopBlock: false },
     { name: 'g1a-ordered-multi-skill', prompt: '$ralplan, $autopilot; $team', expectedSkill: 'ralplan', expectedStopBlock: true, expectedDeferredSkills: ['autopilot', 'team'], expectedActiveSkills: ['ralplan'], insideTmux: true },
-    { name: 'g1c-duplicate-alias', prompt: '$autopilot $oh-my-codex:autopilot build it', expectedSkill: 'autopilot', expectedStopBlock: true, expectedDeferredSkills: [], expectedActiveSkills: ['autopilot'] },
+    { name: 'g1c-duplicate-alias', prompt: '$autopilot $oh-my-codex:autopilot build it', expectedSkill: 'autopilot', expectedStopBlock: true, expectedDeferredSkills: [], expectedActiveSkills: [] },
     { name: 'b3-longer-valid-fence', prompt: '```text\n$autopilot build it\n````\n$ralplan plan it', expectedSkill: 'ralplan', expectedStopBlock: true },
     { name: 'b4-shorter-invalid-fence', prompt: '````text\n$autopilot build it\n```\n$ralplan plan it', expectedSkill: null, expectedStopBlock: false },
     { name: 'b5-different-marker-invalid-fence', prompt: '```text\n$autopilot build it\n~~~\n$ralplan plan it', expectedSkill: null, expectedStopBlock: false },
   ]);
+});
+
+test('packed regression workflow expectations distinguish active activation from receipt-unavailable Autopilot termination', () => {
+  assert.doesNotThrow(() => assertPackedRegressionWorkflowState(
+    { name: 'active-ralplan', expectedSkill: 'ralplan' },
+    { active: true, skill: 'ralplan' },
+  ));
+  assert.doesNotThrow(() => assertPackedRegressionWorkflowState(
+    { name: 'failed-autopilot', expectedSkill: 'autopilot' },
+    {
+      active: false,
+      skill: 'autopilot',
+      phase: 'failed',
+      error: 'documented_host_consensus_receipt_unavailable',
+      active_skills: [],
+    },
+  ));
+  assert.throws(() => assertPackedRegressionWorkflowState(
+    { name: 'stale-active-autopilot', expectedSkill: 'autopilot' },
+    { active: true, skill: 'autopilot', phase: 'running', active_skills: [{ skill: 'autopilot' }] },
+  ), /persisted unexpected workflow state/);
+});
+
+test('packed regression Stop expectations release terminal receipt-unavailable Autopilot state', () => {
+  assert.equal(shouldPackedRegressionStopBlock({ expectedSkill: 'ralplan', expectedStopBlock: true }), true);
+  assert.equal(shouldPackedRegressionStopBlock({ expectedSkill: 'autopilot', expectedStopBlock: true }), false);
 });
 
 test('packed regression environment clears inherited Team routing state', () => {

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -202,11 +202,33 @@ export const PACKED_INSTALL_NATIVE_HOOK_REGRESSION_PROMPTS = [
   { name: 'percent-suffix', prompt: '$ralplan%docs', expectedSkill: null, expectedStopBlock: false },
   { name: 'fullwidth-percent-suffix', prompt: '$ralplan％docs', expectedSkill: null, expectedStopBlock: false },
   { name: 'g1a-ordered-multi-skill', prompt: '$ralplan, $autopilot; $team', expectedSkill: 'ralplan', expectedStopBlock: true, expectedDeferredSkills: ['autopilot', 'team'], expectedActiveSkills: ['ralplan'], insideTmux: true },
-  { name: 'g1c-duplicate-alias', prompt: '$autopilot $oh-my-codex:autopilot build it', expectedSkill: 'autopilot', expectedStopBlock: true, expectedDeferredSkills: [], expectedActiveSkills: ['autopilot'] },
+  { name: 'g1c-duplicate-alias', prompt: '$autopilot $oh-my-codex:autopilot build it', expectedSkill: 'autopilot', expectedStopBlock: true, expectedDeferredSkills: [], expectedActiveSkills: [] },
   { name: 'b3-longer-valid-fence', prompt: '```text\n$autopilot build it\n````\n$ralplan plan it', expectedSkill: 'ralplan', expectedStopBlock: true },
   { name: 'b4-shorter-invalid-fence', prompt: '````text\n$autopilot build it\n```\n$ralplan plan it', expectedSkill: null, expectedStopBlock: false },
   { name: 'b5-different-marker-invalid-fence', prompt: '```text\n$autopilot build it\n~~~\n$ralplan plan it', expectedSkill: null, expectedStopBlock: false },
 ] as const;
+
+export function assertPackedRegressionWorkflowState(
+  testCase: { readonly name: string; readonly expectedSkill: string },
+  skillState: { readonly active?: boolean; readonly skill?: string; readonly phase?: string; readonly error?: string; readonly active_skills?: readonly unknown[] },
+): void {
+  const matchesExpectedState = testCase.expectedSkill === 'autopilot'
+    ? skillState.active === false
+      && skillState.skill === 'autopilot'
+      && skillState.phase === 'failed'
+      && skillState.error === 'documented_host_consensus_receipt_unavailable'
+      && skillState.active_skills?.length === 0
+    : skillState.active === true && skillState.skill === testCase.expectedSkill;
+  if (!matchesExpectedState) {
+    throw new Error(`packed regression ${testCase.name} persisted unexpected workflow state`);
+  }
+}
+
+export function shouldPackedRegressionStopBlock(
+  testCase: { readonly expectedSkill: string | null; readonly expectedStopBlock: boolean },
+): boolean {
+  return testCase.expectedSkill === 'autopilot' ? false : testCase.expectedStopBlock;
+}
 
 export function buildPackedRegressionEnvironment(
   testCase: { readonly name: string; readonly insideTmux?: boolean },
@@ -4503,10 +4525,8 @@ PY`],
         if (existsSync(skillStatePath)) throw new Error(`packed regression ${testCase.name} created workflow state`);
       } else {
         if (!existsSync(skillStatePath)) throw new Error(`packed regression ${testCase.name} did not create workflow state`);
-        const skillState = JSON.parse(readFileSync(skillStatePath, 'utf-8')) as { active?: boolean; skill?: string; deferred_skills?: string[]; active_skills?: Array<{ skill?: string }> };
-        if (!skillState.active || skillState.skill !== testCase.expectedSkill) {
-          throw new Error(`packed regression ${testCase.name} persisted unexpected workflow state`);
-        }
+        const skillState = JSON.parse(readFileSync(skillStatePath, 'utf-8')) as { active?: boolean; skill?: string; phase?: string; error?: string; deferred_skills?: string[]; active_skills?: Array<{ skill?: string }> };
+        assertPackedRegressionWorkflowState(testCase, skillState);
         if ('expectedDeferredSkills' in testCase && JSON.stringify(skillState.deferred_skills ?? []) !== JSON.stringify(testCase.expectedDeferredSkills)) {
           throw new Error(`packed regression ${testCase.name} persisted unexpected deferred workflows`);
         }
@@ -4521,10 +4541,11 @@ PY`],
         input: JSON.stringify({ ...promptPayload, hook_event_name: 'Stop', turn_id: `stop-${caseIndex}` }),
       });
       const stopOutput = JSON.parse(String(stopResult.stdout || '{}')) as { decision?: string };
-      if (testCase.expectedStopBlock && stopOutput.decision !== 'block') {
+      const expectedStopBlock = shouldPackedRegressionStopBlock(testCase);
+      if (expectedStopBlock && stopOutput.decision !== 'block') {
         throw new Error(`packed regression ${testCase.name} did not block Stop`);
       }
-      if (!testCase.expectedStopBlock && stopOutput.decision === 'block') {
+      if (!expectedStopBlock && stopOutput.decision === 'block') {
         throw new Error(`packed regression ${testCase.name} blocked Stop: ${JSON.stringify(stopOutput)}`);
       }
     }


### PR DESCRIPTION
## Summary
- distinguish ordinary active packed workflow activation from intentional Autopilot host-receipt-unavailable termination
- require `active:false`, `phase:failed`, `documented_host_consensus_receipt_unavailable`, and no active skills for packed Autopilot cases
- release Stop for that terminal state while preserving active workflow expectations and all classifier/runtime behavior

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/scripts/__tests__/smoke-packed-install.test.js dist/scripts/__tests__/codex-native-hook.test.js` (691 tests passed: 641 native-hook + 50 smoke-helper)
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- `env -u GJC_SESSION_CWD -u GJC_SESSION_ID npm run smoke:packed-install` advances past all Autopilot regressions, then exposes a separate pre-existing packed fixture failure: `neg-advance-reopen did not create workflow state`; direct reproduction shows that unrelated Ultragoal case creates state only with the tmux environment already used by the native-hook fixture. Per #3435 owner scope, this PR does not alter unrelated smoke cases.

Closes #3435

Signed-off-by: GJC <gjc@openai.com>