### PR TITLE
fix(hooks): keep zsh fast-startup control allowed under ambient shell startup env (#3477)

### DIFF
--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -13414,6 +13414,10 @@ function nestedShellHasUnsafeStartup(words: string[], commandIndex: number, comm
   for (let index = commandIndex + 1; index < words.length; index += 1) {
     const word = shellWordLiteral(words[index] ?? "");
     if (!word || isShellCommandSeparator(word)) break;
+    // `--` ends option parsing; any following `-f`/`--norc`/etc. is a positional
+    // operand, not a shell option, so it must not satisfy the fast-startup or
+    // no-startup-files flags below.
+    if (word === "--") break;
     if (word === "--login" || /^-[^-]*l/.test(word)) login = true;
     if (word === "--interactive" || /^-[^-]*i/.test(word)) interactive = true;
     if (word === "--noprofile") noProfile = true;

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -13817,7 +13817,16 @@ function inspectConductorRuntimeExecutions(command: string, cwd?: string, depth 
         inspection.uninspectedCommandNames.push(commandName);
       } else if (isNestedShellCommandWord(commandName)) {
         const nestedIndex = findShellCommandStringArgIndex(words, commandIndex + 1);
-        if (commandSetsShellStartup || nestedShellHasUnsafeStartup(words, commandIndex, index) || (nestedIndex === null && firstInterpreterScriptOperands(words, commandIndex).length === 0)) {
+        const nestedShellUnsafeStartup = nestedShellHasUnsafeStartup(words, commandIndex, index);
+        // A `zsh -f` (fast startup) invocation reads no startup files
+        // (.zshenv/.zprofile/.zshrc/.zlogin), so ambient BASH_ENV/ENV/ZDOTDIR
+        // cannot influence it. Ambient shell-startup variables only matter for
+        // invocation shapes that actually read them (e.g. non-interactive bash
+        // reads $BASH_ENV; zsh without -f reads $ZDOTDIR/.zshenv), so a
+        // fast-startup zsh stays positively classified instead of being denied
+        // as an uninspected runtime.
+        const zshFastStartup = commandName === "zsh" && !nestedShellUnsafeStartup;
+        if ((commandSetsShellStartup && !zshFastStartup) || nestedShellUnsafeStartup || (nestedIndex === null && firstInterpreterScriptOperands(words, commandIndex).length === 0)) {
           inspection.uninspectedOtherRuntimeCount += 1;
           inspection.uninspectedCommandNames.push(commandName);
         }

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -2946,6 +2946,15 @@ function runPackedTransportRegressions(hookScript: string, smokeCwd: string): vo
     }, { OMX_RUNTIME_BINARY: runtimeBinary })).length !== 0) {
       throw new Error('packed main-root zsh fast startup control should be allowed');
     }
+    if (Object.keys(runActorProbe('main-root', 'zsh fast startup control ambient startup environment', 'Bash', {
+      command: `zsh -f -c ':'`,
+    }, {
+      OMX_RUNTIME_BINARY: runtimeBinary,
+      ENV: '/dev/null',
+      ZDOTDIR: join(smokeCwd, '.omx', 'state', 'zsh-home'),
+    })).length !== 0) {
+      throw new Error('packed main-root zsh fast startup control should remain allowed with ambient shell-startup environment');
+    }
     const boxedPlanningRoot = join(smokeCwd, 'boxed-planning-root');
     const boxedPlanningStateDir = join(boxedPlanningRoot, '.omx', 'state');
     const boxedPlanningStatePath = join(boxedPlanningStateDir, 'sessions', leaderAgentId, 'ralplan-state.json');


### PR DESCRIPTION
## Summary

Closes #3477. The packed `Smoke Test Packed Global Install` in the Release workflow failed on exact green dev head `9e31b19` (tag `v0.20.5`) at `packed main-root zsh fast startup control should be allowed`; npm publish stayed skipped.

### Root cause

The hook's Conductor nested-shell runtime classification in `inspectConductorRuntimeExecutions` marked **any** nested shell as an uninspected runtime when the hook's ambient environment carried shell-startup variables (`BASH_ENV`/`ENV`/`ZDOTDIR`):

```
if (commandSetsShellStartup || nestedShellHasUnsafeStartup(words, commandIndex, index) || ...) {
  inspection.uninspectedOtherRuntimeCount += 1;
  inspection.uninspectedCommandNames.push(commandName);
}
```

For `zsh -f -c ':'` (the runtime's own fast-startup command-execution pattern) this is over-broad: `-f` provably disables **all** zsh startup files (`.zshenv`/`.zprofile`/`.zshrc`/`.zlogin`), so ambient `ENV`/`ZDOTDIR` cannot influence it. The result was a `Bash executable runtime is not positively classified as read-only: zsh` deny for the main-root actor — exactly the failure the GitHub Actions Release runner reproduces (the runner's failure signature — every other main-root metadata probe passing while only the zsh probe denies — matches this classification path).

### Fix (2 commits)

1. **`src/scripts/codex-native-hook.ts`** — ambient `commandSetsShellStartup` no longer forces a fast-startup `zsh -f` invocation to be uninspected. All other behavior is unchanged: `zsh` without `-f`, `bash`/`sh`/`ksh` shapes, and every other deny path retain their existing fail-closed semantics.
2. **`src/scripts/codex-native-hook.ts`** — `nestedShellHasUnsafeStartup` now honors `--` end-of-options in its flag scan: a `-f`/`--norc`/etc. word after `--` is a positional operand, not an option, so it no longer satisfies the fast-startup/no-startup-files flags (verified: real `zsh -- -f -c ':'` reads `.zshenv` and stays denied).
3. **`src/scripts/smoke-packed-install.ts`** — durable regression: the packed smoke also probes the same main-root `zsh -f -c ':'` control with the ambient startup environment bound (poisoned `ZDOTDIR` fixture + `ENV`), asserting fast-startup control stays allowed. This regression fails under the previous hook and passes with the fix.

### Verification (all run in this lane on the exact PR head)

- Release-equivalent packed smoke (`node dist/scripts/smoke-packed-install.js`, codex-absent PATH like the runner): **PASS**
- Adversarial classification matrix (clean / ambient `ENV`+`ZDOTDIR` / ambient `BASH_ENV`+`ENV`+`ZDOTDIR`): `zsh -f -c ':'` allowed under ambient startup env; `zsh -c ':'`, `zsh -- -f -c ':'`, `zsh -f` (stdin), `bash`/`sh`/`ksh` shapes, and all unrelated deny paths stay fail-closed; `cp` metadata probes stay allowed under ambient `ENV`+`ZDOTDIR`
- `npm run build`: PASS
- `dist/scripts/__tests__/smoke-packed-install.test.js`: 56/56 pass
- `dist/scripts/__tests__/codex-native-hook.test.js`: 665 pass / 2 fail — both failures (`#3343` omx PATH-shim tests) reproduce identically on the pristine pre-change head in this local Node 25 sandbox and are unrelated (CI at this exact head is green on Node 20)
- `npm run lint` (biome): PASS
- `tsc -p tsconfig.no-unused.json --noEmit`: PASS
- `git diff --check`: PASS

### Scope guard

- `OMX_RUNTIME_BINARY` stays bound only to the intended main-root zsh actor probe; all unrelated probes remain runtime-absent.
- No tag move, no release rerun, no npm publish from this lane.