### PR TITLE
fix(setup): tolerate Windows hook mode synthesis

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3351,6 +3351,37 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("rejects Windows mode drift after a stable hook read-back", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-post-read-mode-drift-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		const tempPath = (path: string, purpose: "write" | "delete") =>
+			join(dirname(path), `.${basename(path)}.post-read-${purpose}.tmp`);
+		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
+		let injected = false;
+		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
+			if (stage !== "before_rename" || artifact.kind !== "hooks" || injected) return;
+			injected = true;
+			chmodSync(tempPath(artifact.path, "write"), 0o666);
+		});
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await assert.rejects(
+						setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true }),
+						/read-back changed/,
+					);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+				});
+			});
+			assert.equal(injected, true);
+		} finally {
+			resetFailureInjector();
+			resetTemporaryPath();
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("rejects Windows writable-bit drift with unchanged bytes and file identity", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-readonly-drift-"));
 		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -20,6 +20,7 @@ import { parse as parseToml } from "@iarna/toml";
 import {
 	decideWindowsNativeHookShimReference,
 	setNativeHookClaimJournalDurabilityForTest,
+	setNativeHookTransactionArtifactLstatForTest,
 	setNativeHookTransactionFailureInjectorForTest,
 	setSetupLatePhaseFailureInjectorForTest,
 	setNativeHookTransactionPlatformForTest,
@@ -3316,36 +3317,35 @@ describe("omx setup install mode behavior", () => {
 		});
 	}
 
-	it("accepts Windows synthetic mode drift while retaining file identity", async () => {
-		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-mode-drift-"));
+	it("accepts Windows mode synthesis during a newly created hook read-back", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-mode-readback-"));
 		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
-		const tempPath = (path: string, purpose: "write" | "delete") =>
-			join(dirname(path), `.${basename(path)}.mode-${purpose}.tmp`);
-		const resetTemporaryPath = setNativeHookTransactionTemporaryPathForTest(tempPath);
-		let checkedIdentity = 0;
-		const resetFailureInjector = setNativeHookTransactionFailureInjectorForTest((stage, artifact) => {
-			if (stage !== "before_rename") return;
-			const temporaryPath = tempPath(artifact.path, "write");
-			const before = lstatSync(temporaryPath);
-			chmodSync(temporaryPath, 0o666);
-			const after = lstatSync(temporaryPath);
-			assert.equal(after.dev, before.dev);
-			assert.equal(after.ino, before.ino);
-			checkedIdentity += 1;
+		const successfulStatsByPath = new Map<string, number>();
+		const synthesizedPaths = new Set<string>();
+		const resetArtifactLstat = setNativeHookTransactionArtifactLstatForTest(async (path) => {
+			const status = await lstat(path);
+			if (!basename(path).includes("hooks.json")) return status;
+			const successfulStats = successfulStatsByPath.get(path) ?? 0;
+			successfulStatsByPath.set(path, successfulStats + 1);
+			const mode = successfulStats === 0 ? 0o600 : 0o666;
+			if (successfulStats === 1) synthesizedPaths.add(path);
+			return new Proxy(status, {
+				get(target, property, receiver) {
+					if (property === "mode") return (target.mode & ~0o7777) | mode;
+					return Reflect.get(target, property, receiver);
+				},
+			});
 		});
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
 				await withTempCwd(wd, async () => {
-					const configPath = join(codexHomeDir, "config.toml");
-					await writeFile(configPath, 'notify = ["node", "/tmp/user-notify.js"]\n');
-					chmodSync(configPath, 0o600);
 					await setup({ scope: "user", installMode: "legacy", skipNativeAgentRefresh: true });
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
 				});
 			});
-			assert.ok(checkedIdentity >= 4);
+			assert.ok(synthesizedPaths.size >= 2);
 		} finally {
-			resetFailureInjector();
-			resetTemporaryPath();
+			resetArtifactLstat();
 			resetPlatform();
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -20,7 +20,7 @@ import {
 
 import { join, dirname, relative, basename, isAbsolute, sep, win32 } from "path";
 
-import { constants, existsSync } from "fs";
+import { constants, existsSync, type Stats } from "fs";
 import { spawnSync } from "child_process";
 import { createInterface } from "readline/promises";
 import { homedir } from "os";
@@ -552,8 +552,9 @@ let nativeHookTransactionRegularFileSyncOverride:
 	| ((platform: NodeJS.Platform) => Promise<void>)
 	| undefined;
 let nativeHookClaimJournalDurabilityOverride: NativeHookClaimJournalDurability | undefined;
-
-
+let nativeHookTransactionArtifactLstatOverride:
+	| ((path: string) => Promise<Stats>)
+	| undefined;
 
 /** @internal Test seam for deterministic atomic-write and rollback coverage. */
 export function setNativeHookTransactionFailureInjectorForTest(
@@ -616,6 +617,17 @@ export function setNativeHookTransactionRegularFileSyncForTest(
 	nativeHookTransactionRegularFileSyncOverride = sync;
 	return () => {
 		nativeHookTransactionRegularFileSyncOverride = previous;
+	};
+}
+
+/** @internal Test seam for deterministic artifact read-back coverage. */
+export function setNativeHookTransactionArtifactLstatForTest(
+	artifactLstat: ((path: string) => Promise<Stats>) | undefined,
+): () => void {
+	const previous = nativeHookTransactionArtifactLstatOverride;
+	nativeHookTransactionArtifactLstatOverride = artifactLstat;
+	return () => {
+		nativeHookTransactionArtifactLstatOverride = previous;
 	};
 }
 
@@ -707,7 +719,7 @@ function nativeHookTransactionTopologyEqual(
 		: left.mode === right.mode;
 }
 
-function nativeHookTransactionTopologyMatchesAcrossOpen(
+function nativeHookTransactionTopologyMatchesDuringReadback(
 	left: NativeHookTransactionTopology,
 	right: NativeHookTransactionTopology,
 ): boolean {
@@ -715,13 +727,13 @@ function nativeHookTransactionTopologyMatchesAcrossOpen(
 		nativeHookPlatform() === "win32" &&
 		left.kind === "regular_file" &&
 		right.kind === "regular_file" &&
-		((left.mode === 0o600 && right.mode === 0o666) ||
-			(left.mode === 0o666 && right.mode === 0o600))
+		left.mode === 0o600 &&
+		right.mode === 0o666
 	) {
-		// Windows synthesizes the requested new-file mode 0o600 as 0o666 from
-		// the read-only attribute. Keep this exception exact so writable/read-only
-		// drift remains an ownership failure; bytes, dev, ino, and nlink are
-		// still compared in the full snapshot.
+		// Windows can synthesize a requested new-file mode of 0o600 as 0o666
+		// when the same file is reopened for read-back. Accept only that one-way
+		// transition inside a single identity-checked snapshot; later snapshots
+		// remain mode-strict so real permission drift still fails closed.
 		return true;
 	}
 	return nativeHookTransactionTopologyEqual(left, right);
@@ -892,7 +904,7 @@ async function captureNativeHookTransactionArtifact(
 ): Promise<NativeHookTransactionArtifactSnapshot> {
 	let before;
 	try {
-		before = await lstat(path);
+		before = await (nativeHookTransactionArtifactLstatOverride?.(path) ?? lstat(path));
 	} catch (error) {
 		if (isMissingPathError(error)) {
 			return { bytes: null, topology: { kind: "absent" } };
@@ -905,7 +917,7 @@ async function captureNativeHookTransactionArtifact(
 		);
 	}
 	const bytes = await readFile(path);
-	const after = await lstat(path);
+	const after = await (nativeHookTransactionArtifactLstatOverride?.(path) ?? lstat(path));
 	const beforeTopology = {
 		kind: "regular_file" as const,
 		mode: before.mode & 0o7777,
@@ -917,7 +929,7 @@ async function captureNativeHookTransactionArtifact(
 	if (
 		!after.isFile() ||
 		after.nlink !== 1 ||
-		!nativeHookTransactionTopologyEqual(beforeTopology, afterTopology) ||
+		!nativeHookTransactionTopologyMatchesDuringReadback(beforeTopology, afterTopology) ||
 		before.dev !== after.dev ||
 		before.ino !== after.ino ||
 		before.nlink !== after.nlink
@@ -928,7 +940,7 @@ async function captureNativeHookTransactionArtifact(
 	}
 	return {
 		bytes,
-		topology: beforeTopology,
+		topology: afterTopology,
 		device: before.dev,
 		inode: before.ino,
 		links: before.nlink,
@@ -941,7 +953,7 @@ function nativeHookTransactionSnapshotsEqual(
 ): boolean {
 	return (
 		hookTransactionBytesEqual(left.bytes, right.bytes) &&
-		nativeHookTransactionTopologyMatchesAcrossOpen(left.topology, right.topology) &&
+		nativeHookTransactionTopologyEqual(left.topology, right.topology) &&
 		left.device === right.device &&
 		left.inode === right.inode &&
 		left.links === right.links
@@ -954,7 +966,7 @@ function nativeHookTransactionSnapshotMatchesExpected(
 ): boolean {
 	return (
 		hookTransactionBytesEqual(snapshot.bytes, expected.bytes) &&
-		nativeHookTransactionTopologyMatchesAcrossOpen(snapshot.topology, expected.topology)
+		nativeHookTransactionTopologyMatchesDuringReadback(expected.topology, snapshot.topology)
 	);
 }
 


### PR DESCRIPTION
## Summary
- accept the Windows-only one-way `0o600` → `0o666` mode synthesis while identity-checking a newly created native-hook artifact during read-back
- record the post-read topology so all later transaction snapshots remain mode-strict
- add deterministic positive and negative regressions for read-time synthesis versus post-read mode drift

## Safety
- content, device, inode, link-count, ancestor, ownership, path, race, rollback, and atomicity checks remain unchanged
- later snapshot comparisons reject real mode drift; writable-bit drift remains fail-closed
- no release flow or unrelated hook transaction behavior changed

## Verification
- `npm run build`
- targeted Windows synthesis, post-read drift, and writable-bit drift tests (3/3)
- full `dist/cli/__tests__/setup-install-mode.test.js` (127/127)
- `npm run lint`
- `npm run check:no-unused`
- `git diff --check`

Closes #3464