### PR TITLE
fix(deep-interview): restore trusted Windows cancellation

### DIFF
--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -512,7 +512,9 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 </Tool_Usage>
 
 <Escalation_And_Stop_Conditions>
-- User says stop/cancel/abort -> persist state and stop
+- User says stop/cancel/abort -> run the exact bare command `omx cancel` immediately, then run the exact read-only command `omx state get-status --json` and verify that neither standalone deep-interview nor a supervising Autopilot lifecycle in its deep-interview phase remains active before reporting success
+- Cancellation must use only that canonical CLI path: do not substitute `omx state clear`, `omx state write`, direct edits/deletes under `.omx/state/**`, shell redirection, leading environment assignments, wrappers, or chained commands
+- If PreToolUse returns `permissionDecisionReason: "cancelled_exact_session"`, treat that as successful hook-owned cancellation (the external command is intentionally suppressed) and still perform the read-only inactive-state verification
 - Ambiguity stalls for 3 rounds (+/- 0.05) -> force Ontologist mode once
 - Max rounds reached -> proceed with explicit residual-risk warning
 - All dimensions >= 0.9 -> allow early crystallization even before max rounds

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -512,7 +512,9 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 </Tool_Usage>
 
 <Escalation_And_Stop_Conditions>
-- User says stop/cancel/abort -> persist state and stop
+- User says stop/cancel/abort -> run the exact bare command `omx cancel` immediately, then run the exact read-only command `omx state get-status --json` and verify that neither standalone deep-interview nor a supervising Autopilot lifecycle in its deep-interview phase remains active before reporting success
+- Cancellation must use only that canonical CLI path: do not substitute `omx state clear`, `omx state write`, direct edits/deletes under `.omx/state/**`, shell redirection, leading environment assignments, wrappers, or chained commands
+- If PreToolUse returns `permissionDecisionReason: "cancelled_exact_session"`, treat that as successful hook-owned cancellation (the external command is intentionally suppressed) and still perform the read-only inactive-state verification
 - Ambiguity stalls for 3 rounds (+/- 0.05) -> force Ontologist mode once
 - Max rounds reached -> proceed with explicit residual-risk warning
 - All dimensions >= 0.9 -> allow early crystallization even before max rounds

--- a/src/cli/__tests__/session-scoped-runtime.test.ts
+++ b/src/cli/__tests__/session-scoped-runtime.test.ts
@@ -143,6 +143,79 @@ describe('CLI session-scoped state parity', () => {
     }
   });
 
