### PR TITLE
fix(setup): tolerate unsupported Windows directory fsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,13 @@ omx wiki refresh --json
 Native Windows remains a secondary path, and WSL2 is generally the better choice if you want a Windows-hosted setup.
 On native Windows, OMX accepts `psmux` as the tmux-compatible binary for the existing tmux-backed paths it already uses.
 
+Native Windows filesystems may report `EPERM` when Node.js requests `fsync()`
+on an otherwise valid regular-file or directory handle. OMX treats only that
+exact Windows capability failure as degraded durability after a successful
+native-hook transaction and emits one warning. Non-Windows errors, other error
+codes, unsafe paths or links, concurrent content changes, and transaction
+validation failures remain fatal.
+
 | Platform | Install |
 | --- | --- |
 | macOS | `brew install tmux` |

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -2839,7 +2839,7 @@ command = "node"
 							throw Object.assign(new Error("injected Windows EPERM"), { code: "EPERM" });
 						},
 					}, "win32"),
-					syncDirectory: async () => undefined,
+					syncDirectory: async () => "synced",
 				});
 				process.stderr.write = ((chunk: string | Uint8Array) => {
 					stderr.push(String(chunk));
@@ -2871,7 +2871,7 @@ command = "node"
 			const restoreDurability = setDoctorClaimJournalDurabilityForTest({
 				platform: "win32",
 				syncRegularFile: async () => { throw regularError; },
-				syncDirectory: async () => undefined,
+				syncDirectory: async () => "synced",
 			});
 			try {
 				await assert.rejects(doctor(), (error) => error === regularError);

--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { link, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -8,6 +8,7 @@ import {
 	createNativeHookClaimJournalDurability,
 	persistNativeHookClaimJournal as persistNativeHookClaimJournalWithDurability,
 	recoverNativeHookClaimJournal as recoverNativeHookClaimJournalWithDurability,
+	restoreNativeHookClaimNoClobber,
 } from "../native-hook-claim-journal.js";
 
 const durability = createNativeHookClaimJournalDurability();
@@ -170,10 +171,66 @@ test("claim journal treats only injected Windows regular-file EPERM as degraded"
 				order.push("regular");
 				return "unsupported-windows-eperm";
 			},
-			syncDirectory: async () => { order.push("directory"); },
+			syncDirectory: async () => { order.push("directory"); return "synced"; },
 		});
 		assert.equal(outcome, "unsupported-windows-eperm");
 		assert.deepEqual(order, ["directory", "regular", "directory"]);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal rejects paths outside its controlled root", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-controlled-root-"));
