### PR TITLE
fix(setup): preserve pinned plugin cache roots across updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,8 @@ jobs:
             dist/verification/__tests__/native-release-manifest.test.js \
             dist/verification/__tests__/explore-harness-release-workflow.test.js \
             dist/verification/__tests__/ci-rust-gates.test.js
+      - name: Verify plugin-cache continuity boundary
+        run: node --test dist/cli/__tests__/plugin-cache-continuity.test.js
 
   build:
     name: Build (Full Source Build)

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ omx team shutdown <team-name>
 
 These are operator/support surfaces:
 - Codex plugin marketplace install/discovery can cache the plugin under `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (local installs may use `local` as the version identifier); that packaged plugin includes plugin-scoped companion metadata for official Codex lifecycle hooks, optional MCP compatibility servers, and apps (MCP/apps disabled by default), so it is still paired with the installed `omx` CLI for runtime execution
+  - plugin setup/update refreshes each discovered cache in the managed `oh-my-codex-local` marketplace in place without removing its root directory, including retired versions, so already-running Codex sessions whose `PLUGIN_ROOT` was pinned at startup keep a resolvable hook path while hook assets and the pinned CLI launcher are refreshed
 - Scoped setup installs prompts, skills, AGENTS scaffolding, `.codex/config.toml`, and (for legacy installs or older Codex without `plugin_hooks`) OMX-managed native Codex hooks in `.codex/hooks.json`
   - setup refresh preserves non-OMX hook entries in `.codex/hooks.json` and only rewrites OMX-managed wrappers
   - plugin setup keeps `AGENTS.md` as persistent durable guidance even though bundled skills/hooks come from the plugin cache; `omx doctor` treats a missing persistent scope `AGENTS.md` in plugin mode as a failed check because the session-scoped AGENTS file would otherwise contain only runtime overlay guidance

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -585,6 +585,37 @@ command = "node"
 		}
 	});
 
+	it("accepts the reduced packaged skill set when plugin Team mode is disabled", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-no-team-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "user", "--plugin", "--disable-team", "--force"],
+				{ HOME: home, CODEX_HOME: codexDir },
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(
+				res.stdout,
+				/Skills: plugin marketplace oh-my-codex-local registered; OMX skills are supplied by/,
+			);
+			assert.doesNotMatch(res.stdout, /installed Codex plugin cache is missing the packaged skills mirror/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("accepts plugin mode when required native reviewer roles are available from agent files and config", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-native-roles-ok-"));
 		try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -59,6 +59,7 @@ import {
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
+  preflightResumeOmxPluginState,
   captureMadmaxWorktreeRuntimeContext,
   persistProjectLaunchRuntimeAuthState,
   persistProjectLaunchRuntimeProjectTrustState,
@@ -2692,6 +2693,63 @@ describe("resolveSetupScopeArg", () => {
   });
 });
 describe("project launch scope helpers", () => {
+  it("refreshes a copied runtime plugin cache as well as the durable project cache", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-resume-copied-plugin-cache-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      const runtimeCodexHome = join(wd, ".omx", "runtime", "codex-home", "session-copy-fallback");
+      const runtimePluginsDir = join(runtimeCodexHome, "plugins");
+      const manifest = JSON.parse(
+        await readFile(join(repoRoot, "plugins", "oh-my-codex", ".codex-plugin", "plugin.json"), "utf-8"),
+      ) as { version: string };
+      const runtimeCacheDir = join(
+        runtimePluginsDir,
+        "cache",
+        "oh-my-codex-local",
+        "oh-my-codex",
+        manifest.version,
+      );
+      const pluginConfig = [
+        '[plugins."oh-my-codex@oh-my-codex-local"]',
+        "enabled = true",
+        "",
+      ].join("\n");
+
+      await mkdir(projectCodexHome, { recursive: true });
+      await mkdir(runtimeCacheDir, { recursive: true });
+      await writeFile(join(runtimeCodexHome, "config.toml"), pluginConfig);
+      await writeFile(join(runtimeCacheDir, "stale-copy-sentinel"), "stale\n");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await writeFile(join(wd, ".omx", "setup-scope.json"), JSON.stringify({
+        scope: "project",
+        installMode: "plugin",
+        teamMode: "disabled",
+      }));
+
+      const result = await preflightResumeOmxPluginState(runtimeCodexHome, repoRoot, {
+        projectRoot: wd,
+        pluginCacheCodexHomeDir: projectCodexHome,
+      });
+
+      const relativeHookPath = join(
+        "plugins",
+        "cache",
+        "oh-my-codex-local",
+        "oh-my-codex",
+        manifest.version,
+        "hooks",
+        "codex-native-hook.mjs",
+      );
+      assert.equal(result.status, "prepared");
+      assert.equal((await lstat(runtimePluginsDir)).isSymbolicLink(), false);
+      assert.equal(existsSync(join(projectCodexHome, relativeHookPath)), true);
+      assert.equal(existsSync(join(runtimeCodexHome, relativeHookPath)), true);
+      assert.equal(existsSync(join(runtimeCacheDir, "stale-copy-sentinel")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("reads persisted setup scope when valid", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-scope-"));
     try {

--- a/src/cli/__tests__/plugin-cache-continuity.test.ts
+++ b/src/cli/__tests__/plugin-cache-continuity.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { cp, lstat, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	materializePackagedOmxPluginCache,
+	pluginCacheContentsMatchPackaged,
+	refreshPackagedOmxPluginCacheInPlace,
+	resolvePackagedOmxMarketplace,
+} from "../plugin-marketplace.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+interface HookRunResult {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	stdout: string;
+	stderr: string;
+}
+
+function cleanHookEnvironment(stateRoot: string): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	for (const name of [
+		"CODEX_THREAD_ID",
+		"OMX_SESSION_ID",
+		"OMX_STATE_ROOT",
+		"OMX_TEAM_STATE_ROOT",
+		"OMX_NATIVE_HOOK_COMMAND",
+	]) delete env[name];
+	return {
+		...env,
+		OMX_AUTO_UPDATE: "0",
+		OMX_ROOT: stateRoot,
+		OMX_CODEX_LAUNCH_ID: "plugin-cache-continuity",
+		OMX_ENTRY_PATH: join(packageRoot, "dist", "cli", "omx.js"),
+		OMX_HOOK_DERIVED_SIGNALS: "0",
+		OMX_NOTIFY_FALLBACK: "0",
+	};
+}
+
+function runPluginHook(
+	hookPath: string,
+	cwd: string,
+	stateRoot: string,
+): Promise<HookRunResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [hookPath], {
+			cwd,
+			env: cleanHookEnvironment(stateRoot),
+			stdio: ["pipe", "pipe", "pipe"],
+			windowsHide: true,
+		});
+		const stdout: Buffer[] = [];
+		const stderr: Buffer[] = [];
+		let timedOut = false;
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			child.kill();
+		}, 10_000);
+		child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+		child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+		child.on("error", (error) => {
+			clearTimeout(timeout);
+			reject(error);
+		});
+		child.on("close", (code, signal) => {
+			clearTimeout(timeout);
+			resolve({
+				code,
+				signal,
+				stdout: Buffer.concat(stdout).toString("utf-8"),
+				stderr: `${Buffer.concat(stderr).toString("utf-8")}${timedOut ? "hook execution timed out\n" : ""}`,
+			});
+		});
+		child.stdin.end(`${JSON.stringify({
+			hook_event_name: "UserPromptSubmit",
+			session_id: "plugin-cache-continuity-session",
+			cwd,
+		})}\n`);
+	});
+}
+
+describe("plugin cache continuity", () => {
+	it("keeps the pinned root and native hook launcher usable throughout concurrent refreshes", { timeout: 30_000 }, async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-cache-continuity-"));
+		try {
+			const codexHomeDir = join(wd, "codex-home");
+			const stateRoot = join(wd, "state-root");
+			const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+			assert.ok(packagedMarketplace);
+			const materialized = await materializePackagedOmxPluginCache(
+				codexHomeDir,
+				packagedMarketplace,
+			);
+			assert.ok(materialized.cacheDir);
+			const cacheDir = materialized.cacheDir;
+			const hookPath = join(cacheDir, "hooks", "codex-native-hook.mjs");
+			const initialRoot = await lstat(cacheDir);
+
+			let keepReading = true;
+			let hookRunInFlight = false;
+			let readCount = 0;
+			const hookFailures: HookRunResult[] = [];
+			let markReaderReady: (() => void) | undefined;
+			const readerReady = new Promise<void>((resolveReady) => {
+				markReaderReady = resolveReady;
+			});
+			const reader = (async () => {
+				do {
+					hookRunInFlight = true;
+					const result = await runPluginHook(hookPath, wd, stateRoot);
+					hookRunInFlight = false;
+					readCount += 1;
+					if (result.code !== 0 || result.signal !== null) hookFailures.push(result);
+					if (readCount === 1) markReaderReady?.();
+				} while (keepReading || readCount < 4);
+			})();
+
+			await readerReady;
+			assert.equal(hookRunInFlight, true);
+			let refreshError: unknown;
+			try {
+				await Promise.all(Array.from({ length: 6 }, () =>
+					refreshPackagedOmxPluginCacheInPlace(cacheDir, packagedMarketplace),
+				));
+			} catch (error) {
+				refreshError = error;
+			} finally {
+				keepReading = false;
+			}
+			await reader;
+			if (refreshError !== undefined) throw refreshError;
+
+			const finalRoot = await lstat(cacheDir);
+			assert.equal(finalRoot.dev, initialRoot.dev);
+			assert.equal(finalRoot.ino, initialRoot.ino);
+			assert.ok(readCount >= 4);
+			assert.deepEqual(hookFailures, []);
+			assert.equal(
+				await readFile(hookPath, "utf-8"),
+				await readFile(join(packagedMarketplace.pluginRoot, "hooks", "codex-native-hook.mjs"), "utf-8"),
+			);
+			assert.equal(
+				await pluginCacheContentsMatchPackaged(cacheDir, packagedMarketplace),
+				true,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers namespace locks whose owner and reaper records are missing or malformed", { timeout: 10_000 }, async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-cache-invalid-lock-"));
+		try {
+			const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+			assert.ok(packagedMarketplace);
+			for (const [name, ownerJson, reaperJson] of [
+				["missing", null, null],
+				["invalid-json", "{not-json\n", null],
+				["invalid-schema", `${JSON.stringify({ token: 42, pid: "wrong" })}\n`, null],
+				["out-of-range-pid", `${JSON.stringify({ token: "invalid", pid: 0x80000000 })}\n`, null],
+				["empty-token", `${JSON.stringify({ token: "", pid: process.pid })}\n`, null],
+				["invalid-reaper", null, "{bad-reaper\n"],
+			] as const) {
+				const codexHomeDir = join(wd, name, "codex-home");
+				const materialized = await materializePackagedOmxPluginCache(
+					codexHomeDir,
+					packagedMarketplace,
+				);
+				assert.ok(materialized.cacheDir);
+				const cacheDir = materialized.cacheDir;
+				const lockPath = `${dirname(cacheDir)}.omx-refresh.lock`;
+				const sentinelPath = join(cacheDir, "sentinel.txt");
+				const initialRoot = await lstat(cacheDir);
+				await writeFile(sentinelPath, "remove during refresh\n");
+				await mkdir(lockPath);
+				if (ownerJson !== null) {
+					await writeFile(join(lockPath, "owner.json"), ownerJson);
+				}
+				if (reaperJson !== null) {
+					await writeFile(join(lockPath, "reaper.json"), reaperJson);
+				}
+
+				await refreshPackagedOmxPluginCacheInPlace(cacheDir, packagedMarketplace);
+				const finalRoot = await lstat(cacheDir);
+				assert.equal(finalRoot.dev, initialRoot.dev, name);
+				assert.equal(finalRoot.ino, initialRoot.ino, name);
+				await assert.rejects(readFile(sentinelPath, "utf-8"), { code: "ENOENT" });
+				await assert.rejects(lstat(lockPath), { code: "ENOENT" });
+				assert.equal(
+					await pluginCacheContentsMatchPackaged(cacheDir, packagedMarketplace),
+					true,
+					name,
+				);
+				const namespaceRoot = dirname(cacheDir);
+				assert.deepEqual(
+					(await readdir(dirname(namespaceRoot))).filter((entry) =>
+						entry.startsWith(`${basename(namespaceRoot)}.omx-refresh.lock`)
+					),
+					[],
+					name,
+				);
+			}
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses a non-directory namespace lock without modifying it", { timeout: 10_000 }, async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-cache-file-lock-"));
+		try {
+			const codexHomeDir = join(wd, "codex-home");
+			const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+			assert.ok(packagedMarketplace);
+			const materialized = await materializePackagedOmxPluginCache(
+				codexHomeDir,
+				packagedMarketplace,
+			);
+			assert.ok(materialized.cacheDir);
+			const cacheDir = materialized.cacheDir;
+			const lockPath = `${dirname(cacheDir)}.omx-refresh.lock`;
+			const initialRoot = await lstat(cacheDir);
+			await writeFile(lockPath, "foreign lock occupant\n");
+
+			await assert.rejects(
+				refreshPackagedOmxPluginCacheInPlace(cacheDir, packagedMarketplace),
+				/non-directory OMX plugin cache refresh lock/,
+			);
+			const finalRoot = await lstat(cacheDir);
+			assert.equal(finalRoot.dev, initialRoot.dev);
+			assert.equal(finalRoot.ino, initialRoot.ino);
+			assert.equal(await readFile(lockPath, "utf-8"), "foreign lock occupant\n");
+			assert.equal(
+				await pluginCacheContentsMatchPackaged(cacheDir, packagedMarketplace),
+				true,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("serializes parent and nested version refreshes on one namespace lock", { timeout: 30_000 }, async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-cache-nested-lock-"));
+		try {
+			const codexHomeDir = join(wd, "codex-home");
+			const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+			assert.ok(packagedMarketplace);
+			const materialized = await materializePackagedOmxPluginCache(
+				codexHomeDir,
+				packagedMarketplace,
+			);
+			assert.ok(materialized.cacheDir);
+			const parentCacheDir = materialized.cacheDir;
+			const nestedCacheDir = join(parentCacheDir, "0.0.1");
+			await cp(packagedMarketplace.pluginRoot, nestedCacheDir, { recursive: true });
+			await cp(
+				join(parentCacheDir, "hooks", "omx-command.json"),
+				join(nestedCacheDir, "hooks", "omx-command.json"),
+			);
+			const initialParent = await lstat(parentCacheDir);
+			const initialNested = await lstat(nestedCacheDir);
+			const namespaceRoot = dirname(parentCacheDir);
+			const canonicalLockPath = `${namespaceRoot}.omx-refresh.lock`;
+			const obsoleteNestedLockPath = `${parentCacheDir}.omx-refresh.lock`;
+			await mkdir(canonicalLockPath);
+			await writeFile(join(canonicalLockPath, "owner.json"), "{invalid-canonical-owner\n");
+
+			await refreshPackagedOmxPluginCacheInPlace(
+				nestedCacheDir,
+				packagedMarketplace,
+			);
+			await assert.rejects(lstat(canonicalLockPath), { code: "ENOENT" });
+			await assert.rejects(lstat(obsoleteNestedLockPath), { code: "ENOENT" });
+
+			await Promise.all(Array.from({ length: 8 }, (_, index) =>
+				refreshPackagedOmxPluginCacheInPlace(
+					index % 2 === 0 ? parentCacheDir : nestedCacheDir,
+					packagedMarketplace,
+				),
+			));
+
+			const finalParent = await lstat(parentCacheDir);
+			const finalNested = await lstat(nestedCacheDir);
+			assert.equal(finalParent.dev, initialParent.dev);
+			assert.equal(finalParent.ino, initialParent.ino);
+			assert.equal(finalNested.dev, initialNested.dev);
+			assert.equal(finalNested.ino, initialNested.ino);
+			assert.equal(
+				await pluginCacheContentsMatchPackaged(parentCacheDir, packagedMarketplace),
+				true,
+			);
+			assert.equal(
+				await pluginCacheContentsMatchPackaged(nestedCacheDir, packagedMarketplace),
+				true,
+			);
+			assert.deepEqual(
+				(await readdir(parentCacheDir)).filter((entry) => entry.includes(".omx-refresh.lock")),
+				[],
+			);
+			await assert.rejects(lstat(canonicalLockPath), { code: "ENOENT" });
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/cli/__tests__/plugin-marketplace-idempotent.test.ts
+++ b/src/cli/__tests__/plugin-marketplace-idempotent.test.ts
@@ -1,14 +1,57 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import TOML from "@iarna/toml";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../../config/omx-first-party-mcp.js";
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
 	OMX_LOCAL_PLUGIN_CONFIG_KEY,
+	discoverOmxPluginCacheDirs,
+	isOmxPluginCacheVersionEntryName,
 	upsertLocalOmxMarketplaceRegistration,
 	upsertLocalOmxPluginEnablement,
 	upsertLocalOmxPluginMcpServerEnablement,
 } from "../plugin-marketplace.js";
+
+describe("plugin cache discovery", () => {
+	it("recognizes supported cache version names without accepting work artifacts", () => {
+		for (const name of ["local", "0.20.5", "1.0.0-alpha.1", "1.0.0+build.7"]) {
+			assert.equal(isOmxPluginCacheVersionEntryName(name), true, name);
+		}
+		for (const name of [".materializing-0.20.5-123", "v0.20.5", "0.20", "latest"]) {
+			assert.equal(isOmxPluginCacheVersionEntryName(name), false, name);
+		}
+	});
+
+	it("finds corrupt version roots by namespace and ignores materialization workdirs", async () => {
+		const codexHomeDir = await mkdtemp(join(tmpdir(), "omx-plugin-discovery-"));
+		try {
+			const namespaceRoot = join(
+				codexHomeDir,
+				"plugins",
+				"cache",
+				"oh-my-codex-local",
+				"oh-my-codex",
+			);
+			const corruptVersionRoot = join(namespaceRoot, "0.20.3");
+			const workdir = join(namespaceRoot, ".materializing-0.20.5-123");
+			await mkdir(corruptVersionRoot, { recursive: true });
+			await mkdir(join(workdir, ".codex-plugin"), { recursive: true });
+			await writeFile(
+				join(workdir, ".codex-plugin", "plugin.json"),
+				JSON.stringify({ name: "oh-my-codex", version: "0.20.5" }),
+			);
+
+			assert.deepEqual(await discoverOmxPluginCacheDirs(codexHomeDir), [
+				corruptVersionRoot,
+			]);
+		} finally {
+			await rm(codexHomeDir, { recursive: true, force: true });
+		}
+	});
+});
 
 function countMatches(content: string, pattern: RegExp): number {
 	return [...content.matchAll(pattern)].length;

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -342,6 +342,7 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-explicit-session.jsonl" ]; then
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-project-filter-'));
     try {
       const home = join(wd, 'home');
+      const unrelatedCodexHome = join(wd, 'unrelated-codex-home');
       const projectCodexHome = join(wd, '.codex');
       const runtimeCodexHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
       const fakeBin = join(wd, 'bin');
@@ -349,18 +350,29 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-explicit-session.jsonl" ]; then
       const fakePsPath = join(fakeBin, 'ps');
       const projectRolloutPath = join(projectCodexHome, 'sessions', '2026', '06', '17', 'rollout-project-session.jsonl');
       const runtimeRolloutPath = join(runtimeCodexHome, 'sessions', '2026', '06', '17', 'rollout-runtime-session.jsonl');
+      const testDir = dirname(fileURLToPath(import.meta.url));
+      const repoRoot = join(testDir, '..', '..', '..');
+      const manifest = JSON.parse(await readFile(join(repoRoot, 'plugins', 'oh-my-codex', '.codex-plugin', 'plugin.json'), 'utf-8')) as { version: string };
 
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await mkdir(dirname(projectRolloutPath), { recursive: true });
       await mkdir(dirname(runtimeRolloutPath), { recursive: true });
-      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await mkdir(join(projectCodexHome, 'plugins'), { recursive: true });
+      await mkdir(unrelatedCodexHome, { recursive: true });
+      await symlink(join(projectCodexHome, 'plugins'), join(runtimeCodexHome, 'plugins'), 'dir');
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({
+        scope: 'project',
+        installMode: 'plugin',
+        teamMode: 'disabled',
+      }));
       await writeFile(projectRolloutPath, '{"type":"session_meta","payload":{"id":"project-session"}}\n');
       await writeFile(runtimeRolloutPath, '{"type":"session_meta","payload":{"id":"runtime-session"}}\n');
       await writeFile(fakeCodexPath, `#!/bin/sh
 printf 'fake-codex:%s\n' "$*"
 if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-runtime-session.jsonl" ]; then echo runtime-rollout-present=yes; else echo runtime-rollout-present=no; fi
 if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-project-session.jsonl" ]; then echo project-rollout-present=yes; else echo project-rollout-present=no; fi