+  it('releases standalone deep-interview locks when cancellation reaches a terminal state', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-cli-deep-interview-cancel-lock-'));
+    try {
+      const stateDir = join(wd, '.omx', 'state');
+      const sessionId = 'deep-interview-session';
+      const scopedDir = join(stateDir, 'sessions', sessionId);
+      const statePath = join(scopedDir, 'deep-interview-state.json');
+      await mkdir(scopedDir, { recursive: true });
+      await writeFile(join(stateDir, 'session.json'), JSON.stringify({
+        session_id: sessionId,
+        cwd: wd,
+        state_root: stateDir,
+      }));
+      await writeFile(statePath, JSON.stringify({
+        active: true,
+        mode: 'deep-interview',
+        current_phase: 'intent-first',
+        session_id: sessionId,
+        input_lock: {
+          active: true,
+          status: 'active',
+          acquired_at: '2026-08-05T00:00:00.000Z',
+          released_at: '',
+        },
+        question_enforcement: {
+          status: 'pending',
+          question_id: 'question-1',
+        },
+      }));
+
+      const cancelResult = runOmx(wd, 'cancel');
+      if (cancelResult.error && /(EPERM|EACCES)/i.test(cancelResult.error.message)) return;
+      assert.equal(cancelResult.status, 0, cancelResult.stderr || cancelResult.stdout);
+      assert.match(cancelResult.stdout, /Cancelled: deep-interview/);
+
+      const updated = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(updated.active, false);
+      assert.equal(updated.current_phase, 'cancelled');
+      assert.equal(updated.input_lock.active, false);
+      assert.equal(updated.input_lock.status, 'released');
+      assert.equal(updated.input_lock.released_at, updated.completed_at);
+      assert.equal(updated.input_lock.release_reason, 'terminal_state_normalization');
+      assert.equal(updated.question_enforcement.status, 'cleared');
+      assert.equal(updated.question_enforcement.clear_reason, 'abort');
+
+      const completedAt = updated.completed_at;
+      updated.input_lock = {
+        active: true,
+        status: 'active',
+        acquired_at: '2026-08-05T00:00:00.000Z',
+        released_at: '',
+      };
+      updated.question_enforcement = {
+        status: 'pending',
+        question_id: 'question-2',
+      };
+      await writeFile(statePath, JSON.stringify(updated));
+
+      const repairResult = runOmx(wd, 'cancel');
+      assert.equal(repairResult.status, 0, repairResult.stderr || repairResult.stdout);
+      assert.match(repairResult.stdout, /No active modes to cancel/);
+      const repaired = JSON.parse(await readFile(statePath, 'utf-8'));
+      assert.equal(repaired.completed_at, completedAt);
+      assert.equal(repaired.input_lock.active, false);
+      assert.equal(repaired.input_lock.status, 'released');
+      assert.equal(repaired.input_lock.release_reason, 'terminal_state_normalization');
+      assert.equal(repaired.question_enforcement.status, 'cleared');
+      assert.equal(repaired.question_enforcement.clear_reason, 'abort');
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('does not mutate an unmatched implicit OMX session, including force cleanup', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-cli-cancel-unmatched-session-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8048,6 +8048,7 @@ async function cancelModes(
             : skill
         ));
       }
+      entry.state = normalizeTerminalWorkflowState(entry.state, { mode, nowIso }).state;
       changed.add(mode);
       if (reportIfWasActive && wasActive && mode !== SKILL_ACTIVE_STATE_MODE) reported.add(mode);
     };
@@ -8121,6 +8122,14 @@ async function cancelModes(
       for (const [mode, entry] of states.entries()) {
         if (entry.state.active === true) cancelMode(mode, "cancelled", true);
       }
+    }
+
+    for (const [mode, entry] of states.entries()) {
+      if (entry.state.active === true) continue;
+      const normalized = normalizeTerminalWorkflowState(entry.state, { mode, nowIso });
+      if (!normalized.changed) continue;
+      entry.state = normalized.state;
+      changed.add(mode);
     }
 
     const assertRunAuthority = (): void => {

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -302,6 +302,22 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 	});
 