+	try {
+		await assert.rejects(
+			persistNativeHookClaimJournal(root, {
+				canonicalPath: join(root, "..", "foreign-hooks.json"),
+				claimPath: join(root, ".hooks.json.claim"),
+				before: Buffer.from("before\n"),
+				after: null,
+			}),
+			/outside controlled root/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim restore rejects an unexpected hard-linked claim", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-hard-link-"));
+	try {
+		const claimPath = join(root, ".hooks.json.claim");
+		await writeFile(claimPath, "before\n");
+		await link(claimPath, join(root, "foreign-link"));
+		await assert.rejects(
+			restoreNativeHookClaimNoClobber(
+				claimPath,
+				join(root, "hooks.json"),
+				durability,
+			),
+			/refuses unsafe claim/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal continues when Windows directory sync reports unsupported EPERM", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-directory-durability-"));
+	try {
+		const outcome = await persistNativeHookClaimJournalWithDurability(root, {
+			canonicalPath: join(root, "hooks.json"),
+			claimPath: join(root, ".hooks.json.claim"),
+			before: Buffer.from("before\n"),
+			after: null,
+		}, {
+			platform: "win32",
+			syncRegularFile: async () => "synced",
+			syncDirectory: async () => "unsupported-windows-eperm",
+		});
+		assert.equal(outcome, "synced");
+		await assert.doesNotReject(readFile(join(root, ".omx", "native-hook-claim-journal.json")));
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
@@ -193,14 +250,14 @@ test("claim journal keeps POSIX regular-file and directory EPERM fatal", async (
 			persistNativeHookClaimJournalWithDurability(root, entry, {
 				platform: "linux",
 				syncRegularFile: async () => { throw regularError; },
-				syncDirectory: async () => undefined,
+				syncDirectory: async () => "synced",
 			}),
 			(error) => error === regularError,
 		);
 		const directoryError = Object.assign(new Error("EPERM"), { code: "EPERM" });
 		await assert.rejects(
 			persistNativeHookClaimJournalWithDurability(root, entry, {
-				platform: "win32",
+				platform: "linux",
 				syncRegularFile: async () => "synced",
 				syncDirectory: async () => { throw directoryError; },
 			}),
@@ -224,7 +281,7 @@ test("claim journal recovery returns independent recovered and no-op outcomes", 
 		const recovered = await recoverNativeHookClaimJournalWithDurability(root, {
 			platform: "win32",
 			syncRegularFile: async () => "unsupported-windows-eperm",
-			syncDirectory: async () => undefined,
+			syncDirectory: async () => "synced",
 		});
 		assert.deepEqual(recovered, { recovered: true, outcome: "unsupported-windows-eperm" });
 		assert.deepEqual(

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -19,6 +19,7 @@ import { basename, dirname, join } from "node:path";
 import { parse as parseToml } from "@iarna/toml";
 import {
 	decideWindowsNativeHookShimReference,
+	setNativeHookClaimJournalDurabilityForTest,
 	setNativeHookTransactionFailureInjectorForTest,
 	setSetupLatePhaseFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
@@ -27,6 +28,7 @@ import {
 	setup,
 } from "../setup.js";
 import { resolveSetupRefreshArgs } from "../update.js";
+import { doctor } from "../doctor.js";
 import { uninstall } from "../uninstall.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
 import {
@@ -3233,6 +3235,124 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("completes Windows native-hook transactions with one directory fsync EPERM warning", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-directory-fsync-eperm-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const resetRegularSync = setNativeHookTransactionRegularFileSyncForTest(async () => undefined);
+		let directorySyncCalls = 0;
+		const stderr: string[] = [];
+		const originalStderrWrite = process.stderr.write;
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderr.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+		const resetDurability = setNativeHookClaimJournalDurabilityForTest({
+			platform: "win32",
+			syncRegularFile: async () => "synced",
+			syncDirectory: async () => {
+				directorySyncCalls += 1;
+				return "unsupported-windows-eperm";
+			},
+		});
+		let doctorOutput = "";
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					doctorOutput = await captureConsoleOutput(() => doctor());
+				});
+				assert.ok(directorySyncCalls > 0);
+				assert.equal(existsSync(buildManagedCodexNativeHookWindowsShimPath(codexHomeDir)), true);
+				assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
+				assert.equal(existsSync(join(codexHomeDir, ".omx", "notify-dispatch.json")), true);
+				assert.doesNotThrow(() => parseToml(readFileSync(join(codexHomeDir, "config.toml"), "utf-8")));
+			});
+			assert.match(doctorOutput, /\[OK\] Config:/);
+			assert.match(doctorOutput, /\[OK\] Native hooks:/);
+			assert.deepEqual(
+				stderr.filter((line) => line.includes("native-hook setup")),
+				["[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n"],
+			);
+		} finally {
+			process.stderr.write = originalStderrWrite;
+			resetDurability();
+			resetRegularSync();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	for (const fixture of [
+		{ platform: "win32" as const, code: "EACCES" },
+		{ platform: "linux" as const, code: "EPERM" },
+	]) {
+		it(`fails native-hook setup for ${fixture.platform} directory fsync ${fixture.code}`, async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-directory-fsync-fatal-"));
+			const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+			const resetDurability = setNativeHookClaimJournalDurabilityForTest({
+				platform: fixture.platform,
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => {
+					throw Object.assign(new Error(`${fixture.code}: fsync`), { code: fixture.code });
+				},
+			});
+			try {
+				await withIsolatedUserHome(wd, async () => {
+					await withTempCwd(wd, async () => {
+						await assert.rejects(
+							setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+							new RegExp(fixture.code),
+						);
+					});
+				});
+			} finally {
+				resetDurability();
+				resetPlatform();
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("accepts hash-identical Windows temporary read-back with a different file identity", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-identity-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const tempPath = (path: string, purpose: "write" | "delete") =>
+			join(dirname(path), `.${basename(path)}.identity-${purpose}.tmp`);
+		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
+		let replacements = 0;
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
+			if (stage !== "before_rename") return;
+			const temporaryPath = tempPath(artifact.path, "write");
+			const replacementPath = `${temporaryPath}.replacement`;
+			writeFileSync(replacementPath, readFileSync(temporaryPath));
+			rmSync(temporaryPath);
+			renameSync(replacementPath, temporaryPath);
+			replacements += 1;
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+				});
+				assert.ok(replacements >= 4);
+				assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
+				assert.equal(existsSync(join(codexHomeDir, ".omx", "notify-dispatch.json")), true);
+			});
+		} finally {
+			resetFailureInjector();
+			resetTemporaryPath();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 	it("orders Windows plugin-transition mutations as hooks, shim, then config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-removal-"));
 		const forwardOrder: string[] = [];
@@ -5364,8 +5484,9 @@ describe("omx setup install mode behavior", () => {
 			}
 		}
 	});
-	it("preserves a same-byte foreign replacement made immediately after a native-hook rename", async () => {
+	it("accepts a same-byte Windows replacement made immediately after a native-hook rename", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-immediate-post-rename-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
 		let resetFailureInjector: (() => void) | undefined;
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -5390,24 +5511,22 @@ describe("omx setup install mode behavior", () => {
 							assert.notEqual(replacedInode, ownedInode);
 						},
 					);
-					await assert.rejects(
-						setup({
-							scope: "user",
-							installMode: "legacy",
-							skipNativeAgentRefresh: true,
-							codexFeaturesProbe: () => null,
-							codexVersionProbe: () => null,
-						}),
-						/rollback failed/,
-					);
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: () => null,
+						codexVersionProbe: () => null,
+					});
 					assert.ok(replacement);
 					assert.ok(replacedInode);
 					assert.deepEqual(await readFile(hooksPath), replacement);
-					assert.deepEqual(await readFile(configPath), configBefore);
+					assert.notDeepEqual(await readFile(configPath), configBefore);
 				});
 			});
 		} finally {
 			resetFailureInjector?.();
+			resetPlatform();
 			await rm(wd, { recursive: true, force: true });
 		}
 	});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -291,7 +291,8 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
 	const recovery = await recoverNativeHookClaimJournal(
 		paths.codexHomeDir,
-		doctorClaimJournalDurabilityOverride ?? createNativeHookClaimJournalDurability(),
+		doctorClaimJournalDurabilityOverride ??
+			createNativeHookClaimJournalDurability(process.platform, recoveryTracker),
 	);
 	recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
 	emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -3,14 +3,18 @@ import { constants } from "fs";
 import { copyFile, link, open, lstat, mkdir, readFile, rm, type FileHandle } from "fs/promises";
 import { dirname, isAbsolute, join, relative, sep } from "path";
 import {
+	recordDirectorySyncOutcome,
+	syncDirectory,
 	syncRegularFile,
+	type DirectorySyncOutcome,
+	type RegularFileDurabilityTracker,
 	type RegularFileSyncOutcome,
 } from "../utils/file-durability.js";
 
 export interface NativeHookClaimJournalDurability {
 	platform: NodeJS.Platform;
 	syncRegularFile(handle: Pick<FileHandle, "sync">): Promise<RegularFileSyncOutcome>;
-	syncDirectory(path: string): Promise<void>;
+	syncDirectory(path: string): Promise<DirectorySyncOutcome>;
 }
 
 interface ClaimJournalEntry {
@@ -48,10 +52,13 @@ function processIsAlive(pid: number): boolean {
 	}
 }
 
