### PR TITLE
fix(setup): preserve Windows identity during fsync fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,13 @@ omx wiki refresh --json
 Native Windows remains a secondary path, and WSL2 is generally the better choice if you want a Windows-hosted setup.
 On native Windows, OMX accepts `psmux` as the tmux-compatible binary for the existing tmux-backed paths it already uses.
 
+Native Windows filesystems may report `EPERM` when Node.js requests `fsync()`
+on an otherwise valid regular-file or directory handle. OMX treats only that
+exact Windows capability failure as degraded durability after a successful
+native-hook transaction and emits one warning. Non-Windows errors, other error
+codes, unsafe paths or links, concurrent content changes, and transaction
+validation failures remain fatal.
+
 | Platform | Install |
 | --- | --- |
 | macOS | `brew install tmux` |

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -2839,7 +2839,7 @@ command = "node"
 							throw Object.assign(new Error("injected Windows EPERM"), { code: "EPERM" });
 						},
 					}, "win32"),
-					syncDirectory: async () => undefined,
+					syncDirectory: async () => "synced",
 				});
 				process.stderr.write = ((chunk: string | Uint8Array) => {
 					stderr.push(String(chunk));
@@ -2871,7 +2871,7 @@ command = "node"
 			const restoreDurability = setDoctorClaimJournalDurabilityForTest({
 				platform: "win32",
 				syncRegularFile: async () => { throw regularError; },
-				syncDirectory: async () => undefined,
+				syncDirectory: async () => "synced",
 			});
 			try {
 				await assert.rejects(doctor(), (error) => error === regularError);

--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -1,5 +1,16 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+	copyFile,
+	link,
+	lstat,
+	mkdtemp,
+	open,
+	readFile,
+	rename,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -8,6 +19,7 @@ import {
 	createNativeHookClaimJournalDurability,
 	persistNativeHookClaimJournal as persistNativeHookClaimJournalWithDurability,
 	recoverNativeHookClaimJournal as recoverNativeHookClaimJournalWithDurability,
+	restoreNativeHookClaimNoClobber,
 } from "../native-hook-claim-journal.js";
 
 const durability = createNativeHookClaimJournalDurability();
@@ -23,7 +35,9 @@ const recoverNativeHookClaimJournal = (root: string) =>
 
 async function markJournalOwnerDead(root: string): Promise<void> {
 	const path = join(root, ".omx", "native-hook-claim-journal.json");
-	const journal = JSON.parse(await readFile(path, "utf-8")) as { ownerPid: number };
+	const journal = JSON.parse(await readFile(path, "utf-8")) as {
+		ownerPid: number;
+	};
 	journal.ownerPid = 2_147_483_647;
 	await writeFile(path, `${JSON.stringify(journal, null, 2)}\n`, "utf-8");
 }
@@ -159,21 +173,326 @@ test("claim journal treats only injected Windows regular-file EPERM as degraded"
 		const canonicalPath = join(root, "hooks.json");
 		const claimPath = join(root, ".hooks.json.claim");
 		const order: string[] = [];
-		const outcome = await persistNativeHookClaimJournalWithDurability(root, {
-			canonicalPath,
-			claimPath,
-			before: Buffer.from("before\n"),
-			after: null,
-		}, {
-			platform: "win32",
-			syncRegularFile: async () => {
-				order.push("regular");
-				return "unsupported-windows-eperm";
+		const outcome = await persistNativeHookClaimJournalWithDurability(
+			root,
+			{
+				canonicalPath,
+				claimPath,
+				before: Buffer.from("before\n"),
+				after: null,
 			},
-			syncDirectory: async () => { order.push("directory"); },
-		});
+			{
+				platform: "win32",
+				syncRegularFile: async () => {
+					order.push("regular");
+					return "unsupported-windows-eperm";
+				},
+				syncDirectory: async () => {
+					order.push("directory");
+					return "synced";
+				},
+			},
+		);
 		assert.equal(outcome, "unsupported-windows-eperm");
 		assert.deepEqual(order, ["directory", "regular", "directory"]);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal rejects paths outside its controlled root", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-controlled-root-"));
+	try {
+		await assert.rejects(
+			persistNativeHookClaimJournal(root, {
+				canonicalPath: join(root, "..", "foreign-hooks.json"),
+				claimPath: join(root, ".hooks.json.claim"),
+				before: Buffer.from("before\n"),
+				after: null,
+			}),
+			/outside controlled root/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim restore rejects an unexpected hard-linked claim", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-hard-link-"));
+	try {
+		const claimPath = join(root, ".hooks.json.claim");
+		await writeFile(claimPath, "before\n");
+		await link(claimPath, join(root, "foreign-link"));
+		await assert.rejects(
+			restoreNativeHookClaimNoClobber(
+				claimPath,
+				join(root, "hooks.json"),
+				durability,
+			),
+			/refuses unsafe claim/,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim recovery rejects a linked-directory escape from the controlled root", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-root-"));
+	const outside = await mkdtemp(join(tmpdir(), "omx-claim-outside-"));
+	try {
+		const claimPath = join(root, ".hooks.claim");
+		const safeCanonicalPath = join(root, "hooks.json");
+		const linkedDirectory = join(root, "escape");
+		const escapedCanonicalPath = join(linkedDirectory, "victim");
+		const before = Buffer.from("before\n");
+		await writeFile(claimPath, before);
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath: safeCanonicalPath,
+			claimPath,
+			before,
+			after: null,
+		});
+		await symlink(
+			outside,
+			linkedDirectory,
+			process.platform === "win32" ? "junction" : "dir",
+		);
+		const path = join(root, ".omx", "native-hook-claim-journal.json");
+		const journal = JSON.parse(await readFile(path, "utf-8")) as {
+			ownerPid: number;
+			canonicalPath: string;
+		};
+		journal.ownerPid = 2_147_483_647;
+		journal.canonicalPath = escapedCanonicalPath;
+		await writeFile(path, `${JSON.stringify(journal, null, 2)}\n`, "utf-8");
+
+		await assert.rejects(
+			recoverNativeHookClaimJournal(root),
+			/ancestor is unsafe/,
+		);
+		await assert.rejects(readFile(join(outside, "victim")), /ENOENT/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+		await rm(outside, { recursive: true, force: true });
+	}
+});
+
+test("claim recovery rejects a journal replacement after opening the original", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-journal-identity-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.claim");
+		const before = Buffer.from("before\n");
+		await writeFile(claimPath, before);
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after: null,
+		});
+		await markJournalOwnerDead(root);
+		const path = join(root, ".omx", "native-hook-claim-journal.json");
+		const parkedPath = `${path}.parked`;
+		const replacementPath = `${path}.replacement`;
+		let replaced = false;
+
+		await assert.rejects(
+			recoverNativeHookClaimJournalWithDurability(root, {
+				...durability,
+				openFileForRead: async (targetPath) => {
+					const handle = await open(targetPath, "r");
+					if (targetPath === path && !replaced) {
+						await writeFile(replacementPath, await readFile(path));
+						await rename(path, parkedPath);
+						await rename(replacementPath, path);
+						replaced = true;
+					}
+					return handle;
+				},
+			}),
+			/refuses unsafe artifact/,
+		);
+		assert.equal(replaced, true);
+		await assert.doesNotReject(readFile(path));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim recovery treats post-open journal removal as a race", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-journal-removal-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.claim");
+		const before = Buffer.from("before\n");
+		await writeFile(claimPath, before);
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after: null,
+		});
+		await markJournalOwnerDead(root);
+		const path = join(root, ".omx", "native-hook-claim-journal.json");
+		let removed = false;
+
+		await assert.rejects(
+			recoverNativeHookClaimJournalWithDurability(root, {
+				...durability,
+				openFileForRead: async (targetPath) => {
+					const handle = await open(targetPath, "r");
+					if (targetPath === path && !removed) {
+						await rm(path);
+						removed = true;
+					}
+					return handle;
+				},
+			}),
+			/ENOENT/,
+		);
+		assert.equal(removed, true);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim recovery treats post-open artifact removal as a race", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-post-open-removal-"));
+	try {
+		const canonicalPath = join(root, "hooks.json");
+		const claimPath = join(root, ".hooks.claim");
+		const before = Buffer.from("before\n");
+		await writeFile(claimPath, before);
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after: null,
+		});
+		await markJournalOwnerDead(root);
+		let removed = false;
+
+		await assert.rejects(
+			recoverNativeHookClaimJournalWithDurability(root, {
+				...durability,
+				openFileForRead: async (targetPath) => {
+					const handle = await open(targetPath, "r");
+					if (targetPath === claimPath && !removed) {
+						await rm(claimPath);
+						removed = true;
+					}
+					return handle;
+				},
+			}),
+			/ENOENT/,
+		);
+		assert.equal(removed, true);
+		await assert.doesNotReject(
+			readFile(join(root, ".omx", "native-hook-claim-journal.json")),
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim restore rejects a hardlink added during durability sync", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-hardlink-race-"));
+	try {
+		const claimPath = join(root, ".hooks.claim");
+		const destinationPath = join(root, "hooks.json");
+		const foreignLink = join(root, "foreign-link");
+		await writeFile(claimPath, "before\n");
+		let injected = false;
+		await assert.rejects(
+			restoreNativeHookClaimNoClobber(claimPath, destinationPath, {
+				platform: "win32",
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => {
+					if (!injected) {
+						injected = true;
+						await link(claimPath, foreignLink);
+					}
+					return "synced";
+				},
+			}),
+			/changed during restore/,
+		);
+		assert.equal(injected, true);
+		const [claim, destination, foreign] = await Promise.all([
+			lstat(claimPath),
+			lstat(destinationPath),
+			lstat(foreignLink),
+		]);
+		assert.equal(claim.nlink, 3);
+		assert.equal(destination.ino, claim.ino);
+		assert.equal(foreign.ino, claim.ino);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("copy fallback rejects a same-byte destination with a new identity", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-copy-identity-"));
+	try {
+		const claimPath = join(root, ".hooks.claim");
+		const destinationPath = join(root, "hooks.json");
+		const replacementPath = join(root, ".replacement");
+		await writeFile(claimPath, "before\n");
+		let replaced = false;
+		await assert.rejects(
+			restoreNativeHookClaimNoClobber(claimPath, destinationPath, {
+				platform: "win32",
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => {
+					if (!replaced) {
+						const owned = await lstat(destinationPath);
+						await writeFile(replacementPath, await readFile(destinationPath));
+						const replacement = await lstat(replacementPath);
+						assert.notEqual(replacement.ino, owned.ino);
+						await rm(destinationPath);
+						await rename(replacementPath, destinationPath);
+						replaced = true;
+					}
+					return "synced";
+				},
+				linkFile: async () => {
+					throw Object.assign(new Error("forced link fallback"), {
+						code: "EPERM",
+					});
+				},
+				copyFileExclusive: async (sourcePath, targetPath) =>
+					copyFile(sourcePath, targetPath),
+			}),
+			/changed during restore/,
+		);
+		assert.equal(replaced, true);
+		assert.equal(await readFile(destinationPath, "utf-8"), "before\n");
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal continues when Windows directory sync reports unsupported EPERM", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-directory-durability-"));
+	try {
+		const outcome = await persistNativeHookClaimJournalWithDurability(
+			root,
+			{
+				canonicalPath: join(root, "hooks.json"),
+				claimPath: join(root, ".hooks.json.claim"),
+				before: Buffer.from("before\n"),
+				after: null,
+			},
+			{
+				platform: "win32",
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => "unsupported-windows-eperm",
+			},
+		);
+		assert.equal(outcome, "synced");
+		await assert.doesNotReject(
+			readFile(join(root, ".omx", "native-hook-claim-journal.json")),
+		);
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
@@ -192,17 +511,21 @@ test("claim journal keeps POSIX regular-file and directory EPERM fatal", async (
 		await assert.rejects(
 			persistNativeHookClaimJournalWithDurability(root, entry, {
 				platform: "linux",
-				syncRegularFile: async () => { throw regularError; },
-				syncDirectory: async () => undefined,
+				syncRegularFile: async () => {
+					throw regularError;
+				},
+				syncDirectory: async () => "synced",
 			}),
 			(error) => error === regularError,
 		);
 		const directoryError = Object.assign(new Error("EPERM"), { code: "EPERM" });
 		await assert.rejects(
 			persistNativeHookClaimJournalWithDurability(root, entry, {
-				platform: "win32",
+				platform: "linux",
 				syncRegularFile: async () => "synced",
-				syncDirectory: async () => { throw directoryError; },
+				syncDirectory: async () => {
+					throw directoryError;
+				},
 			}),
 			(error) => error === directoryError,
 		);
@@ -217,16 +540,24 @@ test("claim journal recovery returns independent recovered and no-op outcomes", 
 		const canonicalPath = join(root, "hooks.json");
 		const claimPath = join(root, ".hooks.json.claim");
 		const before = Buffer.from("before\n");
-		await persistNativeHookClaimJournal(root, { canonicalPath, claimPath, before, after: null });
+		await persistNativeHookClaimJournal(root, {
+			canonicalPath,
+			claimPath,
+			before,
+			after: null,
+		});
 		await rename(canonicalPath, claimPath).catch(() => undefined);
 		await writeFile(claimPath, before);
 		await markJournalOwnerDead(root);
 		const recovered = await recoverNativeHookClaimJournalWithDurability(root, {
 			platform: "win32",
 			syncRegularFile: async () => "unsupported-windows-eperm",
-			syncDirectory: async () => undefined,
+			syncDirectory: async () => "synced",
 		});
-		assert.deepEqual(recovered, { recovered: true, outcome: "unsupported-windows-eperm" });
+		assert.deepEqual(recovered, {
+			recovered: true,
+			outcome: "unsupported-windows-eperm",
+		});
 		assert.deepEqual(
 			await recoverNativeHookClaimJournalWithDurability(root, durability),
 			{ recovered: false, outcome: "synced" },

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, lstatSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import {
 	chmod,
 	cp,
@@ -19,6 +19,7 @@ import { basename, dirname, join } from "node:path";
 import { parse as parseToml } from "@iarna/toml";
 import {
 	decideWindowsNativeHookShimReference,
+	setNativeHookClaimJournalDurabilityForTest,
 	setNativeHookTransactionFailureInjectorForTest,
 	setSetupLatePhaseFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
@@ -27,6 +28,7 @@ import {
 	setup,
 } from "../setup.js";
 import { resolveSetupRefreshArgs } from "../update.js";
+import { doctor } from "../doctor.js";
 import { uninstall } from "../uninstall.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
 import {
@@ -3233,6 +3235,124 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("completes Windows native-hook transactions with one directory fsync EPERM warning", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-directory-fsync-eperm-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const resetRegularSync = setNativeHookTransactionRegularFileSyncForTest(async () => undefined);
+		let directorySyncCalls = 0;
+		const stderr: string[] = [];
+		const originalStderrWrite = process.stderr.write;
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderr.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+		const resetDurability = setNativeHookClaimJournalDurabilityForTest({
+			platform: "win32",
+			syncRegularFile: async () => "synced",
+			syncDirectory: async () => {
+				directorySyncCalls += 1;
+				return "unsupported-windows-eperm";
+			},
+		});
+		let doctorOutput = "";
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					doctorOutput = await captureConsoleOutput(() => doctor());
+				});
+				assert.ok(directorySyncCalls > 0);
+				assert.equal(existsSync(buildManagedCodexNativeHookWindowsShimPath(codexHomeDir)), true);
+				assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
+				assert.equal(existsSync(join(codexHomeDir, ".omx", "notify-dispatch.json")), true);
+				assert.doesNotThrow(() => parseToml(readFileSync(join(codexHomeDir, "config.toml"), "utf-8")));
+			});
+			assert.match(doctorOutput, /\[OK\] Config:/);
+			assert.match(doctorOutput, /\[OK\] Native hooks:/);
+			assert.deepEqual(
+				stderr.filter((line) => line.includes("native-hook setup")),
+				["[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n"],
+			);
+		} finally {
+			process.stderr.write = originalStderrWrite;
+			resetDurability();
+			resetRegularSync();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	for (const fixture of [
+		{ platform: "win32" as const, code: "EACCES" },
+		{ platform: "linux" as const, code: "EPERM" },
+	]) {
+		it(`fails native-hook setup for ${fixture.platform} directory fsync ${fixture.code}`, async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-directory-fsync-fatal-"));
+			const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+			const resetDurability = setNativeHookClaimJournalDurabilityForTest({
+				platform: fixture.platform,
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => {
+					throw Object.assign(new Error(`${fixture.code}: fsync`), { code: fixture.code });
+				},
+			});
+			try {
+				await withIsolatedUserHome(wd, async () => {
+					await withTempCwd(wd, async () => {
+						await assert.rejects(
+							setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+							new RegExp(fixture.code),
+						);
+					});
+				});
+			} finally {
+				resetDurability();
+				resetPlatform();
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("accepts Windows synthetic mode drift while retaining file identity", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-mode-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const tempPath = (path: string, purpose: "write" | "delete") =>
+			join(dirname(path), `.${basename(path)}.mode-${purpose}.tmp`);
+		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
+		let checkedIdentity = 0;
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
+			if (stage !== "before_rename") return;
+			const temporaryPath = tempPath(artifact.path, "write");
+			const before = lstatSync(temporaryPath);
+			chmodSync(temporaryPath, 0o666);
+			const after = lstatSync(temporaryPath);
+			assert.equal(after.dev, before.dev);
+			assert.equal(after.ino, before.ino);
+			checkedIdentity += 1;
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+				});
+			});
+			assert.ok(checkedIdentity >= 4);
+		} finally {
+			resetFailureInjector();
+			resetTemporaryPath();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("orders Windows plugin-transition mutations as hooks, shim, then config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-removal-"));
 		const forwardOrder: string[] = [];
@@ -5366,6 +5486,7 @@ describe("omx setup install mode behavior", () => {
 	});
 	it("preserves a same-byte foreign replacement made immediately after a native-hook rename", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-immediate-post-rename-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
 		let resetFailureInjector: (() => void) | undefined;
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -5408,6 +5529,7 @@ describe("omx setup install mode behavior", () => {
 			});
 		} finally {
 			resetFailureInjector?.();
+			resetPlatform();
 			await rm(wd, { recursive: true, force: true });
 		}
 	});

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3353,6 +3353,49 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("rejects Windows writable-bit drift with unchanged bytes and file identity", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-readonly-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const tempPath = (path: string, purpose: "write" | "delete") =>
+			join(dirname(path), `.${basename(path)}.readonly-${purpose}.tmp`);
+		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
+		let checkedIdentity = 0;
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
+			if (stage !== "before_rename") return;
+			const temporaryPath = tempPath(artifact.path, "write");
+			const before = lstatSync(temporaryPath);
+			const beforeBytes = readFileSync(temporaryPath);
+			chmodSync(temporaryPath, 0o444);
+			const after = lstatSync(temporaryPath);
+			assert.deepEqual(readFileSync(temporaryPath), beforeBytes);
+			assert.equal(after.dev, before.dev);
+			assert.equal(after.ino, before.ino);
+			assert.equal(after.nlink, before.nlink);
+			assert.notEqual(after.mode & 0o200, before.mode & 0o200);
+			checkedIdentity += 1;
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await assert.rejects(
+						setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+						/read-back changed/,
+					);
+				});
+			});
+			assert.equal(checkedIdentity, 1);
+		} finally {
+			resetFailureInjector();
+			resetTemporaryPath();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("orders Windows plugin-transition mutations as hooks, shim, then config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-removal-"));
 		const forwardOrder: string[] = [];

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -12,7 +12,7 @@ import {
   buildManagedCodexNativeHookWindowsShimContent,
   buildManagedCodexNativeHookWindowsShimPath,
 } from '../../config/codex-hooks.js';
