### PR TITLE
fix(config): preserve user notify/effort and project scope during launch repair (#3447)

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3500,6 +3500,58 @@ describe("project launch scope helpers", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  it("walks upward to find a project-scoped setup for launch resolution", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      const nested = join(wd, "packages", "app", "src");
+      await mkdir(nested, { recursive: true });
+      assert.equal(resolveCodexHomeForLaunch(nested, {}), join(wd, ".codex"));
+      assert.equal(
+        resolveCodexConfigPathForLaunch(nested, {}),
+        join(wd, ".codex", "config.toml"),
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not redirect a launch outside any setup root into project CODEX_HOME", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      const outside = join(wd, "..", `outside-${Date.now()}`);
+      await mkdir(outside, { recursive: true });
+      assert.equal(resolveCodexHomeForLaunch(outside, {}), undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a user-scope setup on the user config when launching from a subdirectory", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
+    try {
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "user" }),
+      );
+      const nested = join(wd, "sub");
+      await mkdir(nested, { recursive: true });
+      assert.equal(resolveCodexHomeForLaunch(nested, {}), undefined);
+      assert.equal(resolveProjectLocalCodexHomeForLaunch(nested, {}), undefined);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("pointer launch aborts", () => {

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -3,6 +3,7 @@ import { codexConfigPath } from "../utils/paths.js";
 import {
 	readPersistedSetupPreferencesSync,
 	readPersistedSetupScopeSync,
+	resolveNearestPersistedSetupScopeSync,
 } from "./setup-preferences.js";
 
 export const readPersistedSetupPreferences = readPersistedSetupPreferencesSync;
@@ -13,9 +14,12 @@ export function resolveProjectLocalCodexHomeForLaunch(
 	env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
 	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return undefined;
-	const persistedScope = readPersistedSetupScope(cwd);
-	if (persistedScope === "project") {
-		return join(cwd, ".codex");
+	// Walk upward so a project-scoped setup is honored from any directory
+	// inside its tree — launching from a subdirectory must not fall through
+	// to the user config (issue #3447).
+	const nearest = resolveNearestPersistedSetupScopeSync(cwd);
+	if (nearest?.scope === "project") {
+		return join(nearest.projectRoot, ".codex");
 	}
 	return undefined;
 }

--- a/src/cli/setup-preferences.ts
+++ b/src/cli/setup-preferences.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { mkdir, rename, rm, writeFile } from "fs/promises";
-import { join } from "path";
+import { dirname, join, resolve } from "path";
 import {
 	isSetupTeamMode,
 	type SetupTeamMode,
@@ -182,4 +182,35 @@ export function readPersistedSetupScopeSync(
 	projectRoot: string,
 ): SetupScope | undefined {
 	return readPersistedSetupPreferencesSync(projectRoot)?.scope;
+}
+export interface NearestPersistedSetupScope {
+	projectRoot: string;
+	scope: SetupScope;
+}
+
+/**
+ * Resolve the nearest persisted setup scope by walking upward from `startDir`.
+ *
+ * Launch-time scope resolution is cwd-sensitive: a project-scoped setup must
+ * keep launches inside its tree on the project-local Codex config, so the
+ * walk stops at the first ancestor (including `startDir` itself) that has a
+ * `.omx/setup-scope.json`. A marker that cannot be parsed stops the walk and
+ * yields no scope rather than skipping a nearer setup marker. Returns
+ * `undefined` when no marker exists anywhere above `startDir`.
+ */
+export function resolveNearestPersistedSetupScopeSync(
+	startDir: string,
+): NearestPersistedSetupScope | undefined {
+	let current = resolve(startDir);
+	while (true) {
+		const scopePath = getSetupScopeFilePath(current);
+		if (existsSync(scopePath)) {
+			const scope = readPersistedSetupScopeSync(current);
+			if (scope === undefined) return undefined;
+			return { projectRoot: current, scope };
+		}
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
 }

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1299,6 +1299,7 @@ describe("config generator idempotency (#384)", () => {
         '[user.before]',
         'name = "kept-before"',
         "",
+        '# OMX MCP Team Run Server',
         '[mcp_servers.omx_team_run]',
         'command = "node"',
         'args = ["/tmp/team-server.js"]',
@@ -1314,13 +1315,19 @@ describe("config generator idempotency (#384)", () => {
       assert.equal(didRepair, true, "legacy team-run config should be repaired");
 
       const toml = await readFile(configPath, "utf-8");
-      assertSingleOmxBlock(toml);
       assert.doesNotMatch(toml, /^\[mcp_servers\.omx_team_run\]$/m);
       assert.doesNotMatch(toml, /team-server\.js/);
       assert.match(toml, /^\[user\.before\]$/m);
       assert.match(toml, /^name = "kept-before"$/m);
       assert.match(toml, /^\[user\.after\]$/m);
       assert.match(toml, /^name = "kept-after"$/m);
+      // Surgical repair: the retired table is dropped, but no OMX managed
+      // block is injected into a config that never had one (issue #3447).
+      assert.doesNotMatch(toml, /oh-my-codex \(OMX\) Configuration/);
+      assert.doesNotMatch(toml, /^\[tui\]$/m);
+      assert.doesNotMatch(toml, /^notify\s*=/m);
+      assert.doesNotMatch(toml, /^model_reasoning_effort\s*=/m);
+      assert.doesNotThrow(() => TOML.parse(toml));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }
@@ -1388,7 +1395,7 @@ describe("config generator idempotency (#384)", () => {
     }
   });
 
-  it("fails closed without rewriting managed hook trust when launch repair cannot prove it", async () => {
+  it("preserves managed hook trust bytes untouched during launch repair", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
     try {
       const { configPath, hooksPath, config: setupConfig, trustState } =
@@ -1402,49 +1409,38 @@ describe("config generator idempotency (#384)", () => {
       );
       await writeFile(configPath, conflicting);
 
-      await assert.rejects(
-        repairConfigIfNeeded(configPath, wd),
-        (error: unknown) =>
-          error instanceof ManagedCodexHooksPlanError &&
-          error.code === "managed_trust_key_conflict",
+      // Surgical repair never rewrites managed hook trust, so it cannot
+      // clobber a conflicting user edit: it only dedupes the duplicate [tui]
+      // and leaves every other byte (including the conflict) untouched.
+      const conflictTrustBlock = conflicting.match(
+        /# OMX-owned Codex hook trust state\n[\s\S]*?# End OMX-owned Codex hook trust state/,
+      )?.[0];
+      assert.ok(
+        conflictTrustBlock,
+        "conflicting fixture must contain fenced managed hook trust",
       );
-      assert.equal(await readFile(configPath, "utf-8"), conflicting);
+      assert.equal(await repairConfigIfNeeded(configPath, wd), true);
+      const repaired = await readFile(configPath, "utf-8");
+      assert.equal(count(repaired, /^\[tui\]$/gm), 1);
+      assert.ok(
+        repaired.includes(conflictTrustBlock),
+        "repair must preserve conflicting trust bytes verbatim",
+      );
 
-      const unprovenHooks = [
-        ["invalid", "{ not valid JSON"],
-        [
-          "ambiguous",
-          JSON.stringify({
-            hooks: {
-              SessionStart: [
-                {
-                  hooks: [
-                    {
-                      type: "command",
-                      command: `NODE ${join(wd, "dist", "scripts", "codex-native-hook.js")}`,
-                    },
-                  ],
-                },
-              ],
-            },
-          }),
-        ],
-        ["missing", null],
-      ] as const;
-      for (const [name, hooksContent] of unprovenHooks) {
+      // An unreadable or missing hooks artifact cannot block the surgical
+      // repair, because the repair never rewrites hook trust state.
+      for (const hooksContent of ["{ not valid JSON", null] as const) {
         await writeFile(configPath, repairTarget);
         if (hooksContent === null) {
           await rm(hooksPath);
         } else {
           await writeFile(hooksPath, hooksContent);
         }
-
-        await assert.rejects(
-          repairConfigIfNeeded(configPath, wd),
-          (error: unknown) => error instanceof ManagedCodexHooksPlanError,
-          name,
+        assert.equal(await repairConfigIfNeeded(configPath, wd), true);
+        assert.equal(
+          count(await readFile(configPath, "utf-8"), /^\[tui\]$/gm),
+          1,
         );
-        assert.equal(await readFile(configPath, "utf-8"), repairTarget, name);
       }
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -2705,6 +2701,166 @@ describe("config generator idempotency (#384)", () => {
 
       assert.equal(repaired, true);
       assert.match(config, /^startup_timeout_sec = 15$/m);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it("repairConfigIfNeeded preserves custom notify and model_reasoning_effort without injecting the OMX block", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const preOmx = [
+        'model = "gpt-5.6-sol"',
+        'model_reasoning_effort = "high"',
+        'notify = ["node", "/opt/computer-use/client.mjs", "--event", "turn-ended"]',
+        "",
+        "[mcp_servers.filesystem]",
+        'command = "npx"',
+        'args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]',
+        "",
+        "[mcp_servers.memory]",
+        'command = "uvx"',
+        'args = ["mcp-server-memory"]',
+        "",
+      ].join("\n");
+      await writeFile(configPath, preOmx);
+
+      const repaired = await repairConfigIfNeeded(configPath, wd);
+      const toml = await readFile(configPath, "utf-8");
+
+      assert.equal(repaired, true, "timeout gap should trigger a repair");
+      assert.equal((toml.match(/^startup_timeout_sec = 15$/gm) ?? []).length, 2);
+      // User-owned values survive byte-for-byte (issue #3447).
+      assert.match(toml, /^model_reasoning_effort = "high"$/m);
+      assert.match(
+        toml,
+        /^notify = \["node", "\/opt\/computer-use\/client\.mjs", "--event", "turn-ended"\]$/m,
+      );
+      // No OMX managed block is injected into a config that never had one.
+      assert.doesNotMatch(toml, /oh-my-codex \(OMX\) Configuration/);
+      assert.doesNotMatch(toml, /^developer_instructions\s*=/m);
+      assert.doesNotMatch(toml, /USE_OMX_EXPLORE_CMD/);
+      assert.doesNotMatch(toml, /^\[tui\]$/m);
+      assert.doesNotMatch(toml, /notify-hook\.js/);
+
+      // Repairing again is a no-op: the timeout backfill is idempotent.
+      assert.equal(await repairConfigIfNeeded(configPath, wd), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+  it("repairConfigIfNeeded dedupes [tui] inside the OMX block without dropping the end marker", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const duplicated = [
+        'model = "managed-model"',
+        "",
+        "# ============================================================",
+        "# oh-my-codex (OMX) Configuration",
+        "# Managed by omx setup - manual edits preserved on next setup",
+        "# ============================================================",
+        "",
+        "[mcp_servers.managed]",
+        'command = "node"',
+        'args = ["managed.js"]',
+        "startup_timeout_sec = 9",
+        "",
+        "[tui]",
+        "# first tui payload",
+        'status_line = ["first"]',
+        "",
+        "[tui]",
+        "# duplicate tui payload",
+        'status_line = ["duplicate"]',
+        "",
+        "# ============================================================",
+        "# End oh-my-codex",
+        "",
+        "[user.after]",
+        'name = "kept"',
+        "",
+      ].join("\n");
+      await writeFile(configPath, duplicated);
+
+      assert.equal(await repairConfigIfNeeded(configPath, wd), true);
+      const repaired = await readFile(configPath, "utf-8");
+
+      assert.equal(count(repaired, /^\[tui\]$/gm), 1);
+      assert.match(repaired, /# oh-my-codex \(OMX\) Configuration/);
+      assert.match(repaired, /# End oh-my-codex/);
+      assert.match(repaired, /^\[user\.after\]$/m);
+      assert.match(repaired, /^name = "kept"$/m);
+      assert.doesNotMatch(repaired, /duplicate tui payload/);
+      assert.doesNotThrow(() => TOML.parse(repaired));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairConfigIfNeeded removes a legacy omx_team_run table inside the OMX block without dropping the end marker", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const legacy = [
+        "# ============================================================",
+        "# oh-my-codex (OMX) Configuration",
+        "# Managed by omx setup - manual edits preserved on next setup",
+        "# ============================================================",
+        "",
+        "[mcp_servers.managed]",
+        'command = "node"',
+        'args = ["managed.js"]',
+        "startup_timeout_sec = 9",
+        "",
+        "[mcp_servers.omx_team_run]",
+        'command = "node"',
+        'args = ["/tmp/team-server.js"]',
+        "enabled = true",
+        "",
+        "# ============================================================",
+        "# End oh-my-codex",
+        "",
+        "[user.after]",
+        'name = "kept"',
+        "",
+      ].join("\n");
+      await writeFile(configPath, legacy);
+
+      assert.equal(await repairConfigIfNeeded(configPath, wd), true);
+      const repaired = await readFile(configPath, "utf-8");
+
+      assert.doesNotMatch(repaired, /^\[mcp_servers\.omx_team_run\]$/m);
+      assert.doesNotMatch(repaired, /team-server\.js/);
+      assert.match(repaired, /# oh-my-codex \(OMX\) Configuration/);
+      assert.match(repaired, /# End oh-my-codex/);
+      assert.match(repaired, /^\[user\.after\]$/m);
+      assert.doesNotThrow(() => TOML.parse(repaired));
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("repairConfigIfNeeded preserves CRLF line endings", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-idem-"));
+    try {
+      const configPath = join(wd, "config.toml");
+      const crlfConfig = [
+        '[mcp_servers.filesystem]',
+        'command = "npx"',
+        'args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]',
+        "",
+      ].join("\r\n");
+      await writeFile(configPath, crlfConfig);
+
+      assert.equal(await repairConfigIfNeeded(configPath, wd), true);
+      const repaired = await readFile(configPath, "utf-8");
+
+      assert.match(repaired, /^startup_timeout_sec = 15$/m);
+      // The repair must not convert the config to LF (issue #3447).
+      assert.equal(count(repaired, /\r\n/g), 4);
+      assert.equal(count(repaired, /(?<!\r)\n/g), 0);
+      assert.doesNotThrow(() => TOML.parse(repaired));
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -32,7 +32,6 @@ import {
   buildManagedCodexHookTrustState,
   escapeTomlBasicString,
   ManagedCodexHooksPlanError,
-  scanManagedCodexHookTrustStateFromContent,
   type CodexHooksJsonTrustStateEntry,
   type ManagedCodexHookTrustState,
   type ManagedCodexHookOptions,
@@ -293,6 +292,38 @@ export async function cleanCodexModelAvailabilityNuxIfNeeded(
 
 export function hasLegacyOmxTeamRunTable(config: string): boolean {
   return LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(config);
+}
+function stripLegacyOmxTeamRunTable(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const result: string[] = [];
+  for (let i = 0; i < lines.length; ) {
+    const line = lines[i];
+    if (!LEGACY_OMX_TEAM_RUN_TABLE_PATTERN.test(line)) {
+      result.push(line);
+      i += 1;
+      continue;
+    }
+    // Retired table found: drop any immediately preceding OMX comment or
+    // blank lines (mirrors stripOrphanedOmxSections), then the table header
+    // and its body up to the next [table] header.
+    while (result.length > 0) {
+      const last = result[result.length - 1];
+      if (last.trim() === "" || /^#\s*(OMX|oh-my-codex)/i.test(last)) {
+        result.pop();
+      } else {
+        break;
+      }
+    }
+    i += 1;
+    // Consume the table body up to the next [table] header, but never past
+    // the OMX block footer — the end marker is a comment, not a header, and
+    // must survive a last-table removal (issue #3447).
+    while (i < lines.length && !/^\s*\[/.test(lines[i])) {
+      if (lines[i].trim() === OMX_CONFIG_END_MARKER) break;
+      i += 1;
+    }
+  }
+  return result.join("\n");
 }
 
 function unwrapTomlString(value: string | undefined): string | undefined {
@@ -3448,6 +3479,49 @@ function upsertTuiStatusLine(
     hadExistingTui: true,
   };
 }
+/**
+ * Collapse duplicate `[tui]` tables to a single verbatim first table.
+ *
+ * The launch repair uses this instead of `upsertTuiStatusLine` so the first
+ * table — including any surrounding OMX marker comments that precede the next
+ * [table] header — is preserved byte-for-byte and no status line is injected.
+ */
+function dedupeTuiTables(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const sections: Array<{ start: number; end: number }> = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!/^\s*\[tui\]\s*$/.test(lines[i])) continue;
+    let end = lines.length;
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (/^\s*\[\[?[^\]]+\]?\]\s*$/.test(lines[j])) {
+        end = j;
+        break;
+      }
+      // The OMX block footer is comments, not a [table] header — stop before
+      // it so dropping a trailing duplicate never swallows the end marker.
+      if (lines[j].trim() === OMX_CONFIG_END_MARKER) {
+        end = j;
+        break;
+      }
+    }
+    sections.push({ start: i, end });
+    i = end - 1;
+  }
+  if (sections.length <= 1) return config;
+  const droppedStarts = new Set(
+    sections.slice(1).map((section) => section.start),
+  );
+  const rebuilt: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const dropped = sections.find((section) => section.start === i);
+    if (dropped && droppedStarts.has(i)) {
+      i = dropped.end - 1;
+      continue;
+    }
+    rebuilt.push(lines[i]);
+  }
+  return rebuilt.join("\n").replace(/\n{3,}/g, "\n\n");
+}
 
 // ---------------------------------------------------------------------------
 // OMX [table] sections block (appended at end of file)
@@ -4057,64 +4131,23 @@ export function buildMergedConfig(
  * OMX builds no longer ship the team MCP entrypoint, so we repair both before
  * the CLI is spawned.
  *
+ * The repair is surgical: only the detected targets are changed — missing
+ * launcher-backed MCP `startup_timeout_sec` entries are added, retired
+ * `[mcp_servers.omx_team_run]` tables are dropped, and duplicate `[tui]`
+ * tables are deduplicated. Everything else is preserved byte-for-byte,
+ * including user-owned `notify` and `model_reasoning_effort` values, managed
+ * hook trust state, and any existing OMX managed block; a config that never
+ * had an OMX block does not get one injected (see issue #3447).
+ *
+ * `pkgRoot` and `options` are retained for API compatibility; the surgical
+ * repair does not rebuild the managed block, so it never needs them.
+ *
  * Returns `true` if a repair was performed.
  */
-function managedHookTrustProofRequiredForRepair(config: string): boolean {
-  const inventory = collectManagedHookTrustStateSourceRepresentations(config);
-  return managedMarkerTrustStateConflicts(
-    inventory.source,
-    inventory.representations,
-    inventory.managedMarkerRanges,
-    inventory.markerContainedHooksStateSpans,
-    inventory.invalidMarkerContainedHooksStateSpans,
-    inventory.parsedStatementSpans,
-    inventory.parsedAssignmentSpans,
-    managedHookTrustStateExpectations(),
-  ).size > 0;
-}
-
-async function launchRepairOptionsWithManagedHookTrustProof(
-  configPath: string,
-  config: string,
-  options: MergeOptions,
-): Promise<MergeOptions> {
-  if (!managedHookTrustProofRequiredForRepair(config)) {
-
-    return options;
-  }
-
-  const hooksPath = options.codexHooksFile ?? resolve(configPath, "..", "hooks.json");
-  let hooksContent: string;
-  try {
-    hooksContent = await readFile(hooksPath, "utf-8");
-  } catch (error) {
-    throw new ManagedCodexHooksPlanError(
-      "invalid_document",
-      `Cannot safely repair config.toml because the current hooks artifact at ${hooksPath} could not be read.`,
-      { cause: String(error), hooksPath },
-    );
-  }
-
-  const trustScan = scanManagedCodexHookTrustStateFromContent(
-    hooksContent,
-    hooksPath,
-    managedCodexHookOptionsFromMergeOptions(options),
-  );
-  if (!trustScan.ok) throw trustScan.error;
-
-  return {
-    ...options,
-    codexHooksFile: hooksPath,
-    codexHooksContent: hooksContent,
-    managedHookTrustState: trustScan.trustState,
-    priorManagedHookTrustState: trustScan.trustState,
-  };
-}
-
 export async function repairConfigIfNeeded(
   configPath: string,
-  pkgRoot: string,
-  options: MergeOptions = {},
+  _pkgRoot: string,
+  _options: MergeOptions = {},
 ): Promise<boolean> {
   if (!existsSync(configPath)) return false;
 
@@ -4126,17 +4159,31 @@ export async function repairConfigIfNeeded(
   if (tuiCount <= 1 && !hasLegacyTeamRunTable && !hasLauncherTimeoutGap)
     return false;
 
-  // Managed config compatibility issue detected — derive proof from the current
-  // hooks artifact before any marker stripping can replace managed trust state.
-  const repairOptions = await launchRepairOptionsWithManagedHookTrustProof(
-    configPath,
-    content,
-    options,
-  );
-  const repaired = buildMergedConfig(content, pkgRoot, repairOptions);
+  let repaired = content;
+  if (hasLauncherTimeoutGap) {
+    repaired = addDefaultLauncherMcpStartupTimeouts(repaired);
+  }
+  if (hasLegacyTeamRunTable) {
+    repaired = stripLegacyOmxTeamRunTable(repaired);
+  }
+  if (tuiCount > 1) {
+    repaired = dedupeTuiTables(repaired);
+  }
   if (repaired === content) return false;
+  // The surgical helpers normalize to LF internally; write back with the
+  // original file's dominant line ending so a CRLF config stays CRLF.
+  const newline = dominantNewline(content);
+  if (newline === "\r\n") {
+    repaired = repaired.replace(/\r?\n/g, "\r\n");
+  }
   await writeFile(configPath, repaired);
   return true;
+}
+
+function dominantNewline(text: string): "\r\n" | "\n" {
+  const crlf = (text.match(/\r\n/g) ?? []).length;
+  const lf = (text.match(/\n/g) ?? []).length - crlf;
+  return crlf >= lf ? "\r\n" : "\n";
 }
 
 export async function mergeConfig(


### PR DESCRIPTION
## Summary

Fix the launch-time config repair so it can no longer clobber a user-owned config block, and keep project-scoped setups project-local for launches from anywhere inside their tree.

### Repair is now surgical (`repairConfigIfNeeded`)

The repair used to rebuild the entire managed config block via `buildMergedConfig`, which replaced a user-owned `notify` with the OMX hook, hardcoded `model_reasoning_effort = "medium"` over the user value, and injected `developer_instructions`, `USE_OMX_EXPLORE_CMD`, and the managed `[tui]` section into configs that never had an OMX block (issue #3447).

Now it applies only the detected targets:
- adds missing `startup_timeout_sec` to launcher-backed (npx/uvx/npm exec) MCP servers,
- drops the retired `[mcp_servers.omx_team_run]` table,
- dedupes duplicate `[tui]` tables (verbatim keep-first, no status-line injection).

Everything else — user `notify`, `model_reasoning_effort`, managed hook trust state, and any existing OMX block — is preserved byte-for-byte. A config that never had an OMX block does not get one injected.

### Project scope resolution walks upward

`resolveProjectLocalCodexHomeForLaunch` read only `<cwd>/.omx/setup-scope.json`, so a project-scoped setup leaked to `~/.codex/config.toml` whenever a launch-family command ran from a subdirectory of the project. It now walks upward to the nearest `.omx/setup-scope.json` and resolves the project-local Codex home at that setup root. Explicit `CODEX_HOME` still wins, and user-scope/no-scope fallback behavior is unchanged.

## Regressions added

- `repairConfigIfNeeded` preserves custom `notify` and `model_reasoning_effort` and repairs only timeout targets (no OMX block injection, idempotent second run).
- Legacy `omx_team_run` removal no longer injects the OMX block.
- Conflicting managed hook trust bytes are preserved verbatim through repair; a missing/unreadable hooks artifact cannot block the surgical repair.
- Scope tests: upward walk from a nested cwd, no redirect when launching outside any setup root, user-scope fallback unchanged.

## Verification

- `npm run build` — passed
- `npm run lint` — passed (790 files)
- `npm run check:no-unused` — passed
- `git diff --check` — clean
- Targeted suites: generator-idempotent (97), cli index (332), setup-preferences (4), setup-scope (14), generator-notify (24) — all pass
- Full `npm run test:node` (407 files): 406 pass; the single failure (`setup-hooks-trust-e2e`) is a pre-existing environment gate (installed `codex-cli 0.145.0` vs the test's pinned 0.142.5 boundary) that fails identically on the clean `origin/dev` baseline.

Closes #3447

Signed-off-by: GJC <gjc@openai.com>
