### PR TITLE
fix(doctor): validate native process identity readiness

### DIFF
--- a/src/cli/__tests__/doctor-process-identity-readiness.test.ts
+++ b/src/cli/__tests__/doctor-process-identity-readiness.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  checkProcessIdentityReadiness,
+} from '../doctor.js';
+import type {
+  ProcessInspectionProvider,
+  ProcessObservation,
+} from '../../hooks/session.js';
+
+function providerReturning(observation: ProcessObservation): Pick<ProcessInspectionProvider, 'observeProcess'> {
+  return {
+    observeProcess: () => observation,
+  };
+}
+
+function providerReturningMalformed(observation: unknown): Pick<ProcessInspectionProvider, 'observeProcess'> {
+  return {
+    observeProcess: () => observation as ProcessObservation,
+  };
+}
+
+describe('doctor native process identity readiness', () => {
+  it('passes when the provider identifies the current process for the current platform', () => {
+    const calls: Array<{ pid: number; platform: NodeJS.Platform }> = [];
+    const check = checkProcessIdentityReadiness({
+      platform: 'darwin',
+      pid: 4242,
+      provider: {
+        observeProcess(pid, platform) {
+          calls.push({ pid, platform });
+          return {
+            kind: 'identity',
+            identity: { platform: 'darwin', birth: '123456' },
+          };
+        },
+      },
+    });
+
+    assert.deepEqual(calls, [{ pid: 4242, platform: 'darwin' }]);
+    assert.deepEqual(check, {
+      name: 'Process identity',
+      status: 'pass',
+      message: 'native process identity provider is ready',
+    });
+  });
+
+  it('preserves Linux compatibility by omitting the native runtime check', () => {
+    let called = false;
+    const check = checkProcessIdentityReadiness({
+      platform: 'linux',
+      provider: {
+        observeProcess() {
+          called = true;
+          return { kind: 'error' };
+        },
+      },
+    });
+
+    assert.equal(check, null);
+    assert.equal(called, false);
+  });
+
+  it('fails safely when the native runtime is missing or unsupported', () => {
+    const check = checkProcessIdentityReadiness({
+      platform: 'win32',
+      provider: providerReturning({ kind: 'unsupported' }),
+    });
+
+    assert.equal(check?.status, 'fail');
+    assert.equal(
+      check?.message,
+      'native process identity is unavailable (provider unavailable); reinstall or update OMX and rerun doctor',
+    );
+  });
+
+  it('fails safely for ambiguous current-process observations', () => {
+    for (const observation of [{ kind: 'gone' }, { kind: 'denied' }] as const) {
+      const check = checkProcessIdentityReadiness({
+        platform: 'darwin',
+        provider: providerReturning(observation),
+      });
+
+      assert.equal(check?.status, 'fail');
+      assert.match(check?.message ?? '', /reinstall or update OMX and rerun doctor$/);
+    }
+  });
+
+  it('rejects foreign-platform identity evidence without trusting or repairing it', () => {
+    const check = checkProcessIdentityReadiness({
+      platform: 'darwin',
+      provider: providerReturning({
+        kind: 'identity',
+        identity: { platform: 'win32', birth: '123456' },
+      }),
+    });
+
+    assert.equal(check?.status, 'fail');
+    assert.match(check?.message ?? '', /platform mismatch/);
+  });
+
+  it('fails safely for malformed, error, and throwing provider outcomes', () => {
+    const providers: Array<Pick<ProcessInspectionProvider, 'observeProcess'>> = [
+      providerReturning({ kind: 'error' }),
+      providerReturning({
+        kind: 'identity',
+        identity: { platform: 'darwin', birth: '' },
+      }),
+      {
+        observeProcess() {
+          throw new Error('synthetic provider failure');
+        },
+      },
+      providerReturningMalformed(undefined),
+      providerReturningMalformed(null),
+      providerReturningMalformed(42),
+    ];
+
+    for (const provider of providers) {
+      const check = checkProcessIdentityReadiness({ platform: 'darwin', provider });
+      assert.equal(check?.status, 'fail');
+      assert.match(check?.message ?? '', /provider response unverifiable/);
+    }
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -107,6 +107,11 @@ import {
 import { AGENT_DEFINITIONS } from "../agents/definitions.js";
 import { getInstallableNativeAgentNames } from "../agents/policy.js";
 import { readCatalogManifest } from "../catalog/reader.js";
+import {
+	defaultProcessInspectionProvider,
+	isValidProcessIdentity,
+	type ProcessInspectionProvider,
+} from "../hooks/session.js";
 
 let doctorClaimJournalDurabilityOverride: NativeHookClaimJournalDurability | undefined;
 
@@ -169,6 +174,12 @@ interface NativeHookDistSmokeOptions {
 	packageRoot?: string;
 	nodePath?: string;
 	runner?: typeof spawnSync;
+}
+
+interface ProcessIdentityReadinessOptions {
+	platform?: NodeJS.Platform;
+	pid?: number;
+	provider?: Pick<ProcessInspectionProvider, "observeProcess">;
 }
 
 type DoctorSetupScope = "user" | "project";
@@ -602,6 +613,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
 	// Check 2: Node.js version
 	checks.push(checkNodeVersion());
+
+	const processIdentityCheck = checkProcessIdentityReadiness();
+	if (processIdentityCheck) checks.push(processIdentityCheck);
 
 	// Check 2.5: Explore harness readiness
 	const exploreRoutingState = await resolveExploreRoutingState(paths.configPath);
@@ -1141,6 +1155,53 @@ function checkNodeVersion(): Check {
 		status: "fail",
 		message: `v${process.versions.node} (need >= 20)`,
 	};
+}
+
+export function checkProcessIdentityReadiness(
+	options: ProcessIdentityReadinessOptions = {},
+): Check | null {
+	const platform = options.platform ?? process.platform;
+	if (platform !== "darwin" && platform !== "win32") return null;
+
+	const pid = options.pid ?? process.pid;
+	const provider = options.provider ?? defaultProcessInspectionProvider;
+	try {
+		const observation = provider.observeProcess(pid, platform);
+		if (
+			observation.kind === "identity"
+			&& isValidProcessIdentity(observation.identity)
+			&& observation.identity.platform === platform
+		) {
+			return {
+				name: "Process identity",
+				status: "pass",
+				message: "native process identity provider is ready",
+			};
+		}
+
+		const reason = observation.kind === "identity"
+			? isValidProcessIdentity(observation.identity)
+				? "platform mismatch"
+				: "provider response unverifiable"
+			: observation.kind === "gone"
+				? "current process not identified"
+				: observation.kind === "denied"
+					? "provider access denied"
+					: observation.kind === "unsupported"
+						? "provider unavailable"
+						: "provider response unverifiable";
+		return {
+			name: "Process identity",
+			status: "fail",
+			message: `native process identity is unavailable (${reason}); reinstall or update OMX and rerun doctor`,
+		};
+	} catch {
+		return {
+			name: "Process identity",
+			status: "fail",
+			message: "native process identity is unavailable (provider response unverifiable); reinstall or update OMX and rerun doctor",
+		};
+	}
 }
 
 export function checkExploreHarness(

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -674,7 +674,7 @@ function isValidBirth(value: unknown): value is string {
   return typeof value === 'string' && PROCESS_BIRTH_PATTERN.test(value);
 }
 
-function isValidProcessIdentity(value: unknown): value is ProcessIdentity {
+export function isValidProcessIdentity(value: unknown): value is ProcessIdentity {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const identity = value as Partial<ProcessIdentity>;
   if (Object.keys(identity).some((key) => key !== 'platform' && key !== 'birth' && key !== 'cmdline_hash')) return false;


### PR DESCRIPTION
## Summary
- exercise the authoritative process-inspection provider from `omx doctor` on Darwin and Windows
- fail closed for unavailable, ambiguous, foreign-platform, malformed, or throwing identity observations
- preserve Linux behavior and keep the diagnostic strictly read-only with bounded reinstall/update guidance

## Verification
- `npm run build`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/doctor-process-identity-readiness.test.js dist/compat/__tests__/doctor-contract.test.js`
- `npm run lint`
- `npm run check:no-unused`

Closes #3462

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*