### PR TITLE
fix(hooks): stop authorization-failure reinjection

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -30327,7 +30327,7 @@ PY`,
     }
   });
 
-  it("bounds Stop replays when session.json is malformed", async () => {
+  it("never reinjects identical Stop authorization failures", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-malformed-session-pointer-"));
     try {
       const stateDir = join(cwd, ".omx", "state");
@@ -30337,23 +30337,126 @@ PY`,
         hook_event_name: "Stop" as const,
         cwd,
         session_id: "sess-current",
+        last_assistant_message: "The provenance tools are denied, so the pointer cannot be repaired.",
       };
 
-      const first = await dispatchCodexNativeHook(payload, { cwd });
-      const replay = await dispatchCodexNativeHook(
-        {
-          ...payload,
-          stop_hook_active: true,
-        },
-        { cwd },
-      );
+      const attempts = [];
+      for (let index = 0; index < 26; index += 1) {
+        attempts.push(await dispatchCodexNativeHook(payload, { cwd }));
+      }
 
-      assert.equal(first.omxEventName, "stop");
-      assert.equal(first.outputJson?.decision, "block");
-      assert.equal(first.outputJson?.stopReason, "session_pointer_unusable");
-      assert.equal(replay.omxEventName, "stop");
-      assert.equal(replay.outputJson, null);
+      assert.deepEqual(attempts.map((attempt) => attempt.omxEventName), Array(26).fill("stop"));
+      assert.deepEqual(attempts.map((attempt) => attempt.outputJson), Array(26).fill(null));
       assert.equal(existsSync(join(stateDir, "native-stop-state.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Stop authorization failures terminal across session, cwd, and reason changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-auth-variants-"));
+    try {
+      const malformedCwd = join(root, "malformed");
+      const foreignCwd = join(root, "foreign");
+      const unmatchedCwd = join(root, "unmatched");
+      await mkdir(join(malformedCwd, ".omx", "state"), { recursive: true });
+      await mkdir(join(foreignCwd, ".omx", "state"), { recursive: true });
+      await writeFile(join(malformedCwd, ".omx", "state", "session.json"), "{not-json");
+      await writeJson(join(foreignCwd, ".omx", "state", "session.json"), {
+        session_id: "foreign-owner",
+        native_session_id: "foreign-owner",
+        cwd: join(root, "other-worktree"),
+        pid: process.pid,
+      });
+      await writeSessionStart(unmatchedCwd, "selected-owner", {
+        nativeSessionId: "selected-owner",
+        pid: process.pid,
+      });
+
+      const cases = [
+        { cwd: malformedCwd, session_id: "malformed-session" },
+        { cwd: foreignCwd, session_id: "foreign-owner" },
+        { cwd: unmatchedCwd, session_id: "unmatched-session" },
+      ];
+      for (const payload of cases) {
+        const first = await dispatchCodexNativeHook({ hook_event_name: "Stop", ...payload }, { cwd: payload.cwd });
+        const changed = await dispatchCodexNativeHook({
+          hook_event_name: "Stop",
+          ...payload,
+          session_id: `${payload.session_id}-changed`,
+          stop_hook_active: true,
+        }, { cwd: payload.cwd });
+        assert.equal(first.outputJson, null);
+        assert.equal(changed.outputJson, null);
+        assert.equal(existsSync(join(payload.cwd, ".omx", "state", "native-stop-state.json")), false);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not inherit authority across sessions and restores ordinary Stop behavior after progress", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-stop-auth-session-isolation-"));
+    try {
+      const stateDir = join(cwd, ".omx", "state");
+      const ownerSessionId = "selected-owner";
+      await writeSessionStart(cwd, ownerSessionId, {
+        nativeSessionId: ownerSessionId,
+        pid: process.pid,
+      });
+      await writeSessionSkillActiveState(stateDir, ownerSessionId, "ralph", "executing");
+      const ralphStatePath = join(stateDir, "sessions", ownerSessionId, "ralph-state.json");
+      await writeJson(ralphStatePath, {
+        active: true,
+        mode: "ralph",
+        current_phase: "executing",
+        session_id: ownerSessionId,
+        workingDirectory: cwd,
+      });
+      const pointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+
+      const foreignStop = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: "foreign-session",
+      }, { cwd });
+      assert.equal(foreignStop.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+
+      const authorizedBlocked = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: ownerSessionId,
+      }, { cwd });
+      assert.equal(authorizedBlocked.outputJson?.decision, "block");
+      assert.match(String(authorizedBlocked.outputJson?.stopReason), /^ralph_/);
+
+      await writeJson(ralphStatePath, {
+        active: false,
+        mode: "ralph",
+        current_phase: "complete",
+        session_id: ownerSessionId,
+        workingDirectory: cwd,
+        completion_audit: {
+          passed: true,
+          prompt_to_artifact_checklist: ["Stop authorization remained session-scoped."],
+          verification_evidence: ["The selected owner retained ordinary Stop enforcement."],
+        },
+      });
+      await writeJson(join(stateDir, "sessions", ownerSessionId, "skill-active-state.json"), {
+        active: false,
+        skill: "ralph",
+        phase: "complete",
+        session_id: ownerSessionId,
+        active_skills: [],
+      });
+
+      const authorizedAfterProgress = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: ownerSessionId,
+      }, { cwd });
+      assert.equal(authorizedAfterProgress.outputJson, null);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -23237,27 +23237,12 @@ export async function dispatchCodexNativeHook(
           : null
       );
     } else {
-      const failure = stopAuthorizationFailure ?? {
-        stopReason: "session_pointer_unusable",
-        reason: "OMX cannot authorize Stop without a writable session authority.",
-      };
-      const stopHookActive = payload.stop_hook_active === true || payload.stopHookActive === true;
-      const pointerCannotAuthorizeThisCwd = pointer.status === "foreign-cwd";
-      const unmatchedStopSession = failure.stopReason === "session_scope_unmatched";
-      // An unmatched payload, foreign-cwd pointer, or identity-indeterminate pointer
-      // cannot authorize continuation. Return no output so Codex cannot reinterpret an
-      // authorization diagnostic as a new action request. Other unusable pointers retain
-      // their bounded replay behavior.
-      if (pointerCannotAuthorizeThisCwd || pointer.status === "identity-indeterminate" || unmatchedStopSession || stopHookActive) {
-        outputJson = null;
-      } else {
-        outputJson = {
-          decision: "block",
-          stopReason: failure.stopReason,
-          reason: failure.reason,
-          systemMessage: failure.reason,
-        };
-      }
+      // Authorization failure never grants continuation authority. It also must not
+      // inject a repair request: the same provenance failure can deny every tool the
+      // model would need to repair it, turning a Stop denial into an unbounded loop.
+      // Returning no hook output permits termination while preserving the denial of
+      // all session-scoped and global side effects above.
+      outputJson = null;
     }
   }
 


