### PR TITLE
fix(team): make guarded split receipts tmux-safe

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -63,6 +63,7 @@ import {
   waitForWorkerReadyAsync,
   paneIsBootstrapping,
   parseSplitWindowPaneId,
+  bindSplitWindowReceiptFormat,
   classifyWorkerStartupInjectSafety,
   checkWorkerStartupInjectSafety,
   dismissTrustPromptIfPresent,
@@ -289,6 +290,12 @@ if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "
   receipt="$(printf '%s' "$success" | sed -n "s/.*\\(omx_source_[A-Za-z0-9_]*\\).*/\\1/p")"
   effect="${'$'}{success%% ; display-message*}"
   eval "set -- $effect"
+  split_format=''
+  previous=''
+  for arg in "${'$'}@"; do
+    if [ "$previous" = '-F' ]; then split_format="$arg"; break; fi
+    previous="$arg"
+  done
   output="$($0 "${'$'}@")" || exit 1
   case "${'$'}1" in
     split-window)
@@ -302,7 +309,7 @@ if [ "${'$'}1" = "if-shell" ] && [ "${'$'}{2:-}" = "-F" ] && [ "${'$'}{3:-}" = "
         mkdir -p "$source_state"
         printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$session" "$session_id" "$created" "$index" "$window_id" "$created_pid" > "$source_state/$created_pane"
       }
-      printf '%s\t%s\n' "$created_pane" "$receipt"
+      printf '%s\n' "$split_format" | sed "s/#{pane_id}/$created_pane/g"
       ;;
     *) printf '%s\\n' "$receipt" ;;
   esac
@@ -342,7 +349,7 @@ esac
         const captured = spawnSync('tmux', ['display-message', '-p', '-t', '%1', '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}'], { encoding: 'utf8' });
         assert.equal(captured.status, 0);
         assert.equal(captured.stdout, 'recycled\t$1\t1\t0\t@0\t%1\t101\n');
-        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}\tomx_source_recycled' ; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
+        const guarded = spawnSync('tmux', ['if-shell', '-F', '-t', '%1', '#{==:#{pane_pid},101}', "split-window -h -t %1 -P -F '#{pane_id}:omx_source_recycled' ; display-message -p 'omx_source_recycled'", "display-message -p ''"], { encoding: 'utf8' });
         assert.equal(guarded.status, 0);
         assert.equal(guarded.stdout, '');
         assert.equal(fs.existsSync(`${logPath}.split`), false);
@@ -376,7 +383,7 @@ esac
         const guarded = spawnSync('tmux', [
           'if-shell', '-F', '-t', '%1',
           '#{&&:#{==:#{pane_dead},0},#{&&:#{==:#{pane_id},%1},#{&&:#{==:#{pane_pid},101},#{&&:#{==:#{session_id},$1},#{&&:#{==:#{session_created},1},#{&&:#{==:#{window_id},@0},#{==:#{@omx_team_pane_owner_id},team:original}}}}}}',
-          `split-window -h -t %1 -P -F '#{pane_id}\\t${receipt}' ; display-message -p '${receipt}'`,
+          `split-window -h -t %1 -P -F '#{pane_id}:${receipt}' ; display-message -p '${receipt}'`,
           "display-message -p ''",
         ], { encoding: 'utf8' });
         assert.equal(guarded.status, 0);
