### PR TITLE
test(setup): lock Windows directory fsync fallback

### DIFF
--- a/src/cli/__tests__/native-hook-claim-journal.test.ts
+++ b/src/cli/__tests__/native-hook-claim-journal.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
 	clearNativeHookClaimJournal as clearNativeHookClaimJournalWithDurability,
 	createNativeHookClaimJournalDurability,
+	setNativeHookClaimJournalOpenForTest,
 	persistNativeHookClaimJournal as persistNativeHookClaimJournalWithDurability,
 	recoverNativeHookClaimJournal as recoverNativeHookClaimJournalWithDurability,
 } from "../native-hook-claim-journal.js";
@@ -27,6 +28,28 @@ async function markJournalOwnerDead(root: string): Promise<void> {
 	journal.ownerPid = 2_147_483_647;
 	await writeFile(path, `${JSON.stringify(journal, null, 2)}\n`, "utf-8");
 }
+
+test("native Windows directory fsync classifies EPERM and closes the handle", async () => {
+	const failure = Object.assign(new Error("EPERM: operation not permitted, fsync"), { code: "EPERM" });
+	let closed = false;
+	const restoreOpen = setNativeHookClaimJournalOpenForTest(async (path, flags) => {
+		assert.equal(path, "C:\\Users\\tester\\.codex\\.omx");
+		assert.equal(flags, "r");
+		return {
+			sync: async () => { throw failure; },
+			close: async () => { closed = true; },
+		};
+	});
+	try {
+		const outcome = await createNativeHookClaimJournalDurability("win32").syncDirectory(
+			"C:\\Users\\tester\\.codex\\.omx",
+		);
+		assert.equal(outcome, "unsupported-windows-eperm");
+		assert.equal(closed, true);
+	} finally {
+		restoreOpen();
+	}
+});
 
 test("claim journal restores an exact original after rename-away interruption", async () => {
 	const root = await mkdtemp(join(tmpdir(), "omx-claim-recovery-"));

--- a/src/cli/native-hook-claim-journal.ts
+++ b/src/cli/native-hook-claim-journal.ts
@@ -52,11 +52,27 @@ function processIsAlive(pid: number): boolean {
 	}
 }
 
+type NativeHookClaimJournalOpen = (
+	path: string,
+	flags: "r",
+) => Promise<Pick<FileHandle, "sync" | "close">>;
+
+let nativeHookClaimJournalOpen: NativeHookClaimJournalOpen = (path, flags) => open(path, flags);
+
+/** @internal Test seam for deterministic native directory-fsync coverage. */
+export function setNativeHookClaimJournalOpenForTest(openFn: NativeHookClaimJournalOpen): () => void {
+	const previous = nativeHookClaimJournalOpen;
+	nativeHookClaimJournalOpen = openFn;
+	return () => {
+		nativeHookClaimJournalOpen = previous;
+	};
+}
+
 async function fsyncDirectory(
 	path: string,
 	platform: NodeJS.Platform,
 ): Promise<DirectorySyncOutcome> {
-	const handle = await open(path, "r");
+	const handle = await nativeHookClaimJournalOpen(path, "r");
 	try {
 		return await syncDirectory(handle, platform);
 	} finally {


### PR DESCRIPTION
## Summary

Lock the native Windows directory-fsync compatibility boundary that prevents `omx setup` from rolling back when a valid directory handle reports unsupported `EPERM` from `fsync`.

The compatibility implementation was already present on `dev`, but its tests only covered the shared classifier and an injected post-classification outcome. This repair adds deterministic coverage through the actual native claim-journal directory open -> sync -> close path.

## Changes

- add a narrow native-hook claim-journal directory-open test seam
- reproduce `win32` directory-handle `EPERM` at the native fsync boundary
- assert the operation returns the degraded durability outcome and still closes the handle
- leave write, rename, content validation, and all non-`win32`/non-`EPERM` failures unchanged and fatal

## Validation

- [x] `npm run build`
- [x] `node --test dist/cli/__tests__/native-hook-claim-journal.test.js dist/utils/__tests__/file-durability.test.js` (26 passed)
- [x] `node --test dist/cli/__tests__/setup-install-mode.test.js` (126 passed)
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [ ] `omx doctor` (not run: deterministic regression covers the exact failing boundary without mutating user setup)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs unchanged; this is an internal durability regression seam/test
- [x] Compatibility remains restricted to Windows directory fsync `EPERM`

## Related

Closes #3465