### PR TITLE
fix(stop): authorize transcript-bound Stop when the selected pointer is stale-dead (#3427)

### DIFF
--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -40354,3 +40354,520 @@ describe("native Team notice ledger reconciliation", () => {
     }
   });
 });
+describe("Stop transcript-backed recovery for a stale-dead selected pointer (issue #3427)", { concurrency: false }, () => {
+  async function writeStaleDeadStopFixture(
+    cwd: string,
+    sessionId: string,
+    options: { transcript?: boolean; sessionDir?: boolean; pointer?: Record<string, unknown> } = {},
+  ): Promise<{ stateDir: string; transcriptPath: string; pointerBefore: string }> {
+    const stateDir = join(cwd, ".omx", "state");
+    await mkdir(stateDir, { recursive: true });
+    await writeJson(join(stateDir, "session.json"), {
+      session_id: sessionId,
+      cwd,
+      pid: 2_147_483_647,
+      ...options.pointer,
+    });
+    const pointerBefore = await readFile(join(stateDir, "session.json"), "utf-8");
+    const transcriptPath = join(cwd, `rollout-${sessionId}.jsonl`);
+    if (options.transcript !== false) {
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId, session_id: sessionId, cwd, timestamp: "2026-08-03T00:00:00.000Z" },
+        })}\n`,
+      );
+    }
+    if (options.sessionDir !== false) {
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+    }
+    return { stateDir, transcriptPath, pointerBefore };
+  }
+
+  async function writeSessionScopedModeState(cwd: string, sessionId: string, mode: string): Promise<void> {
+    const stateDir = join(cwd, ".omx", "state");
+    await writeJson(join(stateDir, "sessions", sessionId, `${mode}-state.json`), {
+      active: true,
+      mode,
+      current_phase: "executing",
+      session_id: sessionId,
+      workingDirectory: cwd,
+    });
+  }
+
+  it("authorizes an exact stale-dead Stop through the payload transcript and evaluates session-scoped state", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-transcript-recovery-"));
+    try {
+      const sessionId = "live-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+      await writeSessionScopedModeState(cwd, sessionId, "autopilot");
+
+      const first = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        turn_id: "3427-stop-turn",
+      }, { cwd });
+
+      assert.equal(first.outputJson?.decision, "block");
+      assert.equal(first.outputJson?.stopReason, "autopilot_executing");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+      assert.equal(existsSync(join(stateDir, "native-stop-state.json")), false);
+
+      // The recovery is read-only, so a repeated Stop is idempotent.
+      const second = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        turn_id: "3427-stop-turn-2",
+      }, { cwd });
+      assert.equal(second.outputJson?.stopReason, "autopilot_executing");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("authorizes the exact stale-dead Stop as a clean no-op when no session-scoped state is active", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-transcript-clean-stop-"));
+    try {
+      const sessionId = "clean-live-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for a foreign transcript cwd", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-foreign-cwd-"));
+    try {
+      const sessionId = "foreign-cwd-session-3427";
+      const foreignCwd = join(tmpdir(), "omx-3427-unrelated-repo");
+      await mkdir(foreignCwd, { recursive: true });
+      const { stateDir, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { sessionDir: false });
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      const transcriptPath = join(cwd, `rollout-${sessionId}.jsonl`);
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId, session_id: sessionId, cwd: foreignCwd },
+        })}\n`,
+      );
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the transcript session_meta id does not match the payload session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-mismatched-id-"));
+    try {
+      const sessionId = "mismatch-session-3427";
+      const { stateDir, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { sessionDir: false });
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      const transcriptPath = join(cwd, `rollout-${sessionId}.jsonl`);
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: "some-other-session", session_id: sessionId, cwd },
+        })}\n`,
+      );
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the transcript filename is not bound to the session id", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-filename-binding-"));
+    try {
+      const sessionId = "filename-bound-session-3427";
+      const { stateDir, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { sessionDir: false });
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+      const transcriptPath = join(cwd, "rollout-unrelated.jsonl");
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId, session_id: sessionId, cwd },
+        })}\n`,
+      );
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for a relative transcript path", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-relative-transcript-"));
+    try {
+      const sessionId = "relative-transcript-session-3427";
+      const { stateDir, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { sessionDir: false });
+      await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: `rollout-${sessionId}.jsonl`,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for conflicting session_id/sessionId aliases", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-conflicting-aliases-"));
+    try {
+      const sessionId = "alias-conflict-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        sessionId: "other-alias-session-3427",
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for non-string transcript aliases", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-nonstring-transcript-"));
+    try {
+      const sessionId = "nonstring-transcript-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: 42,
+        transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when transcript_path and transcriptPath disagree", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-transcript-alias-conflict-"));
+    try {
+      const sessionId = "transcript-alias-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+      const otherPath = join(cwd, `rollout-${sessionId}-other.jsonl`);
+      await writeFile(otherPath, `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: sessionId, session_id: sessionId, cwd },
+      })}\n`);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        transcriptPath: otherPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for owner identity claims", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-owner-claim-"));
+    try {
+      const sessionId = "owner-claim-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        owner_codex_session_id: sessionId,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for subagent thread-spawn provenance", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-subagent-provenance-"));
+    try {
+      const sessionId = "subagent-provenance-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        source: { subagent: { thread_spawn: { parent_thread_id: "some-parent", depth: 1 } } },
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+  it("fails closed for a payload with agent_id subagent provenance", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-agent-id-provenance-"));
+    try {
+      const sessionId = "agent-id-provenance-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        agent_id: "child-agent-thread",
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for a typed agent-role subagent payload", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-agent-role-provenance-"));
+    try {
+      const sessionId = "agent-role-provenance-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        agent_type: "executor",
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the session-scoped state directory is missing", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-missing-session-dir-"));
+    try {
+      const sessionId = "missing-session-dir-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { sessionDir: false });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for a symlink transcript", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-symlink-transcript-"));
+    try {
+      const sessionId = "symlink-transcript-session-3427";
+      const { stateDir, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { transcript: false });
+      const realTranscript = join(cwd, `real-${sessionId}.jsonl`);
+      await writeFile(realTranscript, `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: sessionId, session_id: sessionId, cwd },
+      })}\n`);
+      const transcriptPath = join(cwd, `rollout-${sessionId}.jsonl`);
+      await symlink(realTranscript, transcriptPath);
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the transcript first record is not session_meta", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-non-meta-transcript-"));
+    try {
+      const sessionId = "non-meta-transcript-session-3427";
+      const { stateDir, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, { transcript: false });
+      const transcriptPath = join(cwd, `rollout-${sessionId}.jsonl`);
+      await writeFile(
+        transcriptPath,
+        `${JSON.stringify({ type: "event_msg", payload: { type: "user_message", message: "hi" } })}\n`,
+      );
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for an identity-indeterminate pointer even with a valid transcript", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-indeterminate-pointer-"));
+    try {
+      const sessionId = "indeterminate-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId, {
+        pointer: { identity_schema_version: 1 },
+      });
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson, null);
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("never rewrites the singleton selected pointer during transcript recovery", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-pointer-immutable-"));
+    try {
+      const sessionId = "pointer-immutable-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+      await writeSessionScopedModeState(cwd, sessionId, "autopilot");
+
+      const result = await dispatchCodexNativeHook({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd });
+
+      assert.equal(result.outputJson?.decision, "block");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+      assert.equal(existsSync(join(stateDir, "sessions", "stale-dead", "session.json")), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("covers the built distribution entrypoint for the transcript-backed recovery", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-dist-recovery-"));
+    try {
+      const sessionId = "dist-recovery-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+      await writeSessionScopedModeState(cwd, sessionId, "autopilot");
+
+      const output = parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      }, { cwd }));
+
+      assert.equal(output.decision, "block");
+      assert.equal(output.stopReason, "autopilot_executing");
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed in the built distribution entrypoint for a conflicting alias", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-3427-dist-failclosed-"));
+    try {
+      const sessionId = "dist-failclosed-session-3427";
+      const { stateDir, transcriptPath, pointerBefore } = await writeStaleDeadStopFixture(cwd, sessionId);
+
+      const output = parseSingleJsonStdout(runNativeHookCli({
+        hook_event_name: "Stop",
+        cwd,
+        session_id: sessionId,
+        sessionId: "dist-other-session-3427",
+        transcript_path: transcriptPath,
+      }, { cwd }));
+
+      assert.deepEqual(output, {});
+      assert.equal(await readFile(join(stateDir, "session.json"), "utf-8"), pointerBefore);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -4627,6 +4627,179 @@ async function readStopSessionPinnedState(
     : getStateFilePath(fileName, cwd, sessionId || undefined);
   return readJsonIfExists(statePath);
 }
+/** Fail-closed session-id alias check for Stop recovery: session_id/sessionId must
+ * be strings when present and must normalize to the same exact session id. */
+function readStrictStopPayloadSessionId(payload: CodexHookPayload): string | null {
+  const snake = payload.session_id;
+  const camel = payload.sessionId;
+  if (snake !== undefined && typeof snake !== "string") return null;
+  if (camel !== undefined && typeof camel !== "string") return null;
+  const snakeNormalized = typeof snake === "string" ? normalizeSessionId(snake) : undefined;
+  const camelNormalized = typeof camel === "string" ? normalizeSessionId(camel) : undefined;
+  if (snakeNormalized && camelNormalized && snakeNormalized !== camelNormalized) return null;
+  return snakeNormalized ?? camelNormalized ?? null;
+}
+
+/** Fail-closed transcript alias check for Stop recovery: transcript_path and
+ * transcriptPath must be strings when present and must agree when both exist. */
+function readStrictStopPayloadTranscriptPath(payload: CodexHookPayload): string | null {
+  const snake = payload.transcript_path;
+  const camel = payload.transcriptPath;
+  if (snake !== undefined && typeof snake !== "string") return null;
+  if (camel !== undefined && typeof camel !== "string") return null;
+  const snakePath = typeof snake === "string" ? snake.trim() : "";
+  const camelPath = typeof camel === "string" ? camel.trim() : "";
+  if (snakePath && camelPath && snakePath !== camelPath) return null;
+  return snakePath || camelPath || null;
+}
+
+interface TranscriptSessionMetaBinding {
+  sessionId: string;
+  cwd: string;
+}
+
+/** Parse the bounded first session_meta record and bind payload.id,
+ * payload.session_id, and the resolved payload.cwd. */
+function parseTranscriptSessionMetaBinding(
+  firstLine: string,
+  transcriptPath: string,
+): TranscriptSessionMetaBinding | null {
+  const trimmed = firstLine.trim();
+  if (!trimmed) return null;
+  let record: unknown;
+  try {
+    record = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  const safe = safeObject(record);
+  if (safeString(safe.type) !== "session_meta") return null;
+  const payload = safeObject(safe.payload);
+  const id = normalizeSessionId(payload.id);
+  const sessionId = normalizeSessionId(payload.session_id);
+  if (!id || !sessionId || id !== sessionId) return null;
+  const rawCwd = safeString(payload.cwd).trim();
+  if (!rawCwd) return null;
+  const resolvedCwd = isAbsolute(rawCwd) ? rawCwd : resolve(dirname(transcriptPath), rawCwd);
+  return { sessionId, cwd: resolvedCwd };
+}
+
+/** Bounded first-line read from an already-opened transcript handle. */
+async function readBoundedFirstLineFromHandle(
+  handle: Awaited<ReturnType<typeof open>>,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  const buffer = Buffer.alloc(8192);
+  let position = 0;
+  let totalBytesRead = 0;
+  while (totalBytesRead < MAX_SESSION_META_LINE_BYTES) {
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+    if (bytesRead <= 0) break;
+    totalBytesRead += bytesRead;
+    const newlineOffset = buffer.subarray(0, bytesRead).indexOf(0x0a);
+    if (newlineOffset >= 0) {
+      chunks.push(Buffer.from(buffer.subarray(0, newlineOffset)));
+      break;
+    }
+    chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+    position += bytesRead;
+  }
+  return Buffer.concat(chunks).toString("utf-8").replace(/\r$/, "");
+}
+
+/**
+ * Stop-only transcript-backed recovery for an exact stale-dead selected
+ * pointer with no usable matching owner sidecar (issue #3427). Every check
+ * fails closed. The recovered authority is ephemeral and session-scoped for
+ * this Stop evaluation only; the singleton selected pointer is never
+ * rewritten and no other state is mutated.
+ */
+async function recoverStaleDeadStopTranscriptSession(
+  cwd: string,
+  stateDir: string,
+  payload: CodexHookPayload,
+): Promise<string | null> {
+  try {
+    if (payloadHasConflictingIdentityAliases(payload)) return null;
+    if (payloadHasOwnerIdentityClaim(payload)) return null;
+    if (hasSubagentThreadSpawnProvenance(payload)) return null;
+    if (isTypedAgentRolePayload(payload, cwd)) return null;
+    if (safeString(payload.agent_id).trim() || safeString(payload.agentId).trim()) return null;
+
+    const sessionId = readStrictStopPayloadSessionId(payload);
+    if (!sessionId) return null;
+
+    const transcriptPath = readStrictStopPayloadTranscriptPath(payload);
+    if (!transcriptPath) return null;
+    if (!isAbsolute(transcriptPath)) return null;
+    if (!basename(transcriptPath).includes(sessionId)) return null;
+
+    const payloadCwd = payload.cwd;
+    if (payloadCwd !== undefined) {
+      if (typeof payloadCwd !== "string" || !payloadCwd.trim() || !isAbsolute(payloadCwd.trim())) {
+        return null;
+      }
+      if (!sameFilePath(cwd, payloadCwd.trim())) return null;
+    }
+
+    // Transcript must be a regular non-symlink file pinned by device+inode
+    // across lstat/open/read with O_NOFOLLOW where the platform provides it.
+    let before: Awaited<ReturnType<typeof lstat>>;
+    try {
+      before = await lstat(transcriptPath);
+    } catch {
+      return null;
+    }
+    if (before.isSymbolicLink() || !before.isFile()) return null;
+
+    let handle: Awaited<ReturnType<typeof open>>;
+    try {
+      handle = await open(transcriptPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    } catch {
+      return null;
+    }
+    try {
+      const opened = await handle.stat();
+      if (opened.isSymbolicLink() || !opened.isFile()
+        || opened.dev !== before.dev || opened.ino !== before.ino) {
+        return null;
+      }
+
+      const firstLine = await readBoundedFirstLineFromHandle(handle);
+      const after = await handle.stat();
+      if (after.dev !== opened.dev || after.ino !== opened.ino) return null;
+
+      let afterPath: Awaited<ReturnType<typeof lstat>>;
+      try {
+        afterPath = await lstat(transcriptPath);
+      } catch {
+        return null;
+      }
+      if (afterPath.isSymbolicLink() || !afterPath.isFile()
+        || afterPath.dev !== opened.dev || afterPath.ino !== opened.ino) {
+        return null;
+      }
+
+      const meta = parseTranscriptSessionMetaBinding(firstLine, transcriptPath);
+      if (!meta || meta.sessionId !== sessionId) return null;
+      if (!sameFilePath(cwd, meta.cwd)) return null;
+    } finally {
+      await handle.close().catch(() => {});
+    }
+
+    // The canonical session-scoped state directory must exist.
+    try {
+      const sessionDirStat = await lstat(join(stateDir, "sessions", sessionId));
+      if (sessionDirStat.isSymbolicLink() || !sessionDirStat.isDirectory()) return null;
+    } catch {
+      return null;
+    }
+
+    return sessionId;
+  } catch {
+    return null;
+  }
+}
 
 const DEEP_INTERVIEW_ALLOWED_WRITE_PREFIXES = [
   ".omx/context",
@@ -22659,18 +22832,36 @@ export async function dispatchCodexNativeHook(
         allowGlobalSideEffects = false;
         stopAuthorizationFailure = null;
       } else {
-        canonicalSessionId = "";
-        allowImplicitSessionSideEffects = false;
-        if (declaredTeamWorker && !authorizedWorkerStopSessionId) {
-          stopAuthorizationFailure = {
-            stopReason: "session_scope_unmatched",
-            reason: "OMX cannot authorize Team worker Stop without exactly one valid explicit session id.",
-          };
-        } else if (!stopAuthorizationFailure) {
-          stopAuthorizationFailure = {
-            stopReason: "session_scope_unmatched",
-            reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
-          };
+        // Issue #3427: an exact stale-dead selected pointer with no usable
+        // matching owner sidecar may still authorize this Stop through the
+        // payload transcript's strict session_meta identity boundary. The
+        // recovered authority is ephemeral and session-scoped for this Stop
+        // evaluation only; the singleton pointer is never rewritten.
+        const recoveredTranscriptSessionId = !declaredTeamWorker
+          && pointer.status === "stale-dead"
+          && Boolean(stopPayloadSessionId)
+          ? await recoverStaleDeadStopTranscriptSession(cwd, stateDir, payload)
+          : null;
+        if (recoveredTranscriptSessionId) {
+          canonicalSessionId = recoveredTranscriptSessionId;
+          resolvedNativeSessionId = stopPayloadSessionId;
+          allowImplicitSessionSideEffects = true;
+          allowGlobalSideEffects = false;
+          stopAuthorizationFailure = null;
+        } else {
+          canonicalSessionId = "";
+          allowImplicitSessionSideEffects = false;
+          if (declaredTeamWorker && !authorizedWorkerStopSessionId) {
+            stopAuthorizationFailure = {
+              stopReason: "session_scope_unmatched",
+              reason: "OMX cannot authorize Team worker Stop without exactly one valid explicit session id.",
+            };
+          } else if (!stopAuthorizationFailure) {
+            stopAuthorizationFailure = {
+              stopReason: "session_scope_unmatched",
+              reason: `OMX cannot authorize Stop for unmatched session id ${stopPayloadSessionId}; the selected session pointer remains authoritative.`,
+            };
+          }
         }
       }
     } else if (stopCanonicalSessionId) {


### PR DESCRIPTION
Closes #3427

## Problem

The native Stop hook rejects a live Codex session when the workspace-level selected pointer is `stale-dead`, even when the Stop payload contains a transcript that structurally binds the payload session to the current Codex session and cwd. With no usable matching owner sidecar, current `dev` silently no-ops the Stop, so the live session's session-scoped Stop evaluation (mode/skill stop guards) never runs.

## Fix (bounded, Stop-only)

For **native Stop only**, an exact `stale-dead` selected pointer with **no usable matching owner sidecar** may authorize this Stop ephemerally and session-scoped through the payload transcript's strict `session_meta` identity boundary. The singleton selected pointer is never rewritten and no global side effects are enabled.

Every check fails closed:

- selected pointer status is exactly `stale-dead`; identity-indeterminate/foreign/malformed pointers are untouched
- no conflicting snake/camel identity or transcript aliases; non-string aliases rejected
- no owner claim, `agent_id`, typed agent-role, or subagent `thread_spawn` provenance
- payload session id normalizes exactly and agrees with the transcript
- `transcript_path`/`transcriptPath` are absolute strings, agree when both present, and the filename is bound to the session id
- transcript is a regular non-symlink file pinned by device+inode across lstat/open/read with `O_NOFOLLOW` where available
- first `session_meta` record binds `payload.id`, `payload.session_id`, and the resolved cwd
- the canonical session-scoped state directory exists
- recovered authority is ephemeral and session-scoped for this Stop evaluation only (`allowGlobalSideEffects=false`); foreign cwd, symlinks, missing dirs, and replacement races stay fail-closed

## Verification

- 19 new regression tests (source + built `dist` entrypoint): happy path with session-scoped state, clean `{}` no-op, and every fail-closed branch above; pointer immutability asserted throughout
- `npm run build` PASS, `npm run lint` PASS, `npm run check:no-unused` PASS, `git diff --check` PASS
- Focused suites: `codex-native-hook.test.js` 665/667 (2 failures are pre-existing `#3343` conductor tests reproduced on the exact base commit), `session.test.js` 123/123, `operations.test.js` 68/68, `state-paths.test.js` 107/107, `launch-fallback.test.js` 10/10, `exec.test.js` 36/36