@@ -4430,6 +4437,9 @@ describe('createTeamSession tmux instance tagging', () => {
       ['%2', undefined, '%2'],
       ['%2\n', undefined, '%2'],
       ['%2\r\n', undefined, '%2'],
+      ['%2:omx_source_receipt', 'omx_source_receipt', '%2'],
+      ['%2:omx_source_receipt\n', 'omx_source_receipt', '%2'],
+      ['%2:omx_source_receipt\r\n', 'omx_source_receipt', '%2'],
       ['%2\tomx_source_receipt', 'omx_source_receipt', '%2'],
       ['%2\tomx_source_receipt\n', 'omx_source_receipt', '%2'],
       ['notice\n%2\n', undefined, null],
@@ -4439,11 +4449,46 @@ describe('createTeamSession tmux instance tagging', () => {
       ['%2\n\n', undefined, null],
       ['%2 warning\n', undefined, null],
       [' %2\n', undefined, null],
-      ['%2\tomx_source_other\n', 'omx_source_receipt', null],
-      ['%2\tomx_source_receipt\n%3\tomx_source_receipt\n', 'omx_source_receipt', null],
+      ['%2', 'omx_source_receipt', null],
+      ['%2\\tomx_source_receipt\n', 'omx_source_receipt', null],
+      ['%2:omx_source_other\n', 'omx_source_receipt', null],
+      ['%2:omx_source_receipt:trailing\n', 'omx_source_receipt', null],
+      ['%2:omx_source_receipt trailing\n', 'omx_source_receipt', null],
+      ['%2:omx_source_receipt\n%3:omx_source_receipt\n', 'omx_source_receipt', null],
+      ['%2:omx_source_receipt\nnotice\n', 'omx_source_receipt', null],
       ['notice only\n', undefined, null],
     ] as const) {
       assert.equal(parseSplitWindowPaneId(stdout, receipt), expected);
+    }
+  });
+
+  it('binds one exact tmux-safe split receipt format and rejects malformed construction inputs', () => {
+    const receipt = 'omx_source_123_456_deadbeef';
+    const effect = "split-window -h -P -F '#{pane_id}' -t %1 'worker command'";
+    assert.equal(
+      bindSplitWindowReceiptFormat(effect, receipt),
+      "split-window -h -P -F '#{pane_id}:omx_source_123_456_deadbeef' -t %1 'worker command'",
+    );
+    assert.throws(
+      () => bindSplitWindowReceiptFormat("split-window -h -P -t %1 'worker command'", receipt),
+      /tmux_split_window_format_contract_invalid/,
+    );
+    assert.throws(
+      () => bindSplitWindowReceiptFormat(`${effect} ${effect}`, receipt),
+      /tmux_split_window_format_contract_invalid/,
+    );
+    for (const invalidReceipt of [
+      'omx_source_bad:field',
+      'omx_source_#{pane_id}',
+      'omx_source_bad;kill-pane',
+      "omx_source_bad'quote",
+      'omx_source_bad receipt',
+      'wrong_prefix_receipt',
+    ]) {
+      assert.throws(
+        () => bindSplitWindowReceiptFormat(effect, invalidReceipt),
+        /tmux_source_transaction_receipt_invalid/,
+      );
     }
   });
 

--- a/src/team/__tests__/tmux-source-authority-realtmux.test.ts
+++ b/src/team/__tests__/tmux-source-authority-realtmux.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, type TestContext } from 'node:test';
-import { runSourceAuthorizedTmux, type SourcePaneAuthority } from '../tmux-session.js';
+import { runSourceAuthorizedSplit, runSourceAuthorizedTmux, type SourcePaneAuthority } from '../tmux-session.js';
 import { isRealTmuxAvailable, type TempTmuxSessionFixture, withTempTmuxSession } from './tmux-test-fixture.js';
 
 const SOURCE_AUTHORITY_FORMAT = '#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}\t#{pane_id}\t#{pane_pid}';
