### PR TITLE
fix(team): preserve tmux source-authority separator argv boundaries (#3459)

### DIFF
--- a/docs/adr/3459-team-tmux-argv-separator-boundary.md
+++ b/docs/adr/3459-team-tmux-argv-separator-boundary.md
@@ -1,0 +1,37 @@
+# ADR 3459: Preserve the Team source-authority tmux argv separator boundary
+
+**Status:** Accepted
+
+## Decision
+
+Change the success branch passed by `runSourceAuthorizedTmux()` from `\;` to `;` before the receipt `display-message` command. Export the helper and its `SourcePaneAuthority` input type so a private real-tmux regression can drive the product Node argv construction directly.
+
+The helper continues to send exactly one server-side `if-shell` authority transaction per effect. Its success branch executes the guarded effect and prints the receipt; its failure branch prints an empty receipt; the existing exact-receipt check remains fail-closed. No shell layer is added.
+
+## Drivers
+
+- Real tmux command-string parsing treats `\;` in the single success-branch argv element as an escaped literal semicolon, not a command-list separator. `display-message` is then parsed as surplus effect arguments and real tmux reports `too many arguments`.
+- The shipped detached-launch sibling already uses a literal `;` separator. Matching that behavior fixes the Team transport with a one-line product change.
+- Fake tmux fixtures alone cannot prove the Node argv to real tmux parser boundary. A private-server regression must prove the product helper's exact `if-shell` argv and actual effect behavior.
+
+## Alternatives
+
+1. **Replicate the argv in a test without exporting the helper.** Rejected: test-side construction can drift from production and cannot prove the product receipt path.
+2. **Rewrite every `\;` occurrence in Team, HUD, and scaling into a shared builder.** Rejected: broadens #3459 beyond the affected Team source-authority transport and overlaps separate work.
+3. **Use a shell or `run-shell` indirection.** Rejected: adds an injection-relevant parsing layer and changes the transport contract.
+
+## Why chosen
+
+A literal `;` is the tmux command-list separator required inside the existing Node argv success-branch string. It preserves the single authority transaction, both branches, and receipt behavior while matching the established sibling fix. The exported seam keeps the regression drift-free: it reaches `runTmux()` and `spawnPlatformCommandSync()` instead of recreating their argv in a test.
+
+## Consequences
+
+- Guarded Team effects such as `set-option`, `select-layout`, and `send-keys` execute correctly on real tmux 3.x and still emit the exact receipt.
+- Fake fixtures are updated to parse the same separator form.
+- The real-tmux regression creates a private-server PATH shim, saves/restores and prepends `process.env.PATH` before calling the exported helper, and asserts the exact logged `if-shell` argv. A bounded pane-readiness poll limits fixture startup flakiness without changing production behavior.
+- Literal values remain protected by the existing `shellQuoteSingle` caller discipline; the fix does not introduce shell execution. Hostile receipt and quoted literal-value cases are regression-tested.
+- `runSourceAuthorizedSplit`, Team scaling, HUD helpers, CLI helpers, and #3457/#3458 work remain out of scope.
+
+## Follow-ups
+
+Track the independent real-tmux probes for same-pattern sites in Team scaling and HUD before considering any broader command-list abstraction.

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -756,7 +756,7 @@ if [ "\${1:-}" = "if-shell" ] && [ "\${2:-}" = "-F" ] && [ "\${3:-}" = "-t" ]; t
   log_command "$@"
   if [ "\${effect#*split-window}" != "$effect" ]; then
     receipt="$(printf '%s' "$effect" | sed -n 's/.*\\(omx_source_[A-Za-z0-9_]*\\).*/\\1/p')"
-    effect_command="\${effect%% \\; display-message*}"
+    effect_command="\${effect%% ; display-message*}"
     eval "set -- $effect_command"
     split_output="$("$0" "$@")" || exit 1
     created_pane="$(printf '%s\\n' "$split_output" | awk -F '\\t' 'NR == 1 { print $1 }')"

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -266,6 +266,7 @@ ${standaloneGlobalPaneProofFallback}
 fi
 ` : ''}
 if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "-t" ]; then
+  original_command="${'$'}*"
   source="${'$'}4"
   predicate="${'$'}5"
   success="${'$'}6"
@@ -284,8 +285,9 @@ if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "
       *) printf '' ; exit 0 ;;
     esac
   fi
+  printf '%s\n' "${'$'}original_command" >> ${JSON.stringify(logPath)}
   receipt="$(printf '%s' "$success" | sed -n "s/.*\\(omx_source_[A-Za-z0-9_]*\\).*/\\1/p")"
-  effect="${'$'}{success%% \\; display-message*}"
+  effect="${'$'}{success%% ; display-message*}"
   eval "set -- $effect"
   output="$($0 "${'$'}@")" || exit 1
   case "${'$'}1" in
@@ -340,7 +342,7 @@ esac
         const captured = spawnSync('tmux', ['display-message', '-p', '-t', '%1', '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}'], { encoding: 'utf8' });
         assert.equal(captured.status, 0);
         assert.equal(captured.stdout, 'recycled\t$1\t1\t0\t@0\t%1\t101\n');
-        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}\tomx_source_recycled' \\; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
+        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}\tomx_source_recycled' ; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
         assert.equal(guarded.status, 0);
         assert.equal(guarded.stdout, '');
         assert.equal(fs.existsSync(`${logPath}.split`), false);
@@ -374,7 +376,7 @@ esac
         const guarded = spawnSync('tmux', [
           'if-shell', '-F', '-t', '%1',
           '#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_id},%1},#{&&:#{==:#{pane_pid},101},#{&&:#{==:#{session_id},$1},#{&&:#{==:#{session_created},1},#{&&:#{==:#{window_id},@0},#{==:#{@omx_team_pane_owner_id},team:original}}}}}}',
-          `split-window -h -t %1 -P -F '#{pane_id}\\t${receipt}' \\; display-message -p '${receipt}'`,
+          `split-window -h -t %1 -P -F '#{pane_id}\\t${receipt}' ; display-message -p '${receipt}'`,
           "display-message -p ''",
         ], { encoding: 'utf8' });
         assert.equal(guarded.status, 0);
@@ -5164,13 +5166,13 @@ esac
           const redrawTransactions = commands
             .map((command, index) => ({ command, index }))
             .filter(({ command }) => command.includes('send-keys -t %1 C-l')
-              && command.includes('display-message -p omx_source_'));
+              && command.includes("display-message -p 'omx_source_"));
           assert.equal(redrawTransactions.length, 1);
           const redrawIndex = redrawTransactions[0]!.index;
           assert.ok(redrawIndex > 0);
           assert.match(
             redrawTransactions[0]!.command,
-            /send-keys -t %1 C-l.*display-message -p omx_source_/,
+            /send-keys -t %1 C-l.*display-message -p 'omx_source_/,
             'leader Codex pane redraw must carry the exact guarded transaction receipt',
           );
 
@@ -5367,7 +5369,7 @@ esac
           const commands = tmuxLog.trim().split('\n').filter(Boolean);
           const globalExactPanePidProof = /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/;
           const targetScopedExactPaneSetProof = /^list-panes -t shared:0 -F #\{pane_id\}\t#\{pane_current_command\}\t#\{pane_start_command\}$/;
-          const exactPaneEffects = /^(set-option -p -t %|split-window .* -t %|resize-pane -t %|select-pane -t %|send-keys -t %|if-shell -F -t %)/;
+          const exactPaneEffects = /^(split-window .* -t %|resize-pane -t %|select-pane -t %|send-keys -t %|if-shell -F -t %)/;
           for (const [index, command] of commands.entries()) {
             if (!exactPaneEffects.test(command)) continue;
             const immediatelyPrevious = commands[index - 1] ?? '';
@@ -5385,7 +5387,10 @@ esac
               || (targetScopedExactPaneSetProof.test(immediatelyPrevious)
                 && globalExactPanePidProof.test(previousProof))
               || guardedAuthorityTransaction
-              || command.includes('display-message -p omx_source_');
+              || (immediatelyPrevious.startsWith('if-shell -F -t %')
+                && immediatelyPrevious.includes("display-message -p 'omx_source_"))
+              || command.includes("display-message -p 'omx_source_")
+              || (command.startsWith('split-window ') && command.includes('omx_source_'));
             assert.equal(
               hasAdjacentAuthority,
               true,

--- a/src/team/__tests__/tmux-source-authority-realtmux.test.ts
+++ b/src/team/__tests__/tmux-source-authority-realtmux.test.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, type TestContext } from 'node:test';
+import { runSourceAuthorizedTmux, type SourcePaneAuthority } from '../tmux-session.js';
+import { isRealTmuxAvailable, type TempTmuxSessionFixture, withTempTmuxSession } from './tmux-test-fixture.js';
+
+const SOURCE_AUTHORITY_FORMAT = '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}';
+const PANE_READY_TIMEOUT_MS = 1_000;
+const PANE_READY_INTERVAL_MS = 50;
+
+function skipUnlessPrivateRealTmux(t: TestContext): boolean {
+  if (isRealTmuxAvailable()) return true;
+  assert.equal(process.env.CI, undefined, 'CI must provide tmux for the private-server source-authority regression');
+  t.skip('tmux is not installed');
+  return false;
+}
+
+function quoteTmuxString(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function sourceAuthorityPredicate(source: SourcePaneAuthority): string {
+  return [
+    '#{==:#{pane_dead},0}',
+    `#{==:#{pane_id},${source.paneId}}`,
+    `#{==:#{pane_pid},${source.panePid}}`,
+    `#{==:#{session_id},${source.sessionId}}`,
+    `#{==:#{session_created},${source.sessionCreated}}`,
+    `#{==:#{window_id},${source.windowId}}`,
+    ...(source.teamPaneOwnerId ? [`#{==:#{@omx_team_pane_owner_id},${source.teamPaneOwnerId}}`] : []),
+  ].reduce((combined, condition) => `#{&&:${combined},${condition}}`);
+}
+
+function parseShimTmuxArgv(contents: string): string[][] {
+  return contents
+    .split('tmux argv:\n')
+    .slice(1)
+    .map((record) => record.split('\nend tmux argv')[0]!.split('\n').filter(Boolean));
+}
+
+function captureSourceAuthority(fixture: TempTmuxSessionFixture, paneId: string): SourcePaneAuthority {
+  const fields = fixture.run(['display-message', '-p', '-t', paneId, SOURCE_AUTHORITY_FORMAT]).split('\t');
+  assert.equal(fields.length, 7, 'fixture must provide a complete source authority frame');
+  const [sessionName, sessionId, sessionCreated, windowIndex, windowId, capturedPaneId, panePid] = fields;
+  assert.equal(capturedPaneId, paneId, 'fixture source frame must belong to the tested pane');
+  assert.ok(sessionName && sessionId && sessionCreated && windowIndex && windowId && panePid, 'fixture source frame must not contain empty required fields');
+  const parsedPanePid = Number(panePid);
+  assert.ok(Number.isSafeInteger(parsedPanePid) && parsedPanePid > 0, 'fixture pane pid must be a positive safe integer');
+  return {
+    paneId,
+    panePid: parsedPanePid,
+    sessionName,
+    sessionId,
+    sessionCreated,
+    windowIndex,
+    windowId,
+    teamPaneOwnerId: null,
+  };
+}
+
+async function waitForPaneReady(fixture: TempTmuxSessionFixture, paneId: string): Promise<void> {
+  const deadline = Date.now() + PANE_READY_TIMEOUT_MS;
+  let lastState = '';
+  while (Date.now() < deadline) {
+    lastState = fixture.run(['display-message', '-p', '-t', paneId, '#{pane_dead}']);
+    if (lastState === '0') return;
+    await new Promise((resolve) => setTimeout(resolve, PANE_READY_INTERVAL_MS));
+  }
+  throw new Error(`timed out waiting for private tmux pane readiness: ${paneId} (${lastState})`);
+}
+
+function expectedIfShellArgv(source: SourcePaneAuthority, effect: string, receipt: string): string[] {
+  return [
+    'if-shell',
+    '-F',
+    '-t',
+    source.paneId,
+    sourceAuthorityPredicate(source),
+    `${effect} ; display-message -p ${quoteTmuxString(receipt)}`,
+    "display-message -p ''",
+  ];
+}
+
+describe('runSourceAuthorizedTmux real private-server argv boundary', () => {
+  it('uses a real tmux parser for guarded effects and records the exact product argv', async (t) => {
+    if (!skipUnlessPrivateRealTmux(t)) return;
+
+    const workDir = await mkdtemp(join(tmpdir(), 'omx-source-authority-realtmux-'));
+    const bin = join(workDir, 'bin');
+    const shimLogPath = join(workDir, 'tmux-argv.log');
+    const previousPath = process.env.PATH;
+    try {
+      await mkdir(bin, { recursive: true });
+      await withTempTmuxSession({ serverLog: true }, async (fixture) => {
+        await fixture.createPathShim(bin, shimLogPath);
+        process.env.PATH = `${bin}:${previousPath ?? ''}`;
+        try {
+          await waitForPaneReady(fixture, fixture.leaderPaneId);
+          const source = captureSourceAuthority(fixture, fixture.leaderPaneId);
+          const expectedTransactions: string[][] = [];
+
+          const setOptionEffect = `set-option -p -t ${source.paneId} @omx_probe_3459 ${quoteTmuxString('ok')}`;
+          const setOptionReceipt = 'omx_source_set_option_3459';
+          expectedTransactions.push(expectedIfShellArgv(source, setOptionEffect, setOptionReceipt));
+          assert.equal(runSourceAuthorizedTmux(source, setOptionEffect, setOptionReceipt), setOptionReceipt);
+          assert.equal(fixture.run(['show-options', '-pv', '-t', source.paneId, '@omx_probe_3459']), 'ok');
+
+          const workerPaneId = fixture.run(['split-window', '-d', '-h', '-P', '-F', '#{pane_id}', '-t', source.windowId]);
+          assert.match(workerPaneId, /^%[0-9]+$/, 'private fixture must create a second pane for layout coverage');
+          const selectLayoutEffect = `select-layout -t ${source.windowId} even-horizontal`;
+          const selectLayoutReceipt = 'omx_source_select_layout_3459';
+          expectedTransactions.push(expectedIfShellArgv(source, selectLayoutEffect, selectLayoutReceipt));
+          assert.equal(runSourceAuthorizedTmux(source, selectLayoutEffect, selectLayoutReceipt), selectLayoutReceipt);
+          const paneHeights = fixture.run(['list-panes', '-t', source.windowId, '-F', '#{pane_height}']).split('\n');
+          assert.equal(paneHeights.length, 2, 'layout coverage requires both private fixture panes');
+          assert.equal(new Set(paneHeights).size, 1, 'even-horizontal must assign equal heights');
+
+          const sendKeysEffect = `send-keys -t ${source.paneId} C-l`;
+          const sendKeysReceipt = 'omx_source_send_keys_3459';
+          expectedTransactions.push(expectedIfShellArgv(source, sendKeysEffect, sendKeysReceipt));
+          assert.equal(runSourceAuthorizedTmux(source, sendKeysEffect, sendKeysReceipt), sendKeysReceipt);
+
+          const hostileValue = "literal; no-command 'still literal'";
+          const hostileReceipt = `omx_source_hostile'; kill-session -t ${source.sessionName}; #`;
+          const hostileEffect = `set-option -p -t ${source.paneId} @omx_hostile_3459 ${quoteTmuxString(hostileValue)}`;
+          expectedTransactions.push(expectedIfShellArgv(source, hostileEffect, hostileReceipt));
+          assert.equal(runSourceAuthorizedTmux(source, hostileEffect, hostileReceipt), hostileReceipt);
+          assert.equal(fixture.run(['show-options', '-pv', '-t', source.paneId, '@omx_hostile_3459']), hostileValue);
+          assert.equal(fixture.sessionExists(), true, 'hostile receipt text must not execute a second tmux command');
+
+          const staleEffect = `set-option -p -t ${source.paneId} @omx_stale_3459 ${quoteTmuxString('unexpected')}`;
+          const staleReceipt = 'omx_source_stale_3459';
+          const staleSource = { ...source, panePid: source.panePid + 1 };
+          expectedTransactions.push(expectedIfShellArgv(staleSource, staleEffect, staleReceipt));
+          assert.throws(
+            () => runSourceAuthorizedTmux(staleSource, staleEffect, staleReceipt),
+            /tmux source authority changed before effect/,
+          );
+          assert.equal(
+            fixture.runResult(['show-options', '-pv', '-t', source.paneId, '@omx_stale_3459']).stdout.trim(),
+            '',
+            'failed authority must not apply the guarded effect',
+          );
+
+          const ifShellTransactions = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+            .filter((argv) => argv[0] === 'if-shell');
+          assert.deepEqual(ifShellTransactions, expectedTransactions, 'PATH shim must record exactly the product if-shell argv routed to the private server');
+          assert.doesNotMatch(await fixture.readServerLog(), /too many arguments/i, 'real tmux must not fold the receipt command into the effect argv');
+        } finally {
+          if (typeof previousPath === 'string') process.env.PATH = previousPath;
+          else delete process.env.PATH;
+        }
+      });
+    } finally {
+      if (typeof previousPath === 'string') process.env.PATH = previousPath;
+      else delete process.env.PATH;
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -271,7 +271,7 @@ function runTmuxStructured(args: string[]): { ok: true; stdout: string } | { ok:
 
 }
 
-type SourcePaneAuthority = {
+export type SourcePaneAuthority = {
   paneId: string;
   panePid: number;
   sessionName: string;
@@ -346,10 +346,10 @@ function bindSplitReceiptToPaneCommand(command: string, receipt: string): string
 }
 
 /** Queue an effect in the source pane's tmux server only when its exact pane/session/window incarnation still matches. */
-function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: string, receipt: string = sourceTransactionReceipt()): string {
+export function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: string, receipt: string = sourceTransactionReceipt()): string {
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    `${effect} \\; display-message -p ${shellQuoteSingle(receipt)}`,
+    `${effect} ; display-message -p ${shellQuoteSingle(receipt)}`,
     "display-message -p ''",
   ]);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);


### PR DESCRIPTION
Closes #3459.

Corrects the Team `runSourceAuthorizedTmux()` success-branch Node argv string so real tmux parses the receipt display as a second command in the existing single server-side `if-shell` transaction.

Evidence:
- Private real-tmux socket regression invokes the exported product helper through the actual Node argv layer.
- Regression saves/restores and prepends `process.env.PATH`, uses the private-server shim, asserts the exact `if-shell` argv, includes a bounded pane-readiness poll, and covers `set-option`, `select-layout`, `send-keys`, stale authority failure, exact receipts, and hostile literal input.
- `npm run build`
- `node dist/scripts/run-test-files.js dist/team/__tests__/tmux-source-authority-realtmux.test.js dist/team/__tests__/tmux-session.test.js dist/team/__tests__/runtime.test.js`
- `npm run lint`
- `npm run check:no-unused`

Scope remains limited to the Team authority transport, its test fixtures/regression, and ADR #3459; no HUD, scaling, CLI helper, #3457, or #3458 changes.