### PR TITLE
release: 0.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.20.5] - 2026-08-10
+
+Patch release for the exact 68-commit range `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196`. No intentional breaking CLI or package-layout changes.
+
+### Fixed
+
+- **Darwin detached finalization** — bind readiness and metadata to live launch authority, tear down exact HUD/leader panes, and return control only after finalization (#3472).
+- **Session and hook authority** — finalize exact indeterminate bindings, revalidate directory capabilities, expose trusted lock diagnostics, silence indeterminate Stop handling, and prevent authorization-failure reinjection (#3416, #3421, #3471, #3472).
+- **Ralplan lifecycle and diagnostics** — preserve preflight state, report detected versions structurally, clear stale owner state, permit typed consensus delegation, and recognize Codex 0.148 alpha versions (#3450, #3455, #3456, #3473).
+- **Windows/setup durability** — tolerate directory `fsync` and mode-synthesis platform differences while preserving user launch preferences and project scope (#3448, #3449, #3467, #3468).
+- **Team/tmux boundaries** — explain foreign pane topology and preserve source-authority separator argv boundaries (#3434, #3460).
+- **Plugin/runtime packaging** — make packed runtime/cwd checks deterministic, bind detached state to launch context, and validate native process identity readiness (#3395, #3436, #3454, #3461, #3470).
+
+### Changed
+
+- Updated `windows-sys` from 0.59 to 0.61.2, `tar-stream` from 2.2.0 to 3.2.0, `@types/tar-stream` from 2.2.3 to 3.1.4, `@biomejs/biome` from 2.5.4 to 2.5.6, and `@types/node` from 26.1.1 to 26.1.2 (#3429–#3432).
+
 ## [0.20.4] - 2026-07-28
 
 Patch release for the reliability, workflow-safety, and native-hook trust work in `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f`, plus one additive, backward-compatible feature. No intentional breaking CLI or package-layout changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "omx-api"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -40,14 +40,14 @@ dependencies = [
 
 [[package]]
 name = "omx-explore-harness"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "omx-mux"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "fs2",
  "libc",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "omx-runtime-core"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "fs2",
  "serde",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "omx-sparkshell"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "omx-mux",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.20.4"
+version = "0.20.5"
 
 edition = "2021"
 rust-version = "1.73"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,39 +1,23 @@
-# oh-my-codex 0.20.4
+# oh-my-codex 0.20.5
 
-`0.20.4` is a patch release for the reliability, workflow-safety, and native-hook trust work in the exact range `v0.20.3..73cb50c125c11aca0654b8841e690f011eb5f43f`, plus one additive, backward-compatible feature.
+`0.20.5` is a patch release for the exact range `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196` (68 commits, 35 merged PRs). It contains no intentional breaking CLI or package-layout changes.
 
 ## Highlights
 
-- Dead session-pointer lock recovery with identity-revalidated, no-clobber reversible claims, resumable checkpoints, and atomic quarantine (#3261, #3262; issue #3256).
-- Team startup rollback bound to exact owned panes with split-proof reconciliation, worker liveness pinning, leader session pointer ownership, stale notice invalidation, terminal follow-up boundary guards, and fail-closed managed Codex bypass rejection (#3265; #3231, #3228, #3229, #3230, #3232; issue #3224).
-- Native hook trust and path canonicalization: exact absolute package CLI status trusted (#3333; issues #3320, #3322, #3323, #3325, #3321, #3327), conductor mutation roots and macOS policy/fixture paths canonicalized, planning state transport guards repaired (#3343, #3344, #3348, #3349, #3350, #3351, #3352, #3353).
-- Ultragoal goal-status preservation, canonical state path binding, aggregate completion persistence, and finite Codex goal tool authorization under Main-root Conductor (#3301, #3305, #3294, #3297, #3295, #3300, #3304).
-- State authoritative runtime root with session-scoped authority, authenticated fixtures, and plugin authority isolation (#3160).
-- Opt-in Herdr lifecycle/status bridge Phase 1 (#3241, #3242).
-- Ralplan review authority remains fail-closed without an official host consensus receipt, and autopilot preflight fails before deep-interview and Architect/Critic review work when the receipt verifier is unavailable (#3270).
+- **Darwin detached return-to-shell and finalization** — detached launches now bind readiness and metadata to the live pane, retain exact HUD/leader authority through teardown, release attach only after finalization, and exercise the return-to-shell path on macOS (#3472).
+- **Session and hook authority** — exact indeterminate bindings are finalized with synchronous directory-capability revalidation; trusted lock inspection is available for diagnostics; identity-indeterminate Stop handling is silent; authorization failures are no longer reinjected (#3416, #3421, #3471, #3472).
+- **Ralplan diagnostics and lifecycle** — preflight remains state-preserving, reports structured detected-version diagnostics, clears stale owner-scoped state, permits typed consensus delegation, and recognizes Codex 0.148 alpha versions (#3450, #3455, #3456, #3473).
+- **Windows and setup durability** — directory `fsync` `EPERM`, hook mode synthesis, and mode read-back are tolerated on Windows; launch repair preserves user notify/reasoning settings and project scope (#3448, #3449, #3467, #3468).
+- **Team/tmux boundaries** — foreign pane topology is explained rather than claimed, and source-authority separator argv boundaries are preserved (#3434, #3460).
+- **Plugin/runtime and packed-install fixes** — packed runtime provisioning and cwd checks are deterministic, ambient session state is scrubbed, detached OMX state is bound to launch context, and Doctor validates native process-identity readiness (#3395, #3436, #3454, #3461, #3470).
+- **Dependencies** — `windows-sys` 0.59→0.61.2, `tar-stream` 2.2.0→3.2.0, `@types/tar-stream` 2.2.3→3.1.4, `@biomejs/biome` 2.5.4→2.5.6, and `@types/node` 26.1.1→26.1.2 (#3429–#3432).
 
-> **Current status / supersession (ADR 3212):** Local leader attestation and adapted role intent no longer authorize. Typed routing/tracker evidence are lifecycle/diagnostic only. On `role_routing_unavailable` adapted Ralplan authority attempts, installed role-intent/preflight fails closed with `unsupported_documented_leader_proof`. Consensus is unavailable with `documented_host_consensus_receipt_unavailable` absent an official host receipt.
+## Compatibility
 
-## Additional fixes
-
-- Resumed session cancel ownership reconciliation (#3280, #3290, #3214).
-- Root session self-reopen prevention (#3284, #3289).
-- Identity-indeterminate pointer recovery (#3324, #3332).
-- State alias resolution and stale binding revalidation (#3308, #3272, #3298).
-- Deep-interview cancel hook ownership and PreToolUse self-lock fix (#3293, #3299, #3240).
-- HUD teardown on child exit and deferred resize guards (#3267, #3292, #3296).
-- Native Stop hook bounds: session-scoped sloppy fallback audit, pointer loop bounds, paused guidance bounds, unmatched Stop silence (#3347, #3238, #3237, #3254).
-- Native sidecar and collaboration authority scoping (#3244, #3235, #3264, #3317).
-- Standalone Conductor activation guard and unauthoritative plan bootstrap rejection (#3311, #3312, #3326).
-- Read-only discovery misclassification fix (#3313, #3314, #3318).
-- Auth metadata validation, oversized hook stdin drain, nonexistent assignment guidance removal (#3276, #3273, #3346).
-- Windows session owner PID, Bun install ownership, tmux separator argv boundaries (#3260, #3259, #3258).
-- Ralplan preflight guidance scoping and PowerShell psmux pane safety (#3255, #3145).
-- Autopilot host-receipt preflight and native cache integrity fail-closed (#3270, #3285).
-- Dependency updates: libc, serde, serde_json, @modelcontextprotocol/sdk, @biomejs/biome, c8, @types/yauzl, @types/yazl.
+Patch release with no intentional breaking contract. Publication, tag, GitHub Release, and npm availability remain pending the owner-authorized promotion lane.
 
 ## Contributors
 
-Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with additional contributions from @achieve0410, @bohe76, @chief-impact7, @don9x2E, @huajuan404, @ictechgy, @lux-02, @masterFoad, and @WangErgouaaaa, plus @app/dependabot for dependency updates.
+Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with an additional contribution from @ev78394, plus @app/dependabot for dependency updates.
 
-**Full Changelog**: [`v0.20.3...v0.20.4`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.3...v0.20.4)
+**Full Changelog**: [`v0.20.4...v0.20.5`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.4...v0.20.5)

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -12,6 +12,8 @@
 - **Plugin/runtime and packed-install fixes** — packed runtime provisioning and cwd checks are deterministic, ambient session state is scrubbed, detached OMX state is bound to launch context, and Doctor validates native process-identity readiness (#3395, #3436, #3454, #3461, #3470).
 - **Dependencies** — `windows-sys` 0.59→0.61.2, `tar-stream` 2.2.0→3.2.0, `@types/tar-stream` 2.2.3→3.1.4, `@biomejs/biome` 2.5.4→2.5.6, and `@types/node` 26.1.1→26.1.2 (#3429–#3432).
 
+> **Current status / supersession (ADR 3212):** Local leader attestation and adapted role intent do not authorize. Typed routing and tracker evidence are lifecycle or diagnostic evidence only. When `role_routing_unavailable` applies to an adapted Ralplan authority attempt, installed role-intent and preflight fail closed with `unsupported_documented_leader_proof`. Ralplan consensus remains unavailable with `documented_host_consensus_receipt_unavailable` because no official host receipt verifier exists; native Architect/Critic evidence alone cannot release the transition.
+
 ## Compatibility
 
 Patch release with no intentional breaking contract. Publication, tag, GitHub Release, and npm availability remain pending the owner-authorized promotion lane.

--- a/artifacts/release-0.20.5/inventory.md
+++ b/artifacts/release-0.20.5/inventory.md
@@ -1,0 +1,30 @@
+# Release 0.20.5 inventory
+
+- Previous tag: `v0.20.4` (`a62d5bd77bef6d2bc7df467dcae68082b8616239`)
+- Frozen candidate: `13c08f84cb6c27750b8f5c4a4d5105faad074196`
+- Exact range: `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196`
+- Merge base: `229d5dc4fd82aa87e274ddf22dbe197987f2778e`
+- Count: 68 commits; 35 merged PRs
+- Classification: patch release; no intentional breaking contract
+
+Reproduce the commit inventory:
+
+```sh
+git log --reverse --format='%H%x09%an%x09%s' v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196
+```
+
+## Classification
+
+- **Darwin detached return-to-shell/finalization:** live-pane readiness, atomic launch metadata, exact HUD/leader teardown, attach release after finalization, and macOS CI coverage.
+- **Session/hook authority:** exact indeterminate binding finalization, synchronous capability revalidation, lock inspection diagnostics, schema-safe Stop behavior, and authorization-failure handling.
+- **Ralplan diagnostics/lifecycle:** state-preserving preflight, structured detected-version diagnostics, stale owner-state cleanup, typed consensus delegation, and Codex 0.148 alpha recognition.
+- **Windows/setup durability:** directory `fsync` and mode-synthesis tolerance, platform-aware fixtures, and launch-repair preference/scope preservation.
+- **Team/tmux boundaries:** foreign topology diagnostics and exact source-authority separator argv preservation.
+- **Plugin/runtime/packaging:** deterministic packed runtime/cwd checks, launch-context state binding, native identity readiness, and hermetic smoke behavior.
+- **Dependencies:** `windows-sys`, `tar-stream`, `@types/tar-stream`, `@biomejs/biome`, and `@types/node` updates.
+
+## Merged PRs
+
+#3395, #3396, #3401, #3402, #3403, #3404, #3409, #3410, #3413, #3416, #3419, #3421, #3425, #3429, #3430, #3431, #3432, #3434, #3436, #3446, #3448, #3449, #3450, #3453, #3454, #3455, #3456, #3460, #3461, #3467, #3468, #3470, #3471, #3472, #3473.
+
+Associated issue references in commit subjects are not additional PRs.

--- a/docs/qa/release-readiness-0.20.5.md
+++ b/docs/qa/release-readiness-0.20.5.md
@@ -1,0 +1,41 @@
+# Release readiness — 0.20.5
+
+## Release identity
+
+- Release: `0.20.5` (patch; no intentional breaking contract).
+- Date: 2026-08-10.
+- Previous tag: `v0.20.4` (`a62d5bd77bef6d2bc7df467dcae68082b8616239`).
+- Frozen dev base: `13c08f84cb6c27750b8f5c4a4d5105faad074196`.
+- Exact compare range: `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196`.
+- Range size: 68 commits and 35 merged PRs.
+- Merge base: `229d5dc4fd82aa87e274ddf22dbe197987f2778e`.
+- Compatibility: no intentional breaking CLI or package-layout changes.
+
+## Boundary note
+
+`v0.20.4` is not an ancestor of the frozen `dev` base; both descend from `229d5dc4fd82aa87e274ddf22dbe197987f2778e`. The owner explicitly froze the compare expression above. The promotion lane must reconcile the release-tag/main ancestry before tagging `v0.20.5`; this lane does not merge main or create tags.
+
+## Required gates
+
+| Gate | Evidence | Status |
+|---|---|---|
+| Version carriers | `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, and `plugins/oh-my-codex/.codex-plugin/plugin.json` are `0.20.5`; `cargo check --workspace` built all six workspace packages as `0.20.5`. | Passed locally |
+| Version sync | `node dist/scripts/check-version-sync.js --tag v0.20.5` reported `OK package=0.20.5 workspace=0.20.5 tag=v0.20.5`. | Passed locally |
+| Build | `npm ci`; `npm run build`. | Passed locally |
+| Static check | `npm run check:no-unused`; `npm run lint` (793 files, no fixes). | Passed locally |
+| Bundle/catalog | Native-agent verification (22 agents, 37 prompt assets), plugin mirror verification (29 skill directories), and catalog check. | Passed locally |
+| Release body | `RELEASE_BODY.md` has the required Contributors section and compare line. The generator correctly refused because `v0.20.5` does not exist and `v0.20.4` is not an ancestor of the candidate; generation must run after ancestry reconciliation and tag creation in the promotion lane. | Blocked by recorded ancestry boundary |
+| Package dry run | `npm pack --dry-run` completed for `oh-my-codex@0.20.5`, including prepack bundle checks. | Passed locally |
+| Focused high-risk tests | Launch fallback/session, Ralplan, setup install mode, Team/tmux, real tmux source-authority, and plugin layout: 291 tests passed, 0 failed. | Passed locally |
+| Diff hygiene | `git diff --check`. | Passed locally |
+| Adversarial review | Carrier values, 68-commit/35-PR counts, dependency claims, contributor sentence, no-publication language, and compare links checked; only the explicit ancestry/generator boundary remains. | Passed with recorded boundary |
+| CI / tag / npm | Promotion-lane responsibility; no publication is claimed here. | Pending external gates |
+
+## Known gaps
+
+- Broad cross-platform and native-build matrices are CI-authoritative.
+- No tag, GitHub Release, main merge, or npm publication is performed or claimed by this release-preparation lane.
+
+## Publish boundary
+
+After this PR is green on `dev`, the owner-authorized promotion lane must reconcile ancestry, promote to `main`, wait for green CI, tag `v0.20.5`, verify release assets and npm, and record external evidence here.

--- a/docs/release-notes-0.20.5.md
+++ b/docs/release-notes-0.20.5.md
@@ -1,0 +1,29 @@
+# oh-my-codex 0.20.5 release notes
+
+Release date: 2026-08-10
+
+`0.20.5` is a patch release covering the exact frozen range `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196`: 68 commits and 35 merged PRs, with no intentional breaking CLI or package-layout changes.
+
+## Highlights
+
+- Darwin detached launches now return control only after exact leader/HUD finalization, with live-pane readiness and atomic metadata binding (#3472).
+- Session and native-hook authority is tightened around indeterminate bindings, directory capabilities, lock diagnostics, Stop handling, and authorization-failure reinjection (#3416, #3421, #3471, #3472).
+- Ralplan preflight is state-preserving, emits structured version diagnostics, clears stale owner state, supports typed consensus delegation, and recognizes Codex 0.148 alpha versions (#3450, #3455, #3456, #3473).
+- Windows setup tolerates directory durability and mode-synthesis differences while launch repair preserves user notify/reasoning settings and project scope (#3448, #3449, #3467, #3468).
+- Team preserves tmux source-authority separator boundaries and explains foreign pane topology instead of claiming it (#3434, #3460).
+- Packed-install/runtime checks are deterministic, detached state is launch-bound, and Doctor validates native process identity readiness (#3395, #3436, #3454, #3461, #3470).
+- Dependencies update `windows-sys`, `tar-stream`, `@types/tar-stream`, `@biomejs/biome`, and `@types/node` (#3429–#3432).
+
+## Inventory
+
+The concise, reproducible range and PR inventory is recorded in `artifacts/release-0.20.5/inventory.md`. The merged PRs are [#3395](https://github.com/Yeachan-Heo/oh-my-codex/pull/3395), [#3396](https://github.com/Yeachan-Heo/oh-my-codex/pull/3396), [#3401](https://github.com/Yeachan-Heo/oh-my-codex/pull/3401), [#3402](https://github.com/Yeachan-Heo/oh-my-codex/pull/3402), [#3403](https://github.com/Yeachan-Heo/oh-my-codex/pull/3403), [#3404](https://github.com/Yeachan-Heo/oh-my-codex/pull/3404), [#3409](https://github.com/Yeachan-Heo/oh-my-codex/pull/3409), [#3410](https://github.com/Yeachan-Heo/oh-my-codex/pull/3410), [#3413](https://github.com/Yeachan-Heo/oh-my-codex/pull/3413), [#3416](https://github.com/Yeachan-Heo/oh-my-codex/pull/3416), [#3419](https://github.com/Yeachan-Heo/oh-my-codex/pull/3419), [#3421](https://github.com/Yeachan-Heo/oh-my-codex/pull/3421), [#3425](https://github.com/Yeachan-Heo/oh-my-codex/pull/3425), [#3429](https://github.com/Yeachan-Heo/oh-my-codex/pull/3429), [#3430](https://github.com/Yeachan-Heo/oh-my-codex/pull/3430), [#3431](https://github.com/Yeachan-Heo/oh-my-codex/pull/3431), [#3432](https://github.com/Yeachan-Heo/oh-my-codex/pull/3432), [#3434](https://github.com/Yeachan-Heo/oh-my-codex/pull/3434), [#3436](https://github.com/Yeachan-Heo/oh-my-codex/pull/3436), [#3446](https://github.com/Yeachan-Heo/oh-my-codex/pull/3446), [#3448](https://github.com/Yeachan-Heo/oh-my-codex/pull/3448), [#3449](https://github.com/Yeachan-Heo/oh-my-codex/pull/3449), [#3450](https://github.com/Yeachan-Heo/oh-my-codex/pull/3450), [#3453](https://github.com/Yeachan-Heo/oh-my-codex/pull/3453), [#3454](https://github.com/Yeachan-Heo/oh-my-codex/pull/3454), [#3455](https://github.com/Yeachan-Heo/oh-my-codex/pull/3455), [#3456](https://github.com/Yeachan-Heo/oh-my-codex/pull/3456), [#3460](https://github.com/Yeachan-Heo/oh-my-codex/pull/3460), [#3461](https://github.com/Yeachan-Heo/oh-my-codex/pull/3461), [#3467](https://github.com/Yeachan-Heo/oh-my-codex/pull/3467), [#3468](https://github.com/Yeachan-Heo/oh-my-codex/pull/3468), [#3470](https://github.com/Yeachan-Heo/oh-my-codex/pull/3470), [#3471](https://github.com/Yeachan-Heo/oh-my-codex/pull/3471), [#3472](https://github.com/Yeachan-Heo/oh-my-codex/pull/3472), and [#3473](https://github.com/Yeachan-Heo/oh-my-codex/pull/3473).
+
+## Validation
+
+Local release-blocking evidence is recorded in `docs/qa/release-readiness-0.20.5.md`. Broad platform CI, tagging, GitHub Release creation, and npm publication are intentionally left to the promotion lane.
+
+## Contributors
+
+Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with an additional contribution from @ev78394, plus @app/dependabot for dependency updates.
+
+**Full Changelog**: [`v0.20.4...v0.20.5`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.4...v0.20.5)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.20.4",
+      "version": "0.20.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",


### PR DESCRIPTION
## Summary
- synchronize canonical package, Cargo workspace/lock, and plugin versions to 0.20.5
- add concise release notes, readiness evidence, changelog, GitHub body, and range inventory
- classify the exact `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196` range (68 commits, 35 merged PRs)

## Local gates
- `npm ci`
- `npm run build`
- `node dist/scripts/check-version-sync.js --tag v0.20.5`
- `npm run check:no-unused && npm run lint`
- native agents, plugin bundle, and catalog checks
- focused high-risk tests: 291 passed, 0 failed
- `npm pack --dry-run`
- `git diff --check`

## Recorded boundary
`v0.20.4` is not an ancestor of the frozen dev base; both descend from `229d5dc4fd82aa87e274ddf22dbe197987f2778e`. The promotion lane must reconcile ancestry before main/tag/publish. No tag, main merge, GitHub Release, or npm publication was performed here.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*