-async function fsyncDirectory(path: string): Promise<void> {
+async function fsyncDirectory(
+	path: string,
+	platform: NodeJS.Platform,
+): Promise<DirectorySyncOutcome> {
 	const handle = await open(path, "r");
 	try {
-		await handle.sync();
+		return await syncDirectory(handle, platform);
 	} finally {
 		await handle.close();
 	}
@@ -59,19 +66,34 @@ async function fsyncDirectory(path: string): Promise<void> {
 
 export function createNativeHookClaimJournalDurability(
 	platform: NodeJS.Platform = process.platform,
+	tracker?: RegularFileDurabilityTracker,
 ): NativeHookClaimJournalDurability {
 	return {
 		platform,
 		syncRegularFile: (handle) => syncRegularFile(handle, platform),
-		syncDirectory: fsyncDirectory,
+		async syncDirectory(path) {
+			const outcome = await fsyncDirectory(path, platform);
+			if (tracker) recordDirectorySyncOutcome(tracker, outcome);
+			return outcome;
+		},
 	};
+}
+
+function sameStableFileIdentity(
+	left: { dev: number; ino: number },
+	right: { dev: number; ino: number },
+	platform: NodeJS.Platform,
+): boolean {
+	// Windows file-index metadata is not a stable cross-open ownership token.
+	// Callers pair this with controlled paths, exact bytes, and expected link counts.
+	return platform === "win32" || (left.dev === right.dev && left.ino === right.ino);
 }
 
 export async function syncNativeHookClaimParent(
 	path: string,
 	durability: NativeHookClaimJournalDurability,
-): Promise<void> {
-	await durability.syncDirectory(dirname(path));
+): Promise<DirectorySyncOutcome> {
+	return durability.syncDirectory(dirname(path));
 }
 
 export async function restoreNativeHookClaimNoClobber(
@@ -111,12 +133,15 @@ export async function restoreNativeHookClaimNoClobber(
 		readFile(destinationPath),
 		lstat(destinationPath),
 	]);
+	const expectedLinks = linked ? 2 : 1;
 	if (
-		currentClaimStat.dev !== claimStat.dev ||
-		currentClaimStat.ino !== claimStat.ino ||
+		currentClaimStat.isSymbolicLink() || !currentClaimStat.isFile() ||
+		destinationStat.isSymbolicLink() || !destinationStat.isFile() ||
+		currentClaimStat.nlink !== expectedLinks || destinationStat.nlink !== expectedLinks ||
+		!sameStableFileIdentity(currentClaimStat, claimStat, durability.platform) ||
 		!currentClaimBytes.equals(claimBytes) ||
 		!destinationBytes.equals(claimBytes) ||
-		(linked && (currentClaimStat.dev !== destinationStat.dev || currentClaimStat.ino !== destinationStat.ino))
+		(linked && !sameStableFileIdentity(currentClaimStat, destinationStat, durability.platform))
 	) {
 		throw new Error(`Native hook claim changed during restore: ${claimPath}.`);
 	}
@@ -243,10 +268,13 @@ export async function recoverNativeHookClaimJournal(
 		if (
 			!canonicalStat.isSymbolicLink() && canonicalStat.isFile() && canonicalStat.nlink === 2 &&
 			!claimStat.isSymbolicLink() && claimStat.isFile() && claimStat.nlink === 2 &&
-			canonicalStat.dev === claimStat.dev && canonicalStat.ino === claimStat.ino
+			sameStableFileIdentity(canonicalStat, claimStat, durability.platform)
 		) {
-			const bytes = await readFile(parsed.canonicalPath);
-			if (digest(bytes) !== parsed.beforeHash) {
+			const [canonicalBytes, claimBytes] = await Promise.all([
+				readFile(parsed.canonicalPath),
+				readFile(parsed.claimPath),
+			]);
+			if (!canonicalBytes.equals(claimBytes) || digest(canonicalBytes) !== parsed.beforeHash) {
 				throw new Error("Native hook claim journal cannot finalize a linked restore with changed bytes.");
 			}
 			await rm(parsed.claimPath);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -48,6 +48,7 @@ import {
 } from "../utils/paths.js";
 import {
 	emitDegradedDurabilityWarning,
+	recordDirectorySyncOutcome,
 	recordRegularFileSyncOutcome,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
@@ -633,35 +634,54 @@ function nativeHookPlatform(): NodeJS.Platform {
 }
 
 
-function nativeHookClaimJournalDurability() {
-	return nativeHookClaimJournalDurabilityOverride
-		?? createNativeHookClaimJournalDurability(nativeHookPlatform());
+function nativeHookClaimJournalDurability(tracker?: RegularFileDurabilityTracker) {
+	if (!nativeHookClaimJournalDurabilityOverride) {
+		return createNativeHookClaimJournalDurability(nativeHookPlatform(), tracker);
+	}
+	const durability = nativeHookClaimJournalDurabilityOverride;
+	if (!tracker) return durability;
+	return {
+		...durability,
+		async syncDirectory(path: string) {
+			const outcome = await durability.syncDirectory(path);
+			recordDirectorySyncOutcome(tracker, outcome);
+			return outcome;
+		},
+	};
 }
 
-async function clearNativeHookClaimJournal(root: string): Promise<void> {
-	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability());
+async function clearNativeHookClaimJournal(
+	root: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability(tracker));
 }
 
 async function persistNativeHookClaimJournal(
 	root: string,
 	entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
-	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability());
+	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability(tracker));
 }
 
 async function restoreNativeHookClaimNoClobber(
 	claimPath: string,
 	destinationPath: string,
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
 	return restoreNativeHookClaimNoClobberWithDurability(
 		claimPath,
 		destinationPath,
-		nativeHookClaimJournalDurability(),
+		nativeHookClaimJournalDurability(tracker),
 	);
 }
 
-async function syncNativeHookClaimParent(path: string): Promise<void> {
-	return syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability());
+async function syncNativeHookClaimParent(
+	path: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	await syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability(tracker));
 }
 async function syncNativeHookRegularFile(
 	handle: Awaited<ReturnType<typeof open>>,
@@ -904,6 +924,14 @@ function nativeHookTransactionSnapshotsEqual(
 	left: NativeHookTransactionArtifactSnapshot,
 	right: NativeHookTransactionArtifactSnapshot,
 ): boolean {
+	if (nativeHookPlatform() === "win32") {
+		// Windows can synthesize Unix mode bits and expose unstable file-index
+		// metadata across closed/reopened handles. captureNativeHookTransactionArtifact
+		// still enforces a single-link regular file and a stable identity during
+		// each read; cross-read ownership is proven by the controlled path and bytes.
+		return hookTransactionBytesEqual(left.bytes, right.bytes) &&
+			left.topology.kind === right.topology.kind;
+	}
 	return (
 		hookTransactionBytesEqual(left.bytes, right.bytes) &&
 		nativeHookTransactionTopologyEqual(left.topology, right.topology) &&
@@ -917,6 +945,10 @@ function nativeHookTransactionSnapshotMatchesExpected(
 	snapshot: NativeHookTransactionArtifactSnapshot,
 	expected: Pick<NativeHookTransactionArtifactSnapshot, "bytes" | "topology">,
 ): boolean {
+	if (nativeHookPlatform() === "win32") {
+		return hookTransactionBytesEqual(snapshot.bytes, expected.bytes) &&
+			snapshot.topology.kind === expected.topology.kind;
+	}
 	return (
 		hookTransactionBytesEqual(snapshot.bytes, expected.bytes) &&
 		nativeHookTransactionTopologyEqual(snapshot.topology, expected.topology)
@@ -1170,7 +1202,7 @@ async function restoreNativeHookClaim(
 ): Promise<void> {
 	recordRegularFileSyncOutcome(
 		tracker,
-		await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+		await restoreNativeHookClaimNoClobber(claimPath, destinationPath, tracker),
 	);
 }
 
@@ -1282,7 +1314,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 						claimPath,
 						before: expectedCurrent.bytes,
 						after: content,
-					}),
+					}, tracker),
 				);
 				await refreshNativeHookTransactionAncestorPrecondition(
 					ancestorPrecondition,
@@ -1292,7 +1324,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 			}
 			await rename(artifact.path, claimPath);
 			claimCreated = true;
-			if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+			if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 			await assertNativeHookTransactionArtifactSnapshot(
 				claimPath,
 				`${artifact.label} replacement claim`,
@@ -1310,7 +1342,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 		} finally {
 			await installedHandle.close();
 		}
-		await syncNativeHookClaimParent(artifact.path);
+		await syncNativeHookClaimParent(artifact.path, tracker);
 		const installedSnapshot = await assertNativeHookTransactionArtifactState(
 			artifact.path,
 			artifact.label,
@@ -1319,11 +1351,11 @@ async function atomicWriteNativeHookTransactionArtifact(
 		);
 		if (claimCreated && claimPath) {
 			await rm(claimPath);
-			await syncNativeHookClaimParent(claimPath);
+			await syncNativeHookClaimParent(claimPath, tracker);
 			claimCreated = false;
 		}
 		if (journaledClaim) {
-			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 			journaledClaim = false;
 		}
 		await rm(temporaryPath);
@@ -1344,10 +1376,10 @@ async function atomicWriteNativeHookTransactionArtifact(
 		if (claimCreated && claimPath) {
 			try {
 				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
-				await syncNativeHookClaimParent(artifact.path);
+				await syncNativeHookClaimParent(artifact.path, tracker);
 				claimCreated = false;
 				if (journaledClaim) {
-					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 					journaledClaim = false;
 				}
 			} catch (recoveryError) {
@@ -1388,7 +1420,8 @@ async function assertNativeHookTransactionArtifactState(
 	context: "precondition" | "rollback" | "read-back",
 ): Promise<NativeHookTransactionArtifactSnapshot> {
 	const actual = await captureNativeHookTransactionArtifact(path, label);
-	if (!nativeHookTransactionSnapshotMatchesExpected(actual, expected)) {
+	const matches = nativeHookTransactionSnapshotMatchesExpected(actual, expected);
+	if (!matches) {
 		if (context === "rollback") {
 			throw new Error(
 				`Native hook transaction rollback preserved ${path} for manual recovery because ${label} no longer matches the transaction-owned version.`,
@@ -1407,7 +1440,8 @@ async function assertNativeHookTransactionArtifactSnapshot(
 	context: "precondition" | "rollback" | "read-back",
 ): Promise<NativeHookTransactionArtifactSnapshot> {
 	const actual = await captureNativeHookTransactionArtifact(path, label);
-	if (!nativeHookTransactionSnapshotsEqual(actual, expected)) {
+	const matches = nativeHookTransactionSnapshotsEqual(actual, expected);
+	if (!matches) {
 		if (context === "rollback") {
 			throw new Error(
 				`Native hook transaction rollback preserved ${path} for manual recovery because ${label} no longer matches the transaction-owned version.`,
@@ -1600,11 +1634,11 @@ async function applyNativeHookTransactionArtifact(
 					claimPath,
 					before: artifact.before.bytes!,
 					after: null,
-				}),
+				}, tracker),
 			);
 		}
 		await rename(artifact.path, claimPath);
-		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 		const entry: AppliedNativeHookTransactionArtifact = {
 			artifact,
 			appliedSnapshot: { bytes: null, topology: { kind: "absent" } },
@@ -1631,9 +1665,9 @@ async function applyNativeHookTransactionArtifact(
 					`${artifact.label} removal claim`,
 				);
 				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
-				if (journaledClaim) await syncNativeHookClaimParent(artifact.path);
+				if (journaledClaim) await syncNativeHookClaimParent(artifact.path, tracker);
 				if (journaledClaim) {
-					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 				}
 				await assertNativeHookTransactionArtifactSnapshot(
 					artifact.path,
@@ -1652,9 +1686,9 @@ async function applyNativeHookTransactionArtifact(
 
 		}
 		await rm(claimPath);
-		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 		if (journaledClaim) {
-			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 		}
 		originalRemoved = true;
 		injectNativeHookTransactionFailure("after_remove", artifact);
@@ -3931,7 +3965,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
 		const recovery = await recoverNativeHookClaimJournal(
 			scopeDirs.codexHomeDir,
-			nativeHookClaimJournalDurability(),
+			nativeHookClaimJournalDurability(recoveryTracker),
 		);
 		recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
 		if (recovery.recovered) {

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -58,6 +58,7 @@ import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.
 import TOML from "@iarna/toml";
 import {
   emitDegradedDurabilityWarning,
+  recordDirectorySyncOutcome,
   recordRegularFileSyncOutcome,
   syncRegularFile,
   type RegularFileSyncOutcome,
@@ -898,35 +899,54 @@ function transactionTemporaryPath(
   );
 }
 
-function uninstallClaimJournalDurability() {
-  return uninstallClaimJournalDurabilityOverride
-    ?? createNativeHookClaimJournalDurability();
+function uninstallClaimJournalDurability(tracker?: RegularFileDurabilityTracker) {
+  if (!uninstallClaimJournalDurabilityOverride) {
+    return createNativeHookClaimJournalDurability(process.platform, tracker);
+  }
+  const durability = uninstallClaimJournalDurabilityOverride;
+  if (!tracker) return durability;
+  return {
+    ...durability,
+    async syncDirectory(path: string) {
+      const outcome = await durability.syncDirectory(path);
+      recordDirectorySyncOutcome(tracker, outcome);
+      return outcome;
+    },
+  };
 }
 
-async function clearNativeHookClaimJournal(root: string): Promise<void> {
-  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability());
+async function clearNativeHookClaimJournal(
+  root: string,
+  tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability(tracker));
 }
 
 async function persistNativeHookClaimJournal(
   root: string,
   entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+  tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
-  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability());
+  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability(tracker));
 }
 
 async function restoreNativeHookClaimNoClobber(
   claimPath: string,
   destinationPath: string,
+  tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
   return restoreNativeHookClaimNoClobberWithDurability(
     claimPath,
     destinationPath,
-    uninstallClaimJournalDurability(),
+    uninstallClaimJournalDurability(tracker),
   );
 }
 
-async function syncNativeHookClaimParent(path: string): Promise<void> {
-  return syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability());
+async function syncNativeHookClaimParent(
+  path: string,
+  tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+  await syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability(tracker));
 }
 
 function transactionClaimPath(path: string): string {
@@ -943,7 +963,7 @@ async function restoreUninstallClaim(
 ): Promise<void> {
   recordRegularFileSyncOutcome(
     tracker,
-    await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+    await restoreNativeHookClaimNoClobber(claimPath, destinationPath, tracker),
   );
 }
 
@@ -1190,12 +1210,12 @@ async function atomicReplaceFile(
           claimPath,
           before: expectedCurrent.bytes,
           after: content,
-        }),
+        }, options.durabilityTracker),
       );
       journaledClaim = true;
       await rename(mutation.snapshot.path, claimPath);
       claimCreated = true;
-      await syncNativeHookClaimParent(claimPath);
+      await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
       await assertSnapshotAtPath(claimPath, expectedCurrent, "replacement claim");
     }
     await copyFile(temporaryPath, mutation.snapshot.path, constants.COPYFILE_EXCL);
@@ -1206,18 +1226,18 @@ async function atomicReplaceFile(
     } finally {
       await installedHandle.close();
     }
-    await syncNativeHookClaimParent(mutation.snapshot.path);
+    await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
     const actual = await captureCurrentSnapshot(mutation.snapshot);
     if (actual.bytes === null || actual.mode !== mutation.snapshot.mode || !actual.bytes.equals(content)) {
       throw new Error(`Read-back verification failed for replacement ${mutation.snapshot.path}.`);
     }
     if (claimCreated && claimPath) {
       await rm(claimPath);
-      await syncNativeHookClaimParent(claimPath);
+      await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
       claimCreated = false;
     }
     if (journaledClaim && controlledRoot) {
-      await clearNativeHookClaimJournal(controlledRoot);
+      await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
       journaledClaim = false;
     }
     await rm(temporaryPath);
@@ -1243,11 +1263,11 @@ async function atomicReplaceFile(
     if (claimCreated && claimPath) {
       try {
         await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
-        await syncNativeHookClaimParent(mutation.snapshot.path);
+        await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
         claimCreated = false;
         const controlledRoot = mutation.snapshot.topology?.root;
         if (journaledClaim && controlledRoot) {
-          await clearNativeHookClaimJournal(controlledRoot);
+          await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
           journaledClaim = false;
         }
       } catch (recoveryError) {
@@ -1324,11 +1344,11 @@ async function stageAndRemoveFile(
           claimPath,
           before: mutation.snapshot.bytes,
           after: null,
-        }),
+        }, options.durabilityTracker),
       );
     }
     await rename(mutation.snapshot.path, claimPath);
-    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
     execution.appliedSnapshot = {
       path: mutation.snapshot.path,
       content: null,
@@ -1345,8 +1365,8 @@ async function stageAndRemoveFile(
     } catch (error) {
       try {
         await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
-        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path);
-        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
+        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
+        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
         execution.appliedSnapshot = undefined;
         execution.phase = "prepared";
       } catch (recoveryError) {
@@ -1357,8 +1377,8 @@ async function stageAndRemoveFile(
       throw error;
     }
     await rm(claimPath);
-    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
-    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
+    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
     await options.transactionFailureInjector?.("after-remove");
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
@@ -1827,7 +1847,10 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
     const recovery = await recoverNativeHookClaimJournal(
       scopeDirs.codexHomeDir,
       uninstallClaimJournalDurabilityOverride
-        ?? createNativeHookClaimJournalDurability(options.transactionPlatform ?? process.platform),
+        ?? createNativeHookClaimJournalDurability(
+          options.transactionPlatform ?? process.platform,
+          recoveryTracker,
+        ),
     );
     recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
     emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
 	emitDegradedDurabilityWarning,
+	recordDirectorySyncOutcome,
 	recordRegularFileSyncOutcome,
+	syncDirectory,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
 } from "../file-durability.js";
@@ -22,6 +24,30 @@ test("regular-file sync returns the Windows EPERM durability outcome", async () 
 test("regular-file sync returns synced after a successful sync", async () => {
 	assert.equal(await syncRegularFile({ sync: async () => {} }, "win32"), "synced");
 });
+
+test("directory sync returns the Windows EPERM durability outcome", async () => {
+	const outcome = await syncDirectory(
+		{ sync: async () => { throw errno("EPERM"); } },
+		"win32",
+	);
+	assert.equal(outcome, "unsupported-windows-eperm");
+});
+
+test("directory sync returns synced after a successful sync", async () => {
+	assert.equal(await syncDirectory({ sync: async () => {} }, "win32"), "synced");
+});
+
+for (const { description, platform, failure } of [
+	{ description: "Linux EPERM", platform: "linux", failure: errno("EPERM") },
+	{ description: "Windows EACCES", platform: "win32", failure: errno("EACCES") },
+] as const) {
+	test(`directory sync preserves fatal error identity for ${description}`, async () => {
+		await assert.rejects(
+			syncDirectory({ sync: async () => { throw failure; } }, platform),
+			(error: unknown) => error === failure,
+		);
+	});
+}
 
 for (const { description, platform, failure } of [
 	{ description: "Linux string EPERM", platform: "linux", failure: errno("EPERM") },
@@ -68,4 +94,23 @@ test("a throwing stderr sink cannot fail an already successful transaction", () 
 	} finally {
 		process.stderr.write = originalWrite;
 	}
+});
+
+test("durability warning accurately names directory degradation", () => {
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordDirectorySyncOutcome(tracker, "unsupported-windows-eperm");
+	const originalWrite = process.stderr.write;
+	const warnings: string[] = [];
+	process.stderr.write = ((value: string) => {
+		warnings.push(value);
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		emitDegradedDurabilityWarning("native-hook setup", tracker);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	assert.deepEqual(warnings, [
+		"[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n",
+	]);
 });

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -1,6 +1,7 @@
 import type { FileHandle } from "fs/promises";
 
 export type RegularFileSyncOutcome = "synced" | "unsupported-windows-eperm";
+export type DirectorySyncOutcome = "synced" | "unsupported-windows-eperm";
 
 export type DurabilityWarningSubsystem =
 	| "session pointer start/reconcile"
@@ -11,9 +12,11 @@ export type DurabilityWarningSubsystem =
 
 export interface RegularFileDurabilityTracker {
 	degraded: boolean;
+	regularFileDegraded?: boolean;
+	directoryDegraded?: boolean;
 }
 
-function isUnsupportedWindowsRegularFileSync(
+function isUnsupportedWindowsSync(
 	error: unknown,
 	platform: NodeJS.Platform,
 ): boolean {
@@ -38,7 +41,25 @@ export async function syncRegularFile(
 		await handle.sync();
 		return "synced";
 	} catch (error) {
-		if (!isUnsupportedWindowsRegularFileSync(error, platform)) throw error;
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
+		return "unsupported-windows-eperm";
+	}
+}
+
+/**
+ * Windows can also report EPERM when fsync is unsupported for an otherwise
+ * valid directory handle. Keep the capability boundary as narrow as the
+ * regular-file fallback: every other platform/error pair remains fatal.
+ */
+export async function syncDirectory(
+	handle: Pick<FileHandle, "sync">,
+	platform: NodeJS.Platform = process.platform,
+): Promise<DirectorySyncOutcome> {
+	try {
+		await handle.sync();
+		return "synced";
+	} catch (error) {
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
 		return "unsupported-windows-eperm";
 	}
 }
@@ -47,7 +68,18 @@ export function recordRegularFileSyncOutcome(
 	tracker: RegularFileDurabilityTracker,
 	outcome: RegularFileSyncOutcome,
 ): void {
-	tracker.degraded ||= outcome === "unsupported-windows-eperm";
+	if (outcome !== "unsupported-windows-eperm") return;
+	tracker.degraded = true;
+	tracker.regularFileDegraded = true;
+}
+
+export function recordDirectorySyncOutcome(
+	tracker: RegularFileDurabilityTracker,
+	outcome: DirectorySyncOutcome,
+): void {
+	if (outcome !== "unsupported-windows-eperm") return;
+	tracker.degraded = true;
+	tracker.directoryDegraded = true;
 }
 
 export function emitDegradedDurabilityWarning(
@@ -55,9 +87,14 @@ export function emitDegradedDurabilityWarning(
 	tracker: RegularFileDurabilityTracker,
 ): void {
 	if (!tracker.degraded) return;
+	const target = tracker.directoryDegraded
+		? tracker.regularFileDegraded
+			? "regular-file and directory fsync"
+			: "directory fsync"
+		: "regular-file fsync";
 	try {
 		process.stderr.write(
-			`[omx] warning: Windows EPERM regular-file fsync unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
+			`[omx] warning: Windows EPERM ${target} unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
 		);
 	} catch {
 		// Diagnostics must not fail an already committed transaction.


### PR DESCRIPTION
## Summary

Fix native Windows setup failures in the native-hook transaction by:

- treating only Windows directory `fsync()` failures with `code === "EPERM"` as an unsupported durability capability
- aggregating regular-file and directory degradation into one accurate post-commit warning
- avoiding cross-open Windows `dev`/`ino`/mode equality as a transaction ownership token when the controlled path, single-link regular-file topology, and exact bytes still match
- applying the shared directory durability outcome to setup, uninstall, doctor recovery, and claim-journal paths

## Environment

Reproduced on native Windows 25H2 with:

- Node.js 24.19.0
- Codex CLI 0.146.0
- oh-my-codex 0.20.4
- PowerShell 5.1

## Reproduction

Run:

```powershell
omx setup --force --merge-agents
```

Before this change, the transaction rejects hash-identical temporary files and then aborts on directory synchronization:

```text
Native hook transaction read-back changed for native hook Windows shim ... temporary;
refusing to overwrite concurrent content.

Native hook transaction read-back changed for native hooks ... temporary;
refusing to overwrite concurrent content.

Native hook transaction read-back changed for notification metadata ... temporary;
refusing to overwrite concurrent content.

EPERM: operation not permitted, fsync
```

## Root cause

PR #3191 added a deliberately narrow fallback for Windows regular-file `fsync()` returning `EPERM`, but native-hook claim-journal directory synchronization still called `handle.sync()` directly and treated the same Windows capability failure as fatal.

The transaction also compared cross-open `dev`, `ino`, link-count, and Unix-mode snapshot metadata in addition to bytes. On Windows, file-index-derived identity and synthesized mode metadata are not reliable cross-open ownership tokens. That caused false rejection even when the exclusive controlled path remained a single-link regular file with exactly the expected SHA-256/content.

## Safety boundary

The durability fallback remains fail-closed except for the exact pair:

```text
process.platform === "win32" && error.code === "EPERM"
```

All non-Windows failures and all non-`EPERM` failures are rethrown.

Windows transaction validation still requires:

- controlled paths and safe ancestor topology
- regular files rather than symlinks
- exactly one link for transaction artifacts
- exact expected bytes
- capture-time identity stability
- claim-journal ownership, digest, and link-topology checks
- no-clobber copy/link behavior

Actual byte mutation, symlinks, unexpected hard links, path escape, stale content, and foreign content remain fatal. POSIX retains strict cross-open device/inode/mode equality.

## After

Setup completes and emits one diagnostic when durability is degraded:

```text
[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.

Setup complete! Run "omx doctor" to verify installation.
```

If both regular-file and directory synchronization are unsupported, the single warning names both.

## Tests

Added or extended regression coverage for:

- Windows directory `EPERM` succeeds and emits one warning
- Windows directory non-`EPERM` fails
- POSIX directory `EPERM` fails
- hash-identical Windows temporary read-back with different file identity succeeds
- actual byte mutation fails closed
- symlinked ancestry, unexpected hard links, and path escape fail closed
- shim, `hooks.json`, notification metadata, and `config.toml` commit successfully
- `doctor` recognizes the committed config and native hooks
- claim-journal recovery keeps exact byte/link safety checks

Verification:

```text
npm run build
npm run lint
npm run check:no-unused
node dist/scripts/run-test-files.js dist/utils/__tests__/file-durability.test.js dist/cli/__tests__/native-hook-claim-journal.test.js
focused setup-install-mode Windows durability/read-back/safety tests
focused doctor setup-recognition and claim-journal recovery tests
```

## Relationship to #3189 / #3191

This is a narrow follow-up to #3189 and the regular-file fix in #3191. It extends the same exact Windows-`EPERM` capability boundary to transactional directory synchronization and preserves the original rule that every other filesystem failure remains fatal.