@@ -121,6 +121,28 @@ describe('runSourceAuthorizedTmux real private-server argv boundary', () => {
           const sendKeysReceipt = 'omx_source_send_keys_3459';
           expectedTransactions.push(expectedIfShellArgv(source, sendKeysEffect, sendKeysReceipt));
           assert.equal(runSourceAuthorizedTmux(source, sendKeysEffect, sendKeysReceipt), sendKeysReceipt);
+
+          const guardedSplitPaneId = runSourceAuthorizedSplit(
+            source,
+            (receipt) => `split-window -d -h -P -F '#{pane_id}' -t ${source.windowId} ${quoteTmuxString(`sleep 60 # ${receipt}`)}`,
+          );
+          assert.match(guardedSplitPaneId, /^%[0-9]+$/, 'guarded split must parse the exact pane/receipt frame');
+          assert.equal(
+            fixture.run(['display-message', '-p', '-t', guardedSplitPaneId, '#{window_id}']),
+            source.windowId,
+            'guarded split must create the pane in the authorized source window',
+          );
+          const guardedSplitTransaction = parseShimTmuxArgv(await readFile(shimLogPath, 'utf-8'))
+            .filter((argv) => argv[0] === 'if-shell')
+            .at(-1);
+          assert.ok(guardedSplitTransaction, 'PATH shim must record the guarded split transaction');
+          assert.match(
+            guardedSplitTransaction[5] ?? '',
+            /split-window .* -F '#\{pane_id\}:omx_source_[A-Za-z0-9_]+'/,
+            'product argv must use a literal tmux-safe separator before the exact split receipt',
+          );
+          assert.doesNotMatch(guardedSplitTransaction[5] ?? '', /#\{pane_id\}\\t/, 'product argv must not depend on tmux expanding backslash-t');
+          expectedTransactions.push(guardedSplitTransaction);
 
           const hostileValue = "literal; no-command 'still literal'";
           const hostileReceipt = `omx_source_hostile'; kill-session -t ${source.sessionName}; #`;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -254,7 +254,7 @@ function runTmux(args: string[], preserveStdout = false): { ok: true; stdout: st
 export function parseSplitWindowPaneId(stdout: string, expectedReceipt?: string): string | null {
   const match = expectedReceipt === undefined
     ? /^(%\d+)(?:\r?\n)?$/.exec(stdout)
-    : /^(%\d+)\t([^\r\n\t]+)(?:\r?\n)?$/.exec(stdout);
+    : /^(%\d+)(?::|\t)([^\r\n:\t]+)(?:\r?\n)?$/.exec(stdout);
   if (!match || (expectedReceipt !== undefined && match[2] !== expectedReceipt)) return null;
   return match[1];
 }
@@ -337,8 +337,26 @@ function sourceAuthorityPredicate(source: SourcePaneAuthority): string {
   ].reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
 
+const SOURCE_TRANSACTION_RECEIPT_PATTERN = /^omx_source_[A-Za-z0-9_]+$/;
+const SPLIT_WINDOW_PANE_FORMAT = "-F '#{pane_id}'";
+
 function sourceTransactionReceipt(): string {
-  return `omx_source_${process.pid}_${Date.now()}_${randomBytes(16).toString('hex')}`;
+  const receipt = `omx_source_${process.pid}_${Date.now()}_${randomBytes(16).toString('hex')}`;
+  if (!SOURCE_TRANSACTION_RECEIPT_PATTERN.test(receipt)) {
+    throw new Error('tmux_source_transaction_receipt_invalid');
+  }
+  return receipt;
+}
+
+export function bindSplitWindowReceiptFormat(effect: string, receipt: string): string {
+  if (!SOURCE_TRANSACTION_RECEIPT_PATTERN.test(receipt)) {
+    throw new Error('tmux_source_transaction_receipt_invalid');
+  }
+  const firstFormatIndex = effect.indexOf(SPLIT_WINDOW_PANE_FORMAT);
+  if (firstFormatIndex < 0 || effect.indexOf(SPLIT_WINDOW_PANE_FORMAT, firstFormatIndex + SPLIT_WINDOW_PANE_FORMAT.length) >= 0) {
+    throw new Error('tmux_split_window_format_contract_invalid');
+  }
+  return `${effect.slice(0, firstFormatIndex)}-F '#{pane_id}:${receipt}'${effect.slice(firstFormatIndex + SPLIT_WINDOW_PANE_FORMAT.length)}`;
 }
 
 function bindSplitReceiptToPaneCommand(command: string, receipt: string): string {
@@ -357,7 +375,7 @@ export function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: str
   return receipt;
 }
 
-function runSourceAuthorizedSplit(
+export function runSourceAuthorizedSplit(
   source: SourcePaneAuthority,
   buildEffect: (receipt: string) => string,
 ): string {
@@ -374,7 +392,7 @@ function runSourceAuthorizedSplit(
   const effect = buildEffect(receipt);
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    effect.replace("-F '#{pane_id}'", `-F '#{pane_id}\\t${receipt}'`),
+    bindSplitWindowReceiptFormat(effect, receipt),
     "display-message -p ''",
   ], true);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);


### PR DESCRIPTION
Fixes #3488

## Summary
- replace the guarded `split-window -P -F` receipt separator from backslash-t to a literal colon that tmux emits byte-for-byte through the nested `if-shell` command path
- validate the generated receipt alphabet and require exactly one canonical `-F '#{pane_id}'` replacement target before the split can execute
- keep parsing fail-closed for wrong, missing, trailing, duplicate, and multiline frames; literal `\\t` is rejected
- retain actual-TAB parsing only for already-valid callers/fixtures; pane IDs and generated receipts exclude TAB and colon, so both accepted separators remain structurally unambiguous while all product callsites now emit only colon

## Reproduction
On host tmux 3.2a, the exact nested path produced:
- old format: `%1\\tomx_source_repro`, bytes `25315c746f6d785f736f757263655f726570726f`
- fixed format: `%2:omx_source_repro`, bytes `25323a6f6d785f736f757263655f726570726f`

This is byte-level equivalent to the tmux 3.4 report: backslash-t is data, not a portable request for a TAB in this command string.

## Validation
- `npm run build`
- focused Team suites: hardening e2e 3/3, runtime 196/196, tmux-session 291/291, real private-tmux 1/1
- `npm run lint`
- `npm run check:no-unused`
- `npm run verify:native-agents`
- `npm run verify:plugin-bundle`
- `node dist/scripts/generate-catalog-docs.js --check`
- full repository run reached 411/412 test files green; the sole unrelated installed-Codex hooks e2e file is blocked by ambient unsupported Codex candidates and is untouched by this three-file Team change

Exact base: `94b6dc5b9877a13cb0d7e6ed51b60c126c2eab24`
Exact head: `da9799bc`
Frozen change-set hash: `sha256:b85a9c16ec1bd336035631fc193f2883223fbd0450e44d957873deb25c9be7fd`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*