### PR TITLE
fix(setup): tolerate Windows directory-fsync EPERM and mode-synthesis read-back (#3442)

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -2839,7 +2839,7 @@ command = "node"
 							throw Object.assign(new Error("injected Windows EPERM"), { code: "EPERM" });
 						},
 					}, "win32"),
-					syncDirectory: async () => undefined,
+					syncDirectory: async () => "synced",
 				});
 				process.stderr.write = ((chunk: string | Uint8Array) => {
 					stderr.push(String(chunk));
@@ -2865,13 +2865,47 @@ command = "node"
 		}
 	});
 
+	it("recovers a claim journal after Windows directory-fsync EPERM with one degraded-durability warning", async () => {
+		const originalStderrWrite = process.stderr.write;
+		const stderr: string[] = [];
+		try {
+			await withRecoverableDoctorClaimJournal(async (codexHomeDir) => {
+				const restoreDurability = setDoctorClaimJournalDurabilityForTest({
+					platform: "win32",
+					syncRegularFile: async () => "synced",
+					syncDirectory: async () => "unsupported-windows-eperm",
+				});
+				process.stderr.write = ((chunk: string | Uint8Array) => {
+					stderr.push(String(chunk));
+					return true;
+				}) as typeof process.stderr.write;
+				try {
+					await doctor();
+					assert.equal(await readFile(join(codexHomeDir, "hooks.json"), "utf-8"), "{\"hooks\":{}}\n");
+					await assert.rejects(
+						readFile(join(codexHomeDir, ".omx", "native-hook-claim-journal.json")),
+						/ENOENT/,
+					);
+				} finally {
+					restoreDurability();
+				}
+			});
+			assert.equal(stderr.length, 1);
+			assert.match(stderr[0]!, /Windows EPERM directory fsync/);
+			assert.match(stderr[0]!, /native-hook claim-journal recovery/);
+			assert.match(stderr[0]!, /degraded durability/);
+		} finally {
+			process.stderr.write = originalStderrWrite;
+		}
+	});
+
 	it("keeps non-EPERM regular-file and directory claim-journal sync failures fatal", async () => {
 		const regularError = Object.assign(new Error("injected regular-file EIO"), { code: "EIO" });
 		await withRecoverableDoctorClaimJournal(async () => {
 			const restoreDurability = setDoctorClaimJournalDurabilityForTest({
 				platform: "win32",
 				syncRegularFile: async () => { throw regularError; },
-				syncDirectory: async () => undefined,
+				syncDirectory: async () => "synced",
 			});
 			try {
 				await assert.rejects(doctor(), (error) => error === regularError);
@@ -2883,7 +2917,7 @@ command = "node"
 		const directoryError = Object.assign(new Error("injected directory EPERM"), { code: "EPERM" });
 		await withRecoverableDoctorClaimJournal(async () => {
 			const restoreDurability = setDoctorClaimJournalDurabilityForTest({
-				platform: "win32",
+				platform: "linux",
 				syncRegularFile: async () => "synced",
 				syncDirectory: async () => { throw directoryError; },
 			});

--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -170,7 +170,7 @@ test("claim journal treats only injected Windows regular-file EPERM as degraded"
 				order.push("regular");
 				return "unsupported-windows-eperm";
 			},
-			syncDirectory: async () => { order.push("directory"); },
+			syncDirectory: async () => { order.push("directory"); return "synced"; },
 		});
 		assert.equal(outcome, "unsupported-windows-eperm");
 		assert.deepEqual(order, ["directory", "regular", "directory"]);
@@ -193,18 +193,48 @@ test("claim journal keeps POSIX regular-file and directory EPERM fatal", async (
 			persistNativeHookClaimJournalWithDurability(root, entry, {
 				platform: "linux",
 				syncRegularFile: async () => { throw regularError; },
-				syncDirectory: async () => undefined,
+				syncDirectory: async () => "synced",
 			}),
 			(error) => error === regularError,
 		);
 		const directoryError = Object.assign(new Error("EPERM"), { code: "EPERM" });
 		await assert.rejects(
 			persistNativeHookClaimJournalWithDurability(root, entry, {
-				platform: "win32",
+				platform: "linux",
 				syncRegularFile: async () => "synced",
 				syncDirectory: async () => { throw directoryError; },
 			}),
 			(error) => error === directoryError,
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("claim journal continues when Windows directory sync reports unsupported EPERM", async () => {
+	const root = await mkdtemp(join(tmpdir(), "omx-claim-directory-durability-"));
+	try {
+		const order: string[] = [];
+		const outcome = await persistNativeHookClaimJournalWithDurability(root, {
+			canonicalPath: join(root, "hooks.json"),
+			claimPath: join(root, ".hooks.json.claim"),
+			before: Buffer.from("before\n"),
+			after: null,
+		}, {
+			platform: "win32",
+			syncRegularFile: async () => {
+				order.push("regular");
+				return "synced";
+			},
+			syncDirectory: async () => {
+				order.push("directory");
+				return "unsupported-windows-eperm";
+			},
+		});
+		assert.equal(outcome, "synced");
+		assert.deepEqual(order, ["directory", "regular", "directory"]);
+		await assert.doesNotReject(
+			readFile(join(root, ".omx", "native-hook-claim-journal.json")),
 		);
 	} finally {
 		await rm(root, { recursive: true, force: true });
@@ -224,7 +254,7 @@ test("claim journal recovery returns independent recovered and no-op outcomes", 
 		const recovered = await recoverNativeHookClaimJournalWithDurability(root, {
 			platform: "win32",
 			syncRegularFile: async () => "unsupported-windows-eperm",
-			syncDirectory: async () => undefined,
+			syncDirectory: async () => "synced",
 		});
 		assert.deepEqual(recovered, { recovered: true, outcome: "unsupported-windows-eperm" });
 		assert.deepEqual(

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, lstatSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import {
 	chmod,
 	cp,
@@ -19,6 +19,7 @@ import { basename, dirname, join } from "node:path";
 import { parse as parseToml } from "@iarna/toml";
 import {
 	decideWindowsNativeHookShimReference,
+	setNativeHookClaimJournalDurabilityForTest,
 	setNativeHookTransactionFailureInjectorForTest,
 	setSetupLatePhaseFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
@@ -28,6 +29,7 @@ import {
 } from "../setup.js";
 import { resolveSetupRefreshArgs } from "../update.js";
 import { uninstall } from "../uninstall.js";
+import { doctor } from "../doctor.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
 import {
 	OMX_DEVELOPER_INSTRUCTIONS,
@@ -3229,6 +3231,165 @@ describe("omx setup install mode behavior", () => {
 		} finally {
 			process.stderr.write = originalStderrWrite;
 			resetSync();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("completes Windows native-hook transactions with one directory fsync EPERM warning", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-directory-fsync-eperm-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const resetRegularSync = setNativeHookTransactionRegularFileSyncForTest(async () => undefined);
+		let directorySyncCalls = 0;
+		const stderr: string[] = [];
+		const originalStderrWrite = process.stderr.write;
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderr.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+		const resetDurability = setNativeHookClaimJournalDurabilityForTest({
+			platform: "win32",
+			syncRegularFile: async () => "synced",
+			syncDirectory: async () => {
+				directorySyncCalls += 1;
+				return "unsupported-windows-eperm";
+			},
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await writeFile(
+						join(codexHomeDir, "config.toml"),
+						'notify = ["node", "/tmp/user-notify.js"]\n',
+					);
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					assert.ok(directorySyncCalls > 0);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
+					assert.equal(
+						existsSync(buildManagedCodexNativeHookWindowsShimPath(codexHomeDir)),
+						true,
+					);
+					assert.equal(existsSync(join(codexHomeDir, "config.toml")), true);
+				});
+				assert.deepEqual(
+					stderr.filter((line) => line.includes("native-hook setup")),
+					["[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n"],
+				);
+			});
+		} finally {
+			process.stderr.write = originalStderrWrite;
+			resetDurability();
+			resetRegularSync();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	for (const fixture of [
+		{ platform: "win32" as const, code: "EACCES" },
+		{ platform: "linux" as const, code: "EPERM" },
+	]) {
+		it(`fails native-hook setup for ${fixture.platform} directory fsync ${fixture.code}`, async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-setup-directory-fsync-fatal-"));
+			const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+			const resetDurability = setNativeHookClaimJournalDurabilityForTest({
+				platform: fixture.platform,
+				syncRegularFile: async () => "synced",
+				syncDirectory: async () => {
+					throw Object.assign(new Error(`${fixture.code}: fsync`), { code: fixture.code });
+				},
+			});
+			try {
+				await withIsolatedUserHome(wd, async () => {
+					await withTempCwd(wd, async () => {
+						await assert.rejects(
+							setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+							new RegExp(fixture.code),
+						);
+					});
+				});
+			} finally {
+				resetDurability();
+				resetPlatform();
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+	}
+
+	it("accepts Windows synthetic mode drift while retaining file identity", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-mode-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const tempPath = (path: string, purpose: "write" | "delete") =>
+			join(dirname(path), `.${basename(path)}.mode-${purpose}.tmp`);
+		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
+		let checkedIdentity = 0;
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
+			if (stage !== "before_rename") return;
+			const temporaryPath = tempPath(artifact.path, "write");
+			const before = lstatSync(temporaryPath);
+			chmodSync(temporaryPath, 0o666);
+			const after = lstatSync(temporaryPath);
+			assert.equal(after.dev, before.dev);
+			assert.equal(after.ino, before.ino);
+			checkedIdentity += 1;
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(configPath, 'notify = ["node", "/tmp/user-notify.js"]\n');
+					chmodSync(configPath, 0o600);
+					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+				});
+			});
+			assert.ok(checkedIdentity >= 4);
+		} finally {
+			resetFailureInjector();
+			resetTemporaryPath();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects Windows writable-bit drift with unchanged bytes and file identity", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-readonly-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const tempPath = (path: string, purpose: "write" | "delete") =>
+			join(dirname(path), `.${basename(path)}.readonly-${purpose}.tmp`);
+		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
+		let checkedIdentity = 0;
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
+			if (stage !== "before_rename") return;
+			const temporaryPath = tempPath(artifact.path, "write");
+			const before = lstatSync(temporaryPath);
+			const beforeBytes = readFileSync(temporaryPath);
+			chmodSync(temporaryPath, 0o444);
+			const after = lstatSync(temporaryPath);
+			assert.deepEqual(readFileSync(temporaryPath), beforeBytes);
+			assert.equal(after.dev, before.dev);
+			assert.equal(after.ino, before.ino);
+			assert.equal(after.nlink, before.nlink);
+			assert.notEqual(after.mode & 0o200, before.mode & 0o200);
+			checkedIdentity += 1;
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const configPath = join(codexHomeDir, "config.toml");
+					const original = 'notify = ["node", "/tmp/user-notify.js"]\n';
+					await writeFile(configPath, original);
+					chmodSync(configPath, 0o600);
+					await assert.rejects(
+						setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+						/read-back changed/,
+					);
+					assert.equal(await readFile(configPath, "utf-8"), original);
+				});
+			});
+			assert.equal(checkedIdentity, 1);
+		} finally {
+			resetFailureInjector();
+			resetTemporaryPath();
 			resetPlatform();
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/uninstall.test.ts
+++ b/src/cli/__tests__/uninstall.test.ts
@@ -12,7 +12,7 @@ import {
   buildManagedCodexNativeHookWindowsShimContent,
   buildManagedCodexNativeHookWindowsShimPath,
 } from '../../config/codex-hooks.js';
-import { uninstall } from '../uninstall.js';
+import { setUninstallClaimJournalDurabilityForTest, uninstall } from '../uninstall.js';
 import TOML from '@iarna/toml';
 
 const tmpdir = (): string => realpathSync(osTmpdir());
@@ -3165,6 +3165,57 @@ describe('omx uninstall', () => {
         assert.match(stderr[0]!, /native-hook uninstall.*degraded durability/);
       });
     } finally {
+      process.stderr.write = originalStderrWrite;
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('completes uninstall when only Windows directory fsync is unsupported', async () => {
+    const wd = await mkdtemp(join(shortTmpdir(), 'omx-uninstall-directory-durability-'));
+    const originalStderrWrite = process.stderr.write;
+    const stderr: string[] = [];
+    const resetDurability = setUninstallClaimJournalDurabilityForTest({
+      platform: 'win32',
+      syncRegularFile: async () => 'synced',
+      syncDirectory: async () => 'unsupported-windows-eperm',
+    });
+    try {
+      await withCwd(wd, async () => {
+        const codexDir = join(wd, '.codex');
+        const configPath = join(codexDir, 'config.toml');
+        const hooksPath = join(codexDir, 'hooks.json');
+        const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexDir);
+        await mkdir(codexDir, { recursive: true });
+        await mkdir(dirname(shimPath), { recursive: true });
+        await writeFile(configPath, buildOmxConfig());
+        await writeFile(
+          hooksPath,
+          `${JSON.stringify(buildManagedCodexHooksConfig(packageRoot(), {
+            platform: 'win32',
+            codexHomeDir: codexDir,
+          }), null, 2)}\n`,
+        );
+        await writeFile(shimPath, buildManagedCodexNativeHookWindowsShimContent(packageRoot()));
+        process.stderr.write = ((chunk: string | Uint8Array) => {
+          stderr.push(String(chunk));
+          return true;
+        }) as typeof process.stderr.write;
+
+        await uninstall({
+          scope: 'project',
+          transactionPlatform: 'win32',
+          regularFileSyncForTest: async () => 'synced',
+        });
+
+        assert.equal(existsSync(hooksPath), false);
+        assert.equal(existsSync(shimPath), false);
+        assert.deepEqual(
+          stderr.filter((line) => line.includes('native-hook uninstall')),
+          ['[omx] warning: Windows EPERM directory fsync unsupported in native-hook uninstall; operation succeeded with degraded durability.\n'],
+        );
+      });
+    } finally {
+      resetDurability();
       process.stderr.write = originalStderrWrite;
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -5,6 +5,7 @@
 import {
 	createNativeHookClaimJournalDurability,
 	recoverNativeHookClaimJournal,
+	wrapNativeHookClaimJournalDurability,
 	type NativeHookClaimJournalDurability,
 } from "./native-hook-claim-journal.js";
 import {
@@ -291,7 +292,10 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
 	const recovery = await recoverNativeHookClaimJournal(
 		paths.codexHomeDir,
-		doctorClaimJournalDurabilityOverride ?? createNativeHookClaimJournalDurability(),
+		wrapNativeHookClaimJournalDurability(
+			doctorClaimJournalDurabilityOverride ?? createNativeHookClaimJournalDurability(process.platform),
+			recoveryTracker,
+		),
 	);
 	recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
 	emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -3,14 +3,18 @@ import { constants } from "fs";
 import { copyFile, link, open, lstat, mkdir, readFile, rm, type FileHandle } from "fs/promises";
 import { dirname, isAbsolute, join, relative, sep } from "path";
 import {
+	recordDirectorySyncOutcome,
+	syncDirectory,
 	syncRegularFile,
+	type DirectorySyncOutcome,
+	type RegularFileDurabilityTracker,
 	type RegularFileSyncOutcome,
 } from "../utils/file-durability.js";
 
 export interface NativeHookClaimJournalDurability {
 	platform: NodeJS.Platform;
 	syncRegularFile(handle: Pick<FileHandle, "sync">): Promise<RegularFileSyncOutcome>;
-	syncDirectory(path: string): Promise<void>;
+	syncDirectory(path: string): Promise<DirectorySyncOutcome>;
 }
 
 interface ClaimJournalEntry {
@@ -48,31 +52,52 @@ function processIsAlive(pid: number): boolean {
 	}
 }
 
-async function fsyncDirectory(path: string): Promise<void> {
+async function fsyncDirectory(
+	path: string,
+	platform: NodeJS.Platform,
+): Promise<DirectorySyncOutcome> {
 	const handle = await open(path, "r");
 	try {
-		await handle.sync();
+		return await syncDirectory(handle, platform);
 	} finally {
 		await handle.close();
 	}
 }
 
+export function wrapNativeHookClaimJournalDurability(
+	durability: NativeHookClaimJournalDurability,
+	tracker?: RegularFileDurabilityTracker,
+): NativeHookClaimJournalDurability {
+	if (!tracker) return durability;
+	return {
+		platform: durability.platform,
+		syncRegularFile: durability.syncRegularFile,
+		async syncDirectory(path: string) {
+			const outcome = await durability.syncDirectory(path);
+			recordDirectorySyncOutcome(tracker, outcome);
+			return outcome;
+		},
+	};
+}
+
 export function createNativeHookClaimJournalDurability(
 	platform: NodeJS.Platform = process.platform,
+	tracker?: RegularFileDurabilityTracker,
 ): NativeHookClaimJournalDurability {
-	return {
+	return wrapNativeHookClaimJournalDurability({
 		platform,
 		syncRegularFile: (handle) => syncRegularFile(handle, platform),
-		syncDirectory: fsyncDirectory,
-	};
+		syncDirectory: (path) => fsyncDirectory(path, platform),
+	}, tracker);
 }
 
 export async function syncNativeHookClaimParent(
 	path: string,
 	durability: NativeHookClaimJournalDurability,
-): Promise<void> {
-	await durability.syncDirectory(dirname(path));
+): Promise<DirectorySyncOutcome> {
+	return durability.syncDirectory(dirname(path));
 }
+
 
 export async function restoreNativeHookClaimNoClobber(
 	claimPath: string,

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -33,6 +33,7 @@ import {
 	recoverNativeHookClaimJournal,
 	syncNativeHookClaimParent as syncNativeHookClaimParentWithDurability,
 	restoreNativeHookClaimNoClobber as restoreNativeHookClaimNoClobberWithDurability,
+	wrapNativeHookClaimJournalDurability,
 	type NativeHookClaimJournalDurability,
 } from "./native-hook-claim-journal.js";
 import {
@@ -50,6 +51,7 @@ import {
 	emitDegradedDurabilityWarning,
 	recordRegularFileSyncOutcome,
 	syncRegularFile,
+	type DirectorySyncOutcome,
 	type RegularFileDurabilityTracker,
 	type RegularFileSyncOutcome,
 } from "../utils/file-durability.js";
@@ -632,37 +634,50 @@ function nativeHookPlatform(): NodeJS.Platform {
 	return nativeHookTransactionPlatformOverride ?? process.platform;
 }
 
-
-function nativeHookClaimJournalDurability() {
-	return nativeHookClaimJournalDurabilityOverride
-		?? createNativeHookClaimJournalDurability(nativeHookPlatform());
+function nativeHookClaimJournalDurability(
+	tracker?: RegularFileDurabilityTracker,
+): NativeHookClaimJournalDurability {
+	return wrapNativeHookClaimJournalDurability(
+		nativeHookClaimJournalDurabilityOverride
+			?? createNativeHookClaimJournalDurability(nativeHookPlatform()),
+		tracker,
+	);
 }
 
-async function clearNativeHookClaimJournal(root: string): Promise<void> {
-	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability());
+async function clearNativeHookClaimJournal(
+	root: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	return clearNativeHookClaimJournalWithDurability(root, nativeHookClaimJournalDurability(tracker));
 }
 
 async function persistNativeHookClaimJournal(
 	root: string,
 	entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
-	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability());
+	return persistNativeHookClaimJournalWithDurability(root, entry, nativeHookClaimJournalDurability(tracker));
 }
 
 async function restoreNativeHookClaimNoClobber(
 	claimPath: string,
 	destinationPath: string,
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
 	return restoreNativeHookClaimNoClobberWithDurability(
 		claimPath,
 		destinationPath,
-		nativeHookClaimJournalDurability(),
+		nativeHookClaimJournalDurability(tracker),
 	);
 }
 
-async function syncNativeHookClaimParent(path: string): Promise<void> {
-	return syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability());
+async function syncNativeHookClaimParent(
+	path: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<DirectorySyncOutcome> {
+	return syncNativeHookClaimParentWithDurability(path, nativeHookClaimJournalDurability(tracker));
 }
+
 async function syncNativeHookRegularFile(
 	handle: Awaited<ReturnType<typeof open>>,
 ): Promise<RegularFileSyncOutcome> {
@@ -690,6 +705,26 @@ function nativeHookTransactionTopologyEqual(
 	return left.kind === "absent" || right.kind === "absent"
 		? left.kind === right.kind
 		: left.mode === right.mode;
+}
+
+function nativeHookTransactionTopologyMatchesAcrossOpen(
+	left: NativeHookTransactionTopology,
+	right: NativeHookTransactionTopology,
+): boolean {
+	if (
+		nativeHookPlatform() === "win32" &&
+		left.kind === "regular_file" &&
+		right.kind === "regular_file" &&
+		((left.mode === 0o600 && right.mode === 0o666) ||
+			(left.mode === 0o666 && right.mode === 0o600))
+	) {
+		// Windows synthesizes the requested new-file mode 0o600 as 0o666 from
+		// the read-only attribute. Keep this exception exact so writable/read-only
+		// drift remains an ownership failure; bytes, dev, ino, and nlink are
+		// still compared in the full snapshot.
+		return true;
+	}
+	return nativeHookTransactionTopologyEqual(left, right);
 }
 
 function isMissingPathError(error: unknown): boolean {
@@ -906,7 +941,7 @@ function nativeHookTransactionSnapshotsEqual(
 ): boolean {
 	return (
 		hookTransactionBytesEqual(left.bytes, right.bytes) &&
-		nativeHookTransactionTopologyEqual(left.topology, right.topology) &&
+		nativeHookTransactionTopologyMatchesAcrossOpen(left.topology, right.topology) &&
 		left.device === right.device &&
 		left.inode === right.inode &&
 		left.links === right.links
@@ -919,7 +954,7 @@ function nativeHookTransactionSnapshotMatchesExpected(
 ): boolean {
 	return (
 		hookTransactionBytesEqual(snapshot.bytes, expected.bytes) &&
-		nativeHookTransactionTopologyEqual(snapshot.topology, expected.topology)
+		nativeHookTransactionTopologyMatchesAcrossOpen(snapshot.topology, expected.topology)
 	);
 }
 
@@ -1170,7 +1205,7 @@ async function restoreNativeHookClaim(
 ): Promise<void> {
 	recordRegularFileSyncOutcome(
 		tracker,
-		await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+		await restoreNativeHookClaimNoClobber(claimPath, destinationPath, tracker),
 	);
 }
 
@@ -1282,7 +1317,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 						claimPath,
 						before: expectedCurrent.bytes,
 						after: content,
-					}),
+					}, tracker),
 				);
 				await refreshNativeHookTransactionAncestorPrecondition(
 					ancestorPrecondition,
@@ -1292,7 +1327,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 			}
 			await rename(artifact.path, claimPath);
 			claimCreated = true;
-			if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+			if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 			await assertNativeHookTransactionArtifactSnapshot(
 				claimPath,
 				`${artifact.label} replacement claim`,
@@ -1310,7 +1345,7 @@ async function atomicWriteNativeHookTransactionArtifact(
 		} finally {
 			await installedHandle.close();
 		}
-		await syncNativeHookClaimParent(artifact.path);
+		await syncNativeHookClaimParent(artifact.path, tracker);
 		const installedSnapshot = await assertNativeHookTransactionArtifactState(
 			artifact.path,
 			artifact.label,
@@ -1319,11 +1354,11 @@ async function atomicWriteNativeHookTransactionArtifact(
 		);
 		if (claimCreated && claimPath) {
 			await rm(claimPath);
-			await syncNativeHookClaimParent(claimPath);
+			await syncNativeHookClaimParent(claimPath, tracker);
 			claimCreated = false;
 		}
 		if (journaledClaim) {
-			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 			journaledClaim = false;
 		}
 		await rm(temporaryPath);
@@ -1344,10 +1379,10 @@ async function atomicWriteNativeHookTransactionArtifact(
 		if (claimCreated && claimPath) {
 			try {
 				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
-				await syncNativeHookClaimParent(artifact.path);
+				await syncNativeHookClaimParent(artifact.path, tracker);
 				claimCreated = false;
 				if (journaledClaim) {
-					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 					journaledClaim = false;
 				}
 			} catch (recoveryError) {
@@ -1600,11 +1635,11 @@ async function applyNativeHookTransactionArtifact(
 					claimPath,
 					before: artifact.before.bytes!,
 					after: null,
-				}),
+				}, tracker),
 			);
 		}
 		await rename(artifact.path, claimPath);
-		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 		const entry: AppliedNativeHookTransactionArtifact = {
 			artifact,
 			appliedSnapshot: { bytes: null, topology: { kind: "absent" } },
@@ -1631,9 +1666,9 @@ async function applyNativeHookTransactionArtifact(
 					`${artifact.label} removal claim`,
 				);
 				await restoreNativeHookClaim(claimPath, artifact.path, tracker);
-				if (journaledClaim) await syncNativeHookClaimParent(artifact.path);
+				if (journaledClaim) await syncNativeHookClaimParent(artifact.path, tracker);
 				if (journaledClaim) {
-					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+					await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 				}
 				await assertNativeHookTransactionArtifactSnapshot(
 					artifact.path,
@@ -1652,9 +1687,9 @@ async function applyNativeHookTransactionArtifact(
 
 		}
 		await rm(claimPath);
-		if (journaledClaim) await syncNativeHookClaimParent(claimPath);
+		if (journaledClaim) await syncNativeHookClaimParent(claimPath, tracker);
 		if (journaledClaim) {
-			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot);
+			await clearNativeHookClaimJournal(ancestorPrecondition.controlledRoot, tracker);
 		}
 		originalRemoved = true;
 		injectNativeHookTransactionFailure("after_remove", artifact);
@@ -3931,7 +3966,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
 		const recovery = await recoverNativeHookClaimJournal(
 			scopeDirs.codexHomeDir,
-			nativeHookClaimJournalDurability(),
+			nativeHookClaimJournalDurability(recoveryTracker),
 		);
 		recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
 		if (recovery.recovered) {

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -14,6 +14,7 @@ import {
   recoverNativeHookClaimJournal,
   syncNativeHookClaimParent as syncNativeHookClaimParentWithDurability,
   restoreNativeHookClaimNoClobber as restoreNativeHookClaimNoClobberWithDurability,
+  wrapNativeHookClaimJournalDurability,
   type NativeHookClaimJournalDurability,
 } from "./native-hook-claim-journal.js";
 import {
@@ -60,6 +61,7 @@ import {
   emitDegradedDurabilityWarning,
   recordRegularFileSyncOutcome,
   syncRegularFile,
+  type DirectorySyncOutcome,
   type RegularFileSyncOutcome,
   type RegularFileDurabilityTracker,
 } from "../utils/file-durability.js";
@@ -898,35 +900,49 @@ function transactionTemporaryPath(
   );
 }
 
-function uninstallClaimJournalDurability() {
-  return uninstallClaimJournalDurabilityOverride
-    ?? createNativeHookClaimJournalDurability();
+function uninstallClaimJournalDurability(
+  tracker?: RegularFileDurabilityTracker,
+  platform: NodeJS.Platform = process.platform,
+): NativeHookClaimJournalDurability {
+  return wrapNativeHookClaimJournalDurability(
+    uninstallClaimJournalDurabilityOverride
+      ?? createNativeHookClaimJournalDurability(platform),
+    tracker,
+  );
 }
 
-async function clearNativeHookClaimJournal(root: string): Promise<void> {
-  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability());
+async function clearNativeHookClaimJournal(
+  root: string,
+  tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+  return clearNativeHookClaimJournalWithDurability(root, uninstallClaimJournalDurability(tracker));
 }
 
 async function persistNativeHookClaimJournal(
   root: string,
   entry: Parameters<typeof persistNativeHookClaimJournalWithDurability>[1],
+  tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
-  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability());
+  return persistNativeHookClaimJournalWithDurability(root, entry, uninstallClaimJournalDurability(tracker));
 }
 
 async function restoreNativeHookClaimNoClobber(
   claimPath: string,
   destinationPath: string,
+  tracker?: RegularFileDurabilityTracker,
 ): Promise<RegularFileSyncOutcome> {
   return restoreNativeHookClaimNoClobberWithDurability(
     claimPath,
     destinationPath,
-    uninstallClaimJournalDurability(),
+    uninstallClaimJournalDurability(tracker),
   );
 }
 
-async function syncNativeHookClaimParent(path: string): Promise<void> {
-  return syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability());
+async function syncNativeHookClaimParent(
+  path: string,
+  tracker?: RegularFileDurabilityTracker,
+): Promise<DirectorySyncOutcome> {
+  return syncNativeHookClaimParentWithDurability(path, uninstallClaimJournalDurability(tracker));
 }
 
 function transactionClaimPath(path: string): string {
@@ -943,7 +959,7 @@ async function restoreUninstallClaim(
 ): Promise<void> {
   recordRegularFileSyncOutcome(
     tracker,
-    await restoreNativeHookClaimNoClobber(claimPath, destinationPath),
+    await restoreNativeHookClaimNoClobber(claimPath, destinationPath, tracker),
   );
 }
 
@@ -1190,12 +1206,12 @@ async function atomicReplaceFile(
           claimPath,
           before: expectedCurrent.bytes,
           after: content,
-        }),
+        }, options.durabilityTracker),
       );
       journaledClaim = true;
       await rename(mutation.snapshot.path, claimPath);
       claimCreated = true;
-      await syncNativeHookClaimParent(claimPath);
+      await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
       await assertSnapshotAtPath(claimPath, expectedCurrent, "replacement claim");
     }
     await copyFile(temporaryPath, mutation.snapshot.path, constants.COPYFILE_EXCL);
@@ -1206,18 +1222,18 @@ async function atomicReplaceFile(
     } finally {
       await installedHandle.close();
     }
-    await syncNativeHookClaimParent(mutation.snapshot.path);
+    await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
     const actual = await captureCurrentSnapshot(mutation.snapshot);
     if (actual.bytes === null || actual.mode !== mutation.snapshot.mode || !actual.bytes.equals(content)) {
       throw new Error(`Read-back verification failed for replacement ${mutation.snapshot.path}.`);
     }
     if (claimCreated && claimPath) {
       await rm(claimPath);
-      await syncNativeHookClaimParent(claimPath);
+      await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
       claimCreated = false;
     }
     if (journaledClaim && controlledRoot) {
-      await clearNativeHookClaimJournal(controlledRoot);
+      await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
       journaledClaim = false;
     }
     await rm(temporaryPath);
@@ -1243,11 +1259,11 @@ async function atomicReplaceFile(
     if (claimCreated && claimPath) {
       try {
         await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
-        await syncNativeHookClaimParent(mutation.snapshot.path);
+        await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
         claimCreated = false;
         const controlledRoot = mutation.snapshot.topology?.root;
         if (journaledClaim && controlledRoot) {
-          await clearNativeHookClaimJournal(controlledRoot);
+          await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
           journaledClaim = false;
         }
       } catch (recoveryError) {
@@ -1324,11 +1340,11 @@ async function stageAndRemoveFile(
           claimPath,
           before: mutation.snapshot.bytes,
           after: null,
-        }),
+        }, options.durabilityTracker),
       );
     }
     await rename(mutation.snapshot.path, claimPath);
-    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
     execution.appliedSnapshot = {
       path: mutation.snapshot.path,
       content: null,
@@ -1345,8 +1361,8 @@ async function stageAndRemoveFile(
     } catch (error) {
       try {
         await restoreUninstallClaim(claimPath, mutation.snapshot.path, options.durabilityTracker);
-        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path);
-        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
+        if (controlledRoot) await syncNativeHookClaimParent(mutation.snapshot.path, options.durabilityTracker);
+        if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
         execution.appliedSnapshot = undefined;
         execution.phase = "prepared";
       } catch (recoveryError) {
@@ -1357,8 +1373,8 @@ async function stageAndRemoveFile(
       throw error;
     }
     await rm(claimPath);
-    if (controlledRoot) await syncNativeHookClaimParent(claimPath);
-    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot);
+    if (controlledRoot) await syncNativeHookClaimParent(claimPath, options.durabilityTracker);
+    if (controlledRoot) await clearNativeHookClaimJournal(controlledRoot, options.durabilityTracker);
     await options.transactionFailureInjector?.("after-remove");
     await assertControlledTopologyCurrent(mutation.snapshot.topology);
     const absent = await captureCurrentSnapshot(mutation.snapshot);
@@ -1826,8 +1842,10 @@ export async function uninstall(options: UninstallOptions = {}): Promise<void> {
     const recoveryTracker: RegularFileDurabilityTracker = { degraded: false };
     const recovery = await recoverNativeHookClaimJournal(
       scopeDirs.codexHomeDir,
-      uninstallClaimJournalDurabilityOverride
-        ?? createNativeHookClaimJournalDurability(options.transactionPlatform ?? process.platform),
+      uninstallClaimJournalDurability(
+        recoveryTracker,
+        options.transactionPlatform ?? process.platform,
+      ),
     );
     recordRegularFileSyncOutcome(recoveryTracker, recovery.outcome);
     emitDegradedDurabilityWarning("native-hook claim-journal recovery", recoveryTracker);

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
 	emitDegradedDurabilityWarning,
+	recordDirectorySyncOutcome,
 	recordRegularFileSyncOutcome,
+	syncDirectory,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
 } from "../file-durability.js";
@@ -22,6 +24,32 @@ test("regular-file sync returns the Windows EPERM durability outcome", async () 
 test("regular-file sync returns synced after a successful sync", async () => {
 	assert.equal(await syncRegularFile({ sync: async () => {} }, "win32"), "synced");
 });
+
+test("directory sync returns the Windows EPERM durability outcome", async () => {
+	const outcome = await syncDirectory(
+		{ sync: async () => { throw errno("EPERM"); } },
+		"win32",
+	);
+	assert.equal(outcome, "unsupported-windows-eperm");
+});
+
+test("directory sync returns synced after a successful sync", async () => {
+	assert.equal(await syncDirectory({ sync: async () => {} }, "win32"), "synced");
+});
+
+for (const { description, platform, failure } of [
+	{ description: "Linux EPERM", platform: "linux", failure: errno("EPERM") },
+	{ description: "Windows EACCES", platform: "win32", failure: errno("EACCES") },
+	{ description: "Windows non-string code", platform: "win32", failure: errno(1) },
+	{ description: "Windows message-only EPERM", platform: "win32", failure: new Error("EPERM") },
+] as const) {
+	test(`directory sync preserves fatal error identity for ${description}`, async () => {
+		await assert.rejects(
+			syncDirectory({ sync: async () => { throw failure; } }, platform),
+			(error: unknown) => error === failure,
+		);
+	});
+}
 
 for (const { description, platform, failure } of [
 	{ description: "Linux string EPERM", platform: "linux", failure: errno("EPERM") },
@@ -55,6 +83,46 @@ test("durability tracker aggregates outcomes and emits one exact best-effort war
 	}
 	assert.deepEqual(warnings, [
 		"[omx] warning: Windows EPERM regular-file fsync unsupported in session pointer start/reconcile; operation succeeded with degraded durability.\n",
+	]);
+});
+
+test("durability warning accurately names directory-only degradation", () => {
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordDirectorySyncOutcome(tracker, "unsupported-windows-eperm");
+	recordDirectorySyncOutcome(tracker, "synced");
+	const originalWrite = process.stderr.write;
+	const warnings: string[] = [];
+	process.stderr.write = ((value: string) => {
+		warnings.push(value);
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		emitDegradedDurabilityWarning("native-hook setup", tracker);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	assert.deepEqual(warnings, [
+		"[omx] warning: Windows EPERM directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n",
+	]);
+});
+
+test("durability warning names combined regular-file and directory degradation", () => {
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordRegularFileSyncOutcome(tracker, "unsupported-windows-eperm");
+	recordDirectorySyncOutcome(tracker, "unsupported-windows-eperm");
+	const originalWrite = process.stderr.write;
+	const warnings: string[] = [];
+	process.stderr.write = ((value: string) => {
+		warnings.push(value);
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		emitDegradedDurabilityWarning("native-hook setup", tracker);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	assert.deepEqual(warnings, [
+		"[omx] warning: Windows EPERM regular-file and directory fsync unsupported in native-hook setup; operation succeeded with degraded durability.\n",
 	]);
 });
 

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -1,6 +1,7 @@
 import type { FileHandle } from "fs/promises";
 
 export type RegularFileSyncOutcome = "synced" | "unsupported-windows-eperm";
+export type DirectorySyncOutcome = "synced" | "unsupported-windows-eperm";
 
 export type DurabilityWarningSubsystem =
 	| "session pointer start/reconcile"
@@ -11,9 +12,11 @@ export type DurabilityWarningSubsystem =
 
 export interface RegularFileDurabilityTracker {
 	degraded: boolean;
+	regularFileDegraded?: boolean;
+	directoryDegraded?: boolean;
 }
 
-function isUnsupportedWindowsRegularFileSync(
+function isUnsupportedWindowsSync(
 	error: unknown,
 	platform: NodeJS.Platform,
 ): boolean {
@@ -38,7 +41,26 @@ export async function syncRegularFile(
 		await handle.sync();
 		return "synced";
 	} catch (error) {
-		if (!isUnsupportedWindowsRegularFileSync(error, platform)) throw error;
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
+		return "unsupported-windows-eperm";
+	}
+}
+
+/**
+ * Windows can also report EPERM when fsync is unsupported for an otherwise
+ * valid directory handle. Keep the capability boundary as narrow as the
+ * regular-file fallback: every other platform/error pair remains fatal.
+ */
+
+export async function syncDirectory(
+	handle: Pick<FileHandle, "sync">,
+	platform: NodeJS.Platform = process.platform,
+): Promise<DirectorySyncOutcome> {
+	try {
+		await handle.sync();
+		return "synced";
+	} catch (error) {
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
 		return "unsupported-windows-eperm";
 	}
 }
@@ -47,7 +69,18 @@ export function recordRegularFileSyncOutcome(
 	tracker: RegularFileDurabilityTracker,
 	outcome: RegularFileSyncOutcome,
 ): void {
-	tracker.degraded ||= outcome === "unsupported-windows-eperm";
+	if (outcome !== "unsupported-windows-eperm") return;
+	tracker.degraded = true;
+	tracker.regularFileDegraded = true;
+}
+
+export function recordDirectorySyncOutcome(
+	tracker: RegularFileDurabilityTracker,
+	outcome: DirectorySyncOutcome,
+): void {
+	if (outcome !== "unsupported-windows-eperm") return;
+	tracker.degraded = true;
+	tracker.directoryDegraded = true;
 }
 
 export function emitDegradedDurabilityWarning(
@@ -55,9 +88,14 @@ export function emitDegradedDurabilityWarning(
 	tracker: RegularFileDurabilityTracker,
 ): void {
 	if (!tracker.degraded) return;
+	const target = tracker.directoryDegraded
+		? tracker.regularFileDegraded
+			? "regular-file and directory fsync"
+			: "directory fsync"
+		: "regular-file fsync";
 	try {
 		process.stderr.write(
-			`[omx] warning: Windows EPERM regular-file fsync unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
+			`[omx] warning: Windows EPERM ${target} unsupported in ${subsystem}; operation succeeded with degraded durability.\n`,
 		);
 	} catch {
 		// Diagnostics must not fail an already committed transaction.


### PR DESCRIPTION
Fixes #3442 — native-Windows `omx setup` durability/claim-journal repair.

## Root cause

Two separable platform defects reported with a fresh native-Windows reproduction (Windows 11 25H2, Node 24.19, Codex 0.146):

1. **Directory `fsync` `EPERM` was fatal.** `src/cli/native-hook-claim-journal.ts` called `handle.sync()` directly on a directory handle; Windows reports `EPERM` and the claim-journal/setup transaction aborted (`EPERM: operation not permitted, fsync`). The repo already degrades exactly `win32`+`EPERM` for regular files; directory sync had no such boundary.

2. **Hash-identical temporary files were rejected by read-back verification.** `src/cli/setup.ts` required exact mode equality across opens. Windows synthesizes Unix modes from the read-only attribute (writable `0o666`, read-only `0o444`), so a temporary created with requested mode `0o600` read back as `0o666` and the transaction threw `Native hook transaction read-back changed for … temporary; refusing to overwrite concurrent content.` even though the preserved temporary's SHA-256 was identical to the expected bytes (verified by the reporter).

## Repair

- **Directory durability**: add a shared `syncDirectory(handle, platform)` outcome mirroring `syncRegularFile` — only `win32`+`EPERM` degrades, every other platform/error pair rethrows the original error. `NativeHookClaimJournalDurability.syncDirectory` now returns the outcome; `RegularFileDurabilityTracker` records directory degradation; `emitDegradedDurabilityWarning` names the exact target (`regular-file fsync` / `directory fsync` / `regular-file and directory fsync`). Tracker threaded through setup, uninstall, and doctor recovery.
- **Read-back verification**: add `nativeHookTransactionTopologyMatchesAcrossOpen`, which on `win32` accepts exactly the cross-open mode-synthesis pair `{0o600, 0o666}` for regular files, used in both `nativeHookTransactionSnapshotsEqual` and `nativeHookTransactionSnapshotMatchesExpected`. Bytes, `dev`, `ino`, `nlink`, link identity, and the within-read double-lstat stability check stay exact. `0o600↔0o444` (writable-bit drift), `0o644↔0o666`, every POSIX mismatch, and all non-`win32`/non-`EPERM` failures remain fatal (fail-closed).

## Guardrails

- External PR #3445 (closed after exact-head `REQUEST_CHANGES`) is treated as red-team evidence only, not adoptable code: its five Linux test failures were test-shape bugs avoided here by construction (pinned fixture modes via `chmodSync`, shim existence asserted inside `withTempCwd`, fixture dirs created explicitly, no recovery-message-contract changes). Its claim-journal open-handle/controlled-ancestor hardening surface is out of the minimal repair scope.
- No identity/link-check relaxation, no new CLI flags, no docs/templates changes, no test weakened.

## Regression coverage (all deterministic on Linux CI)

- `file-durability`: `syncDirectory` outcome + fatal-identity contract; warning naming for directory-only and combined degradation.
- claim journal: continues when Windows directory sync reports `unsupported-windows-eperm`; POSIX directory EPERM stays fatal.
- setup: completes with exactly one `directory fsync` degraded-durability warning under a win32 seam; linux EPERM / win32 EACCES stay fatal; the `{0o600,0o666}` synthesis pair is accepted with retained file identity; writable-bit drift (`0o600→0o444`) is rejected.
- uninstall: completes with exactly one `directory fsync` warning when only directory sync degrades.
- doctor: claim-journal recovery completes with one accurate warning on directory-only degradation.

## Verification

- `npm run build` — passes (0 type errors).
- `npm run lint` (790 files) and `npm run check:no-unused` — pass.
- Focused compiled suites: file-durability 16/16, native-hook-claim-journal 9/9, doctor-warning-copy 126/126, setup-install-mode 80/80, uninstall 71/71 (302/302).
- Exact-message spot checks: session 122/122, codex-native-hook 641/641 (regular-file warning string byte-identical).
- Full `test:node` run: 407 files; the only failing file (`setup-hooks-trust-e2e`) is untouched by this change and its two tests skip identically on the clean base — a host codex-binary probe condition, not a regression.
- Native-Windows smoke of setup/uninstall/doctor remains a follow-up before relying on the degraded path.

No merge.
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