### PR DESCRIPTION
## Summary
- make every failed Stop authorization terminal by returning no hook output instead of reinjecting an unrepairable authorization diagnostic
- preserve fail-closed session authority: unauthorized paths still skip all session/global side effects and cannot inherit authority from the selected session
- keep the ordinary authorized Stop path unchanged, including Ralph/workflow blockers and post-progress release

## Independent reproduction
Current `origin/dev` already suppresses the reported `foreign-cwd` variant, but the same authorization-failure branch remained unbounded for other unusable pointer states when Codex omitted `stop_hook_active`.

A malformed selected pointer reproduced 12 identical blocks on current dev:

```text
["session_pointer_unusable", "session_pointer_unusable", ... x12]
```

The model cannot make progress in that state when provenance-denied tools are the only repair route.

## Contract
A Stop authorization failure grants no continuation authority. Because that branch has already denied all implicit/global side effects, it must return no hook output and permit termination rather than inject a repair request. Authorized Stop handling continues through `buildStopHookOutput` unchanged.

## Regression coverage
- 26 identical authorization failures without replay metadata produce no reinjection
- malformed, foreign-cwd, and unmatched-session reasons remain terminal across session/cwd/reason changes
- unauthorized attempts do not write native Stop replay state or mutate the selected pointer
- a foreign session cannot inherit the selected owner's authority
- the selected owner still receives ordinary Ralph Stop enforcement
- completed owner progress releases Stop normally

## Verification
- `npm run build`
- `node --test dist/scripts/__tests__/codex-native-hook.test.js` — 647 passed
- `npm run lint`
- `npm run check:no-unused`
- adversarial GJC review: APPROVE, no findings

Closes #3469
