### PR TITLE
fix(smoke): repair packed runtime and cwd checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:compat:node:cross-platform": "npm run build && node dist/scripts/run-test-files.js dist/compat/__tests__",
     "test:compat:rust": "cargo build && OMX_COMPAT_TARGET=./target/debug/omx npm run test:compat:node",
     "build:sparkshell": "node dist/scripts/build-sparkshell.js",
-    "smoke:packed-install": "node dist/scripts/smoke-packed-install.js",
+    "smoke:packed-install": "npm run build:runtime && node dist/scripts/smoke-packed-install.js",
     "test:sparkshell": "node dist/scripts/test-sparkshell.js",
     "test:reply-listener:live": "node dist/scripts/test-reply-listener-live.js",
     "postpack": "npm run clean:native-package-assets",

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -1,12 +1,13 @@
 // @ts-nocheck
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { test } from 'node:test';
 import {
+  assertPackedLaunchCwdPreserved,
   assertInstalledPluginSurface,
   assertInstalledReasoningDeclarationContract,
   assertInstalledReasoningRuntimeContract,
@@ -18,6 +19,7 @@ import {
   buildNativeHookSmokePayload,
   ensureRepoDependencies,
   hasUsableNodeModules,
+  buildPackedProbeEnv,
   buildPackedRegressionEnvironment,
   CODEX_APP_SERVER_TIMEOUTS,
   CodexAppServer,
@@ -42,8 +44,11 @@ import {
   parseNpmPackJsonOutput,
   parseCodexHooksListResult,
   probeCodexVersion,
+  parseArgs,
   resolveGitCommonDir,
   resolveReusableNodeModulesSource,
+  replacePathKeyCaseInsensitive,
+  resolvePackedSmokeRuntimeBinary,
   validateHookStdout,
   shouldPackedRegressionStopBlock,
   assertCodexBatchWriteResult,
@@ -66,6 +71,126 @@ function createFakeCodexAppServer(
   return new CodexAppServer(child as never);
 }
 
+
+test('packed smoke resolves and validates the platform-aware repo runtime', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-packed-runtime-'));
+  try {
+    const debugDir = join(root, 'target', 'debug');
+    await mkdir(debugDir, { recursive: true });
+    const runtimePath = join(debugDir, 'omx-runtime');
+    await writeFile(runtimePath, '#!/bin/sh\nexit 0\n');
+    await chmod(runtimePath, 0o755);
+    assert.equal(resolvePackedSmokeRuntimeBinary(root, { platform: 'linux' }), runtimePath);
+
+    const windowsRuntimePath = join(debugDir, 'omx-runtime.exe');
+    await writeFile(windowsRuntimePath, 'windows executable fixture');
+    assert.equal(resolvePackedSmokeRuntimeBinary(root, { platform: 'win32' }), windowsRuntimePath);
+    assert.throws(
+      () => resolvePackedSmokeRuntimeBinary(root, { platform: 'linux', candidate: 'relative/omx-runtime' }),
+      /must be absolute/,
+    );
+    assert.equal(
+      resolvePackedSmokeRuntimeBinary(root, { platform: 'linux', candidate: runtimePath }),
+      runtimePath,
+    );
+    assert.throws(
+      () => resolvePackedSmokeRuntimeBinary(join(root, 'missing'), { platform: 'linux' }),
+      /run "npm run build:runtime"/,
+    );
+    const nonExecutablePath = join(root, 'non-executable-runtime');
+    await writeFile(nonExecutablePath, 'not executable');
+    await chmod(nonExecutablePath, 0o644);
+    assert.throws(
+      () => resolvePackedSmokeRuntimeBinary(root, { platform: 'linux', candidate: nonExecutablePath }),
+      /executable regular file/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed probe env strips ambient runtime and supports default, absent, and explicit provisioning', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-packed-probe-env-'));
+  try {
+    const debugDir = join(root, 'target', 'debug');
+    await mkdir(debugDir, { recursive: true });
+    const runtimePath = join(debugDir, 'omx-runtime');
+    await writeFile(runtimePath, '#!/bin/sh\nexit 0\n');
+    await chmod(runtimePath, 0o755);
+
+    const defaultEnv = buildPackedProbeEnv(
+      { OMX_RUNTIME_BINARY: '/tmp/ambient-decoy' },
+      { repoRoot: root },
+    );
+    assert.equal(defaultEnv.OMX_RUNTIME_BINARY, runtimePath);
+    const absentEnv = buildPackedProbeEnv({}, { runtimeBinary: null });
+    assert.equal(Object.hasOwn(absentEnv, 'OMX_RUNTIME_BINARY'), false);
+    const explicitEnv = buildPackedProbeEnv({}, { runtimeBinary: runtimePath });
+    assert.equal(explicitEnv.OMX_RUNTIME_BINARY, runtimePath);
+    assert.throws(
+      () => buildPackedProbeEnv({}, { runtimeBinary: 'relative/omx-runtime' }),
+      /must be absolute/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed fail-closed PATH replacement removes a win32-shaped decoy runtime and every casing variant', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'omx-packed-path-isolation-'));
+  try {
+    const decoyDir = join(root, 'decoy');
+    const isolatedDir = join(root, 'isolated');
+    await mkdir(decoyDir);
+    await mkdir(isolatedDir);
+    const decoyRuntime = join(decoyDir, 'omx-runtime.exe');
+    await writeFile(decoyRuntime, 'decoy');
+    await access(decoyRuntime);
+
+    const env = replacePathKeyCaseInsensitive(
+      { Path: decoyDir, PATH: join(root, 'other'), KEEP: '1' },
+      isolatedDir,
+    );
+    const pathKeys = Object.keys(env).filter((key) => key.toUpperCase() === 'PATH');
+    assert.deepEqual(pathKeys, ['Path']);
+    assert.equal(env.Path, isolatedDir);
+    assert.equal(env.Path.split(delimiter).includes(decoyDir), false);
+    assert.equal(env.KEEP, '1');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed fail-closed PATH replacement creates a single POSIX key when absent', () => {
+  const env = replacePathKeyCaseInsensitive({ KEEP: '1' }, '/isolated');
+  assert.deepEqual(env, { KEEP: '1', PATH: '/isolated' });
+});
+
+test('packed launch cwd assertion accepts filesystem aliases and rejects distinct directories', async () => {
+  if (process.platform === 'win32') return;
+  const root = await mkdtemp(join(tmpdir(), 'omx-packed-cwd-'));
+  try {
+    const realDir = join(root, 'real');
+    const otherDir = join(root, 'other');
+    const aliasDir = join(root, 'alias');
+    await mkdir(realDir);
+    await mkdir(otherDir);
+    await symlink(realDir, aliasDir);
+    assert.doesNotThrow(() => assertPackedLaunchCwdPreserved(realDir, aliasDir, 'cwd mismatch'));
+    assert.throws(
+      () => assertPackedLaunchCwdPreserved(realDir, otherDir, 'cwd mismatch'),
+      /cwd mismatch: expected .* received /,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('packed smoke arguments expose a probe-only mode and reject unknown flags', () => {
+  assert.deepEqual(parseArgs([]), { failClosedProbe: false });
+  assert.deepEqual(parseArgs(['--fail-closed-probe']), { failClosedProbe: true });
+  assert.throws(() => parseArgs(['--unknown']), /Unknown argument/);
+});
 
 test('packed install smoke retains narrow boot commands and adds the isolated lifecycle separately', () => {
   assert.deepEqual(PACKED_INSTALL_SMOKE_CORE_COMMANDS, [

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, dirname, join, resolve } from 'node:path';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { TextDecoder } from 'node:util';
@@ -30,6 +30,7 @@ import {
   ensureReusableNodeModules,
 } from '../utils/repo-deps.js';
 import { escapeTomlString } from '../utils/toml.js';
+import { sameFilePath } from '../utils/paths.js';
 
 
 export {
@@ -1251,8 +1252,44 @@ export const PACKED_INSTALL_PLUGIN_MCP_TARGETS = [
 const PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS = 5_000;
 const PACKED_INSTALL_COMMAND_TIMEOUT_MS = 120_000;
 
+export interface PackedProbeEnvOptions {
+  runtimeBinary?: string | null;
+  repoRoot?: string;
+}
 
-function buildPackedProbeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+function runtimeBinaryName(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'omx-runtime.exe' : 'omx-runtime';
+}
+
+function validatePackedSmokeRuntimeBinary(candidate: string, platform: NodeJS.Platform): string {
+  if (!isAbsolute(candidate)) {
+    throw new Error(`packed smoke runtime override must be absolute: ${candidate}`);
+  }
+  let stats;
+  try {
+    stats = statSync(candidate);
+  } catch {
+    throw new Error(`packed smoke requires omx-runtime at "${candidate}"; run "npm run build:runtime"`);
+  }
+  if (!stats.isFile() || (platform !== 'win32' && (stats.mode & 0o111) === 0)) {
+    throw new Error(`packed smoke runtime must be an executable regular file: ${candidate}`);
+  }
+  return candidate;
+}
+
+export function resolvePackedSmokeRuntimeBinary(
+  repoRoot: string = process.cwd(),
+  options: { platform?: NodeJS.Platform; candidate?: string } = {},
+): string {
+  const platform = options.platform ?? process.platform;
+  const candidate = options.candidate ?? resolve(join(repoRoot, 'target', 'debug', runtimeBinaryName(platform)));
+  return validatePackedSmokeRuntimeBinary(candidate, platform);
+}
+
+export function buildPackedProbeEnv(
+  overrides: NodeJS.ProcessEnv = {},
+  options: PackedProbeEnvOptions = {},
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const key of Object.keys(env)) {
     const upper = key.toUpperCase();
@@ -1274,7 +1311,26 @@ function buildPackedProbeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessE
     if (value === undefined) delete env[key];
     else env[key] = value;
   }
+  if (options.runtimeBinary === null) {
+    delete env.OMX_RUNTIME_BINARY;
+  } else {
+    env.OMX_RUNTIME_BINARY = options.runtimeBinary === undefined
+      ? resolvePackedSmokeRuntimeBinary(options.repoRoot)
+      : validatePackedSmokeRuntimeBinary(options.runtimeBinary, process.platform);
+  }
   return env;
+}
+
+export function replacePathKeyCaseInsensitive(env: NodeJS.ProcessEnv, value: string): NodeJS.ProcessEnv {
+  const result = { ...env };
+  let pathKey: string | undefined;
+  for (const key of Object.keys(result)) {
+    if (key.toUpperCase() !== 'PATH') continue;
+    pathKey ??= key;
+    delete result[key];
+  }
+  result[pathKey ?? 'PATH'] = value;
+  return result;
 }
 
 export interface PackedInstallNpmFile {
@@ -1729,7 +1785,7 @@ async function assertInstalledReasoningArtifacts(packageRoot: string): Promise<v
 function smokeInstalledRootReasoningRejections(omxPath: string, cwd: string): void {
   const codexHome = mkdtempSync(join(tmpdir(), 'omx-packed-root-reasoning-'));
   try {
-    const env = buildPackedProbeEnv({ CODEX_HOME: codexHome });
+    const env = buildPackedProbeEnv({ CODEX_HOME: codexHome }, { runtimeBinary: null });
     const configPath = join(codexHome, 'config.toml');
     const usageResult = spawnSync(omxPath, ['reasoning'], { cwd, encoding: 'utf-8', env });
     if (usageResult.status !== 0) {
@@ -1784,8 +1840,18 @@ function readFakeCodexLaunches(capturePath: string): FakeCodexLaunch[] {
   if (!existsSync(capturePath)) return [];
   return parseFakeCodexLaunches(readFileSync(capturePath, 'utf-8'));
 }
+export function assertPackedLaunchCwdPreserved(
+  expectedCwd: string,
+  receivedCwd: string,
+  message: string,
+): void {
+  if (!sameFilePath(expectedCwd, receivedCwd)) {
+    throw new Error(`${message}: expected ${expectedCwd}, received ${receivedCwd}`);
+  }
+}
 
-function smokeInstalledLaunchArgumentBoundary(omxPath: string): void {
+
+function smokeInstalledLaunchArgumentBoundary(omxPath: string, runtimeBinary: string): void {
   const smokeRoot = mkdtempSync(join(tmpdir(), 'omx-packed-launch-boundary-'));
   const modelInstructionsPath = join(smokeRoot, 'model-instructions.md');
   try {
@@ -1842,7 +1908,7 @@ function smokeInstalledLaunchArgumentBoundary(omxPath: string): void {
       OMX_MODEL_INSTRUCTIONS_FILE: modelInstructionsPath,
       OMX_LAUNCH_POLICY: 'direct',
       OMX_PACKED_FAKE_CODEX_CAPTURE_PATH: capturePath,
-    });
+    }, { runtimeBinary });
     delete env.OMX_NOTIFY_TEMP_CONTRACT;
     delete env.OMX_TEAM_WORKER_LAUNCH_ARGS;
     writeFileSync(modelInstructionsPath, '# Packed launch boundary instructions\n');
@@ -1895,9 +1961,11 @@ function smokeInstalledLaunchArgumentBoundary(omxPath: string): void {
         expectedCodexArgs,
         'omx must inject model instructions before -- and preserve exact post-marker argument boundaries',
       );
-      if (launch.cwd !== launchCwd) {
-        throw new Error(`omx must not change cwd for post-marker arguments: expected ${launchCwd}, received ${launch.cwd}`);
-      }
+      assertPackedLaunchCwdPreserved(
+        launchCwd,
+        launch.cwd,
+        'omx must not change cwd for post-marker arguments',
+      );
       if (launch.OMX_NOTIFY_TEMP_CONTRACT !== null) {
         throw new Error(`omx must not activate temporary notification routing for post-marker arguments: ${JSON.stringify(launch)}`);
       }
@@ -2034,9 +2102,11 @@ function smokeInstalledLaunchArgumentBoundary(omxPath: string): void {
       `model_instructions_file="${escapeTomlString(modelInstructionsPath)}"`,
       ...twoMarkerArgs.slice(1),
     ], 'the first literal -- must terminate OMX parsing and preserve every later argv element');
-    if (twoMarkerLaunch.cwd !== launchCwd) {
-      throw new Error(`the first literal -- must preserve launch cwd: expected ${launchCwd}, received ${twoMarkerLaunch.cwd}`);
-    }
+    assertPackedLaunchCwdPreserved(
+      launchCwd,
+      twoMarkerLaunch.cwd,
+      'the first literal -- must preserve launch cwd',
+    );
     if (twoMarkerLaunch.OMX_NOTIFY_TEMP_CONTRACT !== null) {
       throw new Error(`the first literal -- must not activate notification routing: ${JSON.stringify(twoMarkerLaunch)}`);
     }
@@ -2051,6 +2121,7 @@ function usage(): string {
   return [
     'Usage: node scripts/smoke-packed-install.mjs',
     '',
+    '  --fail-closed-probe  install the package, assert the runtime-absent fail-closed denial, and exit',
     'Creates an npm tarball, installs it into an isolated prefix, and smoke tests the installed omx CLI.',
     'Release smoke validates installed CLI boot, native-hook dispatch, packaged artifacts, installed reasoning boundaries, and the isolated setup/rerun/uninstall lifecycle; Codex trust checks run when the pinned CLI is present.',
   ].join('\n');
@@ -2109,14 +2180,20 @@ export function ensureRepoDependencies(repoRoot: string, options: EnsureRepoDeps
   };
 }
 
-function parseArgs(argv: string[]): void {
+export function parseArgs(argv: string[]): { failClosedProbe: boolean } {
+  let failClosedProbe = false;
   for (const token of argv) {
     if (token === '--help' || token === '-h') {
       console.log(usage());
       process.exit(0);
     }
+    if (token === '--fail-closed-probe') {
+      failClosedProbe = true;
+      continue;
+    }
     throw new Error(`Unknown argument: ${token}\n${usage()}`);
   }
+  return { failClosedProbe };
 }
 
 function run(cmd: string, args: readonly string[], options: Record<string, unknown> = {}): ReturnType<typeof spawnSync> {
@@ -2338,7 +2415,7 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
           OMX_SESSION_ID: `packed-install-smoke-${eventName}`,
           OMX_SOURCE_CWD: smokeCwd,
           OMX_STARTUP_CWD: smokeCwd,
-        }),
+        }, { runtimeBinary: null }),
         input: JSON.stringify(payload),
       });
       validateHookStdout(eventName, result.stdout as string);
@@ -2350,7 +2427,7 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       env: buildPackedProbeEnv({
         OMX_SOURCE_CWD: collaborationCwd,
         OMX_STARTUP_CWD: collaborationCwd,
-      }),
+      }, { runtimeBinary: null }),
       input: JSON.stringify({
         hook_event_name: 'PostToolUse',
         cwd: collaborationCwd,
@@ -2540,7 +2617,7 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
       OMX_ROOT: hookRoot,
       OMX_SOURCE_CWD: smokeCwd,
       OMX_STARTUP_CWD: smokeCwd,
-    });
+    }, { runtimeBinary: null });
     const officialTeamRootPayload = {
       hook_event_name: 'PreToolUse',
       cwd: smokeCwd,
@@ -5203,7 +5280,7 @@ function smokeInstalledPluginHookLauncher(packageRoot: string, omxPath: string):
       OMX_ENTRY_PATH: omxPath,
       OMX_CODEX_LAUNCH_ID: 'packed-plugin-hook-launch',
       OMX_PACKED_PLUGIN_HOOK_CAPTURE_PATH: capturePath,
-    });
+    }, { runtimeBinary: null });
     const runProbe = (
       name: string,
       payload: Record<string, unknown>,
@@ -5353,7 +5430,7 @@ function smokeInstalledMcpTargets(omxPath: string): void {
       OMX_TEAM_WORKER: '',
       OMX_TEAM_WORKER_LAUNCH_ARGS: '',
       OMX_NOTIFY_TEMP_CONTRACT: '',
-    });
+    }, { runtimeBinary: null });
     for (const [serverName, target, expectedServerName] of PACKED_INSTALL_PLUGIN_MCP_TARGETS) {
       const result = spawnSync(omxPath, ['mcp-serve', target], {
         cwd: smokeRoot,
@@ -5387,6 +5464,103 @@ function smokeInstalledMcpTargets(omxPath: string): void {
     rmSync(smokeRoot, { recursive: true, force: true });
   }
 }
+function smokeInstalledFailClosedDenial(omxPath: string, packageRoot: string): void {
+  if (process.platform === 'linux') {
+    console.log('fail-closed probe: skipped on linux');
+    return;
+  }
+
+  const smokeRoot = mkdtempSync(join(tmpdir(), 'omx-packed-fail-closed-'));
+  try {
+    const fakeBinDir = join(smokeRoot, 'bin');
+    const launchCwd = join(smokeRoot, 'cwd');
+    const codexHome = join(smokeRoot, 'codex-home');
+    const isolatedHome = join(smokeRoot, 'home');
+    const capturePath = join(smokeRoot, 'fake-codex-argv.jsonl');
+    const modelInstructionsPath = join(smokeRoot, 'model-instructions.md');
+    mkdirSync(fakeBinDir, { recursive: true });
+    mkdirSync(launchCwd, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(isolatedHome, { recursive: true });
+    writeFileSync(modelInstructionsPath, '# Packed fail-closed probe instructions\n');
+
+    const fakeCodexSource = [
+      'const { appendFileSync, existsSync } = require("node:fs");',
+      'const path = require("node:path");',
+      'const capturePath = process.env.OMX_PACKED_FAKE_CODEX_CAPTURE_PATH;',
+      'if (!capturePath) process.exit(2);',
+      'appendFileSync(capturePath, `${JSON.stringify({',
+      '  argv: process.argv.slice(2),',
+      '  cwd: process.cwd(),',
+      '  hasResumeSqlite: existsSync(path.join(process.env.CODEX_HOME ?? "", "state_5.sqlite")),',
+      '  OMX_NOTIFY_TEMP_CONTRACT: process.env.OMX_NOTIFY_TEMP_CONTRACT ?? null,',
+      '  OMX_TEAM_WORKER_LAUNCH_ARGS: process.env.OMX_TEAM_WORKER_LAUNCH_ARGS ?? null,',
+      '})}\\n`);',
+    ].join('\n');
+    if (process.platform === 'win32') {
+      const fakeCodexScript = join(fakeBinDir, 'codex.cjs');
+      writeFileSync(fakeCodexScript, fakeCodexSource);
+      writeFileSync(join(fakeBinDir, 'codex.cmd'), [
+        '@echo off',
+        `"${process.execPath}" "${fakeCodexScript}" %*`,
+      ].join('\r\n'));
+    } else {
+      const fakeCodexPath = join(fakeBinDir, 'codex');
+      writeFileSync(fakeCodexPath, `#!/usr/bin/env node\n${fakeCodexSource}\n`);
+      chmodSync(fakeCodexPath, 0o755);
+    }
+
+    const systemPathEntries = process.platform === 'win32'
+      ? [join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')]
+      : ['/usr/bin', '/bin'];
+    const isolatedPathEntries = [fakeBinDir, dirname(process.execPath), ...systemPathEntries];
+    const runtimeName = runtimeBinaryName(process.platform);
+    for (const entry of isolatedPathEntries) {
+      if (existsSync(join(entry, runtimeName))) {
+        throw new Error(`fail-closed probe PATH unexpectedly contains ${runtimeName}: ${entry}`);
+      }
+    }
+    for (const profile of ['debug', 'release']) {
+      const workspaceCandidate = join(packageRoot, 'target', profile, runtimeName);
+      if (existsSync(workspaceCandidate)) {
+        throw new Error(`fail-closed probe installed package unexpectedly contains runtime candidate: ${workspaceCandidate}`);
+      }
+    }
+
+    let env = buildPackedProbeEnv({
+      CODEX_HOME: codexHome,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      OMX_BYPASS_DEFAULT_SYSTEM_PROMPT: '1',
+      OMX_MODEL_INSTRUCTIONS_FILE: modelInstructionsPath,
+      OMX_LAUNCH_POLICY: 'direct',
+      OMX_PACKED_FAKE_CODEX_CAPTURE_PATH: capturePath,
+    }, { runtimeBinary: null });
+    env = replacePathKeyCaseInsensitive(env, isolatedPathEntries.join(delimiter));
+    console.log(`fail-closed probe PATH: ${isolatedPathEntries.join(delimiter)}`);
+
+    const result = spawnSync(omxPath, ['--', 'packed-fail-closed-probe'], {
+      cwd: launchCwd,
+      encoding: 'utf-8',
+      env,
+      timeout: PACKED_INSTALL_OPERATIONAL_PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    const launches = readFakeCodexLaunches(capturePath);
+    if (launches.length !== 1) {
+      throw new Error(`fail-closed probe must launch fake Codex exactly once: ${JSON.stringify(launches)}`);
+    }
+    const stderr = String(result.stderr ?? '');
+    if (result.status === 0 || !stderr.includes('session_pointer_unusable')) {
+      throw new Error(`fail-closed probe expected session_pointer_unusable denial, received status ${String(result.status)}\n${stderr}`);
+    }
+    console.log(`fail-closed probe denial: ${stderr.trim()}`);
+    console.log('fail-closed probe: denial observed');
+  } finally {
+    rmSync(smokeRoot, { recursive: true, force: true });
+  }
+}
+
 
 export function parseNpmPackJsonOutput(stdout: string): PackedInstallNpmPackResult[] {
   const start = stdout.lastIndexOf('\n[');
@@ -5398,7 +5572,7 @@ export function parseNpmPackJsonOutput(stdout: string): PackedInstallNpmPackResu
 }
 
 async function main(): Promise<void> {
-  parseArgs(process.argv.slice(2));
+  const { failClosedProbe } = parseArgs(process.argv.slice(2));
 
   const repoRoot = process.cwd();
   const tempRoot = mkdtempSync(join(tmpdir(), 'omx-packed-install-'));
@@ -5416,7 +5590,7 @@ async function main(): Promise<void> {
     CODEX_HOME: installCodexHome,
     npm_config_cache: installNpmCache,
     NPM_CONFIG_CACHE: installNpmCache,
-  });
+  }, { runtimeBinary: null });
 
   let tarballPath: string | undefined;
   try {
@@ -5441,8 +5615,14 @@ async function main(): Promise<void> {
     await assertInstalledReasoningArtifacts(packageRoot);
 
     const omxPath = join(prefixDir, process.platform === 'win32' ? '' : 'bin', npmBinName('omx'));
+    if (failClosedProbe) {
+      smokeInstalledFailClosedDenial(omxPath, packageRoot);
+      return;
+    }
+    const runtimeBinary = resolvePackedSmokeRuntimeBinary(repoRoot);
+    console.log(`packed smoke runtime: ${runtimeBinary}`);
     smokeInstalledRootReasoningRejections(omxPath, repoRoot);
-    smokeInstalledLaunchArgumentBoundary(omxPath);
+    smokeInstalledLaunchArgumentBoundary(omxPath, runtimeBinary);
     smokeInstalledPluginHookLauncher(packageRoot, omxPath);
     smokeInstalledMcpTargets(omxPath);
     for (const argv of PACKED_INSTALL_SMOKE_CORE_COMMANDS) {


### PR DESCRIPTION
## Summary
- build and validate the platform-aware repo `omx-runtime` before the packed gate
- inject that absolute runtime only into installed launch-finalization probes
- add a probe-only, PATH-isolated fail-closed assertion and filesystem-equivalent cwd checks
- keep `neg-advance-reopen` and product identity code unchanged

Closes #3414.

## Verification
- `npm run build` — PASS
- `node --test dist/scripts/__tests__/smoke-packed-install.test.js dist/utils/__tests__/paths.test.js` — PASS (94 passed, 1 platform skip)
- `node --test dist/hooks/__tests__/session.test.js` — PASS (122 passed)
- `npm run lint` — PASS
- `npm run check:no-unused` — PASS
- direct `--fail-closed-probe` with `target/debug/omx-runtime` temporarily parked — PASS on Linux (probe-only skip, no positive runtime resolution)
- `npm run smoke:packed-install` — the #3414 runtime and canonical-cwd gates pass; execution then reaches the admitted independent baseline stop: `packed regression neg-advance-reopen did not create workflow state`

## Scope notes
- No edits to `src/hooks/session.ts`, `src/runtime/bridge.ts`, or `src/utils/paths.ts`.
- `neg-advance-reopen` fixture bytes are unchanged.
- A broad `test:recent-bug-regressions` attempt was interrupted by unrelated workspace `ENOSPC` failures in `dist/team/__tests__/runtime.test.js`; focused #3414 verification above is green and that environment failure is not attributed to this diff.

Do not merge as part of this repair lane.

— GJC, session `omx-issue-3414-packed-smoke-repair`

CI recovery note: PR metadata refreshed after the GitHub Actions incident because the original workflow dispatch was missing.
