### PR TITLE
fix(ralplan): clear stale owner-scoped state and allow typed consensus delegation (#3451)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22485,7 +22485,6 @@ PY`,
     try {
       const { sessionId, leaderThreadId } = await writeFlattenedCollaborationRalplanFixture(cwd);
       for (const [tool_name, tool_input] of [
-        ["collaborationspawn_agent", { agent_type: "planner", message: "draft the plan" }],
         ["collaborationlist_agents", {}],
         ["collaborationfollowup_task", {}],
         ["collaborationwait_agent", {}],
@@ -22520,6 +22519,41 @@ PY`,
       assert.equal(blocked.outputJson?.decision, "block");
       const reason = String(blocked.outputJson?.reason ?? "");
       assert.match(reason, /not a recognized read-only or explicitly authorized planning mutation transport|OWNER_CONFIRMATION_REQUIRED/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("allows installed-role spawn_agent consensus delegation during active ralplan planning (#3451-B)", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3451-ralplan-consensus-spawn-"));
+    try {
+      const { sessionId, leaderThreadId } = await writeFlattenedCollaborationRalplanFixture(cwd);
+      // Spawn with an installed role (planner) should pass through the ralplan boundary
+      for (const [tool_name, tool_input] of [
+        ["collaborationspawn_agent", { agent_type: "planner", message: "draft the plan" }],
+        ["collaboration.spawn_agent", { agent_type: "architect", message: "review the plan" }],
+        ["spawn_agent", { agent_type: "critic", message: "critique the plan" }],
+      ] as const) {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          tool_name,
+          tool_input,
+        }, { cwd });
+        assert.equal(result.outputJson, null, `${tool_name} with installed role should not be blocked during ralplan`);
+      }
+      // Non-spawn collaboration tools still blocked
+      const blockedList = await dispatchCodexNativeHook({
+        hook_event_name: "PreToolUse",
+        cwd,
+        session_id: sessionId,
+        thread_id: leaderThreadId,
+        tool_name: "collaborationlist_agents",
+        tool_input: {},
+      }, { cwd });
+      assert.equal(blockedList.outputJson?.decision, "block");
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -22544,16 +22544,41 @@ PY`,
         }, { cwd });
         assert.equal(result.outputJson, null, `${tool_name} with installed role should not be blocked during ralplan`);
       }
-      // Non-spawn collaboration tools still blocked
-      const blockedList = await dispatchCodexNativeHook({
-        hook_event_name: "PreToolUse",
-        cwd,
-        session_id: sessionId,
-        thread_id: leaderThreadId,
-        tool_name: "collaborationlist_agents",
-        tool_input: {},
-      }, { cwd });
-      assert.equal(blockedList.outputJson?.decision, "block");
+
+      const customRole = "custom-consensus-bypass";
+      const agentsDir = join(cwd, ".codex", "agents");
+      await mkdir(agentsDir, { recursive: true });
+      await writeFile(join(agentsDir, `${customRole}.toml`), "# installed custom role\n");
+      for (const [agent_type, expectedReason] of [
+        ["executor", /not a recognized read-only or explicitly authorized planning mutation transport/],
+        ["debugger", /not a recognized read-only or explicitly authorized planning mutation transport/],
+        [customRole, /not a recognized read-only or explicitly authorized planning mutation transport/],
+        ["", /not a recognized read-only or explicitly authorized planning mutation transport/],
+        ["planner!", /unknown or not installed/],
+      ] as const) {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          tool_name: "collaborationspawn_agent",
+          tool_input: agent_type ? { agent_type, message: "must not bypass consensus role boundary" } : {},
+        }, { cwd });
+        assert.equal(result.outputJson?.decision, "block", `${agent_type || "empty"} role must be denied`);
+        assert.match(String(result.outputJson?.reason ?? ""), expectedReason, `${agent_type || "empty"} role deny reason`);
+      }
+      // Dotted and flattened non-spawn collaboration transports remain blocked.
+      for (const tool_name of ["collaborationlist_agents", "collaboration.list_agents"]) {
+        const blockedList = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd,
+          session_id: sessionId,
+          thread_id: leaderThreadId,
+          tool_name,
+          tool_input: {},
+        }, { cwd });
+        assert.equal(blockedList.outputJson?.decision, "block", `${tool_name} must remain blocked`);
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -10700,6 +10700,8 @@ function teamWorkerMutationTargetsProtectedWorkflowState(
 
 
 
+const RALPLAN_CONSENSUS_NATIVE_ROLE_NAMES = new Set(["planner", "architect", "critic"]);
+
 async function buildRalplanPreToolUseBoundaryOutput(
   payload: CodexHookPayload,
   cwd: string,
@@ -10750,14 +10752,16 @@ async function buildRalplanPreToolUseBoundaryOutput(
   let blocked = false;
   let blockedDetail = "implementation/write tools are blocked until an explicit execution handoff workflow is activated";
 
-  // Allow typed native consensus delegation (planner/architect/critic) during
-  // Ralplan planning. The unknown-role deny (buildNativeUnknownRolePreToolUseOutput)
-  // already ran upstream and blocked uninstalled roles; reaching here with a spawn
-  // tool means the role is installed. Only spawn tools with installed roles pass;
-  // implementation tools and unknown transports remain blocked (#3451-B).
+  // Allow only installed Planner/Architect/Critic native consensus delegation
+  // during Ralplan planning. The upstream unknown-role deny blocks uninstalled
+  // roles. Other installed roles (including executor) are not consensus lanes,
+  // so they and every non-spawn transport remain fail-closed (#3451-B).
   if (mutationTransport === "orchestration" && isNativeSubagentSpawnToolName(toolName)) {
     const requestedSpawnRole = readRequestedSpawnRole(payload);
-    if (requestedSpawnRole && resolveInstalledRoleName(requestedSpawnRole, undefined, cwd) !== null) {
+    if (
+      RALPLAN_CONSENSUS_NATIVE_ROLE_NAMES.has(requestedSpawnRole)
+      && resolveInstalledRoleName(requestedSpawnRole, undefined, cwd) !== null
+    ) {
       return null;
     }
   }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -10750,6 +10750,17 @@ async function buildRalplanPreToolUseBoundaryOutput(
   let blocked = false;
   let blockedDetail = "implementation/write tools are blocked until an explicit execution handoff workflow is activated";
 
+  // Allow typed native consensus delegation (planner/architect/critic) during
+  // Ralplan planning. The unknown-role deny (buildNativeUnknownRolePreToolUseOutput)
+  // already ran upstream and blocked uninstalled roles; reaching here with a spawn
+  // tool means the role is installed. Only spawn tools with installed roles pass;
+  // implementation tools and unknown transports remain blocked (#3451-B).
+  if (mutationTransport === "orchestration" && isNativeSubagentSpawnToolName(toolName)) {
+    const requestedSpawnRole = readRequestedSpawnRole(payload);
+    if (requestedSpawnRole && resolveInstalledRoleName(requestedSpawnRole, undefined, cwd) !== null) {
+      return null;
+    }
+  }
   if (toolName === "Bash") {
     blocked = !isAllowedRalplanBashWrite(cwd, command, activeState, sessionId, readPreToolUseRawCommand(payload));
     if (blocked) {

--- a/src/state/__tests__/skill-active.test.ts
+++ b/src/state/__tests__/skill-active.test.ts
@@ -881,4 +881,68 @@ describe('skill-active state helpers', () => {
       assert.equal(JSON.parse(await readFile(rootPath, 'utf8')).active_skills[0].phase, 'recovered');
     });
   });
+
+  it('removes root-scoped stale ralplan entry owned by the session when clearing, even when session_id is empty (#3451-A)', async () => {
+    await withTempRepo('omx-skill-active-3451-owner-clear-', async (cwd) => {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+      const sessionId = 'sess-3451-owner';
+      // Seed root skill-active with a root-scoped ralplan entry (empty session_id)
+      // owned by the current session via owner_codex_session_id. The entryKey
+      // dedup (skill::session_id) prevents two same-skill unscoped entries, so we
+      // also seed a different-skill entry to verify only the matching entry clears.
+      await writeSkillActiveStateCopiesForStateDir(
+        stateDir,
+        {
+          active: true,
+          skill: 'ralplan',
+          phase: 'planning',
+          session_id: undefined,
+          owner_codex_session_id: sessionId,
+          active_skills: [
+            { skill: 'ralplan', phase: 'planning', active: true, session_id: undefined, owner_codex_session_id: sessionId },
+            { skill: 'team', phase: 'running', active: true, session_id: undefined, owner_codex_session_id: 'other-session' },
+          ],
+        },
+        undefined,
+        {
+          active: true,
+          skill: 'ralplan',
+          phase: 'planning',
+          active_skills: [
+            { skill: 'ralplan', phase: 'planning', active: true, session_id: undefined, owner_codex_session_id: sessionId },
+            { skill: 'team', phase: 'running', active: true, session_id: undefined, owner_codex_session_id: 'other-session' },
+          ],
+        },
+      );
+
+      // Clear ralplan for the current session
+      await syncCanonicalSkillStateForMode({
+        cwd,
+        mode: 'ralplan',
+        active: false,
+        sessionId,
+        ownerCodexSessionId: sessionId,
+        nowIso: '2026-08-07T00:00:00.000Z',
+      });
+
+      const rootState = JSON.parse(
+        await readFile(join(stateDir, 'skill-active-state.json'), 'utf-8'),
+      ) as { active_skills?: Array<{ skill: string; owner_codex_session_id?: string }> };
+
+      const remaining = rootState.active_skills ?? [];
+      // The ralplan entry owned by the current session must be removed
+      assert.equal(
+        remaining.some((e) => e.skill === 'ralplan'),
+        false,
+        'stale root-scoped ralplan entry owned by the current session should be removed',
+      );
+      // The team entry owned by the other session must survive
+      assert.equal(
+        remaining.some((e) => e.skill === 'team' && e.owner_codex_session_id === 'other-session'),
+        true,
+        'team entry owned by a different session should survive',
+      );
+    });
+  });
 });

--- a/src/state/skill-active.ts
+++ b/src/state/skill-active.ts
@@ -274,6 +274,20 @@ export function listTransitionActiveSkills(raw: unknown, sessionId?: string): Sk
   return entries.filter((entry) => safeString(entry.session_id).trim().length === 0);
 }
 
+/**
+ * Matches an active-skill entry to a normalized session id for
+ * deactivation/clear purposes. An entry matches when:
+ *   - its `session_id` equals the normalized session id (normal path), OR
+ *   - its `session_id` is empty AND its `owner_codex_session_id` equals the
+ *     normalized session id (unscoped root entry owned by the session).
+ * This prevents stale root-scoped entries from surviving a mode clear (#3451-A).
+ */
+function entryMatchesSessionOrOwner(entry: SkillActiveEntry, normalizedSessionId: string): boolean {
+  if (safeString(entry.session_id).trim() === normalizedSessionId) return true;
+  return safeString(entry.session_id).trim().length === 0
+    && safeString(entry.owner_codex_session_id).trim() === normalizedSessionId;
+}
+
 /** Owner metadata for read-only provenance preflight; never infers ownership from storage. */
 export function listSkillActiveOwnerCodexSessionIds(raw: unknown): string[] {
   if (!raw || typeof raw !== 'object') return [];
@@ -599,13 +613,14 @@ function mergeRootStateForSession(
   sessionState: SkillActiveStateLike,
   sessionId: string,
 ): SkillActiveStateLike {
+  const normalizedSessionId = safeString(sessionId).trim();
   const currentEntries = listActiveSkills(currentRoot ?? {});
-  const hasCurrentSessionEntry = currentEntries.some((entry) => safeString(entry.session_id).trim() === sessionId);
+  const hasCurrentSessionEntry = currentEntries.some((entry) => entryMatchesSessionOrOwner(entry, normalizedSessionId));
   const incomingEntries = hasCurrentSessionEntry
-    ? listActiveSkills(sessionState).filter((entry) => safeString(entry.session_id).trim() === sessionId)
+    ? listActiveSkills(sessionState).filter((entry) => entryMatchesSessionOrOwner(entry, normalizedSessionId))
     : [];
   const mergedEntries = [
-    ...currentEntries.filter((entry) => safeString(entry.session_id).trim() !== sessionId),
+    ...currentEntries.filter((entry) => !entryMatchesSessionOrOwner(entry, normalizedSessionId)),
     ...incomingEntries,
   ];
   return stateWithActiveEntries(currentRoot ?? sessionState, mergedEntries, sessionState.skill || 'skill-active');
@@ -915,11 +930,11 @@ async function syncCanonicalSkillStateForModeUnlocked(
 
     const nextSessionRootEntries = rootEntries.filter((entry) => !(
       entry.skill === mode
-      && safeString(entry.session_id).trim() === normalizedSessionId
+      && entryMatchesSessionOrOwner(entry, normalizedSessionId)
     ));
     const nextRootEntries = allRootEntries.filter((entry) => !(
       entry.skill === mode
-      && safeString(entry.session_id).trim() === normalizedSessionId
+      && entryMatchesSessionOrOwner(entry, normalizedSessionId)
     ));
 
     const nextSessionState = applyEntriesToState(
@@ -928,6 +943,7 @@ async function syncCanonicalSkillStateForModeUnlocked(
       mode,
       normalizedSessionId,
     );
+    nextSessionState.session_id = normalizedSessionId;
     const nextRootState = nextRootEntries.length > 0
       ? applyEntriesToState(existingRoot, nextRootEntries, mode)
       : applyEntriesToState(


### PR DESCRIPTION
## #3451 — Ralplan lifecycle: stale state clear + typed consensus delegation

### Scope

Two independent fixes preventing Ralplan from becoming unrecoverably blocked in a Codex native-subagent session:

**Fix A — Stale root skill-active entry survives mode clear (#3451-A)**

When a root-scoped active entry has no `session_id` but its `owner_codex_session_id` matches the current session, clearing the mode left the stale entry active. Hooks continued treating Ralplan as active indefinitely.

- New `entryMatchesSessionOrOwner()` helper matches entries by `session_id` OR by empty `session_id` + matching `owner_codex_session_id`.
- Applied in both the direct deactivation filter and `mergeRootStateForSession`.
- `nextSessionState.session_id` explicitly set to canonical session ID so the root merge correctly targets unscoped entries by owner.
- Entries owned by other sessions survive.

**Fix B — `collaboration.spawn_agent` blocked as orchestration (#3451-B)**

The Ralplan `PreToolUse` boundary classified `collaboration.spawn_agent` (and flattened `collaborationspawn_agent`) as `orchestration` and blocked it, preventing Planner→Architect→Critic consensus delegation from starting.

- The boundary now allows a spawn tool through when the requested role (read from `tool_input.agent_type` via `readRequestedSpawnRole`) resolves to an installed OMX role.
- The upstream `buildNativeUnknownRolePreToolUseOutput` already blocks uninstalled roles before the boundary is reached.
- Non-spawn collaboration tools (`list_agents`, `send_message`, etc.) and implementation tools remain blocked.
- **No raw tool-name allowlist** — the exception keys on `isNativeSubagentSpawnToolName` + `resolveInstalledRoleName`.

### Fail-closed authority

Both fixes preserve the existing fail-closed boundary:
- Fix A only widens the removal scope for entries already owned by the clearing session; it never adds authority.
- Fix B only permits typed spawn delegation with installed roles during planning; the unknown-role deny runs first, and implementation tools remain blocked.

### Verification

- **Build**: clean.
- **`check:no-unused`** + **`tsc --noEmit`**: 0 errors.
- **State suite**: 19/19 pass (baseline 18/18 + new #3451-A regression test). Baseline comparison run from isolated clean worktree at exact `ef97d668`.
- **Codex-native-hook scoped tests**: 88/88 pass (ralplan/planning/spawn/consensus patterns) including new #3451-B test.
- **Concurrency regressions**: `serializes concurrent session root RMW`, `serializes genuine multi-process root contention`, `rejects live stale takeover`, `fails closed on malformed root state` — all pass on both baseline and modified.

Closes #3451.