+	it("routes user cancellation through the exact canonical lifecycle command", () => {
+		const stopContract = deepInterviewSkill.match(
+			/<Escalation_And_Stop_Conditions>([\s\S]*?)<\/Escalation_And_Stop_Conditions>/,
+		)?.[1] ?? "";
+
+		assert.match(stopContract, /User says stop\/cancel\/abort.*exact bare command `omx cancel`/i);
+		assert.match(stopContract, /exact read-only command `omx state get-status --json`/i);
+		assert.match(stopContract, /neither standalone deep-interview nor a supervising Autopilot lifecycle/i);
+		assert.match(stopContract, /deep-interview phase remains active/i);
+		assert.match(stopContract, /do not substitute `omx state clear`, `omx state write`/i);
+		assert.match(stopContract, /direct edits\/deletes under `\.omx\/state\/\*\*`/i);
+		assert.match(stopContract, /leading environment assignments, wrappers, or chained commands/i);
+		assert.match(stopContract, /permissionDecisionReason: "cancelled_exact_session"/i);
+		assert.match(stopContract, /successful hook-owned cancellation/i);
+	});
+
 	it("teaches canonical single-choice vs multi-answerable omx question payloads", () => {
 		assert.match(
 			deepInterviewSkill,

--- a/src/scripts/__tests__/issue-3293-hook-owned-cancel.test.ts
+++ b/src/scripts/__tests__/issue-3293-hook-owned-cancel.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { realpathSync } from "node:fs";
 import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 import { dispatchCodexNativeHook } from "../codex-native-hook.js";
 
@@ -62,6 +63,94 @@ async function denialFixture(command: string, mutate?: (f: Fixture) => Promise<v
   } finally { await rm(f.cwd, { recursive: true, force: true }); }
 }
 
+async function withTrustedOmx<T>(run: () => Promise<T>): Promise<T> {
+  const bin = await mkdtemp(join(tmpdir(), "omx-3293-trusted-bin-"));
+  try {
+    await symlink(realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js")), join(bin, "omx"));
+    return await withEnv({ PATH: [bin, dirname(process.execPath)].join(delimiter) }, run);
+  } finally {
+    await rm(bin, { recursive: true, force: true });
+  }
+}
+
+async function standaloneDeepInterviewFixture(sessionId = "session-standalone-deep-interview") {
+  const cwd = await mkdtemp(join(tmpdir(), "omx-3293-standalone-cancel-"));
+  const stateDir = join(cwd, ".omx", "state");
+  const threadId = `thread-${sessionId}`;
+  const sessionDir = join(stateDir, "sessions", sessionId);
+  await json(join(stateDir, "session.json"), { session_id: sessionId, cwd, leader_thread_id: threadId });
+  await json(join(stateDir, "subagent-tracking.json"), { schemaVersion: 1, sessions: { [sessionId]: { session_id: sessionId, leader_thread_id: threadId, threads: { [threadId]: { thread_id: threadId, kind: "leader" } } } } });
+  await json(join(sessionDir, "deep-interview-state.json"), { active: true, mode: "deep-interview", current_phase: "intent-first", session_id: sessionId, thread_id: threadId, workingDirectory: cwd });
+  await json(join(sessionDir, "skill-active-state.json"), { active: true, skill: "deep-interview", phase: "intent-first", session_id: sessionId, thread_id: threadId, active_skills: [{ active: true, skill: "deep-interview", phase: "intent-first", session_id: sessionId, thread_id: threadId }] });
+  return { cwd, stateDir, sessionDir, sessionId, threadId };
+}
+
+const npmShimTarget = "node_modules/oh-my-codex/dist/cli/omx.js";
+const npmPosixShim = `#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+
+case \`uname\` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/${npmShimTarget}" "$@"
+else${" "}
+  exec node  "$basedir/${npmShimTarget}" "$@"
+fi
+`;
+const npmCmdShim = `@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\\node.exe" (
+  SET "_prog=%dp0%\\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\oh-my-codex\\dist\\cli\\omx.js" %*
+`;
+const npmPowerShellShim = `#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "$basedir/node$exe"  "$basedir/${npmShimTarget}" $args
+  } else {
+    & "$basedir/node$exe"  "$basedir/${npmShimTarget}" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "node$exe"  "$basedir/${npmShimTarget}" $args
+  } else {
+    & "node$exe"  "$basedir/${npmShimTarget}" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret
+`;
+
 describe("issue #3293 hook-owned cancellation", () => {
   it("handles bare deep-interview cancellation, terminalizes both files, and does not execute Bash", async () => {
     const f = await fixture();
@@ -69,7 +158,7 @@ describe("issue #3293 hook-owned cancellation", () => {
       const sentinel = join(f.cwd, "plugin-sentinel");
       await mkdir(join(f.cwd, ".omx", "hooks"), { recursive: true });
       await writeFile(join(f.cwd, ".omx", "hooks", "sentinel.mjs"), `import { writeFile } from 'node:fs/promises'; await writeFile(${JSON.stringify(sentinel)}, 'ran');`);
-      const result = await preTool(f, "omx cancel");
+      const result = await withTrustedOmx(() => preTool(f, "omx cancel"));
       assert.equal(result.outputJson?.decision, "block");
       assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
       assert.equal(JSON.parse(await readFile(join(f.sessionDir, "autopilot-state.json"), "utf8")).active, false);
@@ -78,10 +167,79 @@ describe("issue #3293 hook-owned cancellation", () => {
     } finally { await rm(f.cwd, { recursive: true, force: true }); }
   });
 
+  it("handles the native Windows npm shim set and rejects a modified PowerShell shim", { skip: process.platform !== "win32" }, async () => {
+    const f = await fixture("session-hook-cancel-windows-npm");
+    const bin = await mkdtemp(join(tmpdir(), "omx-3293-windows-npm-bin-"));
+    try {
+      const installedCli = join(bin, ...npmShimTarget.split("/"));
+      await mkdir(dirname(installedCli), { recursive: true });
+      await symlink(realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js")), installedCli);
+      await writeFile(join(bin, "omx"), npmPosixShim);
+      await writeFile(join(bin, "omx.cmd"), npmCmdShim.replace(/\n/g, "\r\n"));
+      await writeFile(join(bin, "omx.ps1"), `${npmPowerShellShim}Write-Output attacker\n`);
+
+      await withEnv({ PATH: [bin, dirname(process.execPath)].join(delimiter) }, async () => {
+        const activeContent = await readFile(join(f.sessionDir, "autopilot-state.json"), "utf8");
+        assertValueFreeDenial(await preTool(f, "omx cancel"), f, activeContent, "modified native Windows npm shim");
+        assert.equal(JSON.parse(await readFile(join(f.sessionDir, "autopilot-state.json"), "utf8")).active, true);
+
+        await writeFile(join(bin, "omx.ps1"), npmPowerShellShim);
+        const result = await preTool(f, "omx cancel");
+        assert.equal(result.outputJson?.decision, "block");
+        assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+        assert.equal(JSON.parse(await readFile(join(f.sessionDir, "autopilot-state.json"), "utf8")).active, false);
+        assert.equal(JSON.parse(await readFile(join(f.sessionDir, "skill-active-state.json"), "utf8")).active, false);
+      });
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+      await rm(bin, { recursive: true, force: true });
+    }
+  });
+
+  it("permits standalone Desktop cancellation only through the exact trusted Windows npm shim set", { skip: process.platform !== "win32" }, async () => {
+    const f = await standaloneDeepInterviewFixture();
+    const bin = await mkdtemp(join(tmpdir(), "omx-3313-windows-npm-bin-"));
+    try {
+      const installedCli = join(bin, ...npmShimTarget.split("/"));
+      await mkdir(dirname(installedCli), { recursive: true });
+      await symlink(realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js")), installedCli);
+      await writeFile(join(bin, "omx"), npmPosixShim);
+      await writeFile(join(bin, "omx.cmd"), npmCmdShim.replace(/\n/g, "\r\n"));
+      await writeFile(join(bin, "omx.ps1"), `${npmPowerShellShim}Write-Output attacker\n`);
+
+      await withEnv({ PATH: [bin, dirname(process.execPath)].join(delimiter), PATHEXT: ".COM;.EXE;.BAT;.CMD" }, async () => {
+        const statePath = join(f.sessionDir, "deep-interview-state.json");
+        const activeContent = await readFile(statePath, "utf8");
+        assertValueFreeDenial(await preTool(f, "omx cancel"), f, activeContent, "modified standalone PowerShell npm shim");
+        assert.equal(await readFile(statePath, "utf8"), activeContent);
+
+        await writeFile(join(bin, "omx.ps1"), npmPowerShellShim);
+        await writeFile(join(bin, "node.exe"), "attacker");
+        assertValueFreeDenial(await preTool(f, "omx cancel"), f, activeContent, "adjacent untrusted node.exe");
+        assert.equal(await readFile(statePath, "utf8"), activeContent);
+        await rm(join(bin, "node.exe"), { force: true });
+
+        await writeFile(join(bin, "omx.js"), "attacker");
+        await withEnv({ PATHEXT: ".JS;.CMD" }, async () => {
+          assertValueFreeDenial(await preTool(f, "omx cancel"), f, activeContent, "custom PATHEXT shadow");
+          assert.equal(await readFile(statePath, "utf8"), activeContent);
+        });
+        await rm(join(bin, "omx.js"), { force: true });
+
+        const allowed = await preTool(f, "omx cancel");
+        assert.equal(allowed.outputJson, null);
+        assert.equal(await readFile(statePath, "utf8"), activeContent);
+      });
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+      await rm(bin, { recursive: true, force: true });
+    }
+  });
+
   it("stops repeatedly without continuation, reactivation, or terminal-byte changes", async () => {
     const f = await fixture();
     try {
-      await preTool(f, "omx cancel");
+      await withTrustedOmx(() => preTool(f, "omx cancel"));
       const paths = [join(f.sessionDir, "autopilot-state.json"), join(f.sessionDir, "skill-active-state.json")];
       const terminal = await Promise.all(paths.map((path) => readFile(path)));
       assert.equal((await stop(f)).outputJson, null);
@@ -101,7 +259,8 @@ describe("issue #3293 hook-owned cancellation", () => {
       await json(join(otherDir, "autopilot-state.json"), otherAutopilot);
       await json(join(otherDir, "skill-active-state.json"), otherSkill);
       const before = await Promise.all([readFile(join(otherDir, "autopilot-state.json")), readFile(join(otherDir, "skill-active-state.json"))]);
-      await preTool(f, "omx cancel");
+      await withTrustedOmx(() => preTool(f, "omx cancel"));
+      assert.equal(JSON.parse(await readFile(join(f.sessionDir, "autopilot-state.json"), "utf8")).active, false);
       assert.deepEqual(await Promise.all([readFile(join(otherDir, "autopilot-state.json")), readFile(join(otherDir, "skill-active-state.json"))]), before);
     } finally { await rm(f.cwd, { recursive: true, force: true }); }
   });

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9728,6 +9728,7 @@ function isDirectOmxCancelCommand(command: string, options: { allowForce?: boole
 
 type DirectCancelDenyReason =
   | "invalid_command"
+  | "execution_context"
   | "session_binding"
   | "actor_authority"
   | "active_state"
@@ -9794,6 +9795,9 @@ async function handleDirectOmxCancel(input: {
   if (!workflow) return { kind: "not-direct-cancel" };
   if (input.rawCommand !== input.command || !isDirectOmxCancelCommand(input.command, { allowForce: workflow === "ultragoal" })) {
     return { kind: "denied", reason: "invalid_command", output: directCancelOutput("invalid_command") };
+  }
+  if (!directOmxCancelCommandHasTrustedExecutionContext(input.command, input.cwd)) {
+    return { kind: "denied", reason: "execution_context", output: directCancelOutput("execution_context") };
   }
   if (
     !hookCancelSessionIdIsSafe(input.canonicalSessionId)
@@ -17715,8 +17719,9 @@ function conductorWorkspaceNpmBinPathMayResolveRepositoryExecutable(
 
 // The hook's own Node executable may be user-managed, but only its exact canonical identity is trusted.
 function conductorExecutableHasTrustedCurrentNodeRuntimeIdentity(commandName: string, commandPath: string): boolean {
-  const commandBase = shellWordBaseName(commandPath).toLowerCase();
-  if ((commandName !== "node" && commandName !== "node.exe") || commandBase !== commandName) return false;
+  const normalizedCommandName = commandName.toLowerCase().replace(/\.exe$/, "");
+  const normalizedCommandBase = shellWordBaseName(commandPath).toLowerCase().replace(/\.exe$/, "");
+  if (normalizedCommandName !== "node" || normalizedCommandBase !== normalizedCommandName) return false;
   try {
     const canonical = realpathSync(commandPath);
     if (canonical !== realpathSync(process.execPath)) return false;
@@ -18086,9 +18091,9 @@ function conductorDeclaredPackageCliPath(packageRoot: string, commandName: strin
       || isAbsolute(declaredTarget)
     ) return null;
     const target = resolve(canonicalPackageRoot, declaredTarget);
-    if (target === canonicalPackageRoot || !target.startsWith(`${canonicalPackageRoot}/`)) return null;
+    if (!conductorPathIsInsideRoot(canonicalPackageRoot, target) || target === canonicalPackageRoot) return null;
     const canonicalTarget = realpathSync(target);
-    return canonicalTarget === canonicalPackageRoot || !canonicalTarget.startsWith(`${canonicalPackageRoot}/`)
+    return canonicalTarget === canonicalPackageRoot || !conductorPathIsInsideRoot(canonicalPackageRoot, canonicalTarget)
       ? null
       : canonicalTarget;
   } catch {
@@ -18103,6 +18108,139 @@ function conductorKnownPackageCliPath(commandName: string): string | null {
   } catch {
     return null;
   }
+}
+
+function normalizedNpmShimContent(path: string): string | null {
+  try {
+    if (!lstatSync(path).isFile()) return null;
+    return readFileSync(path, "utf-8").replace(/\r\n/g, "\n");
+  } catch {
+    return null;
+  }
+}
+
+function expectedNpmPosixShim(target: string): string {
+  return `#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+
+case \`uname\` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/${target}" "$@"
+else${" "}
+  exec node  "$basedir/${target}" "$@"
+fi
+`;
+}
+
+function expectedNpmCmdShim(target: string): string {
+  const windowsTarget = target.replace(/\//g, "\\");
+  return `@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\\node.exe" (
+  SET "_prog=%dp0%\\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\${windowsTarget}" %*
+`;
+}
+
+function expectedNpmPowerShellShim(target: string): string {
+  return `#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "$basedir/node$exe"  "$basedir/${target}" $args
+  } else {
+    & "$basedir/node$exe"  "$basedir/${target}" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "node$exe"  "$basedir/${target}" $args
+  } else {
+    & "node$exe"  "$basedir/${target}" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret
+`;
+}
+
+// Native Windows npm installs expose a PowerShell script plus cmd/sh siblings
+// instead of a symlink directly to package.json's bin target. Trust that
+// resolution only when every present sibling is an exact npm-generated shim
+// for this hook package's canonical CLI. Any modified or extra executable
+// variant in the resolving directory keeps the command fail-closed.
+function conductorWindowsNpmPackageShimSetIsTrusted(
+  commandName: string,
+  binDirectory: string,
+  expectedCandidate: string | null,
+  state: ShellPosixState,
+  rootCwd: string,
+): boolean | null {
+  if (process.platform !== "win32" || expectedCandidate === null) return null;
+  const cmdPath = join(binDirectory, `${commandName}.cmd`);
+  const powerShellPath = join(binDirectory, `${commandName}.ps1`);
+  if (!existsSync(cmdPath) && !existsSync(powerShellPath)) return null;
+
+  const target = "node_modules/oh-my-codex/dist/cli/omx.js";
+  try {
+    const canonicalBinDirectory = realpathSync(binDirectory);
+    const canonicalRoot = realpathSync(resolve(rootCwd));
+    if (conductorPathIsInsideRoot(canonicalRoot, canonicalBinDirectory)) return false;
+    const canonicalTarget = realpathSync(join(canonicalBinDirectory, ...target.split("/")));
+    if (canonicalTarget !== expectedCandidate) return false;
+  } catch {
+    return false;
+  }
+
+  const expectedByPath = new Map<string, string>([
+    [join(binDirectory, commandName), expectedNpmPosixShim(target)],
+    [cmdPath, expectedNpmCmdShim(target)],
+    [powerShellPath, expectedNpmPowerShellShim(target)],
+  ]);
+  if ([...expectedByPath.keys()].some((path) => !existsSync(path))) return false;
+  const pathCandidates = conductorExecutablePathCandidates(binDirectory, commandName, state);
+  if (!pathCandidates) return false;
+  const possibleVariants = [...new Set([...pathCandidates, powerShellPath])];
+  for (const path of possibleVariants) {
+    if (!existsSync(path)) continue;
+    const expected = expectedByPath.get(path);
+    if (expected === undefined || normalizedNpmShimContent(path) !== expected) return false;
+  }
+  const localNodePaths = [join(binDirectory, "node"), join(binDirectory, "node.exe")];
+  for (const localNodePath of localNodePaths) {
+    if (existsSync(localNodePath) && !conductorPackageCliNodeInterpreterIsTrusted(localNodePath, rootCwd)) return false;
+  }
+  return localNodePaths.every(existsSync)
+    || conductorPackageCliHasTrustedNodeInterpreter(expectedCandidate, state, rootCwd);
 }
 
 function conductorWorkspacePackageCliCandidateIsTrusted(
@@ -18190,6 +18328,14 @@ function conductorResolvedPackageCliCandidateIsTrusted(
         return false;
       }
     }
+    const windowsNpmShimTrust = conductorWindowsNpmPackageShimSetIsTrusted(
+      commandName,
+      binDirectory,
+      expectedCandidate,
+      state,
+      rootCwd,
+    );
+    if (windowsNpmShimTrust !== null) return windowsNpmShimTrust;
     const candidates = conductorExecutablePathCandidates(binDirectory, commandName, state);
     if (!candidates) return false;
     let candidate: string | undefined;


### PR DESCRIPTION
## Summary

Fix Deep Interview self-cancellation in ChatGPT Desktop on native Windows while preserving the existing exact-session and trusted-executable security boundary.

- teach Deep Interview to use the exact canonical `omx cancel` lifecycle command and verify the full workflow status
- recognize the exact native Windows npm shim set (`omx`, `omx.cmd`, `omx.ps1`) without accepting PATH shadows or modified wrappers
- compare the real Windows Node executable identity correctly
- require trusted execution context before hook-owned state mutation
- normalize cancelled terminal state so input/approval locks are released and pending Deep Interview questions are cleared
- repair stale terminal lock snapshots on a later canonical `omx cancel` without rewriting their terminal phase or `completed_at`

## Root cause

The upstream cancellation fixes were already present on `dev`, but native Windows resolution still failed in Desktop:

1. package CLI containment checks assumed `/` separators
2. PATH enumeration selected the extensionless npm shim even though PowerShell executes `omx.ps1`
3. Node runtime identity compared `node` with `node.exe` literally
4. hook-owned cancellation could mutate state before executable trust was validated
5. the CLI cancellation path did not run terminal-state normalization, leaving `input_lock.active=true`

## Security properties

The change accepts only the exact canonical installed CLI and the exact npm-generated Windows shim set. It fails closed for modified/symlinked/path-shadowed shims, extra commands or arguments, shell operators, redirections, environment injection, cross-session/root selection, non-canonical Node runtimes, and untrusted executable context.

## Validation

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`
- Deep Interview contract: 28/28
- hook-owned cancellation security suite: 41/41
- state operations: 107/107
- focused CLI lock-release/repair regression: pass
- independent final review: APPROVE

## Manual ChatGPT Desktop verification

A fresh native Windows Desktop task:

1. activated Deep Interview and asked exactly one architecture question
2. ran exact bare `omx cancel`
3. returned `Cancelled: deep-interview`
4. `omx state get-status --json` reported the workflow inactive and cancelled
5. `omx doctor` reported 18 passed, 0 warnings, 0 failed

The final installed hook hash matches the local build.

## Scope

This is intentionally separate from #3443, which addresses Windows directory-fsync durability during setup/uninstall. No commits from #3443 are included here.