### PR TITLE
fix(hooks): unblock Conductor delegation lanes

### DIFF
--- a/src/scripts/__tests__/issue-3481-conductor-deadlock.test.ts
+++ b/src/scripts/__tests__/issue-3481-conductor-deadlock.test.ts
@@ -1,0 +1,481 @@
+import assert from "node:assert/strict";
+import { realpathSync } from "node:fs";
+import {
+	chmod,
+	mkdir,
+	mkdtemp,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { dispatchCodexNativeHook } from "../codex-native-hook.js";
+
+// Regression coverage for OMX #3481: under an active Main-root Conductor state
+// the root is (correctly) prohibited from editing source/product/plan directly,
+// but every authorized delegation/orchestration/recovery/read-only path must
+// remain reachable. The reported 0.20.5 deadlock blocked all of them at once.
+// This suite proves the minimum contract: direct root writes stay denied, the
+// static Team implementation lane and typed native delegation spawn stay
+// available on a positively-supported surface, bounded orchestration and
+// session-bound `omx state` mutations stay recognized, representative
+// read-only diagnostics stay available, and denial wording reports the
+// detected capability instead of a fixed upstream version.
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+	await mkdir(dirname(path), { recursive: true }).catch(() => {});
+	await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+async function writeLeaderSessionFixture(
+	stateDir: string,
+	sessionId: string,
+	leaderThreadId: string,
+	cwd: string,
+): Promise<void> {
+	await writeJson(join(stateDir, "session.json"), {
+		session_id: sessionId,
+		native_session_id: leaderThreadId,
+		cwd,
+	});
+	await writeJson(join(stateDir, "subagent-tracking.json"), {
+		schemaVersion: 1,
+		sessions: {
+			[sessionId]: {
+				session_id: sessionId,
+				leader_thread_id: leaderThreadId,
+				threads: {
+					[leaderThreadId]: { thread_id: leaderThreadId, kind: "leader" },
+				},
+			},
+		},
+	});
+}
+
+async function writeActiveUltragoalConductorState(
+	stateDir: string,
+	sessionId: string,
+	phase: string,
+): Promise<void> {
+	await writeJson(
+		join(stateDir, "sessions", sessionId, "skill-active-state.json"),
+		{
+			active: true,
+			skill: "ultragoal",
+			phase,
+			session_id: sessionId,
+			active_skills: [
+				{ skill: "ultragoal", phase, active: true, session_id: sessionId },
+			],
+		},
+	);
+	await writeJson(
+		join(stateDir, "sessions", sessionId, "ultragoal-state.json"),
+		{
+			active: true,
+			mode: "ultragoal",
+			current_phase: phase,
+			session_id: sessionId,
+			workingDirectory: process.env.OMX_ROOT ?? "",
+		},
+	);
+}
+
+interface ConductorFixture {
+	cwd: string;
+	stateDir: string;
+	sessionId: string;
+	leaderThreadId: string;
+	absoluteOmx: string;
+}
+
+async function withConductorFixture<T>(
+	run: (fixture: ConductorFixture) => Promise<T>,
+): Promise<T> {
+	const cwd = await mkdtemp(join(tmpdir(), "omx-native-hook-3481-"));
+	const installRoot = await mkdtemp(
+		join(tmpdir(), "omx-native-hook-3481-install-"),
+	);
+	const stateDir = join(cwd, ".omx", "state");
+	const sessionId = "sess-3481-conductor";
+	const leaderThreadId = "thread-3481-conductor-leader";
+	const cliPath = realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js"));
+	const absoluteOmx = join(installRoot, "bin", "omx");
+	await mkdir(dirname(absoluteOmx), { recursive: true });
+	await symlink(cliPath, absoluteOmx);
+	await mkdir(join(stateDir, "sessions", sessionId), { recursive: true });
+	await writeLeaderSessionFixture(stateDir, sessionId, leaderThreadId, cwd);
+	await writeActiveUltragoalConductorState(stateDir, sessionId, "executing");
+	const previousEnv = new Map<string, string | undefined>();
+	for (const name of [
+		"OMX_ROOT",
+		"OMX_STATE_ROOT",
+		"OMX_TEAM_STATE_ROOT",
+		"OMX_SESSION_ID",
+		"GJC_SESSION_ID",
+		"PATH",
+	]) {
+		previousEnv.set(name, process.env[name]);
+	}
+	try {
+		process.env.OMX_ROOT = cwd;
+		delete process.env.OMX_STATE_ROOT;
+		delete process.env.OMX_TEAM_STATE_ROOT;
+		delete process.env.OMX_SESSION_ID;
+		delete process.env.GJC_SESSION_ID;
+		process.env.PATH = `${dirname(process.execPath)}:/usr/bin:/bin`;
+		return await run({ cwd, stateDir, sessionId, leaderThreadId, absoluteOmx });
+	} finally {
+		for (const [name, value] of previousEnv) {
+			if (value === undefined) delete process.env[name];
+			else process.env[name] = value;
+		}
+		await rm(cwd, { recursive: true, force: true });
+		await rm(installRoot, { recursive: true, force: true });
+	}
+}
+
+function leaderBashPayload(
+	fixture: ConductorFixture,
+	command: string,
+): Record<string, unknown> {
+	return {
+		hook_event_name: "PreToolUse",
+		cwd: fixture.cwd,
+		session_id: fixture.sessionId,
+		thread_id: fixture.leaderThreadId,
+		agent_id: fixture.leaderThreadId,
+		tool_name: "Bash",
+		tool_input: { command },
+	};
+}
+
+describe("issue-3481: Main-root Conductor deadlock contract repair", () => {
+	afterEach(() => {
+		// No ambient session/root state may leak across cases.
+		for (const name of [
+			"OMX_ROOT",
+			"OMX_STATE_ROOT",
+			"OMX_TEAM_STATE_ROOT",
+			"OMX_SESSION_ID",
+			"GJC_SESSION_ID",
+		]) {
+			delete process.env[name];
+		}
+	});
+
+	it("keeps direct Main-root product/source writes denied while Conductor is active", async () => {
+		await withConductorFixture(async (fixture) => {
+			for (const [tool_name, tool_input] of [
+				["Edit", { file_path: "src/runtime.ts" }],
+				["Write", { file_path: "src/runtime.ts", content: "export {};\n" }],
+			] as const) {
+				const result = await dispatchCodexNativeHook(
+					{
+						hook_event_name: "PreToolUse",
+						cwd: fixture.cwd,
+						session_id: fixture.sessionId,
+						thread_id: fixture.leaderThreadId,
+						agent_id: fixture.leaderThreadId,
+						tool_name,
+						tool_input,
+					},
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(result.outputJson?.decision, "block", tool_name);
+				assert.match(
+					String(result.outputJson?.reason ?? ""),
+					/Main-root Conductor mode is active \(ultragoal phase: executing\)/,
+				);
+			}
+
+			const bash = await dispatchCodexNativeHook(
+				leaderBashPayload(
+					fixture,
+					"cat <<'EOF' > src/runtime.ts\nimplementation\nEOF",
+				),
+				{ cwd: fixture.cwd },
+			);
+			assert.equal(bash.outputJson?.decision, "block");
+			assert.match(
+				String(bash.outputJson?.reason ?? ""),
+				/Main-root Conductor mode is active/,
+			);
+		});
+	});
+
+	it("accepts typed native delegation spawn with an installed agent_type on a positively-supported surface", async () => {
+		await withConductorFixture(async (fixture) => {
+			for (const tool_name of [
+				"collaboration.spawn_agent",
+				"multi_agent_v1.spawn_agent",
+				"spawn_agent",
+				"task",
+			]) {
+				const result = await dispatchCodexNativeHook(
+					{
+						hook_event_name: "PreToolUse",
+						cwd: fixture.cwd,
+						session_id: fixture.sessionId,
+						thread_id: fixture.leaderThreadId,
+						agent_id: fixture.leaderThreadId,
+						omx_runtime_capabilities: {
+							native_subagents: true,
+							multi_agent_v1: true,
+							role_routing: true,
+						},
+						tool_name,
+						tool_input: {
+							agent_type: "executor",
+							prompt: "implement the approved plan",
+						},
+					},
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(result.outputJson, null, tool_name);
+			}
+		});
+	});
+
+	it("denies native spawns with a capability-based diagnostic when the surface is not positively supported", async () => {
+		await withConductorFixture(async (fixture) => {
+			const result = await dispatchCodexNativeHook(
+				{
+					hook_event_name: "PreToolUse",
+					cwd: fixture.cwd,
+					session_id: fixture.sessionId,
+					thread_id: fixture.leaderThreadId,
+					agent_id: fixture.leaderThreadId,
+					tool_name: "collaboration.spawn_agent",
+					tool_input: {
+						agent_type: "executor",
+						prompt: "implement the approved plan",
+					},
+				},
+				{ cwd: fixture.cwd },
+			);
+			assert.equal(result.outputJson?.decision, "block");
+			const reason = String(result.outputJson?.reason ?? "");
+			assert.match(reason, /documented host-authenticated Main-root authority/);
+			assert.match(reason, /detected native subagent capability: unknown/);
+			assert.doesNotMatch(reason, /0\.145\.0|Codex 0\.[0-9]+/);
+		});
+	});
+
+	it("still denies uninstalled agent_type roles on native spawn even on a supported surface", async () => {
+		await withConductorFixture(async (fixture) => {
+			const result = await dispatchCodexNativeHook(
+				{
+					hook_event_name: "PreToolUse",
+					cwd: fixture.cwd,
+					session_id: fixture.sessionId,
+					thread_id: fixture.leaderThreadId,
+					agent_id: fixture.leaderThreadId,
+					omx_runtime_capabilities: {
+						native_subagents: true,
+						multi_agent_v1: true,
+						role_routing: true,
+					},
+					tool_name: "collaboration.spawn_agent",
+					tool_input: {
+						agent_type: "not-an-installed-role",
+						prompt: "implement",
+					},
+				},
+				{ cwd: fixture.cwd },
+			);
+			assert.equal(result.outputJson?.decision, "block");
+			assert.match(
+				String(result.outputJson?.reason ?? ""),
+				/unknown or not installed/,
+			);
+		});
+	});
+
+	it("accepts the static omx team launch lane as the authorized implementation path", async () => {
+		await withConductorFixture(async (fixture) => {
+			for (const command of [
+				`${fixture.absoluteOmx} team 1:executor "implement the approved plan"`,
+				`${fixture.absoluteOmx} team "fix the parser and add tests"`,
+				`${fixture.absoluteOmx} team 3:executor "split docs and code tasks"`,
+			]) {
+				const result = await dispatchCodexNativeHook(
+					leaderBashPayload(fixture, command),
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(result.outputJson, null, command);
+			}
+
+			// Documented worker-CLI prefix env is benign launch configuration.
+			const previousWorkerCli = process.env.OMX_TEAM_WORKER_CLI;
+			process.env.OMX_TEAM_WORKER_CLI = "claude";
+			try {
+				const prefixed = await dispatchCodexNativeHook(
+					leaderBashPayload(
+						fixture,
+						`${fixture.absoluteOmx} team 2:executor "update docs and report"`,
+					),
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(prefixed.outputJson, null);
+			} finally {
+				if (previousWorkerCli === undefined)
+					delete process.env.OMX_TEAM_WORKER_CLI;
+				else process.env.OMX_TEAM_WORKER_CLI = previousWorkerCli;
+			}
+
+			const gjcPath = join(dirname(fixture.absoluteOmx), "gjc");
+			await symlink(fixture.absoluteOmx, gjcPath);
+			const gjc = await dispatchCodexNativeHook(
+				leaderBashPayload(
+					fixture,
+					`${gjcPath} team 1:executor "implement via gjc alias"`,
+				),
+				{ cwd: fixture.cwd },
+			);
+			assert.equal(gjc.outputJson, null);
+		});
+	});
+
+	it("keeps dynamic, nested, and lookalike team launches denied under Conductor", async () => {
+		await withConductorFixture(async (fixture) => {
+			const lookalikeOmx = join(fixture.cwd, "lookalike-omx");
+			await writeFile(lookalikeOmx, "#!/bin/sh\necho pwned\n", { mode: 0o755 });
+			await chmod(lookalikeOmx, 0o755);
+			for (const command of [
+				`${fixture.absoluteOmx} team 1:executor "$TASK"`,
+				`bash -c '${fixture.absoluteOmx} team 1:executor "$TASK"'`,
+				`printf ready && ${fixture.absoluteOmx} team 1:executor "implement"`,
+				`${lookalikeOmx} team 1:executor "implement"`,
+				`${fixture.absoluteOmx} team`,
+				`${fixture.absoluteOmx} team 1:executor "implement" > metadata.json`,
+			]) {
+				const result = await dispatchCodexNativeHook(
+					leaderBashPayload(fixture, command),
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(result.outputJson?.decision, "block", command);
+				assert.match(
+					String(result.outputJson?.reason ?? ""),
+					/Main-root Conductor mode is active/,
+					command,
+				);
+			}
+		});
+	});
+
+	it("recognizes representative read-only diagnostics under Conductor", async () => {
+		await withConductorFixture(async (fixture) => {
+			for (const command of [
+				`${fixture.absoluteOmx} doctor`,
+				`${fixture.absoluteOmx} state list-active --json`,
+			]) {
+				const result = await dispatchCodexNativeHook(
+					leaderBashPayload(fixture, command),
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(result.outputJson, null, command);
+			}
+
+			const lookalikeOmx = join(fixture.cwd, "lookalike-omx");
+			await writeFile(lookalikeOmx, "#!/bin/sh\necho pwned\n", { mode: 0o755 });
+			await chmod(lookalikeOmx, 0o755);
+			for (const command of [
+				`${fixture.absoluteOmx} doctor --force`,
+				`${lookalikeOmx} doctor`,
+				`${fixture.absoluteOmx} state list-active --json --unknown`,
+			]) {
+				const result = await dispatchCodexNativeHook(
+					leaderBashPayload(fixture, command),
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(result.outputJson?.decision, "block", command);
+			}
+		});
+	});
+
+	it("allows the documented session-bound omx state write only when inherited binding is canonical", async () => {
+		await withConductorFixture(async (fixture) => {
+			const minimalPayload = JSON.stringify({
+				mode: "ultragoal",
+				active: true,
+				current_phase: "executing",
+			});
+			const previousSessionId = process.env.OMX_SESSION_ID;
+
+			// Inherited OMX_SESSION_ID uniquely bound to the authoritative session:
+			// the documented minimal `omx state write --input '{"mode":...}' --json`
+			// recovery/checkpoint form is a bounded orchestration mutation.
+			process.env.OMX_SESSION_ID = fixture.sessionId;
+			try {
+				const allowed = await dispatchCodexNativeHook(
+					leaderBashPayload(
+						fixture,
+						`${fixture.absoluteOmx} state write --input '${minimalPayload}' --json`,
+					),
+					{ cwd: fixture.cwd },
+				);
+				assert.equal(allowed.outputJson, null);
+			} finally {
+				if (previousSessionId === undefined) delete process.env.OMX_SESSION_ID;
+				else process.env.OMX_SESSION_ID = previousSessionId;
+			}
+
+			// Without any session binding the write stays denied.
+			const unbound = await dispatchCodexNativeHook(
+				leaderBashPayload(
+					fixture,
+					`${fixture.absoluteOmx} state write --input '${minimalPayload}' --json`,
+				),
+				{ cwd: fixture.cwd },
+			);
+			assert.equal(unbound.outputJson?.decision, "block");
+
+			// A foreign prefix assignment cannot borrow the inherited binding.
+			const foreign = await dispatchCodexNativeHook(
+				leaderBashPayload(
+					fixture,
+					`OMX_SESSION_ID=foreign ${fixture.absoluteOmx} state write --input '${minimalPayload}' --json`,
+				),
+				{ cwd: fixture.cwd },
+			);
+			assert.equal(foreign.outputJson?.decision, "block");
+
+			// Guard-breaking payloads stay denied even with a canonical inherited binding.
+			process.env.OMX_SESSION_ID = fixture.sessionId;
+			try {
+				for (const breakingPayload of [
+					JSON.stringify({
+						mode: "ultragoal",
+						active: false,
+						current_phase: "complete",
+					}),
+					JSON.stringify({
+						mode: "team",
+						active: true,
+						current_phase: "active",
+					}),
+					JSON.stringify({
+						mode: "ultragoal",
+						active: true,
+						current_phase: "complete",
+					}),
+				]) {
+					const breaking = await dispatchCodexNativeHook(
+						leaderBashPayload(
+							fixture,
+							`${fixture.absoluteOmx} state write --input '${breakingPayload}' --json`,
+						),
+						{ cwd: fixture.cwd },
+					);
+					assert.equal(breaking.outputJson?.decision, "block", breakingPayload);
+				}
+			} finally {
+				if (previousSessionId === undefined) delete process.env.OMX_SESSION_ID;
+				else process.env.OMX_SESSION_ID = previousSessionId;
+			}
+		});
+	});
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -9467,11 +9467,25 @@ function isStandaloneParsedOmxStateWriteTransport(cwd: string, command: string, 
   const stateWriteOperation = stateWriteOperations[0];
   if (!stateWriteOperation) return false;
   const payload = readStateWriteInputPayload(cwd, canonicalCommand, command);
-  if (!payload
-    || safeString(payload.session_id).trim() !== authoritativeSessionId
-    || !suppliedSessionAliasesMatch(payload, authoritativeSessionId)
-    || safeString(payload.workingDirectory).trim() === ""
-    || !sameFilePath(safeString(payload.workingDirectory), cwd)) return false;
+  if (!payload) return false;
+  const payloadSessionId = safeString(payload.session_id).trim();
+  const payloadWorkingDirectory = safeString(payload.workingDirectory).trim();
+  const payloadHasExplicitBinding = payloadSessionId !== "" || payloadWorkingDirectory !== "";
+  const inheritedSessionSelectors = [...new Set(["OMX_SESSION_ID", "GJC_SESSION_ID"]
+    .map((name) => safeString(process.env[name]).trim())
+    .filter(Boolean))];
+  const inheritedSelectorsAreCanonical = inheritedSessionSelectors.length === 1
+    && inheritedSessionSelectors[0] === authoritativeSessionId;
+  if (
+    payloadHasExplicitBinding
+      ? (
+        payloadSessionId !== authoritativeSessionId
+        || !suppliedSessionAliasesMatch(payload, authoritativeSessionId)
+        || payloadWorkingDirectory === ""
+        || !sameFilePath(payloadWorkingDirectory, cwd)
+      )
+      : !inheritedSelectorsAreCanonical
+  ) return false;
   const usesInputFile = readStateWriteFlagValue(stateWriteOperation.args, "--input-file") !== undefined;
   if (usesInputFile && splitStateScanSegments(canonicalCommand).length !== 1) return false;
   if (extractDeepInterviewCommandRedirectTargets(command).length > 0) return false;
@@ -10319,6 +10333,10 @@ function isAllowedOmxReadOnlyCommand(command: string, cwd: string): boolean {
   if (args[0] === "state" && OMX_STATE_READ_ONLY_OPERATIONS.has(args[1] ?? "")) {
     return stateReadTrailingArgsAreSafe(args.slice(2));
   }
+  if (args[0] === "state" && args[1] === "list-active") {
+    return args.slice(2).every((arg) => arg === "--json");
+  }
+  if (args[0] === "doctor" && args.length === 1) return true;
   return isAllowedOmxCleanupDryRunCommand(command);
 }
 
@@ -10339,6 +10357,10 @@ function isAllowedTrustedAbsoluteOmxReadOnlyCommand(command: string, cwd: string
   if (args.length === 1 && (args[0] === "--help" || args[0] === "-h" || args[0] === "--version" || args[0] === "-v")) return true;
   if (args.length === 1 && (args[0] === "help" || args[0] === "status" || args[0] === "version")) return true;
   if (isAllowedOmxNestedHelpForm(args)) return true;
+  if (args.length === 1 && args[0] === "doctor") return true;
+  if (args[0] === "state" && args[1] === "list-active") {
+    return args.slice(2).every((arg) => arg === "--json");
+  }
   return args.length === 3
     && args[0] === "ultragoal"
     && args[1] === "status"
@@ -16674,6 +16696,11 @@ const CONDUCTOR_KNOWN_OMX_RUNTIME_ENVIRONMENT_NAMES = new Set([
 const CONDUCTOR_BENIGN_ORCHESTRATION_RUNTIME_ENVIRONMENT_NAMES = new Set([
   "GJC_SESSION_CWD", "GJC_SESSION_FILE", "GJC_SESSION_ID",
   "OMX_OPENCLAW", "OMX_OPENCLAW_COMMAND", "OMX_OPENCLAW_DEBUG", "OMX_TEST_RELAX_TMUX_TIMEOUT",
+  // Documented Team worker-launch configuration inputs (skills/team): they
+  // select the worker CLI/model, never roots, output destinations, or helper
+  // commands, so they are benign prefix/inherited environment for the static
+  // `omx team [N:role] "<task>"` orchestration lane.
+  "OMX_TEAM_WORKER_CLI", "OMX_TEAM_WORKER_CLI_MAP", "OMX_TEAM_WORKER_LAUNCH_ARGS",
 ]);
 
 function conductorOrchestrationRuntimeEnvironmentNameIsPermitted(name: string): boolean {
@@ -16965,7 +16992,14 @@ function isStaticallyRecognizedConductorOrchestrationMutation(
     .filter((word) => word && !word.startsWith("-"));
   const command = operands[0] ?? "";
   const subcommand = operands[1] ?? "";
-  if (!invocationWords.every(conductorOrchestrationWordIsStatic) || argumentProducing || !hasExactConductorOrchestrationOptionSchema(commandName, words, commandIndex) && commandName !== "gh") return false;
+  const teamLaunch = (commandName === "omx" || commandName === "gjc")
+    && command === "team"
+    && isStaticallyValidatedOmxTeamLaunchInvocation(words, commandIndex);
+  if (
+    !invocationWords.every(conductorOrchestrationWordIsStatic)
+    || argumentProducing
+    || (commandName !== "gh" && !hasExactConductorOrchestrationOptionSchema(commandName, words, commandIndex) && !teamLaunch)
+  ) return false;
   if (
     (commandName === "omx" || commandName === "gjc")
     && command === "ultragoal"
@@ -16980,6 +17014,7 @@ function isStaticallyRecognizedConductorOrchestrationMutation(
       && ghCommandHasMutationIntent(words, commandIndex);
   }
   if (commandName !== "omx" && commandName !== "gjc") return false;
+  if (teamLaunch) return true;
   return hasExactConductorOrchestrationOptionSchema(commandName, words, commandIndex);
 }
 
@@ -17002,6 +17037,26 @@ function isDirectTrustedAbsoluteUltragoalCheckpoint(command: string, rootCwd: st
     && hasSafeConductorOrchestrationRuntimeEnvironment(words, 0, commandIndex, rootCwd, state)
     && isStaticallyRecognizedConductorOrchestrationMutation(commandName, words, commandIndex, false);
 }
+// Strict static recognition of the documented Team implementation lane
+// `omx team [N:agent-type] "<task description>"` (and the `gjc` alias). The
+// launch is a bounded orchestration mutation: it spawns tmux worker panes and
+// writes Team state under `.omx/state/team/...`; worker-pane product writes
+// are authorized separately by Team-worker provenance, so allowing the launch
+// never grants the Main-root direct product-write authority. Only static,
+// literal invocations qualify; dynamic task text, command substitution,
+// redirects, and unknown flags stay fail-closed.
+function isStaticallyValidatedOmxTeamLaunchInvocation(words: string[], commandIndex: number): boolean {
+  const invocationWords = collectConductorInvocationWords(words, commandIndex);
+  if (invocationWords.length < 2 || !invocationWords.every(conductorOrchestrationWordIsStatic)) return false;
+  const args = invocationWords.map(shellWordLiteral);
+  if ((args[0] ?? "") !== "team") return false;
+  const taskWords = (args[1] ?? "") !== "" && /^[1-9][0-9]*(?::[a-z][a-z0-9-]*)?$/i.test(args[1] ?? "")
+    ? args.slice(2)
+    : args.slice(1);
+  const task = taskWords.join(" ").trim();
+  return task !== "";
+}
+
 
 
 function findConductorIsolatedInvocationBoundary(words: string[], commandStartIndex: number): number {
@@ -20488,13 +20543,6 @@ function conductorStateWriteTransportIsBoundToActiveSession(
   if (!hasStateWrite) return true;
   if (!authoritativeSessionId) return false;
   const statePayload = readStateWriteInputPayload(cwd, canonicalCommand, command);
-  if (
-    !statePayload
-    || safeString(statePayload.session_id).trim() !== authoritativeSessionId
-    || !suppliedSessionAliasesMatch(statePayload, authoritativeSessionId)
-    || safeString(statePayload.workingDirectory).trim() === ""
-    || !sameFilePath(safeString(statePayload.workingDirectory), cwd)
-  ) return false;
   // Inherited hook environment is process-authenticated; model-controlled shell
   // assignments must match the session resolved for this PreToolUse payload.
   const inheritedSessionSelectors = [...new Set(["OMX_SESSION_ID", "GJC_SESSION_ID"]
@@ -20502,6 +20550,27 @@ function conductorStateWriteTransportIsBoundToActiveSession(
     .filter(Boolean))];
   const inheritedSelectorsAreCanonical = inheritedSessionSelectors.length === 1
     && inheritedSessionSelectors[0] === authoritativeSessionId;
+  if (!statePayload) return false;
+  const payloadSessionId = safeString(statePayload.session_id).trim();
+  const payloadWorkingDirectory = safeString(statePayload.workingDirectory).trim();
+  const payloadHasExplicitBinding = payloadSessionId !== "" || payloadWorkingDirectory !== "";
+  // The documented session-bound `omx state write --input '{"mode":...}' --json`
+  // form (no explicit session_id/workingDirectory in the payload) stays bound to
+  // the active session through the inherited OMX_SESSION_ID/GJC_SESSION_ID that
+  // the OMX runtime sets for the hook process. Accept it only when exactly one
+  // inherited selector equals the authoritative session; any explicit payload
+  // binding, prefix assignment, unset, or env-clear below still requires the
+  // existing strict canonical match.
+  if (payloadHasExplicitBinding) {
+    if (
+      payloadSessionId !== authoritativeSessionId
+      || !suppliedSessionAliasesMatch(statePayload, authoritativeSessionId)
+      || payloadWorkingDirectory === ""
+      || !sameFilePath(payloadWorkingDirectory, cwd)
+    ) return false;
+  } else if (!inheritedSelectorsAreCanonical) {
+    return false;
+  }
   for (const segment of splitShellCommandSegments(stripHeredocBodiesForCommandScan(command))) {
     const segmentHasStateWrite = /\b(?:omx|gjc)\s+state\s+write\b/.test(segment);
     const clearsInheritedEnvironment = /\b(?:env\s+(?:(?:-[A-Za-z]*i[A-Za-z]*|--ignore-environment)\s+|--ignore-environment\s+)|exec\s+-[A-Za-z]*c[A-Za-z]*)/.test(segment);
@@ -20928,8 +20997,24 @@ export async function buildConductorPreToolUseWriteGuardOutput(
     }
   } else if (mutationTransport === "orchestration" || mutationTransport === "goal-lifecycle") {
     nativeChildMutationAttempt = true;
-    blocked = true;
-    blockedDetail = `${toolName} requires documented host-authenticated Main-root authority that Codex 0.145.0 does not expose`;
+    // The spawn itself is orchestration transport (delegation), not a product
+    // write: accepting a typed spawn on a positively-supported native surface
+    // lets the Main-root Conductor delegate while the delegated child's own
+    // writes remain governed by the native-child OWNER_CONFIRMATION_REQUIRED
+    // contract below. Every other orchestration/goal-lifecycle tool stays
+    // fail-closed, and denial wording reports the detected capability instead
+    // of a fixed upstream version.
+    const requestedSpawnRole = readRequestedSpawnRole(payload);
+    const typedNativeSpawnOnSupportedSurface = isNativeSubagentSpawnToolName(toolName)
+      && requestedSpawnRole !== ""
+      && resolveInstalledRoleName(requestedSpawnRole, undefined, cwd) !== null
+      && nativeSubagentSupport.status === "supported";
+    if (typedNativeSpawnOnSupportedSurface) {
+      blocked = false;
+    } else {
+      blocked = true;
+      blockedDetail = buildConductorOrchestrationBlockedDetail(toolName, nativeSubagentSupport.status);
+    }
   } else if (mutationTransport === "path") {
     nativeChildMutationAttempt = true;
     const toolPathCandidates = collectImplementationToolPathCandidates(payload, toolName, pathCandidates);
@@ -21004,6 +21089,13 @@ export async function buildConductorPreToolUseWriteGuardOutput(
     },
   };
 
+}
+function buildConductorOrchestrationBlockedDetail(toolName: string, nativeSubagentStatus: string): string {
+  const canonicalToolName = canonicalizeNativeCollaborationToolName(toolName);
+  if (isNativeSubagentSpawnToolName(canonicalToolName)) {
+    return `${toolName} requires documented host-authenticated Main-root authority that this host surface does not positively expose (detected native subagent capability: ${nativeSubagentStatus || "unknown"})`;
+  }
+  return `${toolName} requires documented host-authenticated Main-root authority that this host surface does not expose (detected native subagent capability: ${nativeSubagentStatus || "unknown"})`;
 }
 function isInPlaceEditorCommand(word: string, commandName: string): boolean {
   if (commandName === "sed") return word === "--in-place" || /^--in-place(?:=.+)?$/.test(word) || /^-[^-\s]*i(?:.*)?$/.test(word);

--- a/src/scripts/run-test-files.ts
+++ b/src/scripts/run-test-files.ts
@@ -80,6 +80,7 @@ function shouldScrubRuntimeEnvKey(key: string): boolean {
   return (
     key.startsWith('OMX_') ||
     key.startsWith('OMXBOX_') ||
+    key.startsWith('GJC_') ||
     key.startsWith('CODEX_') ||
     key === 'USE_OMX_EXPLORE_CMD' ||
     key === 'SESSION_ID' ||


### PR DESCRIPTION
Closes #3481

Repairs the Main-root Conductor deadlock while retaining the direct-write boundary. Authorized typed native delegation, trusted static Team launch, bounded session-state recovery, and read-only diagnostics remain reachable.

Validation:
- `npm run build`
- focused regression: 8/8 passing
- existing native hook suite: 667/667 passing
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:plugin-bundle`
- `git diff --check`

Raw-binary dogfood is non-gating: its ad-hoc fixture did not activate the Conductor guard, and the bounded repository check found no existing subprocess test that asserts a Conductor block. Dispatch-level regression and full-suite evidence cover the behavior.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*