-import { uninstall } from '../uninstall.js';
+import { setUninstallClaimJournalDurabilityForTest, uninstall } from '../uninstall.js';
 import TOML from '@iarna/toml';
 
 const tmpdir = (): string => realpathSync(osTmpdir());
@@ -3165,6 +3165,56 @@ describe('omx uninstall', () => {
         assert.match(stderr[0]!, /native-hook uninstall.*degraded durability/);
       });
     } finally {
+      process.stderr.write = originalStderrWrite;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('completes uninstall when only Windows directory fsync is unsupported', async () => {
+    const wd = await mkdtemp(join(shortTmpdir(), 'omx-uninstall-directory-durability-'));
+    const originalStderrWrite = process.stderr.write;
+    const stderr: string[] = [];
+    const resetDurability = setUninstallClaimJournalDurabilityForTest({
+      platform: 'win32',
+      syncRegularFile: async () => 'synced',
+      syncDirectory: async () => 'unsupported-windows-eperm',
+    });
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(
+          hooksPath,
+          `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }), null, 2)}\n`,
+        );
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        process.stderr.write = ((chunk: string | Uint8Array) => {
+          stderr.push(String(chunk));
+          return true;
+        }) as typeof process.stderr.write;
+
+        await uninstall({
+          scope: 'project',
+          transactionPlatform: 'win32',
+          regularFileSyncForTest: async () => 'synced',
+        });
+
+        assert.equal(existsSync(hooksPath), false);
+        assert.equal(existsSync(shimPath), false);
+        assert.deepEqual(
+          stderr.filter((line) => line.includes('native-hook uninstall')),
+          ['[omx] warning: Windows EPERM directory fsync unsupported in native-hook uninstall; operation succeeded with degraded durability.\n'],
+        );
+      });
+    } finally {
+      resetDurability();
       process.stderr.write = originalStderrWrite;
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -291,7 +291,8 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
 	const recovery = await recoverNativeHookClaimJournal(
 		paths.codexHomeDir,
-		doctorClaimJournalDurabilityOverride ?? createNativeHookClaimJournalDurability(),
+		doctorClaimJournalDurabilityOverride ??
+			createNativeHookClaimJournalDurability(process.platform, recoveryTracker),
 	);
 	recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
 	emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -1,16 +1,36 @@
 import { createHash } from "crypto";
 import { constants } from "fs";
-import { copyFile, link, open, lstat, mkdir, readFile, rm, type FileHandle } from "fs/promises";
-import { dirname, isAbsolute, join, relative, sep } from "path";
 import {
+	copyFile,
+	link,
+	open,
+	lstat,
+	mkdir,
+	rm,
+	type FileHandle,
+} from "fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
+import {
+	recordDirectorySyncOutcome,
+	syncDirectory,
 	syncRegularFile,
+	type DirectorySyncOutcome,
+	type RegularFileDurabilityTracker,
 	type RegularFileSyncOutcome,
 } from "../utils/file-durability.js";
 
 export interface NativeHookClaimJournalDurability {
 	platform: NodeJS.Platform;
-	syncRegularFile(handle: Pick<FileHandle, "sync">): Promise<RegularFileSyncOutcome>;
-	syncDirectory(path: string): Promise<void>;
+	syncRegularFile(
+		handle: Pick<FileHandle, "sync">,
+	): Promise<RegularFileSyncOutcome>;
+	syncDirectory(path: string): Promise<DirectorySyncOutcome>;
+	linkFile?(existingPath: string, newPath: string): Promise<void>;
+	copyFileExclusive?(
+		sourcePath: string,
+		destinationPath: string,
+	): Promise<void>;
+	openFileForRead?(path: string): Promise<FileHandle>;
 }
 
 interface ClaimJournalEntry {
@@ -27,15 +47,89 @@ function digest(bytes: Buffer): string {
 }
 
 function isMissing(error: unknown): boolean {
-	return typeof error === "object" && error !== null && "code" in error &&
-		(error as { code?: unknown }).code === "ENOENT";
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(error as { code?: unknown }).code === "ENOENT"
+	);
 }
 
 function assertControlledPath(root: string, path: string): void {
 	const rel = relative(root, path);
-	if (isAbsolute(rel) || rel === ".." || rel.startsWith(`..${sep}`) || rel === "") {
-		throw new Error(`Native hook claim journal path is outside controlled root: ${path}`);
+	if (
+		isAbsolute(rel) ||
+		rel === ".." ||
+		rel.startsWith(`..${sep}`) ||
+		rel === ""
+	) {
+		throw new Error(
+			`Native hook claim journal path is outside controlled root: ${path}`,
+		);
 	}
+}
+
+interface ControlledAncestor {
+	path: string;
+	dev: number;
+	ino: number;
+}
+
+async function captureControlledAncestors(
+	root: string,
+	paths: string[],
+): Promise<ControlledAncestor[]> {
+	const resolvedRoot = resolve(root);
+	const ancestors = new Set<string>([resolvedRoot]);
+	for (const path of paths) {
+		assertControlledPath(resolvedRoot, resolve(path));
+		let current = dirname(resolve(path));
+		while (true) {
+			ancestors.add(current);
+			if (current === resolvedRoot) break;
+			const parent = dirname(current);
+			if (parent === current) {
+				throw new Error(
+					`Native hook claim journal path is outside controlled root: ${path}`,
+				);
+			}
+			current = parent;
+		}
+	}
+	const snapshot: ControlledAncestor[] = [];
+	for (const path of ancestors) {
+		const stat = await lstat(path);
+		if (stat.isSymbolicLink() || !stat.isDirectory()) {
+			throw new Error(`Native hook claim journal ancestor is unsafe: ${path}`);
+		}
+		snapshot.push({ path, dev: stat.dev, ino: stat.ino });
+	}
+	return snapshot;
+}
+
+async function assertControlledAncestorsUnchanged(
+	snapshot: ControlledAncestor[],
+): Promise<void> {
+	for (const expected of snapshot) {
+		const stat = await lstat(expected.path);
+		if (
+			stat.isSymbolicLink() ||
+			!stat.isDirectory() ||
+			stat.dev !== expected.dev ||
+			stat.ino !== expected.ino
+		) {
+			throw new Error(
+				`Native hook claim journal ancestor changed: ${expected.path}`,
+			);
+		}
+	}
+}
+
+function sameFileIdentity(
+	left: { dev: number; ino: number },
+	right: { dev: number; ino: number },
+): boolean {
+	return left.dev === right.dev && left.ino === right.ino;
 }
 
 function processIsAlive(pid: number): boolean {
@@ -43,15 +137,22 @@ function processIsAlive(pid: number): boolean {
 		process.kill(pid, 0);
 		return true;
 	} catch (error) {
-		return typeof error === "object" && error !== null && "code" in error &&
-			(error as { code?: unknown }).code === "EPERM";
+		return (
+			typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			(error as { code?: unknown }).code === "EPERM"
+		);
 	}
 }
 
-async function fsyncDirectory(path: string): Promise<void> {
+async function fsyncDirectory(
+	path: string,
+	platform: NodeJS.Platform,
+): Promise<DirectorySyncOutcome> {
 	const handle = await open(path, "r");
 	try {
-		await handle.sync();
+		return await syncDirectory(handle, platform);
 	} finally {
 		await handle.close();
 	}
@@ -59,82 +160,236 @@ async function fsyncDirectory(path: string): Promise<void> {
 
 export function createNativeHookClaimJournalDurability(
 	platform: NodeJS.Platform = process.platform,
+	tracker?: RegularFileDurabilityTracker,
 ): NativeHookClaimJournalDurability {
 	return {
 		platform,
 		syncRegularFile: (handle) => syncRegularFile(handle, platform),
-		syncDirectory: fsyncDirectory,
+		async syncDirectory(path) {
+			const outcome = await fsyncDirectory(path, platform);
+			if (tracker) recordDirectorySyncOutcome(tracker, outcome);
+			return outcome;
+		},
 	};
 }
 
 export async function syncNativeHookClaimParent(
 	path: string,
 	durability: NativeHookClaimJournalDurability,
-): Promise<void> {
-	await durability.syncDirectory(dirname(path));
+): Promise<DirectorySyncOutcome> {
+	return durability.syncDirectory(dirname(path));
 }
 
 export async function restoreNativeHookClaimNoClobber(
 	claimPath: string,
 	destinationPath: string,
 	durability: NativeHookClaimJournalDurability,
+	validateControlledPaths: () => Promise<void> = async () => undefined,
 ): Promise<RegularFileSyncOutcome> {
-	const claimStat = await lstat(claimPath);
-	if (claimStat.isSymbolicLink() || !claimStat.isFile() || claimStat.nlink !== 1) {
-		throw new Error(`Native hook claim restore refuses unsafe claim ${claimPath}.`);
-	}
-	const claimBytes = await readFile(claimPath);
-	let linked = false;
+	await validateControlledPaths();
+	const originalClaimHandle = await open(claimPath, "r");
 	try {
-		await link(claimPath, destinationPath);
-		linked = true;
-	} catch (error) {
-		const code = typeof error === "object" && error !== null && "code" in error
-			? (error as { code?: unknown }).code
-			: undefined;
-		if (code !== "EPERM" && code !== "ENOTSUP" && code !== "EOPNOTSUPP" && code !== "EXDEV") {
+		const claimStat = await originalClaimHandle.stat();
+		if (!claimStat.isFile() || claimStat.nlink !== 1) {
+			throw new Error(
+				`Native hook claim restore refuses unsafe claim ${claimPath}.`,
+			);
+		}
+		const claimBytes = await originalClaimHandle.readFile();
+		const claimStatAfterRead = await originalClaimHandle.stat();
+		if (
+			!sameFileIdentity(claimStat, claimStatAfterRead) ||
+			claimStatAfterRead.nlink !== 1
+		) {
+			throw new Error(
+				`Native hook claim changed during restore: ${claimPath}.`,
+			);
+		}
+		await validateControlledPaths();
+		const claimPathStat = await lstat(claimPath);
+		if (
+			claimPathStat.isSymbolicLink() ||
+			!claimPathStat.isFile() ||
+			claimPathStat.nlink !== 1 ||
+			!sameFileIdentity(claimStat, claimPathStat)
+		) {
+			throw new Error(
+				`Native hook claim changed during restore: ${claimPath}.`,
+			);
+		}
+		let linked = false;
+		try {
+			await (durability.linkFile ?? link)(claimPath, destinationPath);
+			linked = true;
+		} catch (error) {
+			const code =
+				typeof error === "object" && error !== null && "code" in error
+					? (error as { code?: unknown }).code
+					: undefined;
+			if (
+				code !== "EPERM" &&
+				code !== "ENOTSUP" &&
+				code !== "EOPNOTSUPP" &&
+				code !== "EXDEV"
+			) {
+				throw error;
+			}
+			try {
+				await (
+					durability.copyFileExclusive ??
+					((sourcePath, targetPath) =>
+						copyFile(sourcePath, targetPath, constants.COPYFILE_EXCL))
+				)(claimPath, destinationPath);
+			} catch (copyError) {
+				throw copyError;
+			}
+		}
+		let destinationHandle: FileHandle;
+		try {
+			destinationHandle = await open(destinationPath, "r");
+		} catch (error) {
 			throw error;
 		}
-		await copyFile(claimPath, destinationPath, constants.COPYFILE_EXCL);
-	}
-	const destinationHandle = await open(destinationPath, "r");
-	let outcome: RegularFileSyncOutcome;
-	try {
-		outcome = await durability.syncRegularFile(destinationHandle);
+		let outcome: RegularFileSyncOutcome;
+		try {
+			outcome = await durability.syncRegularFile(destinationHandle);
+			await durability.syncDirectory(dirname(destinationPath));
+			await validateControlledPaths();
+
+			const currentClaimHandle = await open(claimPath, "r");
+			try {
+				const expectedLinks = linked ? 2 : 1;
+				const currentClaimStat = await currentClaimHandle.stat();
+				const destinationHandleStat = await destinationHandle.stat();
+				const currentClaimPathStat = await lstat(claimPath);
+				const destinationPathStat = await lstat(destinationPath);
+				if (
+					!currentClaimStat.isFile() ||
+					!destinationHandleStat.isFile() ||
+					currentClaimPathStat.isSymbolicLink() ||
+					!currentClaimPathStat.isFile() ||
+					destinationPathStat.isSymbolicLink() ||
+					!destinationPathStat.isFile() ||
+					currentClaimStat.nlink !== expectedLinks ||
+					destinationHandleStat.nlink !== expectedLinks ||
+					currentClaimPathStat.nlink !== expectedLinks ||
+					destinationPathStat.nlink !== expectedLinks ||
+					!sameFileIdentity(currentClaimStat, claimStat) ||
+					!sameFileIdentity(currentClaimStat, currentClaimPathStat) ||
+					!sameFileIdentity(destinationHandleStat, destinationPathStat) ||
+					(linked && !sameFileIdentity(currentClaimStat, destinationHandleStat))
+				) {
+					throw new Error(
+						`Native hook claim changed during restore: ${claimPath}.`,
+					);
+				}
+				const [currentClaimBytes, destinationBytes] = await Promise.all([
+					currentClaimHandle.readFile(),
+					destinationHandle.readFile(),
+				]);
+				const currentClaimStatAfterRead = await currentClaimHandle.stat();
+				const destinationStatAfterRead = await destinationHandle.stat();
+				if (
+					!currentClaimBytes.equals(claimBytes) ||
+					!destinationBytes.equals(claimBytes) ||
+					currentClaimStatAfterRead.nlink !== expectedLinks ||
+					destinationStatAfterRead.nlink !== expectedLinks ||
+					!sameFileIdentity(currentClaimStat, currentClaimStatAfterRead) ||
+					!sameFileIdentity(destinationHandleStat, destinationStatAfterRead)
+				) {
+					throw new Error(
+						`Native hook claim changed during restore: ${claimPath}.`,
+					);
+				}
+				await validateControlledPaths();
+				const claimBeforeRemove = await lstat(claimPath);
+				if (
+					claimBeforeRemove.isSymbolicLink() ||
+					!claimBeforeRemove.isFile() ||
+					claimBeforeRemove.nlink !== expectedLinks ||
+					!sameFileIdentity(currentClaimStat, claimBeforeRemove)
+				) {
+					throw new Error(
+						`Native hook claim changed during restore: ${claimPath}.`,
+					);
+				}
+			} finally {
+				await currentClaimHandle.close();
+			}
+			await rm(claimPath);
+			await durability.syncDirectory(dirname(claimPath));
+			return outcome;
+		} finally {
+			await destinationHandle.close();
+		}
 	} finally {
-		await destinationHandle.close();
+		await originalClaimHandle.close();
 	}
-	await durability.syncDirectory(dirname(destinationPath));
-	const [currentClaimStat, currentClaimBytes, destinationBytes, destinationStat] = await Promise.all([
-		lstat(claimPath),
-		readFile(claimPath),
-		readFile(destinationPath),
-		lstat(destinationPath),
-	]);
-	if (
-		currentClaimStat.dev !== claimStat.dev ||
-		currentClaimStat.ino !== claimStat.ino ||
-		!currentClaimBytes.equals(claimBytes) ||
-		!destinationBytes.equals(claimBytes) ||
-		(linked && (currentClaimStat.dev !== destinationStat.dev || currentClaimStat.ino !== destinationStat.ino))
-	) {
-		throw new Error(`Native hook claim changed during restore: ${claimPath}.`);
-	}
-	await rm(claimPath);
-	await durability.syncDirectory(dirname(claimPath));
-	return outcome;
 }
 
-async function readRegularBytes(path: string): Promise<Buffer | null> {
+interface RegularArtifact {
+	bytes: Buffer;
+	dev: number;
+	ino: number;
+}
+
+async function readRegularArtifact(
+	path: string,
+	validateControlledPaths: () => Promise<void>,
+	expectedLinks = 1,
+	openFileForRead: (path: string) => Promise<FileHandle> = (targetPath) =>
+		open(targetPath, "r"),
+): Promise<RegularArtifact | null> {
+	await validateControlledPaths();
+	let handle: FileHandle;
 	try {
-		const stat = await lstat(path);
-		if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
-			throw new Error(`Native hook claim journal refuses unsafe artifact ${path}.`);
-		}
-		return await readFile(path);
+		handle = await openFileForRead(path);
 	} catch (error) {
 		if (isMissing(error)) return null;
 		throw error;
+	}
+	try {
+		const stat = await handle.stat();
+		const pathStat = await lstat(path);
+		if (
+			!stat.isFile() ||
+			stat.nlink !== expectedLinks ||
+			pathStat.isSymbolicLink() ||
+			!pathStat.isFile() ||
+			pathStat.nlink !== expectedLinks ||
+			!sameFileIdentity(stat, pathStat)
+		) {
+			throw new Error(
+				`Native hook claim journal refuses unsafe artifact ${path}.`,
+			);
+		}
+		const bytes = await handle.readFile();
+		const after = await handle.stat();
+		if (!sameFileIdentity(stat, after) || after.nlink !== expectedLinks) {
+			throw new Error(
+				`Native hook claim journal artifact changed while reading: ${path}.`,
+			);
+		}
+		return { bytes, dev: stat.dev, ino: stat.ino };
+	} finally {
+		await handle.close();
+	}
+}
+
+async function assertArtifactStillOwned(
+	path: string,
+	artifact: RegularArtifact,
+): Promise<void> {
+	const stat = await lstat(path);
+	if (
+		stat.isSymbolicLink() ||
+		!stat.isFile() ||
+		stat.nlink !== 1 ||
+		!sameFileIdentity(stat, artifact)
+	) {
+		throw new Error(
+			`Native hook claim journal artifact changed before removal: ${path}.`,
+		);
 	}
 }
 
@@ -144,7 +399,10 @@ function journalPath(root: string): string {
 
 export async function persistNativeHookClaimJournal(
 	root: string,
-	entry: Omit<ClaimJournalEntry, "version" | "ownerPid" | "beforeHash" | "afterHash"> & {
+	entry: Omit<
+		ClaimJournalEntry,
+		"version" | "ownerPid" | "beforeHash" | "afterHash"
+	> & {
 		before: Buffer;
 		after: Buffer | null;
 	},
@@ -152,6 +410,10 @@ export async function persistNativeHookClaimJournal(
 ): Promise<RegularFileSyncOutcome> {
 	assertControlledPath(root, entry.canonicalPath);
 	assertControlledPath(root, entry.claimPath);
+	const artifactAncestors = await captureControlledAncestors(root, [
+		entry.canonicalPath,
+		entry.claimPath,
+	]);
 	const directory = dirname(journalPath(root));
 	let directoryCreated = false;
 	try {
@@ -161,12 +423,17 @@ export async function persistNativeHookClaimJournal(
 		directoryCreated = true;
 	}
 	await mkdir(directory, { recursive: true });
+	await assertControlledAncestorsUnchanged(artifactAncestors);
 	const directoryStat = await lstat(directory);
 	if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
-		throw new Error(`Native hook claim journal directory is unsafe: ${directory}`);
+		throw new Error(
+			`Native hook claim journal directory is unsafe: ${directory}`,
+		);
 	}
 	if (directoryCreated) await durability.syncDirectory(dirname(directory));
 	const path = journalPath(root);
+	const journalAncestors = await captureControlledAncestors(root, [path]);
+	await assertControlledAncestorsUnchanged(journalAncestors);
 	const payload: ClaimJournalEntry = {
 		version: 1,
 		ownerPid: process.pid,
@@ -193,13 +460,17 @@ export async function persistNativeHookClaimJournal(
 export async function clearNativeHookClaimJournal(
 	root: string,
 	durability: NativeHookClaimJournalDurability,
+	expectedJournal?: RegularArtifact,
 ): Promise<void> {
 	const path = journalPath(root);
 	try {
+		const ancestors = await captureControlledAncestors(root, [path]);
+		await assertControlledAncestorsUnchanged(ancestors);
+		if (expectedJournal) await assertArtifactStillOwned(path, expectedJournal);
 		await rm(path);
 		await durability.syncDirectory(dirname(path));
 	} catch (error) {
-		if (!isMissing(error)) throw error;
+		if (expectedJournal || !isMissing(error)) throw error;
 	}
 }
 
@@ -209,16 +480,26 @@ export async function recoverNativeHookClaimJournal(
 ): Promise<{ recovered: boolean; outcome: RegularFileSyncOutcome }> {
 	const path = journalPath(root);
 	let parsed: ClaimJournalEntry;
+	let journal: RegularArtifact;
+	const openFileForRead =
+		durability.openFileForRead ??
+		((targetPath: string) => open(targetPath, "r"));
+	let journalAncestors: ControlledAncestor[];
 	try {
-		const stat = await lstat(path);
-		if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
-			throw new Error(`Native hook claim journal is unsafe: ${path}`);
-		}
-		parsed = JSON.parse(await readFile(path, "utf-8")) as ClaimJournalEntry;
+		journalAncestors = await captureControlledAncestors(root, [path]);
 	} catch (error) {
 		if (isMissing(error)) return { recovered: false, outcome: "synced" };
 		throw error;
 	}
+	const artifact = await readRegularArtifact(
+		path,
+		() => assertControlledAncestorsUnchanged(journalAncestors),
+		1,
+		openFileForRead,
+	);
+	if (artifact === null) return { recovered: false, outcome: "synced" };
+	journal = artifact;
+	parsed = JSON.parse(journal.bytes.toString("utf-8")) as ClaimJournalEntry;
 	if (
 		parsed.version !== 1 ||
 		!Number.isSafeInteger(parsed.ownerPid) ||
@@ -231,64 +512,135 @@ export async function recoverNativeHookClaimJournal(
 	}
 	assertControlledPath(root, parsed.canonicalPath);
 	assertControlledPath(root, parsed.claimPath);
+	const artifactAncestors = await captureControlledAncestors(root, [
+		parsed.canonicalPath,
+		parsed.claimPath,
+	]);
+	const validateArtifactPaths = () =>
+		assertControlledAncestorsUnchanged(artifactAncestors);
 	if (processIsAlive(parsed.ownerPid)) {
-		throw new Error("Native hook claim journal belongs to a live mutation; recovery refused to mutate it.");
+		throw new Error(
+			"Native hook claim journal belongs to a live mutation; recovery refused to mutate it.",
+		);
 	}
 	let outcome: RegularFileSyncOutcome = "synced";
 	try {
-		const [canonicalStat, claimStat] = await Promise.all([
-			lstat(parsed.canonicalPath),
-			lstat(parsed.claimPath),
-		]);
+		await validateArtifactPaths();
+		const canonicalStat = await lstat(parsed.canonicalPath);
+		const claimStat = await lstat(parsed.claimPath);
 		if (
-			!canonicalStat.isSymbolicLink() && canonicalStat.isFile() && canonicalStat.nlink === 2 &&
-			!claimStat.isSymbolicLink() && claimStat.isFile() && claimStat.nlink === 2 &&
-			canonicalStat.dev === claimStat.dev && canonicalStat.ino === claimStat.ino
+			!canonicalStat.isSymbolicLink() &&
+			canonicalStat.isFile() &&
+			canonicalStat.nlink === 2 &&
+			!claimStat.isSymbolicLink() &&
+			claimStat.isFile() &&
+			claimStat.nlink === 2 &&
+			canonicalStat.dev === claimStat.dev &&
+			canonicalStat.ino === claimStat.ino
 		) {
-			const bytes = await readFile(parsed.canonicalPath);
-			if (digest(bytes) !== parsed.beforeHash) {
-				throw new Error("Native hook claim journal cannot finalize a linked restore with changed bytes.");
+			const canonical = await readRegularArtifact(
+				parsed.canonicalPath,
+				validateArtifactPaths,
+				2,
+				openFileForRead,
+			);
+			const claim = await readRegularArtifact(
+				parsed.claimPath,
+				validateArtifactPaths,
+				2,
+				openFileForRead,
+			);
+			if (
+				canonical === null ||
+				claim === null ||
+				!sameFileIdentity(canonical, claim) ||
+				digest(canonical.bytes) !== parsed.beforeHash ||
+				!canonical.bytes.equals(claim.bytes)
+			) {
+				throw new Error(
+					"Native hook claim journal cannot finalize a linked restore with changed bytes.",
+				);
+			}
+			await validateArtifactPaths();
+			const claimBeforeRemove = await lstat(parsed.claimPath);
+			if (
+				claimBeforeRemove.isSymbolicLink() ||
+				!claimBeforeRemove.isFile() ||
+				claimBeforeRemove.nlink !== 2 ||
+				!sameFileIdentity(claimBeforeRemove, claim)
+			) {
+				throw new Error(
+					"Native hook claim journal claim changed before finalization.",
+				);
 			}
 			await rm(parsed.claimPath);
 			await durability.syncDirectory(dirname(parsed.claimPath));
-			await clearNativeHookClaimJournal(root, durability);
+			await clearNativeHookClaimJournal(root, durability, journal);
 			return { recovered: true, outcome };
 		}
 	} catch (error) {
 		if (!isMissing(error)) throw error;
 	}
-	const [canonical, claim] = await Promise.all([
-		readRegularBytes(parsed.canonicalPath),
-		readRegularBytes(parsed.claimPath),
-	]);
+	const canonical = await readRegularArtifact(
+		parsed.canonicalPath,
+		validateArtifactPaths,
+		1,
+		openFileForRead,
+	);
+	const claim = await readRegularArtifact(
+		parsed.claimPath,
+		validateArtifactPaths,
+		1,
+		openFileForRead,
+	);
 	if (claim === null) {
 		if (canonical === null && parsed.afterHash === null) {
-			await clearNativeHookClaimJournal(root, durability);
+			await clearNativeHookClaimJournal(root, durability, journal);
 			return { recovered: true, outcome };
 		}
-		if (canonical !== null && parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
-			await clearNativeHookClaimJournal(root, durability);
+		if (
+			canonical !== null &&
+			parsed.afterHash !== null &&
+			digest(canonical.bytes) === parsed.afterHash
+		) {
+			await clearNativeHookClaimJournal(root, durability, journal);
 			return { recovered: true, outcome };
 		}
-		if (canonical !== null && digest(canonical) === parsed.beforeHash) {
-			await clearNativeHookClaimJournal(root, durability);
+		if (canonical !== null && digest(canonical.bytes) === parsed.beforeHash) {
+			await clearNativeHookClaimJournal(root, durability, journal);
 			return { recovered: true, outcome };
 		}
-		throw new Error("Native hook claim journal cannot recover: claim is missing and canonical bytes are not the recorded original.");
+		throw new Error(
+			"Native hook claim journal cannot recover: claim is missing and canonical bytes are not the recorded original.",
+		);
 	}
-	if (digest(claim) !== parsed.beforeHash) {
-		throw new Error("Native hook claim journal cannot recover: claim bytes do not match recorded ownership.");
+	if (digest(claim.bytes) !== parsed.beforeHash) {
+		throw new Error(
+			"Native hook claim journal cannot recover: claim bytes do not match recorded ownership.",
+		);
 	}
 	if (canonical === null) {
-		outcome = await restoreNativeHookClaimNoClobber(parsed.claimPath, parsed.canonicalPath, durability);
-		await clearNativeHookClaimJournal(root, durability);
+		outcome = await restoreNativeHookClaimNoClobber(
+			parsed.claimPath,
+			parsed.canonicalPath,
+			durability,
+			validateArtifactPaths,
+		);
+		await clearNativeHookClaimJournal(root, durability, journal);
 		return { recovered: true, outcome };
 	}
-	if (parsed.afterHash !== null && digest(canonical) === parsed.afterHash) {
+	if (
+		parsed.afterHash !== null &&
+		digest(canonical.bytes) === parsed.afterHash
+	) {
+		await validateArtifactPaths();
+		await assertArtifactStillOwned(parsed.claimPath, claim);
 		await rm(parsed.claimPath);
 		await durability.syncDirectory(dirname(parsed.claimPath));
-		await clearNativeHookClaimJournal(root, durability);
+		await clearNativeHookClaimJournal(root, durability, journal);
 		return { recovered: true, outcome };
 	}
-	throw new Error("Native hook claim journal cannot recover without overwriting unrecognized canonical content.");
+	throw new Error(
+		"Native hook claim journal cannot recover without overwriting unrecognized canonical content.",
+	);
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -48,6 +48,7 @@ import {
 } from "../utils/paths.js";
 import {
 	emitDegradedDurabilityWarning,
+	recordDirectorySyncOutcome,
 	recordRegularFileSyncOutcome,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
@@ -633,35 +634,54 @@ function nativeHookPlatform(): NodeJS.Platform {
 }
 
 
-function nativeHookClaimJournalDurability() {
-	return nativeHookClaimJournalDurabilityOverride
-		?? createNativeHookClaimJournalDurability(nativeHookPlatform());
+function nativeHookClaimJournalDurability(tracker?: RegularFileDurabilityTracker) {
+	if (!nativeHookClaimJournalDurabilityOverride) {
+		return createNativeHookClaimJournalDurability(nativeHookPlatform(), tracker);
+	}
+	const durability = nativeHookClaimJournalDurabilityOverride;
+	if (!tracker) return durability;
+	return {
+		...durability,
+		async syncDirectory(path: string) {
+			const outcome = await durability.syncDirectory(path);
+			recordDirectorySyncOutcome(tracker, outcome);
+			return outcome;
+		},
+	};
 }
 
-async function clearNativeHookClaimJournal(root: string): Promise<void> {
-	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability());
+async function clearNativeHookClaimJournal(
+	root: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability(tracker));
 }
 
 async function persistNativeHookClaimJournal(
 	root: string,
 	entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
-	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability());
+	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability(tracker));
 }
 
 async function restoreNativeHookClaimNoClobber(
 	claimPath: string,
 	destinationPath: string,
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
 	return restoreNativeHookClaimNoClobberWithDurability(
 		claimPath,
 		destinationPath,
-		nativeHookClaimJournalDurability(),
+		nativeHookClaimJournalDurability(tracker),
 	);
 }
 
-async function syncNativeHookClaimParent(path: string): Promise<void> {
-	return syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability());
+async function syncNativeHookClaimParent(
+	path: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	await syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability(tracker));
 }
 async function syncNativeHookRegularFile(
 	handle: Awaited<ReturnType<typeof open>>,
@@ -690,6 +710,23 @@ function nativeHookTransactionTopologyEqual(
 	return left.kind === "absent" || right.kind === "absent"
 		? left.kind === right.kind
 		: left.mode === right.mode;
+}
+
+function nativeHookTransactionTopologyMatchesAcrossOpen(
+	left: NativeHookTransactionTopology,
+	right: NativeHookTransactionTopology,
+): boolean {
+	if (
+		nativeHookPlatform() === "win32" &&
+		left.kind === "regular_file" &&
+		right.kind === "regular_file"
+	) {
+		// Windows synthesizes Unix permission bits, so chmod(0o600) can read back
+		// as 0o666. Cross-open ownership still requires exact bytes, volume/file
+		// identity (dev + ino), and link count in the full snapshot comparison.
+		return true;
+	}
+	return nativeHookTransactionTopologyEqual(left, right);
 }
 
 function isMissingPathError(error: unknown): boolean {
@@ -906,7 +943,7 @@ function nativeHookTransactionSnapshotsEqual(
 ): boolean {
 	return (
 		hookTransactionBytesEqual(left.bytes, right.bytes) &&
-		nativeHookTransactionTopologyEqual(left.topology, right.topology) &&
+		nativeHookTransactionTopologyMatchesAcrossOpen(left.topology, right.topology) &&
 		left.device === right.device &&
 		left.inode === right.inode &&
 		left.links === right.links
@@ -919,7 +956,7 @@ function nativeHookTransactionSnapshotMatchesExpected(
 ): boolean {
 	return (
 		hookTransactionBytesEqual(snapshot.bytes, expected.bytes) &&
-		nativeHookTransactionTopologyEqual(snapshot.topology, expected.topology)
+		nativeHookTransactionTopologyMatchesAcrossOpen(snapshot.topology, expected.topology)
 	);
 }
 
@@ -1170,7 +1207,7 @@ async function restoreNativeHookClaim(
 ): Promise<void> {
 	recordRegularFileSyncOutcome(
 		tracker,
-		await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+		await restoreNativeHookClaimNoClobber(claimPath, destinationPath, tracker),
 	);
 }
 
@@ -1282,7 +1319,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 						claimPath,
 						before: expectedCurrent.bytes,
 						after: content,
-					}),
+					}, tracker),
 				);
 				await refreshNativeHookTransactionAncestorPrecondition(
 					ancestorPrecondition,
@@ -1292,7 +1329,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 			}
 			await rename(artifact.path, claimPath);
 			claimCreated = true;
-			if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+			if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 			await assertNativeHookTransactionArtifactSnapshot(
 				claimPath,
 				`${artifact.label} replacement claim`,
@@ -1310,7 +1347,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 		} finally {
 			await installedHandle.close();
 		}
-		await syncNativeHookClaimParent(artifact.path);
+		await syncNativeHookClaimParent(artifact.path, tracker);
 		const installedSnapshot = await assertNativeHookTransactionArtifactState(
 			artifact.path,
 			artifact.label,
@@ -1319,11 +1356,11 @@ async function atomicWriteNativeHookTransactionArtifact(
 		);
 		if (claimCreated && claimPath) {
 			await rm(claimPath);
-			await syncNativeHookClaimParent(claimPath);
+			await syncNativeHookClaimParent(claimPath, tracker);
 			claimCreated = false;
 		}
 		if (journaledClaim) {
-			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 			journaledClaim = false;
 		}
 		await rm(temporaryPath);
@@ -1344,10 +1381,10 @@ async function atomicWriteNativeHookTransactionArtifact(
 		if (claimCreated && claimPath) {
 			try {
 				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
-				await syncNativeHookClaimParent(artifact.path);
+				await syncNativeHookClaimParent(artifact.path, tracker);
 				claimCreated = false;
 				if (journaledClaim) {
-					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 					journaledClaim = false;
 				}
 			} catch (recoveryError) {
@@ -1600,11 +1637,11 @@ async function applyNativeHookTransactionArtifact(
 					claimPath,
 					before: artifact.before.bytes!,
 					after: null,
-				}),
+				}, tracker),
 			);
 		}
 		await rename(artifact.path, claimPath);
-		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 		const entry: AppliedNativeHookTransactionArtifact = {
 			artifact,
 			appliedSnapshot: { bytes: null, topology: { kind: "absent" } },
@@ -1631,9 +1668,9 @@ async function applyNativeHookTransactionArtifact(
 					`${artifact.label} removal claim`,
 				);
 				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
-				if (journaledClaim) await syncNativeHookClaimParent(artifact.path);
+				if (journaledClaim) await syncNativeHookClaimParent(artifact.path, tracker);
 				if (journaledClaim) {
-					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 				}
 				await assertNativeHookTransactionArtifactSnapshot(
 					artifact.path,
@@ -1652,9 +1689,9 @@ async function applyNativeHookTransactionArtifact(
 
 		}
 		await rm(claimPath);
-		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 		if (journaledClaim) {
-			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 		}
 		originalRemoved = true;
 		injectNativeHookTransactionFailure("after_remove", artifact);
@@ -3931,7 +3968,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
 		const recovery = await recoverNativeHookClaimJournal(
 			scopeDirs.codexHomeDir,
-			nativeHookClaimJournalDurability(),
+			nativeHookClaimJournalDurability(recoveryTracker),
 		);
 		recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
 		if (recovery.recovered) {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -719,11 +719,13 @@ function nativeHookTransactionTopologyMatchesAcrossOpen(
 	if (
 		nativeHookPlatform() === "win32" &&
 		left.kind === "regular_file" &&
-		right.kind === "regular_file"
+		right.kind === "regular_file" &&
+		((left.mode === 0o600 && right.mode === 0o666) ||
+			(left.mode === 0o666 && right.mode === 0o600))
 	) {
-		// Windows synthesizes Unix permission bits, so chmod(0o600) can read back
-		// as 0o666. Cross-open ownership still requires exact bytes, volume/file
-		// identity (dev + ino), and link count in the full snapshot comparison.
+		// Windows can synthesize requested 0o600 as 0o666. Keep this exception
+		// exact so writable/read-only changes remain ownership failures. Cross-open
+		// ownership also requires bytes, dev, ino, and nlink in the full snapshot.
 		return true;
 	}
 	return nativeHookTransactionTopologyEqual(left, right);

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -58,6 +58,7 @@ import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.
 import TOML from "@iarna/toml";
 import {
   emitDegradedDurabilityWarning,
+  recordDirectorySyncOutcome,
   recordRegularFileSyncOutcome,
   syncRegularFile,
   type RegularFileSyncOutcome,
@@ -898,35 +899,54 @@ function transactionTemporaryPath(
   );
 }
 
-function uninstallClaimJournalDurability() {
-  return uninstallClaimJournalDurabilityOverride
-    ?? createNativeHookClaimJournalDurability();
+function uninstallClaimJournalDurability(tracker?: RegularFileDurabilityTracker) {
+  if (!uninstallClaimJournalDurabilityOverride) {
+    return createNativeHookClaimJournalDurability(process.platform, tracker);
+  }
+  const durability = uninstallClaimJournalDurabilityOverride;
+  if (!tracker) return durability;
+  return {
+    ...durability,
+    async syncDirectory(path: string) {
+      const outcome = await durability.syncDirectory(path);
+      recordDirectorySyncOutcome(tracker, outcome);
+      return outcome;
+    },
+  };
 }
 
-async function clearNativeHookClaimJournal(root: string): Promise<void> {
-  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability());
+async function clearNativeHookClaimJournal(
+  root: string,
+  tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability(tracker));
 }
 
 async function persistNativeHookClaimJournal(
   root: string,
   entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+  tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
-  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability());
+  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability(tracker));
 }
 
 async function restoreNativeHookClaimNoClobber(
   claimPath: string,
   destinationPath: string,
+  tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
   return restoreNativeHookClaimNoClobberWithDurability(
     claimPath,
     destinationPath,
-    uninstallClaimJournalDurability(),
+    uninstallClaimJournalDurability(tracker),
   );
 }
 
-async function syncNativeHookClaimParent(path: string): Promise<void> {
-  return syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability());
+async function syncNativeHookClaimParent(
+  path: string,
+  tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+  await syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability(tracker));
 }
 
 function transactionClaimPath(path: string): string {
@@ -943,7 +963,7 @@ async function restoreUninstallClaim(
 ): Promise<void> {
   recordRegularFileSyncOutcome(
     tracker,
-    await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+    await restoreNativeHookClaimNoClobber(claimPath, destinationPath, tracker),
   );
 }
 
@@ -1190,12 +1210,12 @@ async function atomicReplaceFile(
           claimPath,
           before: expectedCurrent.bytes,
           after: content,
-        }),
+        }, options.durabilityTracker),
       );
       journaledClaim = true;
       await rename(mutation.snapshot.path, claimPath);
       claimCreated = true;
-      await syncNativeHookClaimParent(claimPath);
+      await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
       await assertSnapshotAtPath(claimPath, expectedCurrent, "replacement claim");
     }
     await copyFile(temporaryPath, mutation.snapshot.path, constants.COPYFILE_EXCL);
@@ -1206,18 +1226,18 @@ async function atomicReplaceFile(
     } finally {
       await installedHandle.close();
     }
-    await syncNativeHookClaimParent(mutation.snapshot.path);
+    await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
     const actual = await captureCurrentSnapshot(mutation.snapshot);
     if (actual.bytes === null || actual.mode !== mutation.snapshot.mode || !actual.bytes.equals(content)) {
       throw new Error(`Read-back verification failed for replacement ${mutation.snapshot.path}.`);
     }
     if (claimCreated && claimPath) {
       await rm(claimPath);
-      await syncNativeHookClaimParent(claimPath);
+      await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
       claimCreated = false;
     }
     if (journaledClaim && controlledRoot) {
-      await clearNativeHookClaimJournal(controlledRoot);
+      await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
       journaledClaim = false;
     }
     await rm(temporaryPath);
@@ -1243,11 +1263,11 @@ async function atomicReplaceFile(
     if (claimCreated && claimPath) {
       try {
         await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
-        await syncNativeHookClaimParent(mutation.snapshot.path);
+        await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
         claimCreated = false;
         const controlledRoot = mutation.snapshot.topology?.root;
         if (journaledClaim && controlledRoot) {
-          await clearNativeHookClaimJournal(controlledRoot);
+          await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
           journaledClaim = false;
         }
       } catch (recoveryError) {
@@ -1324,11 +1344,11 @@ async function stageAndRemoveFile(
           claimPath,
           before: mutation.snapshot.bytes,
           after: null,
-        }),
+        }, options.durabilityTracker),
       );
     }
     await rename(mutation.snapshot.path, claimPath);
-    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
     execution.appliedSnapshot = {
       path: mutation.snapshot.path,
       content: null,
@@ -1345,8 +1365,8 @@ async function stageAndRemoveFile(
     } catch (error) {
       try {
         await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
-        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path);
-        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
+        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
+        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
         execution.appliedSnapshot = undefined;
         execution.phase = "prepared";
       } catch (recoveryError) {
@@ -1357,8 +1377,8 @@ async function stageAndRemoveFile(
       throw error;
     }
     await rm(claimPath);
-    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
-    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
+    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
     await options.transactionFailureInjector?.("after-remove");
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
@@ -1827,7 +1847,10 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
     const recovery = await recoverNativeHookClaimJournal(
       scopeDirs.codexHomeDir,
       uninstallClaimJournalDurabilityOverride
-        ?? createNativeHookClaimJournalDurability(options.transactionPlatform ?? process.platform),
+        ?? createNativeHookClaimJournalDurability(
+          options.transactionPlatform ?? process.platform,
+          recoveryTracker,
+        ),
     );
     recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
     emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
 	emitDegradedDurabilityWarning,
+	recordDirectorySyncOutcome,
 	recordRegularFileSyncOutcome,
+	syncDirectory,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
 } from "../file-durability.js";
@@ -22,6 +24,30 @@ test("regular-file sync returns the Windows EPERM durability outcome", async () 
 test("regular-file sync returns synced after a successful sync", async () => {
 	assert.equal(await syncRegularFile({ sync: async () => {} }, "win32"), "synced");
 });
+
+test("directory sync returns the Windows EPERM durability outcome", async () => {
+	const outcome = await syncDirectory(
+		{ sync: async () => { throw errno("EPERM"); } },
+		"win32",
+	);
+	assert.equal(outcome, "unsupported-windows-eperm");
+});
+
+test("directory sync returns synced after a successful sync", async () => {
+	assert.equal(await syncDirectory({ sync: async () => {} }, "win32"), "synced");
+});
+
+for (const { description, platform, failure } of [
+	{ description: "Linux EPERM", platform: "linux", failure: errno("EPERM") },
+	{ description: "Windows EACCES", platform: "win32", failure: errno("EACCES") },
+] as const) {
+	test(`directory sync preserves fatal error identity for ${description}`, async () => {
+		await assert.rejects(
+			syncDirectory({ sync: async () => { throw failure; } }, platform),
+			(error: unknown) => error === failure,
+		);
+	});
+}
 
 for (const { description, platform, failure } of [
 	{ description: "Linux string EPERM", platform: "linux", failure: errno("EPERM") },
@@ -68,4 +94,23 @@ test("a throwing stderr sink cannot fail an already successful transaction", () 
 	} finally {
 		process.stderr.write = originalWrite;
 	}
+});
+
+test("durability warning accurately names directory degradation", () => {
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordDirectorySyncOutcome(tracker, "unsupported-windows-eperm");
+	const originalWrite = process.stderr.write;
+	const warnings: string[] = [];
+	process.stderr.write = ((value: string) => {
+		warnings.push(value);
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		emitDegradedDurabilityWarning("native-hook setup", tracker);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	assert.deepEqual(warnings, [
+		"[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n",
+	]);
 });

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -1,6 +1,7 @@
 import type { FileHandle } from "fs/promises";
 
 export type RegularFileSyncOutcome = "synced" | "unsupported-windows-eperm";
+export type DirectorySyncOutcome = "synced" | "unsupported-windows-eperm";
 
 export type DurabilityWarningSubsystem =
 	| "session pointer start/reconcile"
@@ -11,9 +12,11 @@ export type DurabilityWarningSubsystem =
 
 export interface RegularFileDurabilityTracker {
 	degraded: boolean;
+	regularFileDegraded?: boolean;
+	directoryDegraded?: boolean;
 }
 
-function isUnsupportedWindowsRegularFileSync(
+function isUnsupportedWindowsSync(
 	error: unknown,
 	platform: NodeJS.Platform,
 ): boolean {
@@ -38,7 +41,25 @@ export async function syncRegularFile(
 		await handle.sync();
 		return "synced";
 	} catch (error) {
-		if (!isUnsupportedWindowsRegularFileSync(error, platform)) throw error;
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
+		return "unsupported-windows-eperm";
+	}
+}
+
+/**
+ * Windows can also report EPERM when fsync is unsupported for an otherwise
+ * valid directory handle. Keep the capability boundary as narrow as the
+ * regular-file fallback: every other platform/error pair remains fatal.
+ */
+export async function syncDirectory(
+	handle: Pick<FileHandle, "sync">,
+	platform: NodeJS.Platform = process.platform,
+): Promise<DirectorySyncOutcome> {
+	try {
+		await handle.sync();
+		return "synced";
+	} catch (error) {
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
 		return "unsupported-windows-eperm";
 	}
 }
@@ -47,7 +68,18 @@ export function recordRegularFileSyncOutcome(
 	tracker: RegularFileDurabilityTracker,
 	outcome: RegularFileSyncOutcome,
 ): void {
-	tracker.degraded ||= outcome === "unsupported-windows-eperm";
+	if (outcome !== "unsupported-windows-eperm") return;
+	tracker.degraded = true;
+	tracker.regularFileDegraded = true;
+}
+
+export function recordDirectorySyncOutcome(
+	tracker: RegularFileDurabilityTracker,
+	outcome: DirectorySyncOutcome,
+): void {
+	if (outcome !== "unsupported-windows-eperm") return;
+	tracker.degraded = true;
+	tracker.directoryDegraded = true;
 }
 
 export function emitDegradedDurabilityWarning(
@@ -55,9 +87,14 @@ export function emitDegradedDurabilityWarning(
 	tracker: RegularFileDurabilityTracker,
 ): void {
 	if (!tracker.degraded) return;
+	const target = tracker.directoryDegraded
+		? tracker.regularFileDegraded
+			? "regular-file and directory fsync"
+			: "directory fsync"
+		: "regular-file fsync";
 	try {
 		process.stderr.write(
-			`[omx] warning: Windows EPERM regular-file fsync unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
+			`[omx] warning: Windows EPERM ${target} unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
 		);
 	} catch {
 		// Diagnostics must not fail an already committed transaction.


### PR DESCRIPTION
## Summary

Successor to #3443. This keeps the narrow Windows directory-fsync fallback while removing the rejected bytes-only ownership relaxation.

- degrade durability only for Windows `EPERM` from regular-file or directory fsync
- keep Windows non-`EPERM` and every non-Windows error fatal
- tolerate only synthesized Windows Unix-mode drift across reopen
- continue requiring exact bytes plus `dev`, `ino`, and `nlink` for transaction ownership
- bind claim-journal reads and removals to handle-derived identity
- reject junction/symlink ancestors, hardlink races, post-open replacement/removal, and same-byte copy-fallback substitution
- emit one accurate degraded-durability warning through setup, uninstall, and doctor recovery

## Root cause addressed

The rejected head treated matching bytes as sufficient Windows ownership evidence and accepted a same-byte replacement with a new file identity. Native Windows reproduction also showed the real cross-open mismatch was narrower: requested mode `0o600` reads back as synthesized `0o666`, while `dev`/`ino` remain stable. This PR ignores only that mode mismatch for regular files and preserves identity/link-count checks.

## Verification

- `npm run build`
- `npm run lint` (790 files)
- `npm run check:no-unused`
- file durability: 13/13
- claim journal: 17/17
- targeted setup ownership/durability tests: 5/5
- targeted uninstall ownership/durability tests: 3/3
- targeted doctor claim recovery: 1/1
- independent security review: approved after junction, hardlink, journal-identity, and post-open race regressions were added

On this native Windows host, the broad setup suite remains platform-sensitive: base `dev` produced 108 pre-existing failures and this successor exact head produced 41. The affected contracts above are deterministic and green; upstream Linux CI remains the authority for the maintainer's 121-test baseline.

## Security boundary

Same-byte foreign replacement remains fatal. Recovery verifies controlled ancestors, regular-file type, exact link counts, handle/path identity, bytes, and expected journal identity immediately before destructive cleanup.