+if [ -f "$CODEX_HOME/plugins/cache/oh-my-codex-local/oh-my-codex/${manifest.version}/hooks/codex-native-hook.mjs" ]; then echo current-hook-present=yes; else echo current-hook-present=no; fi
 mkdir -p "$CODEX_HOME/sessions/2026/06/18"
 printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$CODEX_HOME/sessions/2026/06/18/rollout-new-project-resume.jsonl"
 `);
@@ -370,6 +382,7 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
 
       const result = runOmx(wd, ['resume', '--project'], {
         HOME: home,
+        CODEX_HOME: unrelatedCodexHome,
         PATH: `${fakeBin}:/usr/bin:/bin`,
         OMX_AUTO_UPDATE: '0',
         OMX_NOTIFY_FALLBACK: '0',
@@ -380,6 +393,7 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /runtime-rollout-present=yes/);
       assert.match(result.stdout, /project-rollout-present=no/);
+      assert.match(result.stdout, /current-hook-present=yes/);
       const runtimeDirs = await readdir(join(wd, '.omx', 'runtime', 'codex-home'));
       const persistedNewTranscript = await Promise.all(runtimeDirs.map(async (dir) => {
         const transcript = join(wd, '.omx', 'runtime', 'codex-home', dir, 'sessions', '2026', '06', '18', 'rollout-new-project-resume.jsonl');
@@ -447,6 +461,7 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; the
   it('preflights madmax resume to current plugin cache after old cache deletion', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-plugin-preflight-'));
     try {
+      const launchCwd = join(wd, 'nested');
       const home = join(wd, 'home');
       const runsRoot = join(wd, 'runs');
       const projectCodexHome = join(wd, '.codex');
@@ -461,6 +476,7 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; the
       const oldCacheDir = join(projectCodexHome, 'plugins', 'cache', 'oh-my-codex-local', 'oh-my-codex', oldVersion);
 
       await mkdir(home, { recursive: true });
+      await mkdir(launchCwd, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await mkdir(runsRoot, { recursive: true });
       await mkdir(join(projectCodexHome, 'sessions', '2026', '06', '17'), { recursive: true });
@@ -484,14 +500,19 @@ if [ -f "$CODEX_HOME/sessions/2026/06/17/rollout-unrelated-session.jsonl" ]; the
         hooks: './hooks/hooks.json',
       }, null, 2));
       await writeFile(join(oldCacheDir, 'hooks', 'hooks.json'), '{}\n');
-      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
-      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: join(runsRoot, 'run-associated') })}\n`);
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({
+        scope: 'project',
+        installMode: 'plugin',
+        teamMode: 'disabled',
+      }));
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: launchCwd, run_dir: join(runsRoot, 'run-associated') })}\n`);
       await rm(oldCacheDir, { recursive: true, force: true });
 
       await writeFile(fakeCodexPath, `#!/bin/sh
 printf 'fake-codex:%s\n' "$*"
 printf 'codex-home:%s\n' "$CODEX_HOME"
 if [ -f "$CODEX_HOME/plugins/cache/oh-my-codex-local/oh-my-codex/${currentVersion}/hooks/codex-native-hook.mjs" ]; then echo current-hook-present=yes; else echo current-hook-present=no; fi
