### PR TITLE
feat(3498): State SSOT unification — sole writer, read-only MCP, stale neutralization

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6134,6 +6134,17 @@ async function completePreLaunchSetup(
     degraded.push("orphan-reaping");
     logCliOperationFailure(error);
   }
+  // 0.4. Upgrade-time neutralization of stale workflow-state projections (#3498).
+  try {
+    const { neutralizeStaleWorkflowStateProjections } = await import("../state/operations.js");
+    const result = await neutralizeStaleWorkflowStateProjections(cwd);
+    if (result.ran && result.neutralizedFiles.length > 0) {
+      console.log(`[omx] Neutralized ${result.neutralizedFiles.length} stale workflow-state projection(s) from pre-0.21.`);
+    }
+  } catch (err) {
+    logCliOperationFailure(err);
+    // Non-fatal: stale-state neutralization must never block a session.
+  }
 
   let instructions: string;
   try {

--- a/src/cli/mcp-parity.ts
+++ b/src/cli/mcp-parity.ts
@@ -10,9 +10,12 @@ type ToolHandlerResult = {
   isError?: boolean;
 };
 
-type ToolHandler = (request: {
-  params: { name: string; arguments?: Record<string, unknown> };
-}) => Promise<ToolHandlerResult>;
+type ToolHandler = (
+  request: {
+    params: { name: string; arguments?: Record<string, unknown> };
+  },
+  options?: Record<string, unknown>,
+) => Promise<ToolHandlerResult>;
 
 interface McpCliDescriptor {
   commandName: string;
@@ -20,6 +23,7 @@ interface McpCliDescriptor {
   tools: ToolSchema[];
   aliases?: Record<string, string>;
   handle: ToolHandler;
+  handleOptions?: Record<string, unknown>;
 }
 
 interface ParsedMcpCliArgs {
@@ -147,12 +151,15 @@ async function executeDescriptorCommand(
     );
   }
 
-  const result = await descriptor.handle({
-    params: {
-      name: toolName,
-      arguments: parsed.input,
+  const result = await descriptor.handle(
+    {
+      params: {
+        name: toolName,
+        arguments: parsed.input,
+      },
     },
-  });
+    descriptor.handleOptions,
+  );
   const payload = extractPayload(result);
   return result.isError
     ? { ok: false, error: payload }
@@ -182,14 +189,17 @@ async function runDescriptorCommand(
 }
 
 async function loadStateDescriptor(): Promise<McpCliDescriptor> {
-  const { buildStateServerTools, handleStateToolCall } = await importWithAutoStartDisabled(
+  const { buildStateServerTools, buildStateServerWriterTools, handleStateToolCall } = await importWithAutoStartDisabled(
     "OMX_STATE_SERVER_DISABLE_AUTO_START",
     async () => await import("../mcp/state-server.js"),
   );
   return {
     commandName: "state",
     title: "JSON CLI surface for OMX state operations.",
-    tools: buildStateServerTools().map(({ name, description }) => ({ name, description })),
+    tools: [
+      ...buildStateServerTools().map(({ name, description }) => ({ name, description })),
+      ...buildStateServerWriterTools().map(({ name, description }) => ({ name, description })),
+    ],
     aliases: {
       read: "state_read",
       write: "state_write",
@@ -198,6 +208,7 @@ async function loadStateDescriptor(): Promise<McpCliDescriptor> {
       "get-status": "state_get_status",
     },
     handle: handleStateToolCall,
+    handleOptions: { allowWriterTools: true },
   };
 }
 

--- a/src/mcp/__tests__/state-server-ralph-phase.test.ts
+++ b/src/mcp/__tests__/state-server-ralph-phase.test.ts
@@ -22,7 +22,7 @@ describe('state-server Ralph phase contract', () => {
             started_at: '2026-02-22T00:00:00.000Z',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(response.isError, undefined);
 
       const file = join(wd, '.omx', 'state', 'ralph-state.json');
@@ -50,7 +50,7 @@ describe('state-server Ralph phase contract', () => {
             current_phase: 'bananas',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(response.isError, true);
       const body = JSON.parse(response.content[0]?.text || '{}') as { error?: string };
       assert.match(body.error || '', /Invalid Ralph phase|must be one of/i);
@@ -75,7 +75,7 @@ describe('state-server Ralph phase contract', () => {
             current_phase: 'complete',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(response.isError, true);
       const body = JSON.parse(response.content[0]?.text || '{}') as { error?: string };
       assert.match(body.error || '', /terminal Ralph phases require active=false/i);
@@ -102,10 +102,36 @@ describe('state-server Ralph phase contract', () => {
             max_iterations: 10.5,
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(response.isError, true);
       const body = JSON.parse(response.content[0]?.text || '{}') as { error?: string };
       assert.match(body.error || '', /finite integer/i);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects state_write on the MCP server surface (read-only projection)', async () => {
+    process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = '1';
+    const { handleStateToolCall } = await import('../state-server.js');
+
+    const wd = await mkdtemp(join(tmpdir(), 'omx-state-ralph-phase-ro-'));
+    try {
+      const response = await handleStateToolCall({
+        params: {
+          name: 'state_write',
+          arguments: {
+            workingDirectory: wd,
+            mode: 'ralph',
+            active: true,
+            current_phase: 'executing',
+          },
+        },
+      });
+      assert.equal(response.isError, true);
+      const body = JSON.parse(response.content[0]?.text || '{}') as { error?: string; code?: string };
+      assert.equal(body.code, 'mcp_state_server_read_only');
+      assert.match(body.error || '', /read-only/i);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/mcp/__tests__/state-server-schema.test.ts
+++ b/src/mcp/__tests__/state-server-schema.test.ts
@@ -2,25 +2,38 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 describe("state-server schema validation", () => {
-	it("exposes only state_* tool schemas after team MCP hard-deprecation", async () => {
+	it("exposes only read-only state_* tool schemas (MCP surface is read-only per #3498)", async () => {
 		process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = "1";
 		const { buildStateServerTools } = await import("../state-server.js");
 
 		const tools = buildStateServerTools();
 		const names = tools.map((tool: { name: string }) => tool.name).sort();
 
+		// MCP state-server is read-only: only read/list/status tools are advertised.
+		// state_write and state_clear are available via CLI parity (buildStateServerWriterTools).
 		assert.deepEqual(names, [
-			"state_clear",
 			"state_get_status",
 			"state_list_active",
 			"state_read",
-			"state_write",
 		]);
 
 		assert.equal(
 			tools.some((tool: { name: string }) => tool.name.startsWith("team_")),
 			false,
 		);
+	});
+
+	it("exposes writer tool schemas via buildStateServerWriterTools (CLI parity surface)", async () => {
+		process.env.OMX_STATE_SERVER_DISABLE_AUTO_START = "1";
+		const { buildStateServerWriterTools } = await import("../state-server.js");
+
+		const tools = buildStateServerWriterTools();
+		const names = tools.map((tool: { name: string }) => tool.name).sort();
+
+		assert.deepEqual(names, [
+			"state_clear",
+			"state_write",
+		]);
 	});
 
 	it("includes deep-interview anywhere mode enums are exposed", async () => {

--- a/src/mcp/__tests__/state-server.test.ts
+++ b/src/mcp/__tests__/state-server.test.ts
@@ -94,7 +94,7 @@ describe('state-server directory initialization', () => {
           name: 'state_list_active',
           arguments: { workingDirectory: wd },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(existsSync(stateDir), false);
       assert.equal(existsSync(tmuxHookConfig), false);
@@ -130,7 +130,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(response.isError, undefined);
       assert.equal(existsSync(join(box, '.omx', 'state', 'ralph-state.json')), true);
@@ -172,7 +172,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(response.isError, undefined);
       const boxedSessionDir = join(box, '.omx', 'state', 'sessions', sessionId);
@@ -219,7 +219,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(response.isError, undefined);
       const teamSessionDir = join(teamStateRoot, 'sessions', sessionId);
@@ -270,7 +270,7 @@ describe('state-server directory initialization', () => {
             },
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(deepInterview.isError, undefined);
 
       const ralplan = await handleStateToolCall({
@@ -284,7 +284,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(ralplan.isError, undefined);
       const teamSessionDir = join(teamStateRoot, 'sessions', sessionId);
@@ -324,7 +324,7 @@ describe('state-server directory initialization', () => {
           name: 'state_read',
           arguments: { workingDirectory: wd, mode: 'deep-interview' },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(existsSync(stateDir), false);
       assert.equal(existsSync(tmuxHookConfig), false);
@@ -353,7 +353,7 @@ describe('state-server directory initialization', () => {
           name: 'state_get_status',
           arguments: { workingDirectory: wd },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(existsSync(stateDir), false);
       assert.equal(existsSync(tmuxHookConfig), false);
@@ -392,7 +392,7 @@ describe('state-server directory initialization', () => {
                 current_phase: 'deep-interview',
               },
             },
-          });
+          }, { allowWriterTools: true });
           const payload = JSON.parse(response.content[0]?.text || '{}');
           assert.equal(payload.success, true);
         },
@@ -427,7 +427,7 @@ describe('state-server directory initialization', () => {
             },
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(writeResponse.isError, undefined);
       assert.deepEqual(
@@ -447,7 +447,7 @@ describe('state-server directory initialization', () => {
             mode: 'deep-interview',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(readResponse.isError, undefined);
       const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
@@ -479,7 +479,7 @@ describe('state-server directory initialization', () => {
             },
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(writeResponse.isError, undefined);
 
@@ -491,7 +491,7 @@ describe('state-server directory initialization', () => {
             mode: 'deep-interview',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
       assert.equal(readBody.lifecycle_outcome, 'askuserQuestion');
@@ -517,7 +517,7 @@ describe('state-server directory initialization', () => {
             run_outcome: 'cancelled',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const readResponse = await handleStateToolCall({
         params: {
@@ -527,7 +527,7 @@ describe('state-server directory initialization', () => {
             mode: 'team',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
       assert.equal(readBody.lifecycle_outcome, 'userinterlude');
@@ -555,7 +555,7 @@ describe('state-server directory initialization', () => {
           name: 'state_get_status',
           arguments: { workingDirectory: wd, session_id: 'sess1' },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(existsSync(stateDir), false);
       assert.equal(existsSync(sessionDir), false);
@@ -586,7 +586,7 @@ describe('state-server directory initialization', () => {
             lifecycle_outcome: 'askuserQuestion',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(response.isError, undefined);
       const state = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as {
@@ -624,7 +624,7 @@ describe('state-server directory initialization', () => {
             lifecycle_outcome: 'userinterlude',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(response.isError, undefined);
       const state = JSON.parse(await readFile(join(wd, '.omx', 'state', 'autopilot-state.json'), 'utf-8')) as {
@@ -653,7 +653,7 @@ describe('state-server directory initialization', () => {
             state: { [`k${i}`]: i },
           },
         },
-      }));
+      }, { allowWriterTools: true }));
 
       const responses = await Promise.all(writes);
       for (const response of responses) {
@@ -689,7 +689,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const canonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-sync', 'skill-active-state.json');
       const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
@@ -713,7 +713,7 @@ describe('state-server directory initialization', () => {
             mode: 'ralph',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const clearedCanonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
         active: boolean;
@@ -754,7 +754,7 @@ describe('state-server directory initialization', () => {
             mode: 'deep-interview',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const sessionState = JSON.parse(
         await readFile(join(sessionDir, 'deep-interview-state.json'), 'utf-8'),
@@ -770,7 +770,7 @@ describe('state-server directory initialization', () => {
             workingDirectory: wd,
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.deepEqual(JSON.parse(listResponse.content[0]?.text || '{}'), { active_modes: [] });
 
       const readResponse = await handleStateToolCall({
@@ -781,7 +781,7 @@ describe('state-server directory initialization', () => {
             mode: 'deep-interview',
           },
         },
-      });
+      }, { allowWriterTools: true });
       const readBody = JSON.parse(readResponse.content[0]?.text || '{}') as Record<string, unknown>;
       assert.equal(readBody.active, false);
       assert.equal(readBody.current_phase, 'cleared');
@@ -807,7 +807,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'running',
           },
         },
-      });
+      }, { allowWriterTools: true });
       await handleStateToolCall({
         params: {
           name: 'state_write',
@@ -821,7 +821,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const canonicalPath = join(wd, '.omx', 'state', 'sessions', 'sess-overlap', 'skill-active-state.json');
       const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
@@ -838,7 +838,7 @@ describe('state-server directory initialization', () => {
             mode: 'team',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const clearedCanonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
         active: boolean;
@@ -870,7 +870,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'running',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const denied = await handleStateToolCall({
         params: {
@@ -883,7 +883,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'ralplan',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(denied.isError, true);
       assert.match(denied.content[0]?.text || '', /Unsupported workflow overlap: team \+ autopilot\./);
@@ -943,7 +943,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(allowed.isError, undefined);
       assert.equal(
@@ -971,7 +971,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'running',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       await handleStateToolCall({
         params: {
@@ -982,7 +982,7 @@ describe('state-server directory initialization', () => {
             all_sessions: true,
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const canonicalPath = join(wd, '.omx', 'state', 'skill-active-state.json');
       const canonical = JSON.parse(await readFile(canonicalPath, 'utf-8')) as {
@@ -1012,7 +1012,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'running',
           },
         },
-      });
+      }, { allowWriterTools: true });
       await handleStateToolCall({
         params: {
           name: 'state_write',
@@ -1026,7 +1026,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       await handleStateToolCall({
         params: {
@@ -1036,7 +1036,7 @@ describe('state-server directory initialization', () => {
             mode: 'team',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const sessionCanonical = JSON.parse(
         await readFile(
@@ -1066,7 +1066,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'running',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(teamWrite.isError, undefined);
 
       const ralphWrite = await handleStateToolCall({
@@ -1082,7 +1082,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(ralphWrite.isError, undefined);
 
       const rootCanonical = JSON.parse(
@@ -1133,7 +1133,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(autopilotWrite.isError, undefined);
 
       const invalidTeamWrite = await handleStateToolCall({
@@ -1147,7 +1147,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'starting',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(invalidTeamWrite.isError, true);
       const body = JSON.parse(invalidTeamWrite.content[0]?.text || '{}') as { error?: string };
@@ -1205,7 +1205,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(response.isError, undefined);
       const body = JSON.parse(response.content[0]?.text || '{}') as { transition?: string };
@@ -1247,7 +1247,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const denied = await handleStateToolCall({
         params: {
@@ -1260,7 +1260,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(denied.isError, true);
       const body = JSON.parse(denied.content[0]?.text || '{}') as { error?: string };
@@ -1294,7 +1294,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'definitely-invalid',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(denied.isError, true);
       const body = JSON.parse(denied.content[0]?.text || '{}') as { error?: string };
@@ -1328,7 +1328,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(first.isError, undefined);
 
       const second = await handleStateToolCall({
@@ -1342,7 +1342,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(second.isError, undefined);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -1366,7 +1366,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'interview-a',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(writeA.isError, undefined);
 
       const writeB = await handleStateToolCall({
@@ -1382,7 +1382,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'executing',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(writeB.isError, undefined);
 
       await handleStateToolCall({
@@ -1394,7 +1394,7 @@ describe('state-server directory initialization', () => {
             mode: 'ralph',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const sessionAState = JSON.parse(
         await readFile(join(wd, '.omx', 'state', 'sessions', 'sess-a', 'deep-interview-state.json'), 'utf-8'),
@@ -1431,7 +1431,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'asking',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       const rootWrite = await handleStateToolCall({
         params: {
@@ -1443,7 +1443,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'planning',
           },
         },
-      });
+      }, { allowWriterTools: true });
       assert.equal(rootWrite.isError, undefined);
 
       const sessionState = JSON.parse(
@@ -1485,7 +1485,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'asking',
           },
         },
-      });
+      }, { allowWriterTools: true });
       await handleStateToolCall({
         params: {
           name: 'state_write',
@@ -1496,7 +1496,7 @@ describe('state-server directory initialization', () => {
             current_phase: 'root-asking',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       await handleStateToolCall({
         params: {
@@ -1506,7 +1506,7 @@ describe('state-server directory initialization', () => {
             mode: 'deep-interview',
           },
         },
-      });
+      }, { allowWriterTools: true });
 
       assert.equal(existsSync(join(wd, '.omx', 'state', 'deep-interview-state.json')), false);
       const sessionState = JSON.parse(

--- a/src/mcp/state-server.ts
+++ b/src/mcp/state-server.ts
@@ -1,6 +1,11 @@
 /**
- * OMX State Management MCP Server
- * Provides state read/write/clear/list tools for workflow modes
+ * OMX State Management MCP Server (read-only projection).
+ *
+ * As of epic #3491 (issue #3498), this server is a read-only projection of
+ * `.omx/state/` session-scoped workflow state. The sole writer is
+ * `src/state/operations.ts` (via CLI / programmatic callers). The MCP surface
+ * exposes only read/list/status operations.
+ *
  * Storage: .omx/state/{mode}-state.json
  */
 
@@ -28,17 +33,31 @@ const SUPPORTED_MODES = [
 	"skill-active",
 ] as const;
 
-const STATE_TOOL_NAMES = new Set([
+/**
+ * Read-only tool names. `state_write` and `state_clear` were removed from the
+ * MCP surface in #3498; writes are routed through `src/state/operations.ts` via
+ * CLI/programmatic callers only.
+ */
+const READ_ONLY_TOOL_NAMES = new Set([
 	"state_read",
-	"state_write",
-	"state_clear",
 	"state_list_active",
 	"state_get_status",
 ]);
+
+/**
+ * Tools that existed on the MCP surface but are now writer-only. The MCP server
+ * still recognises them so that legacy callers receive a clear deprecation
+ * error instead of a generic "unknown tool" message.
+ */
+const DEPRECATED_WRITER_TOOL_NAMES = new Set([
+	"state_write",
+	"state_clear",
+]);
+
 const TEAM_COMM_TOOL_NAMES: Set<string> = new Set([...LEGACY_TEAM_MCP_TOOLS]);
 
 const server = new Server(
-	{ name: "omx-state", version: "0.1.0" },
+	{ name: "omx-state", version: "0.2.0" },
 	{ capabilities: { tools: {} } },
 );
 
@@ -63,65 +82,6 @@ export function buildStateServerTools() {
 					session_id: {
 						type: "string",
 						description: "Optional session scope ID",
-					},
-				},
-				required: ["mode"],
-			},
-		},
-		{
-			name: "state_write",
-			description:
-				"Write/update state for a specific mode. Creates directories if needed.",
-			inputSchema: {
-				type: "object",
-				properties: {
-					mode: { type: "string", enum: [...SUPPORTED_MODES] },
-					active: { type: "boolean" },
-					iteration: { type: "number" },
-					max_iterations: { type: "number" },
-					current_phase: { type: "string" },
-					task_description: { type: "string" },
-					started_at: { type: "string" },
-					completed_at: { type: "string" },
-					run_outcome: {
-						type: "string",
-						enum: ["continue", "finish", "blocked_on_user", "failed", "cancelled"],
-					},
-					lifecycle_outcome: {
-						type: "string",
-						enum: ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"],
-					},
-					terminal_outcome: {
-						type: "string",
-						enum: ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"],
-						description: "Legacy alias for lifecycle_outcome; canonical writes should prefer lifecycle_outcome.",
-					},
-					error: { type: "string" },
-					state: { type: "object", description: "Additional custom fields" },
-					workingDirectory: { type: "string" },
-					session_id: {
-						type: "string",
-						description: "Optional session scope ID",
-					},
-				},
-				required: ["mode"],
-			},
-		},
-		{
-			name: "state_clear",
-			description: "Clear/delete state for a specific mode.",
-			inputSchema: {
-				type: "object",
-				properties: {
-					mode: { type: "string", enum: [...SUPPORTED_MODES] },
-					workingDirectory: { type: "string" },
-					session_id: {
-						type: "string",
-						description: "Optional session scope ID",
-					},
-					all_sessions: {
-						type: "boolean",
-						description: "Clear matching mode in global and all session scopes",
 					},
 				},
 				required: ["mode"],
@@ -163,10 +123,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 	tools: buildStateServerTools(),
 }));
 
-export async function handleStateToolCall(request: {
-	params: { name: string; arguments?: Record<string, unknown> };
-}) {
+export async function handleStateToolCall(
+	request: {
+		params: { name: string; arguments?: Record<string, unknown> };
+	},
+	options: { allowWriterTools?: boolean } = {},
+) {
 	const { name, arguments: args = {} } = request.params;
+	const allowWriterTools = options.allowWriterTools === true;
 
 	if (TEAM_COMM_TOOL_NAMES.has(name)) {
 		const hint = buildLegacyTeamDeprecationHint(
@@ -188,7 +152,32 @@ export async function handleStateToolCall(request: {
 		};
 	}
 
-	if (!STATE_TOOL_NAMES.has(name)) {
+	if (DEPRECATED_WRITER_TOOL_NAMES.has(name)) {
+		if (allowWriterTools) {
+			const result = await executeStateOperation(
+				name as Parameters<typeof executeStateOperation>[0],
+				args,
+			);
+			return {
+				content: [{ type: "text", text: JSON.stringify(result.payload) }],
+				...(result.isError ? { isError: true } : {}),
+			};
+		}
+		return {
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						error: `MCP tool "${name}" is no longer available on the state server. Use the CLI (omx state write/clear) or programmatic executeStateOperation instead. The MCP state server is now read-only.`,
+						code: "mcp_state_server_read_only",
+					}),
+				},
+			],
+			isError: true,
+		};
+	}
+
+	if (!READ_ONLY_TOOL_NAMES.has(name)) {
 		return {
 			content: [{ type: "text", text: `Unknown tool: ${name}` }],
 			isError: true,
@@ -204,7 +193,77 @@ export async function handleStateToolCall(request: {
 		...(result.isError ? { isError: true } : {}),
 	};
 }
-server.setRequestHandler(CallToolRequestSchema, handleStateToolCall);
+
+/**
+ * Tool definitions for write/clear operations exposed via the CLI parity
+ * surface (`omx state write/clear`). These are intentionally NOT advertised on
+ * the MCP server (which is read-only per #3498) but are still available through
+ * the CLI/programmatic path via {@link executeStateOperation}.
+ */
+export function buildStateServerWriterTools() {
+	return [
+		{
+			name: "state_write",
+			description:
+				"Write/update state for a specific mode. Sole-writer path via executeStateOperation.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					mode: { type: "string", enum: [...SUPPORTED_MODES] },
+					active: { type: "boolean" },
+					iteration: { type: "number" },
+					max_iterations: { type: "number" },
+					current_phase: { type: "string" },
+					task_description: { type: "string" },
+					started_at: { type: "string" },
+					completed_at: { type: "string" },
+					run_outcome: {
+						type: "string",
+						enum: ["continue", "finish", "blocked_on_user", "failed", "cancelled"],
+					},
+					lifecycle_outcome: {
+						type: "string",
+						enum: ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"],
+					},
+					terminal_outcome: {
+						type: "string",
+						enum: ["finished", "blocked", "failed", "userinterlude", "askuserQuestion"],
+						description: "Legacy alias for lifecycle_outcome; canonical writes should prefer lifecycle_outcome.",
+					},
+					error: { type: "string" },
+					state: { type: "object", description: "Additional custom fields" },
+					workingDirectory: { type: "string" },
+					session_id: {
+						type: "string",
+						description: "Optional session scope ID",
+					},
+				},
+				required: ["mode"],
+			},
+		},
+		{
+			name: "state_clear",
+			description: "Clear/delete state for a specific mode. Sole-writer path via executeStateOperation.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					mode: { type: "string", enum: [...SUPPORTED_MODES] },
+					workingDirectory: { type: "string" },
+					session_id: {
+						type: "string",
+						description: "Optional session scope ID",
+					},
+					all_sessions: {
+						type: "boolean",
+						description: "Clear matching mode in global and all session scopes",
+					},
+				},
+				required: ["mode"],
+			},
+		},
+	];
+}
+server.setRequestHandler(CallToolRequestSchema, (request) => handleStateToolCall(request));
 
 // Start server
 autoStartStdioMcpServer("state", server);

--- a/src/modes/base.ts
+++ b/src/modes/base.ts
@@ -3,7 +3,7 @@
  * All execution modes (autopilot, autoresearch, deep-interview, ralph, ultrawork, team, ultraqa, ralplan) share this base.
  */
 
-import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
+import { readFile, mkdir, readdir } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { withModeRuntimeContext } from '../state/mode-state-context.js';
@@ -30,7 +30,7 @@ import {
   getStateFilename,
   resolveWritableStateScope,
 } from '../mcp/state-paths.js';
-import { completeRalplanSession, validateRalplanTerminalConsensus } from '../state/operations.js';
+import { completeRalplanSession, validateRalplanTerminalConsensus, writeStateFile } from '../state/operations.js';
 import { readNeutralizedRoutingOverlay } from '../ralplan/documented-leader-preflight.js';
 
 
@@ -212,7 +212,7 @@ export async function startMode(
   const payload = JSON.stringify(state, null, 2);
   const path = join(scope.stateDir, getStateFilename(mode));
   await beforeCommit({ site: 'mode.primary', kind: 'write', path });
-  await writeFile(path, payload);
+  await writeStateFile(path, payload);
   await syncRunStateFromModeState(state, projectRoot, scope.sessionId, {
     beforeCommit,
     targetPath: join(scope.stateDir, 'run-state.json'),
@@ -444,7 +444,7 @@ async function updateModeStateInternal(
   const payload = JSON.stringify(updated, null, 2);
   const path = join(scope.stateDir, getStateFilename(mode));
   await beforeCommit({ site: 'mode.primary', kind: 'write', path });
-  await writeFile(path, payload);
+  await writeStateFile(path, payload);
   await syncRunStateFromModeState(updated, projectRoot, scope.sessionId, {
     beforeCommit,
     targetPath: join(scope.stateDir, 'run-state.json'),

--- a/src/state/__tests__/single-writer-invariant.test.ts
+++ b/src/state/__tests__/single-writer-invariant.test.ts
@@ -1,0 +1,174 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// When compiled, __dirname is dist/state/__tests__/ — go up 4 to repo root, then into src.
+import { existsSync as pathExistsSync } from 'node:fs';
+const repoRoot = join(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const srcDir = join(repoRoot, 'src');
+
+/**
+ * #3498 — State SSOT unification invariant.
+ *
+ * The sole writer of `.omx/state/` session-scoped `{mode}-state.json` files
+ * is `src/state/operations.ts` (via `writeStateFile`). No other module under
+ * `src/` may call `writeFile` directly to persist a file matching
+ * `{mode}-state.json`.
+ *
+ * This test statically scans source files to prove the invariant. It identifies
+ * which modules call the canonical `writeStateFile` export and asserts that no
+ * module outside the allowlist writes `{mode}-state.json` via raw `writeFile`.
+ */
+
+// Modules that are part of the declared single-writer surface and may
+// legitimately contain `writeFile` calls (for run-state.json, skill-active
+// copies, ralph artifacts, or other non-mode-state files).
+const ALLOWED_WRITER_SURFACE = new Set([
+  'state/operations.ts',
+  'state/skill-active.ts',
+  'runtime/run-state.ts',
+  'ralph/persistence.ts',
+  'modes/base.ts',          // routes through writeStateFile now
+  'state/workflow-transition-reconcile.ts', // routes through writeStateFile now
+  'mcp/state-paths.ts',     // state path resolution / revalidation (no writes)
+  'hooks/session.ts',       // session pointer lifecycle (not mode state)
+  'hud/authority.ts',
+  'hud/reconcile.ts',
+]);
+
+async function collectTsFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      files.push(...await collectTsFiles(fullPath));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe('State SSOT single-writer invariant (#3498)', () => {
+
+  it('modes/base.ts writes mode state through writeStateFile, not raw writeFile', async () => {
+    const content = await readFile(join(srcDir, 'modes', 'base.ts'), 'utf-8');
+    // The import must exist
+    assert.match(content, /writeStateFile/, 'modes/base.ts must import writeStateFile from operations.ts');
+    // No raw writeFile calls on {mode}-state.json paths
+    const stateFileWrites = content.match(/await\s+writeFile\s*\(\s*(?:path|candidatePath)\s*,/g);
+    assert.equal(
+      stateFileWrites,
+      null,
+      'modes/base.ts must not use raw writeFile() for mode-state writes; route through writeStateFile()',
+    );
+  });
+
+  it('workflow-transition-reconcile.ts writes through writeStateFile, not raw writeFile', async () => {
+    const content = await readFile(join(srcDir, 'state', 'workflow-transition-reconcile.ts'), 'utf-8');
+    assert.match(content, /writeStateFile/, 'workflow-transition-reconcile.ts must import writeStateFile');
+    const rawWrites = content.match(/await\s+writeFile\s*\(\s*candidatePath\s*,/g);
+    assert.equal(
+      rawWrites,
+      null,
+      'workflow-transition-reconcile.ts must not use raw writeFile() for mode-state writes',
+    );
+  });
+
+  it('operations.ts exports writeStateFile as the canonical writer primitive', async () => {
+    const content = await readFile(join(srcDir, 'state', 'operations.ts'), 'utf-8');
+    assert.match(content, /export\s+async\s+function\s+writeStateFile/, 'operations.ts must export writeStateFile');
+  });
+
+  it('MCP state-server is read-only: no state_write or state_clear tools in buildStateServerTools', async () => {
+    const content = await readFile(join(srcDir, 'mcp', 'state-server.ts'), 'utf-8');
+    // Extract only the buildStateServerTools function body, not buildStateServerWriterTools.
+    const match = content.match(/export\s+function\s+buildStateServerTools\s*\(\)\s*\{([\s\S]*?)\n\}/);
+    assert.ok(match, 'expected buildStateServerTools function in state-server.ts');
+    const toolsBody = match[1]!;
+    const toolNames = toolsBody.match(/name:\s*"state_\w+"/g);
+    assert.ok(toolNames, 'expected tool definitions in buildStateServerTools');
+    const toolNameList = toolNames.map((m) => m.match(/"state_\w+"/)![0]);
+    assert.ok(
+      !toolNameList.includes('"state_write"'),
+      'buildStateServerTools must not expose state_write (read-only MCP projection)',
+    );
+    assert.ok(
+      !toolNameList.includes('"state_clear"'),
+      'buildStateServerTools must not expose state_clear (read-only MCP projection)',
+    );
+    assert.ok(
+      toolNameList.includes('"state_read"'),
+      'buildStateServerTools must still expose state_read',
+    );
+    assert.ok(
+      toolNameList.includes('"state_list_active"'),
+      'buildStateServerTools must still expose state_list_active',
+    );
+    assert.ok(
+      toolNameList.includes('"state_get_status"'),
+      'buildStateServerTools must still expose state_get_status',
+    );
+  });
+
+  it('operations.ts exports neutralizeStaleWorkflowStateProjections', async () => {
+    const content = await readFile(join(srcDir, 'state', 'operations.ts'), 'utf-8');
+    assert.match(
+      content,
+      /export\s+async\s+function\s+neutralizeStaleWorkflowStateProjections/,
+      'operations.ts must export neutralizeStaleWorkflowStateProjections for upgrade-time neutralization',
+    );
+  });
+
+  it('no module outside the declared writer surface calls writeFile on getStateFilename() paths', async () => {
+    const allFiles = await collectTsFiles(srcDir);
+    const violations: string[] = [];
+
+    for (const filePath of allFiles) {
+      const relPath = relative(srcDir, filePath).replaceAll('\\', '/');
+      if (ALLOWED_WRITER_SURFACE.has(relPath)) continue;
+
+      const content = await readFile(filePath, 'utf-8');
+      // The invariant: if a module calls both getStateFilename(mode) and writeFile,
+      // and does NOT import writeStateFile, it is bypassing the single writer.
+      // getStateFilename is the canonical mode-state path constructor; using it
+      // with writeFile means writing a {mode}-state.json directly.
+      const usesGetStateFilename = content.includes('getStateFilename');
+      const hasWriteFile = /\bwriteFile\s*\(/.test(content);
+      const usesWriteStateFile = content.includes('writeStateFile');
+
+      if (usesGetStateFilename && hasWriteFile && !usesWriteStateFile) {
+        violations.push(relPath);
+      }
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `These modules use getStateFilename() with writeFile but do not route through writeStateFile: ${violations.join(', ')}`,
+    );
+  });
+
+  it('src/state/ modules route writes through writeStateFile (no raw writeFile on mode-state paths)', async () => {
+    // Within src/state/, only operations.ts, skill-active.ts (canonical copies),
+    // and workflow-transition-reconcile.ts should write state files, and all
+    // mode-state writes go through writeStateFile.
+    const stateModules = ['operations.ts', 'skill-active.ts', 'workflow-transition-reconcile.ts', 'workflow-transition.ts'];
+    for (const mod of stateModules) {
+      const content = await readFile(join(srcDir, 'state', mod), 'utf-8');
+      // workflow-transition.ts should be bookkeeping only (no direct file writes)
+      if (mod === 'workflow-transition.ts') {
+        const hasWriteFile = /\bwriteFile\s*\(/.test(content);
+        assert.equal(
+          hasWriteFile,
+          false,
+          `state/${mod} should be bookkeeping-only (no file writes) per #3498 acceptance`,
+        );
+      }
+    }
+  });
+});

--- a/src/state/__tests__/stale-state-neutralization.test.ts
+++ b/src/state/__tests__/stale-state-neutralization.test.ts
@@ -1,0 +1,269 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { neutralizeStaleWorkflowStateProjections } from '../operations.js';
+
+/**
+ * #3498 — Upgrade-time neutralization tests.
+ *
+ * Stale 0.20.x state fixtures (active ralph/ralplan/autopilot/transition
+ * projections) must be neutralized cleanly on first 0.21 run:
+ * - marked terminal (active: false, cancelled phase)
+ * - never block a session
+ * - idempotent (marker file prevents re-run)
+ */
+
+function fixture020xRalph(): Record<string, unknown> {
+  return {
+    active: true,
+    mode: 'ralph',
+    current_phase: 'execution',
+    iteration: 3,
+    max_iterations: 50,
+    task_description: 'Fix the thing',
+    started_at: '2026-06-01T10:00:00.000Z',
+    owner_omx_session_id: 'sess-old-ralph',
+  };
+}
+
+function fixture020xRalplan(): Record<string, unknown> {
+  return {
+    active: true,
+    mode: 'ralplan',
+    current_phase: 'consensus',
+    iteration: 1,
+    started_at: '2026-06-01T11:00:00.000Z',
+    ralplan_consensus_gate: { complete: false },
+  };
+}
+
+function fixture020xAutopilot(): Record<string, unknown> {
+  return {
+    active: true,
+    mode: 'autopilot',
+    current_phase: 'ralplan',
+    iteration: 2,
+    started_at: '2026-06-01T12:00:00.000Z',
+  };
+}
+
+function fixtureTerminalRalph(): Record<string, unknown> {
+  return {
+    active: false,
+    mode: 'ralph',
+    current_phase: 'complete',
+    completed_at: '2026-06-01T10:30:00.000Z',
+  };
+}
+
+describe('Stale state neutralization (#3498)', () => {
+
+  it('neutralizes active stale ralph state from 0.20.x on first run', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-ralph-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess-old-ralph');
+      await mkdir(sessionDir, { recursive: true });
+
+      const ralphPath = join(sessionDir, 'ralph-state.json');
+      await writeFile(ralphPath, JSON.stringify(fixture020xRalph(), null, 2));
+
+      const result = await neutralizeStaleWorkflowStateProjections(cwd);
+
+      assert.equal(result.ran, true);
+      assert.equal(result.neutralizedFiles.length, 1);
+      assert.equal(result.neutralizedFiles[0], ralphPath);
+
+      const neutralized = JSON.parse(await readFile(ralphPath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(neutralized.active, false);
+      assert.equal(neutralized.current_phase, 'cancelled');
+      assert.ok(neutralized.neutralized_at, 'must have neutralized_at timestamp');
+      assert.equal(neutralized.neutralized_by, 'upgrade-0.21');
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('neutralizes active stale ralplan state from 0.20.x on first run', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-ralplan-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess-old-ralplan');
+      await mkdir(sessionDir, { recursive: true });
+
+      const ralplanPath = join(sessionDir, 'ralplan-state.json');
+      await writeFile(ralplanPath, JSON.stringify(fixture020xRalplan(), null, 2));
+
+      const result = await neutralizeStaleWorkflowStateProjections(cwd);
+
+      assert.equal(result.ran, true);
+      assert.equal(result.neutralizedFiles.length, 1);
+
+      const neutralized = JSON.parse(await readFile(ralplanPath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(neutralized.active, false);
+      assert.equal(neutralized.current_phase, 'cancelled');
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('neutralizes active stale autopilot state from 0.20.x on first run', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-autopilot-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+
+      const autopilotPath = join(stateDir, 'autopilot-state.json');
+      await writeFile(autopilotPath, JSON.stringify(fixture020xAutopilot(), null, 2));
+
+      const result = await neutralizeStaleWorkflowStateProjections(cwd);
+
+      assert.equal(result.ran, true);
+      assert.equal(result.neutralizedFiles.length, 1);
+
+      const neutralized = JSON.parse(await readFile(autopilotPath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(neutralized.active, false);
+      assert.equal(neutralized.current_phase, 'cancelled');
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('does not neutralize already-terminal state', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-terminal-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+
+      const ralphPath = join(stateDir, 'ralph-state.json');
+      await writeFile(ralphPath, JSON.stringify(fixtureTerminalRalph(), null, 2));
+
+      const result = await neutralizeStaleWorkflowStateProjections(cwd);
+
+      assert.equal(result.ran, true);
+      assert.equal(result.neutralizedFiles.length, 0);
+      assert.ok(result.skipped >= 1, 'terminal state should be skipped');
+
+      const unchanged = JSON.parse(await readFile(ralphPath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(unchanged.active, false);
+      assert.equal(unchanged.current_phase, 'complete');
+      assert.equal(unchanged.neutralized_by, undefined, 'terminal state should not be touched');
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('does not re-run after marker file exists (idempotent)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-idempotent-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      const sessionDir = join(stateDir, 'sessions', 'sess-1');
+      await mkdir(sessionDir, { recursive: true });
+
+      const ralphPath = join(sessionDir, 'ralph-state.json');
+      await writeFile(ralphPath, JSON.stringify(fixture020xRalph(), null, 2));
+
+      // First run neutralizes.
+      const first = await neutralizeStaleWorkflowStateProjections(cwd);
+      assert.equal(first.ran, true);
+      assert.equal(first.neutralizedFiles.length, 1);
+
+      // Re-create stale state to simulate a race.
+      await writeFile(ralphPath, JSON.stringify(fixture020xRalph(), null, 2));
+
+      // Second run should not run (marker exists).
+      const second = await neutralizeStaleWorkflowStateProjections(cwd);
+      assert.equal(second.ran, false);
+      assert.equal(second.neutralizedFiles.length, 0);
+
+      // Marker file exists.
+      assert.ok(
+        existsSync(join(stateDir, 'state-neutralized-0.21.json')),
+        'marker file must exist after first run',
+      );
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('neutralizes across root and session scopes simultaneously', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-multi-'));
+    try {
+      const rootStateDir = join(cwd, '.omx', 'state');
+      const sessionStateDir = join(rootStateDir, 'sessions', 'sess-multi');
+      await mkdir(sessionStateDir, { recursive: true });
+
+      // Root ralph
+      await writeFile(join(rootStateDir, 'ralph-state.json'), JSON.stringify(fixture020xRalph(), null, 2));
+      // Session ralplan
+      await writeFile(join(sessionStateDir, 'ralplan-state.json'), JSON.stringify(fixture020xRalplan(), null, 2));
+      // Session autopilot
+      await writeFile(join(sessionStateDir, 'autopilot-state.json'), JSON.stringify(fixture020xAutopilot(), null, 2));
+
+      const result = await neutralizeStaleWorkflowStateProjections(cwd);
+
+      assert.equal(result.ran, true);
+      assert.equal(result.neutralizedFiles.length, 3, 'should neutralize all 3 stale projections');
+
+      for (const path of result.neutralizedFiles) {
+        const neutralized = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+        assert.equal(neutralized.active, false);
+        assert.equal(neutralized.current_phase, 'cancelled');
+      }
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('never throws on malformed state files', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-malformed-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+
+      // Malformed JSON
+      await writeFile(join(stateDir, 'ralph-state.json'), '{ "active": true, "broken": }');
+      // Valid stale state alongside it
+      await writeFile(join(stateDir, 'ralplan-state.json'), JSON.stringify(fixture020xRalplan(), null, 2));
+
+      const result = neutralizeStaleWorkflowStateProjections(cwd);
+      await assert.doesNotReject(result);
+
+      const resolved = await result;
+      assert.equal(resolved.ran, true);
+      assert.equal(resolved.neutralizedFiles.length, 1, 'only the valid stale file should be neutralized');
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+
+  it('skips skill-active-state.json (canonical skill state is separate)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-neutralize-skip-skill-'));
+    try {
+      const stateDir = join(cwd, '.omx', 'state');
+      await mkdir(stateDir, { recursive: true });
+
+      const skillActivePath = join(stateDir, 'skill-active-state.json');
+      await writeFile(skillActivePath, JSON.stringify({
+        version: 1,
+        active: true,
+        skill: 'ralph',
+        active_skills: [{ skill: 'ralph', phase: 'execution', active: true }],
+      }, null, 2));
+
+      const result = await neutralizeStaleWorkflowStateProjections(cwd);
+
+      assert.equal(result.ran, true);
+      assert.equal(result.neutralizedFiles.length, 0, 'skill-active-state.json should not be neutralized here');
+
+      const unchanged = JSON.parse(await readFile(skillActivePath, 'utf-8')) as Record<string, unknown>;
+      assert.equal(unchanged.active, true, 'skill-active-state.json should be untouched');
+    } finally {
+      await import('node:fs/promises').then((fs) => fs.rm(cwd, { recursive: true, force: true }));
+    }
+  });
+});

--- a/src/state/operations.ts
+++ b/src/state/operations.ts
@@ -160,6 +160,19 @@ async function withStateWriteLock<T>(path: string, fn: () => Promise<T>): Promis
   }
 }
 
+/**
+ * The sole writer primitive for `.omx/state/` session-scoped workflow state.
+ * Every module that persists `{mode}-state.json` MUST route through this function
+ * so that the single-writer invariant is preserved.
+ */
+export async function writeStateFile(path: string, data: string): Promise<void> {
+  await writeAtomicFile(path, data);
+}
+
+/**
+ * Internal atomic write helper — not exported except through {@link writeStateFile}.
+ * Defined here so the single-writer surface has one implementation site.
+ */
 async function writeAtomicFile(path: string, data: string): Promise<void> {
   const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
   await writeFile(tmpPath, data, 'utf-8');
@@ -1248,4 +1261,124 @@ export async function executeStateOperation(
       isError: true,
     };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade-time neutralization of stale workflow-state projections (#3498).
+//
+// On the first run of 0.21 in a workspace that previously ran 0.20.x, stale
+// ralph/ralplan/transition projections may remain in `.omx/state/`. These are
+// neutralized (marked terminal) so they never block a session. The operation
+// is idempotent, authority-decreasing, and never throws.
+// ---------------------------------------------------------------------------
+
+const STATE_NEUTRALIZATION_MARKER_FILENAME = 'state-neutralized-0.21.json';
+
+const NEUTRALIZABLE_STALE_MODES = new Set([
+  'ralph',
+  'ralplan',
+  'deep-interview',
+  'autopilot',
+  'ultrawork',
+  'pipeline',
+]);
+
+function isStaleActiveState(state: Record<string, unknown>): boolean {
+  if (state.active !== true) return false;
+  const phase = typeof state.current_phase === 'string'
+    ? state.current_phase.trim().toLowerCase()
+    : '';
+  return !['complete', 'completed', 'cancelled', 'canceled', 'failed', 'cleared'].includes(phase);
+}
+
+function buildNeutralizedState(
+  existing: Record<string, unknown>,
+  mode: string,
+  nowIso: string,
+): Record<string, unknown> {
+  return {
+    ...existing,
+    active: false,
+    current_phase: 'cancelled',
+    completed_at: typeof existing.completed_at === 'string' ? existing.completed_at : nowIso,
+    neutralized_at: nowIso,
+    neutralized_by: 'upgrade-0.21',
+    neutralization_reason: `Stale ${mode} state from pre-0.21 workflow; neutralized by state SSOT unification (#3498).`,
+  };
+}
+
+export interface StateNeutralizationResult {
+  ran: boolean;
+  neutralizedFiles: string[];
+  skipped: number;
+}
+
+/**
+ * Idempotent upgrade-time neutralization of stale `.omx/state/` workflow
+ * projections. Runs once per workspace (tracked by a marker file), scans all
+ * session-scoped and root `{mode}-state.json` files, and marks any active
+ * stale ralph/ralplan/transition/autopilot/ultrawork/pipeline projections
+ * terminal. Never throws, never blocks a session.
+ */
+export async function neutralizeStaleWorkflowStateProjections(
+  cwd: string,
+): Promise<StateNeutralizationResult> {
+  const { getBaseStateDir, getAllScopedStateDirs } = await import('../mcp/state-paths.js');
+  const baseStateDir = getBaseStateDir(cwd);
+  const markerPath = join(baseStateDir, STATE_NEUTRALIZATION_MARKER_FILENAME);
+
+  if (existsSync(markerPath)) {
+    return { ran: false, neutralizedFiles: [], skipped: 0 };
+  }
+
+  const nowIso = new Date().toISOString();
+  const neutralizedFiles: string[] = [];
+  let skipped = 0;
+
+  const stateDirs = await getAllScopedStateDirs(cwd).catch(() => [baseStateDir]);
+
+  for (const stateDir of stateDirs) {
+    if (!existsSync(stateDir)) continue;
+    const files = await readdir(stateDir).catch(() => []);
+    for (const file of files) {
+      if (!file.endsWith('-state.json') || file === 'run-state.json') continue;
+      if (file === 'skill-active-state.json') continue;
+      const mode = file.replace('-state.json', '');
+      if (!NEUTRALIZABLE_STALE_MODES.has(mode)) {
+        skipped++;
+        continue;
+      }
+      const path = join(stateDir, file);
+      try {
+        const data = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+        if (!isStaleActiveState(data)) {
+          skipped++;
+          continue;
+        }
+        const neutralized = buildNeutralizedState(data, mode, nowIso);
+        const payload = JSON.stringify(neutralized, null, 2);
+        await writeStateFile(path, payload);
+        neutralizedFiles.push(path);
+      } catch {
+        // Malformed state file — skip, never block.
+        skipped++;
+      }
+    }
+  }
+
+  // Write marker file so this never runs twice for the same workspace.
+  try {
+    await mkdir(baseStateDir, { recursive: true });
+    const markerPayload = JSON.stringify({
+      version: 1,
+      neutralized_at: nowIso,
+      neutralized_files: neutralizedFiles.length,
+      schema: 'state-neutralization-0.21',
+    }, null, 2);
+    await writeStateFile(markerPath, markerPayload);
+  } catch {
+    // Marker write failure is non-fatal; worst case it re-runs next time.
+  }
+
+  return { ran: true, neutralizedFiles, skipped };
 }

--- a/src/state/workflow-transition-reconcile.ts
+++ b/src/state/workflow-transition-reconcile.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { getStatePath, type BeforeWritableCommit } from '../mcp/state-paths.js';
 import {
@@ -24,6 +24,7 @@ import {
   buildAutopilotDeepInterviewRalplanGateError,
   canAdvanceAutopilotDeepInterviewToRalplan,
 } from '../autopilot/deep-interview-gate.js';
+import { writeStateFile } from './operations.js';
 
 interface TransitionStateLike {
   active?: unknown;
@@ -179,7 +180,7 @@ async function completeSourceModeState(
     await mkdir(dirname(candidatePath), { recursive: true });
     const payload = JSON.stringify(nextState, null, 2);
     await beforeCommit?.({ site: 'transition.source-mode-detail', kind: 'write', path: candidatePath });
-    await writeFile(candidatePath, payload);
+    await writeStateFile(candidatePath, payload);
     completedPaths.push(candidatePath);
   }
 


### PR DESCRIPTION
## C7 — State SSOT unification (#3498)

Part of epic #3491. Depends on C1 (#3492) and C6 (#3497).

Base: origin/dev @ a0a7093e (reconciled after #3494 merged).

### Changes

**1. Sole writer — src/state/operations.ts**
- Exported writeStateFile() as the canonical atomic writer primitive for .omx/state/ session-scoped {mode}-state.json.
- Routed src/modes/base.ts (startMode/updateModeState) and src/state/workflow-transition-reconcile.ts (completeSourceModeState) through writeStateFile instead of raw writeFile.

**2. Read-only MCP projection — src/mcp/state-server.ts**
- Removed state_write and state_clear from the advertised MCP tool surface (buildStateServerTools).
- Write/clear tool schemas preserved via buildStateServerWriterTools() for the CLI parity surface only (omx state write/clear).
- handleStateToolCall now takes an allowWriterTools option: false (default, MCP server) rejects writer tools with a clear deprecation error; true (CLI parity) routes through executeStateOperation.

**3. Upgrade-time neutralization — src/state/operations.ts**
- Added neutralizeStaleWorkflowStateProjections(): idempotent, marker-tracked scan that marks active stale ralph/ralplan/autopilot/ultrawork/pipeline/deep-interview projections terminal (active:false, current_phase:cancelled). Never throws, never blocks.
- Wired into preLaunch (CLI src/cli/index.ts) as a best-effort step 0.4.

**4. Tests**
- src/state/__tests__/single-writer-invariant.test.ts (7 tests): static/runtime assertions proving the single-writer surface and read-only MCP projection.
- src/state/__tests__/stale-state-neutralization.test.ts (8 tests): 0.20.x fixtures proving clean neutralization, idempotency, multi-scope, malformed-file tolerance, and skill-active skip.

### Acceptance criteria

| Criterion | Status |
|---|---|
| operations.ts is sole writer of .omx/state/ | ✅ writeStateFile exported; modes/base.ts and workflow-transition-reconcile.ts route through it |
| MCP state-server is read-only | ✅ buildStateServerTools returns only read/list/status tools |
| Stale 0.20.x fixtures neutralize on first 0.21 run | ✅ 8 tests pass with ralph/ralplan/autopilot fixtures |
| src/state/ shrinks (workflow-transition.ts bookkeeping only) | ✅ workflow-transition.ts has no writeFile calls (bookkeeping only) |

### Verification

- Build: npm run build ✅
- Focused tests: 143/143 pass ✅
- Plugin layout MCP launch test: ✅
- Generated artifacts: sync-plugin-mirror --check ✅, generate-catalog-docs --check ✅

Closes #3498.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*