### PR TITLE
test: use platform-aware active session fixture in agents-init test (#3408)

### DIFF
--- a/src/cli/__tests__/agents-init.test.ts
+++ b/src/cli/__tests__/agents-init.test.ts
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { writeSessionStart } from '../../hooks/session.js';
 import { agentsInit } from '../agents-init.js';
 
 function runOmx(
@@ -42,18 +43,8 @@ async function withCwd<T>(cwd: string, fn: () => Promise<T>): Promise<T> {
   }
 }
 
-async function readCurrentLinuxStartTicks(): Promise<number | undefined> {
-  if (process.platform !== 'linux') return undefined;
-  try {
-    const stat = await readFile('/proc/self/stat', 'utf-8');
-    const commandEnd = stat.lastIndexOf(')');
-    if (commandEnd === -1) return undefined;
-    const fields = stat.slice(commandEnd + 1).trim().split(/\s+/);
-    const ticks = Number(fields[19]);
-    return Number.isFinite(ticks) ? ticks : undefined;
-  } catch {
-    return undefined;
-  }
+async function writeActiveSessionFixture(cwd: string): Promise<void> {
+  await writeSessionStart(cwd, 'sess-test');
 }
 
 describe('omx agents-init', () => {
@@ -157,21 +148,11 @@ describe('omx agents-init', () => {
   it('protects project-root AGENTS.md during an active OMX session', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-agents-init-'));
     try {
-      const pidStartTicks = await readCurrentLinuxStartTicks();
       await mkdir(join(wd, '.omx', 'state'), { recursive: true });
       await mkdir(join(wd, 'src'), { recursive: true });
       await writeFile(join(wd, 'AGENTS.md'), '# unmanaged\n');
       await writeFile(join(wd, 'src', 'index.ts'), 'export const x = 1;\n');
-      await writeFile(
-        join(wd, '.omx', 'state', 'session.json'),
-        JSON.stringify({
-          session_id: 'session-1',
-          started_at: new Date().toISOString(),
-          cwd: wd,
-          pid: process.pid,
-          pid_start_ticks: pidStartTicks,
-        }, null, 2),
-      );
+      await writeActiveSessionFixture(wd);
 
       await withCwd(wd, async () => {
         await agentsInit({ force: true });


### PR DESCRIPTION
## Summary

Fixes the remaining Darwin session-identity fixture failure from #3408 in `agents-init.test.ts`, mirroring the already-merged PR #3410 that fixed the identical pattern in `setup-agents-overwrite.test.ts`.

## Problem

The "protects project-root AGENTS.md during an active OMX session" test in `agents-init.test.ts` used a Linux-only `readCurrentLinuxStartTicks()` helper that returns `undefined` on Darwin. The manually-written `session.json` fixture with `pid_start_ticks: undefined` is classified as `identity-indeterminate`, so `agentsInit` treats the session as inactive and the root `AGENTS.md` protection does not engage — causing the test to fail on macOS.

## Fix

Replace the broken Linux-only fixture with the platform-aware `writeSessionStart(cwd, 'sess-test')` helper from `src/hooks/session.ts`. This uses the production session-start path (`sessionIdentityFor(pid, platform)` → `observeProcess(pid, platform)`) that writes valid identity evidence on both Linux (`/proc/<pid>/stat` start ticks + cmdline hash) and Darwin (`pid_birth`/command identity).

This is the exact same fix pattern applied in PR #3410 for `setup-agents-overwrite.test.ts`.

## Scope

- **Test-only change**: `src/cli/__tests__/agents-init.test.ts` (1 file, +4/−23 lines)
- **No production changes**: no changes to `src/hooks/session.ts`, `src/cli/agents-init.ts`, or any classification logic
- **No policy weakening**: the identity-indeterminate/stale-pointer classification thresholds are untouched

## Verification

- ✅ `npm run build` succeeds
- ✅ `node --test dist/cli/__tests__/agents-init.test.js` — 5/5 pass (including the fixed test)
- ✅ `node --test dist/cli/__tests__/setup-agents-overwrite.test.js` — 26/26 pass (regression guard)

Closes #3408

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*