+if [ -d "$CODEX_HOME/plugins/cache/oh-my-codex-local/oh-my-codex/${currentVersion}/skills/team" ]; then echo team-skill-present=yes; else echo team-skill-present=no; fi
 if [ -e "$CODEX_HOME/plugins/cache/oh-my-codex-local/oh-my-codex/${oldVersion}" ]; then echo old-cache-present=yes; else echo old-cache-present=no; fi
 case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo marketplace-current=yes;; *) echo marketplace-current=no;; esac
 `);
@@ -499,7 +520,7 @@ case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo mark
       await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
       await chmod(fakePsPath, 0o755);
 
-      const result = runOmx(wd, ['--madmax', 'resume', 'stale-session'], {
+      const result = runOmx(launchCwd, ['--madmax', 'resume', 'stale-session'], {
         HOME: home,
         OMX_RUNS_DIR: runsRoot,
         PATH: `${fakeBin}:/usr/bin:/bin`,
@@ -511,6 +532,7 @@ case "$(cat "$CODEX_HOME/config.toml")" in *'source = "${repoRoot}"'*) echo mark
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:.*resume stale-session\b/);
       assert.match(result.stdout, /current-hook-present=yes/);
+      assert.match(result.stdout, /team-skill-present=no/);
       assert.match(result.stdout, /old-cache-present=no/);
       assert.match(result.stdout, /marketplace-current=yes/);
     } finally {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -38,6 +38,8 @@ import {
 } from "../../config/generator.js";
 import {
 	materializePackagedOmxPluginCache,
+	pluginCacheContentsMatchPackaged,
+	refreshPackagedOmxPluginCacheInPlace,
 	resolvePackagedOmxMarketplace,
 } from "../plugin-marketplace.js";
 import {
@@ -1277,7 +1279,7 @@ describe("omx setup install mode behavior", () => {
 					);
 					assert.match(
 						output,
-						/Invalidated 1 stale Codex plugin discovery cache entry/,
+						/Refreshed 1 stale Codex plugin discovery cache entry in place/,
 					);
 					assert.equal(
 						existsSync(join(codexHomeDir, "skills", "old-only", "SKILL.md")),
@@ -1290,33 +1292,399 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
-	it("invalidates old versioned plugin cache dirs while materializing the current cache", async () => {
+	it("refreshes old versioned plugin caches without removing their pinned roots", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
 				await withTempCwd(wd, async () => {
 					const oldCacheDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+					const oldCacheStats = await lstat(oldCacheDir);
 
 					const output = await captureConsoleOutput(async () => {
 						await setup({ scope: "user", installMode: "plugin" });
 					});
 
 					const currentCacheDir = await packagedPluginCacheDir(codexHomeDir);
-					assert.equal(existsSync(oldCacheDir), false);
+					const refreshedOldCacheStats = await lstat(oldCacheDir);
+					assert.equal(refreshedOldCacheStats.isDirectory(), true);
+					assert.equal(refreshedOldCacheStats.dev, oldCacheStats.dev);
+					assert.equal(refreshedOldCacheStats.ino, oldCacheStats.ino);
+					assert.equal(existsSync(join(oldCacheDir, "hooks", "codex-native-hook.mjs")), true);
+					assert.equal(existsSync(join(oldCacheDir, "hooks", "omx-command.json")), true);
+					assert.equal(existsSync(join(oldCacheDir, "skills", "old-only")), false);
 					assert.equal(existsSync(join(currentCacheDir, ".codex-plugin", "plugin.json")), true);
 					assert.equal(existsSync(join(currentCacheDir, "hooks", "hooks.json")), true);
 					assert.equal(existsSync(join(currentCacheDir, "hooks", "codex-native-hook.mjs")), true);
 					assert.equal(existsSync(join(currentCacheDir, "hooks", "omx-command.json")), true);
 					assert.equal(existsSync(join(currentCacheDir, "skills", "ask", "SKILL.md")), true);
-					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
+					assert.match(output, /Refreshed 1 stale Codex plugin discovery cache entry in place/);
 					assert.match(output, /Installed local Codex plugin cache/);
-					assert.doesNotMatch(output, /Retained .* old versioned Codex plugin cache/);
 				});
 			});
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+
+	it("recovers a stale namespace lock and serializes concurrent cache refreshes", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const oldCacheDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+				const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+				assert.ok(packagedMarketplace);
+				const staleLockPath = `${dirname(oldCacheDir)}.omx-refresh.lock`;
+				await mkdir(staleLockPath, { recursive: true });
+				await writeFile(
+					join(staleLockPath, "owner.json"),
+					JSON.stringify({ token: "dead-owner", pid: 2_147_483_647 }),
+				);
+				await writeFile(
+					join(staleLockPath, "reaper.json"),
+					JSON.stringify({ token: "dead-reaper", pid: 2_147_483_646 }),
+				);
+
+				await Promise.all(
+					Array.from({ length: 4 }, () =>
+						refreshPackagedOmxPluginCacheInPlace(
+							oldCacheDir,
+							packagedMarketplace,
+						),
+					),
+				);
+
+				assert.equal((await lstat(oldCacheDir)).isDirectory(), true);
+				assert.equal(
+					existsSync(join(oldCacheDir, "hooks", "codex-native-hook.mjs")),
+					true,
+				);
+				assert.equal(
+					existsSync(join(oldCacheDir, "hooks", "omx-command.json")),
+					true,
+				);
+				assert.equal(existsSync(staleLockPath), false);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("serializes different packaged revisions into one coherent cache snapshot", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const cacheDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+				const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+				assert.ok(packagedMarketplace);
+				const revisions = await Promise.all(["a", "b"].map(async (revision) => {
+					const pluginRoot = join(wd, `plugin-${revision}`);
+					await cp(packagedMarketplace.pluginRoot, pluginRoot, { recursive: true });
+					await writeFile(
+						join(pluginRoot, "hooks", "codex-native-hook.mjs"),
+						`${await readFile(join(pluginRoot, "hooks", "codex-native-hook.mjs"), "utf-8")}\n// revision-${revision}\n`,
+					);
+					await writeFile(
+						join(pluginRoot, "skills", "ask", "SKILL.md"),
+						`# revision-${revision}\n`,
+					);
+					return {
+						...packagedMarketplace,
+						packageRoot: join(wd, `package-${revision}`),
+						pluginRoot,
+						pluginManifestPath: join(pluginRoot, ".codex-plugin", "plugin.json"),
+					};
+				}));
+
+				await Promise.all(revisions.map((revision) =>
+					refreshPackagedOmxPluginCacheInPlace(cacheDir, revision),
+				));
+
+				const matches = await Promise.all(revisions.map((revision) =>
+					pluginCacheContentsMatchPackaged(cacheDir, revision),
+				));
+				assert.equal(matches.filter(Boolean).length, 1);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to materialize through a cache-root symlink into a foreign directory", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+				assert.ok(packagedMarketplace);
+				const currentCacheDir = await packagedPluginCacheDir(codexHomeDir);
+				const foreignTarget = join(wd, "foreign-target");
+				await mkdir(dirname(currentCacheDir), { recursive: true });
+				await mkdir(foreignTarget, { recursive: true });
+				await writeFile(join(foreignTarget, "sentinel.txt"), "do not touch\n");
+				await symlink(foreignTarget, currentCacheDir, "dir");
+
+				await assert.rejects(
+					materializePackagedOmxPluginCache(
+						codexHomeDir,
+						packagedMarketplace,
+					),
+					/non-directory plugin cache root/,
+				);
+
+				assert.equal(await readFile(join(foreignTarget, "sentinel.txt"), "utf-8"), "do not touch\n");
+				assert.deepEqual(await readdir(foreignTarget), ["sentinel.txt"]);
+				assert.equal((await lstat(currentCacheDir)).isSymbolicLink(), true);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to materialize through a symlinked cache namespace", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+				assert.ok(packagedMarketplace);
+				const currentCacheDir = await packagedPluginCacheDir(codexHomeDir);
+				const namespaceRoot = dirname(currentCacheDir);
+				const foreignNamespace = join(wd, "foreign-namespace");
+				const foreignVersionDir = join(foreignNamespace, basename(currentCacheDir));
+				await mkdir(dirname(namespaceRoot), { recursive: true });
+				await mkdir(foreignVersionDir, { recursive: true });
+				await writeFile(join(foreignVersionDir, "sentinel.txt"), "do not touch\n");
+				await symlink(foreignNamespace, namespaceRoot, "dir");
+
+				await assert.rejects(
+					materializePackagedOmxPluginCache(
+						codexHomeDir,
+						packagedMarketplace,
+					),
+					/non-directory namespace component/,
+				);
+
+				assert.equal(
+					await readFile(join(foreignVersionDir, "sentinel.txt"), "utf-8"),
+					"do not touch\n",
+				);
+				assert.deepEqual(await readdir(foreignVersionDir), ["sentinel.txt"]);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to materialize through a symlinked plugins ancestor", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+				assert.ok(packagedMarketplace);
+				const currentCacheDir = await packagedPluginCacheDir(codexHomeDir);
+				const foreignPlugins = join(wd, "foreign-plugins");
+				const foreignVersionDir = join(
+					foreignPlugins,
+					"cache",
+					"oh-my-codex-local",
+					"oh-my-codex",
+					basename(currentCacheDir),
+				);
+				await mkdir(codexHomeDir, { recursive: true });
+				await mkdir(foreignVersionDir, { recursive: true });
+				await writeFile(join(foreignVersionDir, "sentinel.txt"), "do not touch\n");
+				await symlink(foreignPlugins, join(codexHomeDir, "plugins"), "dir");
+
+				await assert.rejects(
+					materializePackagedOmxPluginCache(
+						codexHomeDir,
+						packagedMarketplace,
+					),
+					/non-directory namespace component/,
+				);
+
+				assert.equal(
+					await readFile(join(foreignVersionDir, "sentinel.txt"), "utf-8"),
+					"do not touch\n",
+				);
+				assert.deepEqual(await readdir(foreignVersionDir), ["sentinel.txt"]);
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("refreshes nested version caches beneath a legacy plugin root", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const legacyRoot = await seedStalePluginDiscoveryCache(codexHomeDir);
+					const nestedVersionDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					assert.equal((await lstat(legacyRoot)).isDirectory(), true);
+					assert.equal((await lstat(nestedVersionDir)).isDirectory(), true);
+					assert.equal(
+						existsSync(join(nestedVersionDir, "hooks", "codex-native-hook.mjs")),
+						true,
+					);
+					assert.equal(
+						existsSync(join(nestedVersionDir, "hooks", "omx-command.json")),
+						true,
+					);
+					assert.equal(existsSync(join(legacyRoot, "skills", "old-only")), false);
+					assert.equal(existsSync(join(nestedVersionDir, "skills", "old-only")), false);
+					assert.match(
+						output,
+						/Refreshed 2 stale Codex plugin discovery cache entries in place/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("repairs corrupt version roots nested beneath another managed version", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const parentVersionDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+					const nestedVersionDir = join(parentVersionDir, "0.0.1");
+					await cp(join(packageRoot, "plugins", "oh-my-codex"), nestedVersionDir, {
+						recursive: true,
+					});
+					await rm(join(nestedVersionDir, ".codex-plugin", "plugin.json"));
+					await mkdir(join(nestedVersionDir, "skills", "old-only"), { recursive: true });
+					await writeFile(join(nestedVersionDir, "skills", "old-only", "SKILL.md"), "# old\n");
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					assert.equal(existsSync(join(nestedVersionDir, ".codex-plugin", "plugin.json")), true);
+					assert.equal(existsSync(join(nestedVersionDir, "hooks", "omx-command.json")), true);
+					assert.equal(existsSync(join(nestedVersionDir, "skills", "old-only")), false);
+					assert.match(
+						output,
+						/Refreshed 2 stale Codex plugin discovery cache entries in place/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("repairs a version cache whose plugin manifest is missing", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const oldCacheDir = await seedOldVersionedPluginDiscoveryCache(codexHomeDir);
+					await rm(join(oldCacheDir, ".codex-plugin", "plugin.json"));
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					const repairedManifest = JSON.parse(
+						await readFile(
+							join(oldCacheDir, ".codex-plugin", "plugin.json"),
+							"utf-8",
+						),
+					) as { name?: string };
+					assert.equal(repairedManifest.name, "oh-my-codex");
+					assert.equal(
+						existsSync(join(oldCacheDir, "hooks", "codex-native-hook.mjs")),
+						true,
+					);
+					assert.match(
+						output,
+						/Refreshed 1 stale Codex plugin discovery cache entry in place/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("repairs a legacy managed cache root whose manifest is missing", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const legacyRoot = await seedStalePluginDiscoveryCache(codexHomeDir);
+					await rm(join(legacyRoot, ".codex-plugin", "plugin.json"));
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					const repairedManifest = JSON.parse(await readFile(
+						join(legacyRoot, ".codex-plugin", "plugin.json"),
+						"utf-8",
+					)) as { name?: string };
+					assert.equal(repairedManifest.name, "oh-my-codex");
+					assert.equal(
+						existsSync(join(legacyRoot, "hooks", "codex-native-hook.mjs")),
+						true,
+					);
+					assert.match(
+						output,
+						/Refreshed 1 stale Codex plugin discovery cache entry in place/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("does not mutate a same-named plugin cache owned by another marketplace", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const externalCacheDir = join(
+						codexHomeDir,
+						"plugins",
+						"cache",
+						"acme",
+						"oh-my-codex",
+						"9.0.0",
+					);
+					await mkdir(join(externalCacheDir, ".codex-plugin"), { recursive: true });
+					await writeFile(
+						join(externalCacheDir, ".codex-plugin", "plugin.json"),
+						JSON.stringify({ name: "oh-my-codex", version: "9.0.0" }),
+					);
+					await writeFile(join(externalCacheDir, "acme-only-runtime.js"), "acme\n");
+
+					await setup({ scope: "user", installMode: "plugin" });
+
+					assert.equal(
+						await readFile(join(externalCacheDir, "acme-only-runtime.js"), "utf-8"),
+						"acme\n",
+					);
+					assert.deepEqual(
+						JSON.parse(await readFile(
+							join(externalCacheDir, ".codex-plugin", "plugin.json"),
+							"utf-8",
+						)),
+						{ name: "oh-my-codex", version: "9.0.0" },
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("invalidates same-version plugin caches when hook file contents drift", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {
@@ -1332,8 +1700,49 @@ describe("omx setup install mode behavior", () => {
 						await readFile(join(cacheDir, "hooks", "hooks.json"), "utf-8"),
 					) as { hooks?: { PreToolUse?: Array<{ matcher?: unknown }> } };
 					assert.equal(refreshedHooks.hooks?.PreToolUse?.[0]?.matcher, undefined);
-					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
-					assert.match(output, /Installed local Codex plugin cache/);
+					assert.match(output, /Refreshed 1 stale Codex plugin discovery cache entry in place/);
+					assert.match(output, /Local Codex plugin cache already exposes packaged OMX skills/);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("refreshes same-version plugin caches when a skill file drifts", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+					await mkdir(dirname(cacheDir), { recursive: true });
+					await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+						recursive: true,
+					});
+					await writeFile(
+						join(cacheDir, "hooks", "omx-command.json"),
+						JSON.stringify({
+							command: process.execPath,
+							argsPrefix: [join(packageRoot, "dist", "cli", "omx.js")],
+						}),
+					);
+					await writeFile(join(cacheDir, "skills", "ask", "SKILL.md"), "# stale\n");
+
+					const output = await captureConsoleOutput(async () => {
+						await setup({ scope: "user", installMode: "plugin" });
+					});
+
+					assert.equal(
+						await readFile(join(cacheDir, "skills", "ask", "SKILL.md"), "utf-8"),
+						await readFile(
+							join(packageRoot, "plugins", "oh-my-codex", "skills", "ask", "SKILL.md"),
+							"utf-8",
+						),
+					);
+					assert.match(
+						output,
+						/Refreshed 1 stale Codex plugin discovery cache entry in place/,
+					);
 				});
 			});
 		} finally {
@@ -1357,8 +1766,8 @@ describe("omx setup install mode behavior", () => {
 					) as { command?: string; argsPrefix?: string[] };
 					assert.equal(launcher.command, process.execPath);
 					assert.deepEqual(launcher.argsPrefix, [join(packageRoot, "dist", "cli", "omx.js")]);
-					assert.match(output, /Invalidated 1 stale Codex plugin discovery cache entry/);
-					assert.match(output, /Installed local Codex plugin cache/);
+					assert.match(output, /Refreshed 1 stale Codex plugin discovery cache entry in place/);
+					assert.match(output, /Local Codex plugin cache already exposes packaged OMX skills/);
 				});
 			});
 		} finally {
@@ -1370,28 +1779,29 @@ describe("omx setup install mode behavior", () => {
 		try {
 			await withIsolatedUserHome(wd, async (codexHomeDir) => {
 				const cacheDir = await seedSameVersionPluginCacheWithStaleHooks(codexHomeDir);
+				const cacheStats = await lstat(cacheDir);
 				const staleOnlyPath = join(cacheDir, "stale-only.txt");
+				const nestedPinnedCacheDir = join(cacheDir, "0.0.0-pinned");
 				await writeFile(staleOnlyPath, "stale\n");
+				await mkdir(nestedPinnedCacheDir, { recursive: true });
+				await writeFile(join(nestedPinnedCacheDir, "sentinel.txt"), "pinned\n");
 				const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
 				assert.ok(packagedMarketplace, "expected packaged OMX plugin marketplace fixture");
 
-				let observedPreparedCache = false;
-				await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace, {
-					onCacheDirPrepared: async (preparedCacheDir) => {
-						if (preparedCacheDir !== cacheDir) return;
-						observedPreparedCache = true;
-						assert.equal(existsSync(cacheDir), true, "cache root must remain present before overlay replacement starts");
-						assert.equal(existsSync(join(cacheDir, ".codex-plugin", "plugin.json")), true);
-						assert.equal(existsSync(join(cacheDir, "hooks", "codex-native-hook.mjs")), true);
-					},
-				});
-
-				assert.equal(observedPreparedCache, true, "test hook should observe cache root during replacement");
+				await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
+				const refreshedStats = await lstat(cacheDir);
+				assert.equal(refreshedStats.dev, cacheStats.dev);
+				assert.equal(refreshedStats.ino, cacheStats.ino);
 				assert.equal(existsSync(cacheDir), true);
 				assert.equal(existsSync(join(cacheDir, ".codex-plugin", "plugin.json")), true);
 				assert.equal(existsSync(join(cacheDir, "hooks", "codex-native-hook.mjs")), true);
 				assert.equal(existsSync(join(cacheDir, "hooks", "omx-command.json")), true);
 				assert.equal(existsSync(staleOnlyPath), false, "overlay cleanup should remove stale files after refreshed files are present");
+				assert.equal(
+					await readFile(join(nestedPinnedCacheDir, "sentinel.txt"), "utf-8"),
+					"pinned\n",
+					"materialization must retain nested version roots pinned by running sessions",
+				);
 			});
 		} finally {
 			await rm(wd, { recursive: true, force: true });
@@ -1412,7 +1822,7 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(existsSync(cacheDir), true);
 					assert.match(
 						output,
-						/Would invalidate 1 stale Codex plugin discovery cache entry/,
+						/Would refresh 1 stale Codex plugin discovery cache entry in place/,
 					);
 				});
 			});

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -21,6 +21,7 @@ import {
   runImmediateUpdate,
   shouldCheckForUpdates,
   spawnInstalledSetupRefresh,
+  updateCommandExitCode,
   writeUserInstallStamp,
 } from '../update.js';
 import {
@@ -40,6 +41,15 @@ const frozenNpmOwnership: PackageManagerOwnership = {
   packageRoot: '/configured/node_modules/oh-my-codex',
   environment: { OMX_UPDATE_TEST: '1' },
 };
+
+describe('updateCommandExitCode', () => {
+  it('returns a failing shell exit code only for failed explicit updates', () => {
+    assert.equal(updateCommandExitCode({ status: 'failed' }), 1);
+    for (const status of ['updated', 'scheduled', 'up-to-date', 'declined', 'unavailable'] as const) {
+      assert.equal(updateCommandExitCode({ status }), undefined);
+    }
+  });
+});
 
 describe('isNewerVersion', () => {
   it('returns true when latest has higher major', () => {

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -9,6 +9,21 @@ import {
 export const readPersistedSetupPreferences = readPersistedSetupPreferencesSync;
 export const readPersistedSetupScope = readPersistedSetupScopeSync;
 
+export function resolvePersistedSetupProjectRoot(
+	cwd: string,
+): string | undefined {
+	return resolveNearestPersistedSetupScopeSync(cwd)?.projectRoot;
+}
+
+export function resolvePersistedProjectCodexHome(
+	cwd: string,
+): string | undefined {
+	const nearest = resolveNearestPersistedSetupScopeSync(cwd);
+	return nearest?.scope === "project"
+		? join(nearest.projectRoot, ".codex")
+		: undefined;
+}
+
 export function resolveProjectLocalCodexHomeForLaunch(
 	cwd: string,
 	env: NodeJS.ProcessEnv = process.env,
@@ -17,11 +32,7 @@ export function resolveProjectLocalCodexHomeForLaunch(
 	// Walk upward so a project-scoped setup is honored from any directory
 	// inside its tree — launching from a subdirectory must not fall through
 	// to the user config (issue #3447).
-	const nearest = resolveNearestPersistedSetupScopeSync(cwd);
-	if (nearest?.scope === "project") {
-		return join(nearest.projectRoot, ".codex");
-	}
-	return undefined;
+	return resolvePersistedProjectCodexHome(cwd);
 }
 
 export function resolveCodexHomeForLaunch(

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -65,6 +65,7 @@ import {
 	validateCodexHooksConfigStrict,
 } from "../config/codex-hooks.js";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
+import type { SetupTeamMode } from "../config/team-mode.js";
 import { getDefaultBridge, isBridgeEnabled } from "../runtime/bridge.js";
 import {
 	OMX_EXPLORE_CMD_ENV,
@@ -189,6 +190,7 @@ interface DoctorScopeResolution {
 	source: "persisted" | "config" | "default";
 	installMode?: SetupInstallMode;
 	mcpMode?: SetupMcpMode;
+	teamMode?: SetupTeamMode;
 }
 
 interface DoctorPaths {
@@ -210,6 +212,7 @@ async function resolveDoctorScope(cwd: string): Promise<DoctorScopeResolution> {
 			source: "persisted",
 			installMode: persisted.installMode ?? inferred?.installMode,
 			mcpMode: persisted.mcpMode ?? inferred?.mcpMode ?? "none",
+			teamMode: persisted.teamMode,
 		};
 	}
 
@@ -680,7 +683,11 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 	);
 
 	// Check 6: Skills installed
-	checks.push(await checkSkills(paths, scopeResolution.installMode));
+	checks.push(await checkSkills(
+		paths,
+		scopeResolution.installMode,
+		scopeResolution.teamMode,
+	));
 	if (scopeResolution.installMode === "plugin") {
 		checks.push(await checkPluginVersionDiagnostics(paths.codexHomeDir));
 	}
@@ -3141,6 +3148,7 @@ function getParsedPluginMarketplaceConfig(content: string): {
 async function checkPluginMarketplaceRegistration(
 	configPath: string,
 	codexHomeDir: string,
+	teamMode?: SetupTeamMode,
 ): Promise<Check> {
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(
 		getPackageRoot(),
@@ -3197,7 +3205,7 @@ async function checkPluginMarketplaceRegistration(
 		const [packagedManifestVersion, expectedSkillNames, cacheDirs] =
 			await Promise.all([
 				packagedOmxPluginVersion(packagedMarketplace),
-				expectedPackagedOmxSkillNames(packagedMarketplace),
+				expectedPackagedOmxSkillNames(packagedMarketplace, { teamMode }),
 				discoverOmxPluginCacheDirs(codexHomeDir),
 			]);
 		if (!packagedManifestVersion) {
@@ -3639,11 +3647,13 @@ export function checkSparkRouting(paths: DoctorPaths): Check {
 async function checkSkills(
 	paths: DoctorPaths,
 	installMode?: SetupInstallMode,
+	teamMode?: SetupTeamMode,
 ): Promise<Check> {
 	if (installMode === "plugin") {
 		return checkPluginMarketplaceRegistration(
 			paths.configPath,
 			paths.codexHomeDir,
+			teamMode,
 		);
 	}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -82,6 +82,8 @@ import { evaluateRalphCompletionAuditEvidence, isRalphCompletePhase } from "../r
 import { normalizeTerminalWorkflowState } from "../state/terminal-normalization.js";
 import {
   readPersistedSetupPreferences,
+  resolvePersistedProjectCodexHome,
+  resolvePersistedSetupProjectRoot,
   resolveCodexConfigPathForLaunch,
   resolveCodexHomeForLaunch,
   resolveProjectLocalCodexHomeForLaunch,
@@ -120,7 +122,7 @@ import {
   type SkillActiveStateLike,
 } from "../state/skill-active.js";
 import { isTrackedWorkflowMode } from "../state/workflow-transition.js";
-import { maybeCheckAndPromptUpdate, runImmediateUpdate, type UpdateChannel } from "./update.js";
+import { maybeCheckAndPromptUpdate, runImmediateUpdate, updateCommandExitCode, type UpdateChannel } from "./update.js";
 import { maybePromptGithubStar } from "./star-prompt.js";
 import {
   generateOverlay,
@@ -1284,6 +1286,7 @@ export interface ResumePluginPreflightResult {
 
 export interface ResumePluginPreflightOptions {
   projectRoot?: string;
+  pluginCacheCodexHomeDir?: string;
 }
 
 async function shouldPreflightResumeOmxPluginState(
@@ -1294,11 +1297,15 @@ async function shouldPreflightResumeOmxPluginState(
   if (hasLocalOmxPluginEnablement(existingConfig)) return true;
   if (
     options.projectRoot &&
-    readPersistedSetupPreferences(options.projectRoot)?.installMode === "plugin"
+    readPersistedSetupPreferences(
+      resolvePersistedSetupProjectRoot(options.projectRoot) ?? options.projectRoot,
+    )?.installMode === "plugin"
   ) {
     return true;
   }
-  return (await discoverOmxPluginCacheDirs(selectedCodexHomeDir)).length > 0;
+  return (await discoverOmxPluginCacheDirs(
+    options.pluginCacheCodexHomeDir ?? selectedCodexHomeDir,
+  )).length > 0;
 }
 
 export async function preflightResumeOmxPluginState(
@@ -1320,9 +1327,25 @@ export async function preflightResumeOmxPluginState(
     return { status: "unavailable", prunedStaleDirs: [], configUpdated: false };
   }
 
-  const materialized = await materializePackagedOmxPluginCache(selectedCodexHomeDir, packagedMarketplace);
+  const persistedPreferences = options.projectRoot
+    ? readPersistedSetupPreferences(
+      resolvePersistedSetupProjectRoot(options.projectRoot) ?? options.projectRoot,
+    )
+    : undefined;
+  const materialized = await materializePackagedOmxPluginCache(
+	options.pluginCacheCodexHomeDir ?? selectedCodexHomeDir,
+	packagedMarketplace,
+	{ teamMode: persistedPreferences?.teamMode },
+  );
   const version = materialized.version ?? (await packagedOmxPluginVersion(packagedMarketplace)) ?? undefined;
-  const currentCacheDir = materialized.cacheDir ?? (version ? join(selectedCodexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version) : undefined);
+  const currentCacheDir = materialized.cacheDir ?? (version ? join(
+    options.pluginCacheCodexHomeDir ?? selectedCodexHomeDir,
+    "plugins",
+    "cache",
+    "oh-my-codex-local",
+    "oh-my-codex",
+    version,
+  ) : undefined);
   const prunedStaleDirs: string[] = [];
 
   const nextConfig = upsertLocalOmxMarketplaceRegistration(
@@ -1389,6 +1412,9 @@ async function prepareResumeCodexHomeForLaunch(
   }
 
   const projectHomes = await discoverProjectRuntimeCodexHomes(cwd);
+  const projectPluginCacheCodexHome = selection.projectOnly
+    ? resolvePersistedProjectCodexHome(cwd)
+    : resolveProjectLocalCodexHomeForLaunch(cwd, env);
   if (selection.projectOnly) {
     if (projectHomes.length === 0) {
       const emptyRuntimeCodexHome = runtimeCodexHomePath(cwd, sessionId);
@@ -1407,7 +1433,10 @@ async function prepareResumeCodexHomeForLaunch(
       includeHistoryArtifacts: true,
       extraHistoryCodexHomes: projectHomes.slice(1).map((home) => home.path),
     });
-    await preflightResumeOmxPluginState(runtimeCodexHome, getPackageRoot(), { projectRoot: cwd });
+    await preflightResumeOmxPluginState(runtimeCodexHome, getPackageRoot(), {
+      projectRoot: cwd,
+      pluginCacheCodexHomeDir: projectPluginCacheCodexHome,
+    });
     return {
       args: selection.args,
       prepared: {
@@ -1420,7 +1449,10 @@ async function prepareResumeCodexHomeForLaunch(
     includeHistoryArtifacts: true,
     extraHistoryCodexHomes: projectHomes.map((home) => home.path),
   });
-  await preflightResumeOmxPluginState(prepared.codexHomeOverride, getPackageRoot(), { projectRoot: cwd });
+  await preflightResumeOmxPluginState(prepared.codexHomeOverride, getPackageRoot(), {
+    projectRoot: cwd,
+    pluginCacheCodexHomeDir: prepared.projectLocalCodexHomeForCleanup,
+  });
   return { args: selection.args, prepared };
 }
 
@@ -3438,7 +3470,14 @@ if (command !== "launch" && command !== "resume") {
         });
         break;
       case "update":
-        await runImmediateUpdate(process.cwd(), {}, { channel: resolveUpdateChannelArg(args.slice(1)) });
+        {
+          const exitCode = updateCommandExitCode(
+            await runImmediateUpdate(process.cwd(), {}, {
+              channel: resolveUpdateChannelArg(args.slice(1)),
+            }),
+          );
+          if (exitCode !== undefined) process.exitCode = exitCode;
+        }
         break;
       case "list":
         await listCommand(args.slice(1));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1308,6 +1308,19 @@ async function shouldPreflightResumeOmxPluginState(
   )).length > 0;
 }
 
+async function runtimePluginCacheNeedsIndependentRefresh(
+  selectedCodexHomeDir: string,
+  pluginCacheCodexHomeDir: string,
+): Promise<boolean> {
+  if (resolve(selectedCodexHomeDir) === resolve(pluginCacheCodexHomeDir)) return false;
+  try {
+    return !(await lstat(join(selectedCodexHomeDir, "plugins"))).isSymbolicLink();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+}
+
 export async function preflightResumeOmxPluginState(
   codexHomeDir: string | undefined,
   pkgRoot = getPackageRoot(),
@@ -1332,14 +1345,19 @@ export async function preflightResumeOmxPluginState(
       resolvePersistedSetupProjectRoot(options.projectRoot) ?? options.projectRoot,
     )
     : undefined;
+  const pluginCacheCodexHomeDir = options.pluginCacheCodexHomeDir ?? selectedCodexHomeDir;
+  const materializeOptions = { teamMode: persistedPreferences?.teamMode };
   const materialized = await materializePackagedOmxPluginCache(
-	options.pluginCacheCodexHomeDir ?? selectedCodexHomeDir,
-	packagedMarketplace,
-	{ teamMode: persistedPreferences?.teamMode },
+    pluginCacheCodexHomeDir,
+    packagedMarketplace,
+    materializeOptions,
   );
+  if (await runtimePluginCacheNeedsIndependentRefresh(selectedCodexHomeDir, pluginCacheCodexHomeDir)) {
+    await materializePackagedOmxPluginCache(selectedCodexHomeDir, packagedMarketplace, materializeOptions);
+  }
   const version = materialized.version ?? (await packagedOmxPluginVersion(packagedMarketplace)) ?? undefined;
   const currentCacheDir = materialized.cacheDir ?? (version ? join(
-    options.pluginCacheCodexHomeDir ?? selectedCodexHomeDir,
+    pluginCacheCodexHomeDir,
     "plugins",
     "cache",
     "oh-my-codex-local",

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "fs";
-import { cp, lstat, mkdir, readdir, readFile, rename, rm, writeFile } from "fs/promises";
-import { join, resolve } from "path";
+import { cp, link, lstat, mkdir, readdir, readFile, rename, rm, writeFile } from "fs/promises";
+import { basename, dirname, join, resolve } from "path";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
 
@@ -135,13 +137,375 @@ export function omxPluginCacheBase(codexHomeDir: string): string {
 	);
 }
 
+export function isOmxPluginCacheVersionEntryName(name: string): boolean {
+	return /^(?:local|\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/.test(name);
+}
+
+const OMX_PLUGIN_CACHE_LOCK_RETRY_MS = 25;
+const OMX_PLUGIN_CACHE_LOCK_TIMEOUT_MS = 30_000;
+
+interface OmxPluginCacheLockOwner {
+	token: string;
+	pid: number;
+}
+
+interface OmxPluginCacheLock extends OmxPluginCacheLockOwner {
+	path: string;
+}
+
+type OmxPluginCacheOwnerRecordState =
+	| { kind: "valid"; owner: OmxPluginCacheLockOwner }
+	| { kind: "missing" }
+	| { kind: "malformed"; raw: string }
+	| { kind: "unreadable"; error: unknown };
+
+function pluginCacheNamespaceRoot(cacheDir: string): string {
+	let candidate = cacheDir;
+	for (;;) {
+		if (basename(candidate) === OMX_PLUGIN_NAME) return candidate;
+		const parent = dirname(candidate);
+		if (parent === candidate) {
+			throw new Error(`OMX plugin cache path is outside the managed namespace: ${cacheDir}`);
+		}
+		candidate = parent;
+	}
+}
+
+async function assertPluginCacheNamespaceHasNoSymlinkAncestors(
+	cacheDir: string,
+): Promise<void> {
+	const namespaceRoot = pluginCacheNamespaceRoot(cacheDir);
+	const marketplaceRoot = dirname(namespaceRoot);
+	const cacheRoot = dirname(marketplaceRoot);
+	const pluginsRoot = dirname(cacheRoot);
+	for (const candidate of [pluginsRoot, cacheRoot, marketplaceRoot, namespaceRoot]) {
+		try {
+			const stats = await lstat(candidate);
+			if (!stats.isDirectory()) {
+				throw new Error(
+					`Refusing to mutate an OMX plugin cache through a non-directory namespace component: ${candidate}`,
+				);
+			}
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+}
+
+function pluginCacheLockPath(cacheDir: string): string {
+	return `${pluginCacheNamespaceRoot(cacheDir)}.omx-refresh.lock`;
+}
+
+async function inspectPluginCacheOwnerRecord(
+	recordPath: string,
+): Promise<OmxPluginCacheOwnerRecordState> {
+	let raw: string;
+	try {
+		raw = await readFile(recordPath, "utf-8");
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "ENOENT"
+			? { kind: "missing" }
+			: { kind: "unreadable", error };
+	}
+	try {
+		const parsed = JSON.parse(raw) as { token?: unknown; pid?: unknown };
+		return typeof parsed.token === "string" &&
+			parsed.token.length > 0 &&
+			Number.isSafeInteger(parsed.pid) &&
+			(parsed.pid as number) > 0 &&
+			(parsed.pid as number) <= 0x7fffffff
+			? { kind: "valid", owner: { token: parsed.token, pid: parsed.pid as number } }
+			: { kind: "malformed", raw };
+	} catch {
+		return { kind: "malformed", raw };
+	}
+}
+
+async function inspectPluginCacheLockOwner(
+	lockPath: string,
+): Promise<OmxPluginCacheOwnerRecordState> {
+	return inspectPluginCacheOwnerRecord(join(lockPath, "owner.json"));
+}
+
+async function inspectPluginCacheReaperOwner(
+	lockPath: string,
+): Promise<OmxPluginCacheOwnerRecordState> {
+	return inspectPluginCacheOwnerRecord(join(lockPath, "reaper.json"));
+}
+
+function pluginCacheOwnerRecordStatesMatch(
+	left: OmxPluginCacheOwnerRecordState,
+	right: OmxPluginCacheOwnerRecordState,
+): boolean {
+	if (left.kind !== right.kind) return false;
+	if (left.kind === "missing") return true;
+	if (left.kind === "malformed" && right.kind === "malformed") {
+		return left.raw === right.raw;
+	}
+	if (left.kind === "valid" && right.kind === "valid") {
+		return left.owner.token === right.owner.token && left.owner.pid === right.owner.pid;
+	}
+	return false;
+}
+
+async function readPluginCacheLockOwner(
+	lockPath: string,
+): Promise<OmxPluginCacheLockOwner | null> {
+	const state = await inspectPluginCacheLockOwner(lockPath);
+	return state.kind === "valid" ? state.owner : null;
+}
+
+async function readPluginCacheReaperOwner(
+	lockPath: string,
+): Promise<OmxPluginCacheLockOwner | null> {
+	const state = await inspectPluginCacheReaperOwner(lockPath);
+	return state.kind === "valid" ? state.owner : null;
+}
+
+function processIsDead(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return false;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === "ESRCH";
+	}
+}
+
+async function sleepForPluginCacheLock(): Promise<void> {
+	await new Promise<void>((resolveSleep) =>
+		setTimeout(resolveSleep, OMX_PLUGIN_CACHE_LOCK_RETRY_MS),
+	);
+}
+
+async function recoverOrphanedPluginCacheReaper(
+	lockPath: string,
+	takeoverToken: string,
+): Promise<void> {
+	const observed = await inspectPluginCacheReaperOwner(lockPath);
+	if (observed.kind === "missing") return;
+	if (observed.kind === "unreadable") throw observed.error;
+	if (observed.kind === "valid" && !processIsDead(observed.owner.pid)) return;
+	const reaperPath = join(lockPath, "reaper.json");
+	const quarantinePath = join(lockPath, `reaper-stale-${takeoverToken}.json`);
+	try {
+		await rename(reaperPath, quarantinePath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	const moved = await inspectPluginCacheOwnerRecord(quarantinePath);
+	if (!pluginCacheOwnerRecordStatesMatch(observed, moved)) {
+		await rename(quarantinePath, reaperPath).catch(() => undefined);
+		return;
+	}
+	await rm(quarantinePath, { force: true });
+}
+
+async function withPluginCacheReaperClaim(
+	lockPath: string,
+	reaperToken: string,
+	operation: () => Promise<boolean>,
+): Promise<boolean> {
+	const reaperPath = join(lockPath, "reaper.json");
+	const candidatePath = join(lockPath, `reaper-candidate-${reaperToken}.json`);
+	let claimedReaper = false;
+	try {
+		await recoverOrphanedPluginCacheReaper(lockPath, reaperToken);
+		await writeFile(
+			candidatePath,
+			`${JSON.stringify({ token: reaperToken, pid: process.pid }, null, 2)}\n`,
+			{ flag: "wx" },
+		);
+		try {
+			await link(candidatePath, reaperPath);
+			claimedReaper = true;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+			throw error;
+		}
+		const claimedOwner = await readPluginCacheReaperOwner(lockPath);
+		if (claimedOwner?.token !== reaperToken) return false;
+
+		return await operation();
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	} finally {
+		await rm(candidatePath, { force: true }).catch(() => undefined);
+		if (claimedReaper) {
+			try {
+				const reaper = JSON.parse(await readFile(reaperPath, "utf-8")) as {
+					token?: unknown;
+				};
+				if (reaper.token === reaperToken) await rm(reaperPath, { force: true });
+			} catch {
+				// The lock may already have moved to its stale quarantine path.
+			}
+		}
+	}
+}
+
+async function tryReapDeadPluginCacheLock(
+	lockPath: string,
+	reaperToken: string,
+): Promise<boolean> {
+	return withPluginCacheReaperClaim(lockPath, reaperToken, async () => {
+		const owner = await readPluginCacheLockOwner(lockPath);
+		if (!owner || !processIsDead(owner.pid)) return false;
+		const stalePath = `${lockPath}.stale-${reaperToken}`;
+		await rename(lockPath, stalePath);
+		const movedOwner = await readPluginCacheLockOwner(stalePath);
+		if (movedOwner?.token !== owner.token) {
+			throw new Error(`OMX plugin cache refresh lock changed during stale recovery: ${lockPath}`);
+		}
+		await rm(stalePath, { recursive: true, force: true });
+		return true;
+	});
+}
+
+async function tryReapInvalidPluginCacheLock(
+	lockPath: string,
+	reaperToken: string,
+): Promise<boolean> {
+	return withPluginCacheReaperClaim(lockPath, reaperToken, async () => {
+		const ownerState = await inspectPluginCacheLockOwner(lockPath);
+		if (ownerState.kind === "valid") return false;
+		if (ownerState.kind === "unreadable") throw ownerState.error;
+
+		const stalePath = `${lockPath}.stale-${reaperToken}`;
+		await rename(lockPath, stalePath);
+		const movedReaper = await readPluginCacheReaperOwner(stalePath);
+		const movedOwnerState = await inspectPluginCacheLockOwner(stalePath);
+		if (
+			movedReaper?.token !== reaperToken ||
+			!pluginCacheOwnerRecordStatesMatch(ownerState, movedOwnerState)
+		) {
+			throw new Error(`OMX plugin cache refresh lock changed during invalid-owner recovery: ${lockPath}`);
+		}
+		await rm(stalePath, { recursive: true, force: true });
+		return true;
+	});
+}
+
+async function acquirePluginCacheLock(
+	cacheDir: string,
+): Promise<OmxPluginCacheLock> {
+	const lockPath = pluginCacheLockPath(cacheDir);
+	const token = `${process.pid}-${randomUUID()}`;
+	const deadline = Date.now() + OMX_PLUGIN_CACHE_LOCK_TIMEOUT_MS;
+	await assertPluginCacheNamespaceHasNoSymlinkAncestors(cacheDir);
+	await mkdir(dirname(lockPath), { recursive: true });
+	await assertPluginCacheNamespaceHasNoSymlinkAncestors(cacheDir);
+
+	for (;;) {
+		const candidatePath = `${lockPath}.candidate-${token}`;
+		try {
+			await mkdir(candidatePath);
+			await writeFile(
+				join(candidatePath, "owner.json"),
+				`${JSON.stringify({ token, pid: process.pid }, null, 2)}\n`,
+				{ flag: "wx" },
+			);
+			await rename(candidatePath, lockPath);
+			return { path: lockPath, token, pid: process.pid };
+		} catch (error) {
+			await rm(candidatePath, { recursive: true, force: true }).catch(() => undefined);
+			const code = (error as NodeJS.ErrnoException).code;
+			if (
+				code !== "EEXIST" &&
+				code !== "ENOTEMPTY" &&
+				code !== "ENOTDIR" &&
+				code !== "EACCES" &&
+				code !== "EPERM"
+			) throw error;
+			let lockStats;
+			try {
+				lockStats = await lstat(lockPath);
+			} catch (lockStatError) {
+				if (
+					(lockStatError as NodeJS.ErrnoException).code === "ENOENT" &&
+					(code === "EEXIST" || code === "ENOTEMPTY")
+				) continue;
+				throw error;
+			}
+			if (!lockStats.isDirectory()) {
+				throw new Error(
+					`Refusing to replace a non-directory OMX plugin cache refresh lock: ${lockPath}`,
+					{ cause: error },
+				);
+			}
+
+			const observedOwnerState = await inspectPluginCacheLockOwner(lockPath);
+			if (observedOwnerState.kind === "unreadable") throw observedOwnerState.error;
+			if (
+				observedOwnerState.kind !== "valid" &&
+				await tryReapInvalidPluginCacheLock(lockPath, token)
+			) continue;
+			const observedOwner = observedOwnerState.kind === "valid"
+				? observedOwnerState.owner
+				: null;
+			if (
+				observedOwner &&
+				processIsDead(observedOwner.pid) &&
+				await tryReapDeadPluginCacheLock(lockPath, token)
+			) continue;
+
+			if (Date.now() >= deadline) {
+				throw new Error(`Timed out waiting for OMX plugin cache refresh lock: ${lockPath}`);
+			}
+			await sleepForPluginCacheLock();
+		}
+	}
+}
+
+async function releasePluginCacheLock(lock: OmxPluginCacheLock): Promise<void> {
+	const owner = await readPluginCacheLockOwner(lock.path);
+	if (owner?.token !== lock.token) {
+		throw new Error(`OMX plugin cache refresh lock ownership was lost: ${lock.path}`);
+	}
+	const releasedPath = `${lock.path}.released-${lock.token}`;
+	await rename(lock.path, releasedPath);
+	const releasedOwner = await readPluginCacheLockOwner(releasedPath);
+	if (releasedOwner?.token !== lock.token) {
+		throw new Error(`OMX plugin cache refresh lock changed during release: ${lock.path}`);
+	}
+	await rm(releasedPath, { recursive: true, force: true });
+}
+
+async function withPluginCacheLock<T>(
+	cacheDir: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const lock = await acquirePluginCacheLock(cacheDir);
+	let operationError: unknown;
+	try {
+		await assertPluginCacheNamespaceHasNoSymlinkAncestors(cacheDir);
+		return await operation();
+	} catch (error) {
+		operationError = error;
+		throw error;
+	} finally {
+		try {
+			await releasePluginCacheLock(lock);
+		} catch (releaseError) {
+			if (operationError !== undefined) {
+				throw new AggregateError(
+					[operationError, releaseError],
+					`OMX plugin cache operation and lock release both failed: ${cacheDir}`,
+				);
+			}
+			throw releaseError;
+		}
+	}
+}
+
 export async function discoverOmxPluginCacheDirs(
 	codexHomeDir: string,
 ): Promise<string[]> {
-	const cacheRoot = join(codexHomeDir, "plugins", "cache");
+	const cacheRoot = omxPluginCacheBase(codexHomeDir);
 	if (!existsSync(cacheRoot)) return [];
 
-	const queue: Array<{ path: string; depth: number }> = [
+	const queue: Array<{ path: string; depth: number; namespaceVersionRoot?: boolean }> = [
 		{ path: cacheRoot, depth: 0 },
 	];
 	const maxDepth = 5;
@@ -151,30 +515,48 @@ export async function discoverOmxPluginCacheDirs(
 		const current = queue.shift();
 		if (!current) break;
 
+		let matchedPluginRoot = current.namespaceVersionRoot === true;
 		const manifestPath = join(current.path, ".codex-plugin", "plugin.json");
 		if (existsSync(manifestPath)) {
 			const manifest = await readPluginManifest(manifestPath);
 			if (manifest?.name === OMX_PLUGIN_NAME) {
-				matches.push(current.path);
-				continue;
+				matchedPluginRoot = true;
 			}
 		}
+		if (
+			current.path === cacheRoot &&
+			(
+				existsSync(join(current.path, "hooks", "codex-native-hook.mjs")) ||
+				existsSync(join(current.path, "hooks", "hooks.json")) ||
+				existsSync(join(current.path, "skills"))
+			)
+		) matchedPluginRoot = true;
+		if (matchedPluginRoot) matches.push(current.path);
 
 		if (current.depth >= maxDepth) continue;
 
 		let entries;
 		try {
 			entries = await readdir(current.path, { withFileTypes: true });
-		} catch {
-			continue;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw error;
 		}
 
+		const isOmxNamespaceRoot = basename(current.path) === OMX_PLUGIN_NAME;
 		for (const entry of entries) {
 			if (!entry.isDirectory()) continue;
 			if (entry.name === ".git" || entry.name === "node_modules") continue;
+			if (
+				(matchedPluginRoot || isOmxNamespaceRoot) &&
+				!isOmxPluginCacheVersionEntryName(entry.name)
+			) continue;
 			queue.push({
 				path: join(current.path, entry.name),
 				depth: current.depth + 1,
+				namespaceVersionRoot:
+					(isOmxNamespaceRoot || matchedPluginRoot) &&
+					isOmxPluginCacheVersionEntryName(entry.name),
 			});
 		}
 	}
@@ -236,7 +618,11 @@ export async function hasExpectedOmxPluginCache(
 		return false;
 	}
 
-	return pluginHookCacheMatchesPackaged(state.cacheDir, packagedMarketplace);
+	return pluginCacheContentsMatchPackaged(
+		state.cacheDir,
+		packagedMarketplace,
+		options,
+	);
 }
 
 async function fileContentsEqual(leftPath: string, rightPath: string): Promise<boolean> {
@@ -246,6 +632,90 @@ async function fileContentsEqual(leftPath: string, rightPath: string): Promise<b
 			readFile(rightPath),
 		]);
 		return left.equals(right);
+	} catch {
+		return false;
+	}
+}
+
+interface CollectPluginTreeOptions {
+	excludeDisabledTeamSkills?: boolean;
+	ignoreTopLevelVersionRoots?: boolean;
+	ignoreAtomicTemps?: boolean;
+}
+
+async function collectPluginTree(
+	root: string,
+	options: CollectPluginTreeOptions,
+	segments: string[] = [],
+	entries = new Map<string, Buffer>(),
+): Promise<Map<string, Buffer>> {
+	const children = await readdir(root, { withFileTypes: true });
+	children.sort((left, right) => left.name.localeCompare(right.name));
+	for (const child of children) {
+		if (
+			segments.length === 0 &&
+			options.ignoreTopLevelVersionRoots &&
+			isOmxPluginCacheVersionEntryName(child.name) &&
+			(child.isDirectory() || child.isSymbolicLink())
+		) continue;
+		if (
+			options.ignoreAtomicTemps &&
+			isOmxAtomicTempEntryName(child.name)
+		) continue;
+		if (
+			options.excludeDisabledTeamSkills &&
+			segments.length === 1 &&
+			segments[0] === "skills" &&
+			TEAM_MODE_PLUGIN_SKILL_NAMES.has(child.name)
+		) continue;
+
+		const childSegments = [...segments, child.name];
+		const key = childSegments.join("/");
+		const childPath = join(root, child.name);
+		if (child.isDirectory()) {
+			entries.set(`${key}/`, Buffer.from("directory"));
+			await collectPluginTree(childPath, options, childSegments, entries);
+		} else if (child.isFile()) {
+			entries.set(key, await readFile(childPath));
+		} else {
+			entries.set(key, Buffer.from(`unsupported:${child.isSymbolicLink() ? "symlink" : "other"}`));
+		}
+	}
+	return entries;
+}
+
+function pluginTreeMapsEqual(
+	left: ReadonlyMap<string, Buffer>,
+	right: ReadonlyMap<string, Buffer>,
+): boolean {
+	if (left.size !== right.size) return false;
+	for (const [key, leftValue] of left) {
+		const rightValue = right.get(key);
+		if (!rightValue?.equals(leftValue)) return false;
+	}
+	return true;
+}
+
+export async function pluginCacheContentsMatchPackaged(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+	options: { teamMode?: SetupTeamMode } = {},
+): Promise<boolean> {
+	try {
+		const [expected, actual] = await Promise.all([
+			collectPluginTree(packagedMarketplace.pluginRoot, {
+				excludeDisabledTeamSkills: !teamModeEnabled(options.teamMode),
+			}),
+			collectPluginTree(cacheDir, {
+				ignoreTopLevelVersionRoots: true,
+				ignoreAtomicTemps: true,
+			}),
+		]);
+		expected.set(
+			`hooks/${OMX_PLUGIN_HOOK_LAUNCHER_FILE}`,
+			Buffer.from(buildPinnedHookLauncherContent(packagedMarketplace)),
+		);
+		return pluginTreeMapsEqual(expected, actual);
 	} catch {
 		return false;
 	}
@@ -317,8 +787,70 @@ async function pathIsDirectory(path: string): Promise<boolean> {
 	}
 }
 
+interface PluginCacheRootIdentity {
+	path: string;
+	dev: number | bigint;
+	ino: number | bigint;
+}
+
+function pluginCacheRootIdentity(
+	path: string,
+	stats: Awaited<ReturnType<typeof lstat>>,
+): PluginCacheRootIdentity {
+	return { path, dev: stats.dev, ino: stats.ino };
+}
+
+async function readPluginCacheRootIdentity(
+	path: string,
+): Promise<PluginCacheRootIdentity | null> {
+	try {
+		const stats = await lstat(path);
+		if (!stats.isDirectory()) {
+			throw new Error(`Refusing to overlay a non-directory plugin cache root: ${path}`);
+		}
+		return pluginCacheRootIdentity(path, stats);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
+	}
+}
+
+async function ensureRealDirectoryRoot(path: string): Promise<Awaited<ReturnType<typeof lstat>>> {
+	try {
+		const stats = await lstat(path);
+		if (!stats.isDirectory()) {
+			throw new Error(`Refusing to overlay a non-directory plugin cache root: ${path}`);
+		}
+		return stats;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	await mkdir(path, { recursive: true });
+	const stats = await lstat(path);
+	if (!stats.isDirectory()) {
+		throw new Error(`Refusing to overlay a non-directory plugin cache root: ${path}`);
+	}
+	return stats;
+}
+
+async function assertPluginCacheRootIdentity(
+	identity: PluginCacheRootIdentity,
+): Promise<void> {
+	const stats = await lstat(identity.path);
+	if (
+		!stats.isDirectory() ||
+		stats.dev !== identity.dev ||
+		stats.ino !== identity.ino
+	) {
+		throw new Error(`OMX plugin cache root identity changed during refresh: ${identity.path}`);
+	}
+}
+
 async function copyFileAtomically(sourcePath: string, destinationPath: string): Promise<void> {
-	const tempPath = `${destinationPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	const tempPath = join(
+		dirname(destinationPath),
+		`.${basename(destinationPath)}.omx-atomic-${process.pid}-${randomUUID()}`,
+	);
 	try {
 		await cp(sourcePath, tempPath, { force: true });
 		if (await pathIsDirectory(destinationPath)) {
@@ -326,45 +858,93 @@ async function copyFileAtomically(sourcePath: string, destinationPath: string): 
 		}
 		await rename(tempPath, destinationPath);
 	} catch (error) {
-		await rm(tempPath, { recursive: true, force: true });
+		try {
+			await rm(tempPath, { recursive: true, force: true });
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				`Atomic plugin cache copy and cleanup both failed: ${destinationPath}`,
+			);
+		}
 		throw error;
 	}
 }
 
+async function withTemporaryPluginTree<T>(
+	tempDir: string,
+	operation: () => Promise<T>,
+): Promise<T> {
+	let operationError: unknown;
+	try {
+		return await operation();
+	} catch (error) {
+		operationError = error;
+		throw error;
+	} finally {
+		try {
+			await rm(tempDir, { recursive: true, force: true });
+		} catch (cleanupError) {
+			if (operationError !== undefined) {
+				throw new AggregateError(
+					[operationError, cleanupError],
+					`Plugin cache operation and staging cleanup both failed: ${tempDir}`,
+				);
+			}
+			throw cleanupError;
+		}
+	}
+}
+
+function isOmxAtomicTempEntryName(name: string): boolean {
+	return /^\..+\.omx-atomic-\d+-[0-9a-f-]+$/.test(name);
+}
+
 interface OverlayDirectoryOptions {
-	onDestinationRootReady?: (destinationDir: string) => void | Promise<void>;
+	preserveDestinationEntry?: (name: string) => boolean;
+	mutationRootIdentity?: PluginCacheRootIdentity;
 }
 
 async function overlayDirectoryKeepingRootPresent(sourceDir: string, destinationDir: string, options: OverlayDirectoryOptions = {}): Promise<void> {
-	await mkdir(destinationDir, { recursive: true });
-	await options.onDestinationRootReady?.(destinationDir);
+	const destinationStats = await ensureRealDirectoryRoot(destinationDir);
+	const mutationRootIdentity = options.mutationRootIdentity ?? pluginCacheRootIdentity(
+		destinationDir,
+		destinationStats,
+	);
+	await assertPluginCacheRootIdentity(mutationRootIdentity);
 	const sourceEntries = await readdir(sourceDir, { withFileTypes: true });
 	const sourceNames = new Set(sourceEntries.map((entry) => entry.name));
 
 	for (const entry of sourceEntries) {
+		await assertPluginCacheRootIdentity(mutationRootIdentity);
 		const sourcePath = join(sourceDir, entry.name);
 		const destinationPath = join(destinationDir, entry.name);
 		if (entry.isDirectory()) {
 			if (existsSync(destinationPath) && !(await pathIsDirectory(destinationPath))) {
 				await rm(destinationPath, { recursive: true, force: true });
 			}
-			await overlayDirectoryKeepingRootPresent(sourcePath, destinationPath);
+			await overlayDirectoryKeepingRootPresent(sourcePath, destinationPath, {
+				mutationRootIdentity,
+			});
 		} else if (entry.isFile()) {
 			await copyFileAtomically(sourcePath, destinationPath);
 		}
 	}
 
-	let destinationEntries;
-	try {
-		destinationEntries = await readdir(destinationDir, { withFileTypes: true });
-	} catch {
-		return;
-	}
+	const destinationEntries = await readdir(destinationDir, { withFileTypes: true });
 	await Promise.all(
 		destinationEntries
-			.filter((entry) => !sourceNames.has(entry.name))
-			.map((entry) => rm(join(destinationDir, entry.name), { recursive: true, force: true })),
+			.filter(
+				(entry) =>
+					!sourceNames.has(entry.name) &&
+					!isOmxAtomicTempEntryName(entry.name) &&
+					!options.preserveDestinationEntry?.(entry.name),
+			)
+			.map(async (entry) => {
+				await assertPluginCacheRootIdentity(mutationRootIdentity);
+				await rm(join(destinationDir, entry.name), { recursive: true, force: true });
+			}),
 	);
+	await assertPluginCacheRootIdentity(mutationRootIdentity);
 }
 
 async function applyTeamModeToPluginCache(
@@ -377,6 +957,40 @@ async function applyTeamModeToPluginCache(
 	}
 }
 
+export async function refreshPackagedOmxPluginCacheInPlace(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+	options: { teamMode?: SetupTeamMode } = {},
+): Promise<void> {
+	const initialRootIdentity = await readPluginCacheRootIdentity(cacheDir);
+	if (!initialRootIdentity) {
+		throw new Error(`Cannot refresh a missing OMX plugin cache root: ${cacheDir}`);
+	}
+	const tempDir = join(
+		tmpdir(),
+		`omx-plugin-cache-refresh-${process.pid}-${randomUUID()}`,
+	);
+	await withTemporaryPluginTree(tempDir, async () => {
+		await cp(packagedMarketplace.pluginRoot, tempDir, { recursive: true });
+		await applyTeamModeToPluginCache(tempDir, options.teamMode);
+		await writePinnedHookLauncher(tempDir, packagedMarketplace);
+		await withPluginCacheLock(cacheDir, async () => {
+			await assertPluginCacheRootIdentity(initialRootIdentity);
+			await overlayDirectoryKeepingRootPresent(tempDir, cacheDir, {
+				preserveDestinationEntry: isOmxPluginCacheVersionEntryName,
+				mutationRootIdentity: initialRootIdentity,
+			});
+			if (!(await pluginCacheContentsMatchPackaged(
+				cacheDir,
+				packagedMarketplace,
+				options,
+			))) {
+				throw new Error(`OMX plugin cache refresh postcondition failed: ${cacheDir}`);
+			}
+		});
+	});
+}
+
 export interface OmxPluginCacheMaterializeResult {
 	status: "unavailable" | "unchanged" | "materialized";
 	cacheDir?: string;
@@ -386,30 +1000,57 @@ export interface OmxPluginCacheMaterializeResult {
 export async function materializePackagedOmxPluginCache(
 	codexHomeDir: string,
 	packagedMarketplace: PackagedOmxMarketplace | null,
-	options: { dryRun?: boolean; teamMode?: SetupTeamMode; onCacheDirPrepared?: (cacheDir: string) => void | Promise<void> } = {},
+	options: {
+		dryRun?: boolean;
+		teamMode?: SetupTeamMode;
+	} = {},
 ): Promise<OmxPluginCacheMaterializeResult> {
 	if (!packagedMarketplace) return { status: "unavailable" };
 	const version = await packagedOmxPluginVersion(packagedMarketplace);
 	if (!version) return { status: "unavailable" };
 	const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+	const initialRootIdentity = await readPluginCacheRootIdentity(cacheDir);
 	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace, options)) {
 		return { status: "unchanged", cacheDir, version };
 	}
 	if (!options.dryRun) {
-		const cacheBase = omxPluginCacheBase(codexHomeDir);
-		await mkdir(cacheBase, { recursive: true });
-		const tempDir = join(cacheBase, `.materializing-${version}-${process.pid}-${Date.now()}`);
-		await rm(tempDir, { recursive: true, force: true });
-		await cp(packagedMarketplace.pluginRoot, tempDir, { recursive: true });
-		await applyTeamModeToPluginCache(tempDir, options.teamMode);
-		await writePinnedHookLauncher(tempDir, packagedMarketplace);
-		try {
-			await overlayDirectoryKeepingRootPresent(tempDir, cacheDir, {
-				onDestinationRootReady: options.onCacheDirPrepared,
+		const tempDir = join(
+			tmpdir(),
+			`omx-plugin-cache-materialize-${process.pid}-${randomUUID()}`,
+		);
+		await withTemporaryPluginTree(tempDir, async () => {
+			await cp(packagedMarketplace.pluginRoot, tempDir, { recursive: true });
+			await applyTeamModeToPluginCache(tempDir, options.teamMode);
+			await writePinnedHookLauncher(tempDir, packagedMarketplace);
+			await withPluginCacheLock(cacheDir, async () => {
+				if (initialRootIdentity) {
+					await assertPluginCacheRootIdentity(initialRootIdentity);
+				} else {
+					const currentRootIdentity = await readPluginCacheRootIdentity(cacheDir);
+					if (currentRootIdentity) {
+						if (await pluginCacheContentsMatchPackaged(
+							cacheDir,
+							packagedMarketplace,
+							options,
+						)) return;
+						throw new Error(
+							`OMX plugin cache root appeared during materialization: ${cacheDir}`,
+						);
+					}
+				}
+				await overlayDirectoryKeepingRootPresent(tempDir, cacheDir, {
+					preserveDestinationEntry: isOmxPluginCacheVersionEntryName,
+					mutationRootIdentity: initialRootIdentity ?? undefined,
+				});
+				if (!(await pluginCacheContentsMatchPackaged(
+					cacheDir,
+					packagedMarketplace,
+					options,
+				))) {
+					throw new Error(`OMX plugin cache materialization postcondition failed: ${cacheDir}`);
+				}
 			});
-		} finally {
-			await rm(tempDir, { recursive: true, force: true });
-		}
+		});
 	}
 	return { status: "materialized", cacheDir, version };
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -138,13 +138,16 @@ import {
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
 	OMX_PLUGIN_NAME,
+	discoverOmxPluginCacheDirs,
+	expectedPackagedOmxSkillNames,
 	materializePackagedOmxPluginCache,
+	refreshPackagedOmxPluginCacheInPlace,
 	resolvePackagedOmxMarketplace,
 	upsertLocalOmxMarketplaceRegistration,
 	upsertLocalOmxPluginEnablement,
 	upsertLocalOmxPluginMcpServerEnablement,
 	hasLocalOmxPluginMcpServerRegistrations,
-	pluginHookCacheMatchesPackaged,
+	pluginCacheContentsMatchPackaged,
 } from "./plugin-marketplace.js";
 import { resolveCodexHookFeatureSupportForCli } from "./codex-feature-probe.js";
 
@@ -2800,22 +2803,6 @@ async function resolveSetupScope(
 	return { scope: DEFAULT_SETUP_SCOPE, source: "default" };
 }
 
-async function readPluginManifestName(
-	manifestPath: string,
-): Promise<string | null> {
-	try {
-		const parsed = JSON.parse(await readFile(manifestPath, "utf-8")) as unknown;
-		return typeof parsed === "object" &&
-			parsed !== null &&
-			"name" in parsed &&
-			typeof (parsed as { name?: unknown }).name === "string"
-			? (parsed as { name: string }).name
-			: null;
-	} catch {
-		return null;
-	}
-}
-
 interface OmxPluginCacheManifest {
 	name: string | null;
 	version: string | null;
@@ -2858,56 +2845,10 @@ async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
 	}
 }
 
-async function discoverOmxPluginCacheDirs(
-	cacheRoot = join(codexHome(), "plugins", "cache"),
-): Promise<string[]> {
-	if (!existsSync(cacheRoot)) return [];
-
-	const queue: Array<{ path: string; depth: number }> = [
-		{ path: cacheRoot, depth: 0 },
-	];
-	const maxDepth = 5;
-	const matches: string[] = [];
-
-	while (queue.length > 0) {
-		const current = queue.shift();
-		if (!current) break;
-
-		const manifestPath = join(current.path, ".codex-plugin", "plugin.json");
-		if (existsSync(manifestPath)) {
-			const name = await readPluginManifestName(manifestPath);
-			if (name === "oh-my-codex") {
-				matches.push(current.path);
-				continue;
-			}
-		}
-
-		if (current.depth >= maxDepth) continue;
-
-		let entries;
-		try {
-			entries = await readdir(current.path, { withFileTypes: true });
-		} catch {
-			continue;
-		}
-
-		for (const entry of entries) {
-			if (!entry.isDirectory()) continue;
-			if (entry.name === ".git" || entry.name === "node_modules") continue;
-			queue.push({
-				path: join(current.path, entry.name),
-				depth: current.depth + 1,
-			});
-		}
-	}
-
-	return matches.sort();
-}
-
 async function discoverOmxPluginCacheDir(
-	cacheRoot = join(codexHome(), "plugins", "cache"),
+	codexHomeDir = codexHome(),
 ): Promise<string | null> {
-	return (await discoverOmxPluginCacheDirs(cacheRoot))[0] ?? null;
+	return (await discoverOmxPluginCacheDirs(codexHomeDir))[0] ?? null;
 }
 
 interface PluginDiscoveryCacheRefreshResult {
@@ -2917,7 +2858,7 @@ interface PluginDiscoveryCacheRefreshResult {
 
 async function refreshOmxPluginDiscoveryCache(
 	pkgRoot: string,
-	options: Pick<SetupOptions, "dryRun" | "verbose">,
+	options: Pick<SetupOptions, "dryRun" | "verbose" | "teamMode">,
 	codexHomeDir = codexHome(),
 ): Promise<PluginDiscoveryCacheRefreshResult> {
 	const packagedMarketplace = await resolvePackagedOmxMarketplace(pkgRoot);
@@ -2929,8 +2870,10 @@ async function refreshOmxPluginDiscoveryCache(
 		readFile(join(pkgRoot, "package.json"), "utf-8").then((raw) =>
 			JSON.parse(raw) as { version?: unknown },
 		),
-		listChildDirectoryNames(join(packagedMarketplace.pluginRoot, "skills")),
-		discoverOmxPluginCacheDirs(join(codexHomeDir, "plugins", "cache")),
+		expectedPackagedOmxSkillNames(packagedMarketplace, {
+			teamMode: options.teamMode,
+		}),
+		discoverOmxPluginCacheDirs(codexHomeDir),
 	]);
 	const expectedVersion = typeof pkg.version === "string" ? pkg.version : null;
 	const staleDirs: string[] = [];
@@ -2939,29 +2882,33 @@ async function refreshOmxPluginDiscoveryCache(
 		const manifest = await readPluginManifestSummary(
 			join(cacheDir, ".codex-plugin", "plugin.json"),
 		);
-		if (manifest?.name !== "oh-my-codex") continue;
 
 		const cachedSkillNames = await listChildDirectoryNames(join(cacheDir, "skills"));
+		const manifestIdentityChanged = manifest?.name !== "oh-my-codex";
 		const versionChanged =
-			expectedVersion !== null && manifest.version !== expectedVersion;
-		const skillsPointerChanged = manifest.skills !== "./skills/";
-		const hooksPointerChanged = manifest.hooks !== "./hooks/hooks.json";
+			expectedVersion !== null && manifest?.version !== expectedVersion;
+		const skillsPointerChanged = manifest?.skills !== "./skills/";
+		const hooksPointerChanged = manifest?.hooks !== "./hooks/hooks.json";
 		const hookFilesMissing = !existsSync(join(cacheDir, "hooks", "hooks.json"))
 			|| !existsSync(join(cacheDir, "hooks", "codex-native-hook.mjs"))
 			|| !existsSync(join(cacheDir, "hooks", "omx-command.json"));
-		const hookFilesChanged = !hookFilesMissing
-			&& !(await pluginHookCacheMatchesPackaged(cacheDir, packagedMarketplace));
+		const cacheContentsChanged = !(await pluginCacheContentsMatchPackaged(
+			cacheDir,
+			packagedMarketplace,
+			{ teamMode: options.teamMode },
+		));
 		const skillListChanged =
 			expectedSkillNames !== null &&
 			cachedSkillNames !== null &&
 			JSON.stringify(cachedSkillNames) !== JSON.stringify(expectedSkillNames);
 
 		if (
+			!manifestIdentityChanged &&
 			!versionChanged &&
 			!skillsPointerChanged &&
 			!hooksPointerChanged &&
 			!hookFilesMissing &&
-			!hookFilesChanged &&
+			!cacheContentsChanged &&
 			!skillListChanged
 		) continue;
 
@@ -2969,25 +2916,55 @@ async function refreshOmxPluginDiscoveryCache(
 
 		staleDirs.push(cacheDir);
 		if (!options.dryRun) {
-			await rm(cacheDir, { recursive: true, force: true });
+			await refreshPackagedOmxPluginCacheInPlace(
+				cacheDir,
+				packagedMarketplace,
+				{ teamMode: options.teamMode },
+			);
+			const [refreshedManifest, refreshedSkillNames, contentsMatch] =
+				await Promise.all([
+					readPluginManifestSummary(
+						join(cacheDir, ".codex-plugin", "plugin.json"),
+					),
+					listChildDirectoryNames(join(cacheDir, "skills")),
+					pluginCacheContentsMatchPackaged(
+						cacheDir,
+						packagedMarketplace,
+						{ teamMode: options.teamMode },
+					),
+				]);
+			if (
+				refreshedManifest?.name !== "oh-my-codex" ||
+				refreshedManifest.version !== expectedVersion ||
+				refreshedManifest.skills !== "./skills/" ||
+				refreshedManifest.hooks !== "./hooks/hooks.json" ||
+				JSON.stringify(refreshedSkillNames) !==
+					JSON.stringify(expectedSkillNames) ||
+				!contentsMatch
+			) {
+				throw new Error(
+					`Codex plugin discovery cache refresh did not produce a complete packaged plugin at ${cacheDir}`,
+				);
+			}
 		}
 		if (options.verbose) {
 			const reasons = [
+				manifestIdentityChanged ? "plugin manifest missing or invalid" : null,
 				versionChanged
-					? `version ${manifest.version ?? "unknown"} -> ${expectedVersion}`
+					? `version ${manifest?.version ?? "unknown"} -> ${expectedVersion}`
 					: null,
 				skillsPointerChanged
-					? `skills pointer ${manifest.skills ?? "missing"} -> ./skills/`
+					? `skills pointer ${manifest?.skills ?? "missing"} -> ./skills/`
 					: null,
 				hooksPointerChanged
-					? `hooks pointer ${manifest.hooks ?? "missing"} -> ./hooks/hooks.json`
+					? `hooks pointer ${manifest?.hooks ?? "missing"} -> ./hooks/hooks.json`
 					: null,
 				hookFilesMissing ? "plugin hook files missing" : null,
-				hookFilesChanged ? "plugin hook files changed" : null,
+				cacheContentsChanged ? "plugin cache contents changed" : null,
 				skillListChanged ? "skill directory list changed" : null,
 			].filter(Boolean);
 			console.log(
-				`  ${options.dryRun ? "would invalidate" : "invalidated"} Codex plugin discovery cache ${cacheDir} (${reasons.join(", ")})`,
+				`  ${options.dryRun ? "would refresh" : "refreshed"} Codex plugin discovery cache in place at ${cacheDir} (${reasons.join(", ")})`,
 			);
 		}
 	}
@@ -4471,16 +4448,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		}
 		const pluginCacheRefresh = await refreshOmxPluginDiscoveryCache(
 			pkgRoot,
-			{
-				dryRun,
-				verbose,
-			},
+			{ dryRun, verbose, teamMode: resolvedTeamMode },
 			scopeDirs.codexHomeDir,
 		);
 		if (pluginCacheRefresh.status === "refreshed") {
 			if (pluginCacheRefresh.staleDirs.length > 0) {
 				console.log(
-					`  ${dryRun ? "Would invalidate" : "Invalidated"} ${pluginCacheRefresh.staleDirs.length} stale Codex plugin discovery cache entr${pluginCacheRefresh.staleDirs.length === 1 ? "y" : "ies"} so plugin skills refresh from the packaged manifest.`,
+					`  ${dryRun ? "Would refresh" : "Refreshed"} ${pluginCacheRefresh.staleDirs.length} stale Codex plugin discovery cache entr${pluginCacheRefresh.staleDirs.length === 1 ? "y" : "ies"} in place so pinned paths stay present while plugin assets update.`,
 				);
 			}
 		} else if (pluginCacheRefresh.status === "unchanged") {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -60,6 +60,12 @@ export interface UpdateExecutionResult {
   latestVersion: string | null;
 }
 
+export function updateCommandExitCode(
+  result: Pick<UpdateExecutionResult, 'status'>,
+): number | undefined {
+  return result.status === 'failed' ? 1 : undefined;
+}
+
 export type UpdateChannel = 'stable' | 'dev';
 
 export interface UpdateChannelConfig {


### PR DESCRIPTION
## Summary

Codex resolves plugin hooks through a versioned `PLUGIN_ROOT` that is fixed when a session starts. During a later OMX update, plugin-mode setup removed stale cache directories before materializing the new version. Any still-running session pinned to one of those removed directories then invoked a missing `hooks/codex-native-hook.mjs`, causing every plugin lifecycle hook to exit with code 1 until the session restarted.

Keep every discovered OMX plugin cache root present and refresh its packaged assets in place. This preserves the path held by running sessions while updating the native hook and its pinned CLI launcher to the newly installed package.

## Changes

- Refresh stale OMX plugin cache roots in place instead of recursively deleting them.
- Limit repair ownership to the managed `oh-my-codex-local` namespace; same-name plugins in other marketplaces remain untouched.
- Discover and refresh retired versions, nested legacy/version roots, and corrupt roots whose manifest is missing.
- Stage packaged assets outside the cache namespace, replace individual files atomically, and keep each cache root's filesystem identity stable.
- Serialize every legacy, direct-version, and nested-version writer on one canonical cache-namespace lock so concurrent refresh/materialize operations cannot publish mixed snapshots or delete one another's work.
- Recover abandoned locks only after an owner-token hard-link claim; distinguish missing/malformed owner records from permission or I/O failures and fail closed on non-directory lock occupants.
- Reject symlinked cache namespaces and changed root identities before mutation; preserve nested semver/local roots held by older sessions.
- Validate the complete manifest, skill/app/MCP tree, hook files, and pinned launcher before setup or resume preflight reports success.
- Preserve persisted Team-mode filtering during resume preflight and doctor validation, including launches from nested project directories.
- Return a failing shell exit code when an explicit `omx update` reports a failed update/setup handoff.
- Document the pinned-path compatibility behavior.

## Validation

- [x] `npm run build`
- [ ] `npm test` (the full run reaches unrelated active-session/tmux suites that are not hermetic in this Codex session; see note below)
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] Isolated plugin-mode `setup` → `doctor` smoke (21 checks passed; the source checkout lacks the optional native process-identity provider)
- [x] Targeted plugin marketplace, cache continuity, setup install-mode, update, resume, and doctor regression suites (315/315)
- [x] Plugin-cache continuity stress rerun (20/20 local iterations; 80/80 tests)
- [ ] Hosted three-OS plugin-cache continuity matrix (configured on Ubuntu, macOS, and Windows; pending PR CI)

Key regression coverage includes:

- an old versioned cache root retains the same filesystem identity while its hook assets are refreshed;
- a legacy plugin root and nested old versions are refreshed without deleting nested pinned roots;
- direct and recursively nested version roots with missing manifests are repaired from managed namespace provenance;
- concurrent writers publish one coherent packaged snapshot under a recoverable namespace lock;
- parent and recursively nested version roots share that same lock and retain both filesystem identities under concurrent refresh;
- missing, malformed JSON, schema-invalid, and empty-token lock owners plus malformed reaper records are quarantined and recovered without a 30-second timeout, while unreadable/non-directory locks remain fail-closed;
- the actual cached `codex-native-hook.mjs` keeps executing successfully while six concurrent refresh callers serialize against the same namespace;
- cache-root and ancestor symlinks cannot redirect cleanup into a foreign directory;
- same-version skill/app/MCP drift is detected, not just manifest and hook drift;
- `resume --project` ignores an unrelated ambient `CODEX_HOME`, retains Team-disabled cache shape, and works from nested project directories;
- a same-name plugin cache in another marketplace namespace is left unchanged;
- explicit update failures map to exit code 1.

The full repository test command was also attempted. Its change-related suites passed, while existing launch/exec/state tests observed the live Codex session pointer, active tmux server, and macOS `/var` versus `/private/var` aliases and failed their isolation assumptions. Those failures are outside the files and behavior changed here; the focused suites run with `OMX_ROOT` and `CODEX_THREAD_ID` unset.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated for the setup/update behavior change
- [x] Backward-compatibility impact considered

Retired cache roots intentionally remain on disk because OMX has no reliable signal that every session pinned to them has ended. The tradeoff is bounded only by the number of previously materialized plugin versions; an arbitrary retention limit would recreate the same failure for a sufficiently old but still-running session.

## Related

No issue linked yet.
