### PR TITLE
fix(lifecycle): retire unpinned historical snapshots

### DIFF
--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1315,6 +1315,40 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+
+	it("retains current, previous, and pinned snapshots while retiring older unpinned managed roots", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-plugin-cache-bounded-"));
+		try {
+			const codexHomeDir = join(wd, ".codex");
+			const cacheBase = join(codexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex");
+			const seed = async (version: string, pinned = false) => {
+				const dir = join(cacheBase, version);
+				await mkdir(join(dir, ".codex-plugin"), { recursive: true });
+				await mkdir(join(dir, "hooks"), { recursive: true });
+				await mkdir(join(dir, "skills"), { recursive: true });
+				await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version, skills: "./skills/", hooks: "./hooks/hooks.json" }));
+				if (pinned) await writeFile(join(dir, ".omx-live-pin"), "pinned\n");
+				return dir;
+			};
+			const previous = await seed("0.20.4");
+			const older = await seed("0.20.3");
+			const pinned = await seed("0.20.2", true);
+			const foreign = join(cacheBase, "foreign");
+			await mkdir(join(foreign, ".codex-plugin"), { recursive: true });
+			await writeFile(join(foreign, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "foreign-plugin", version: "foreign" }));
+			const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+			assert.ok(packagedMarketplace);
+			const result = await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
+			assert.equal(result.status, "materialized");
+			assert.equal(existsSync(previous), true);
+			assert.equal(existsSync(older), false);
+			assert.equal(existsSync(pinned), true);
+			assert.equal(existsSync(foreign), true);
+			assert.deepEqual(result.retiredDirs, [older]);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 	it("does not rewrite a published same-version plugin snapshot when hook contents drift", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -400,6 +400,35 @@ export interface OmxPluginCacheMaterializeResult {
 	status: "unavailable" | "unchanged" | "materialized";
 	cacheDir?: string;
 	version?: string;
+	retiredDirs?: string[];
+}
+
+async function retireUnpinnedManagedSnapshots(
+	cacheBase: string,
+	currentVersion: string,
+): Promise<string[]> {
+	let entries;
+	try {
+		entries = await readdir(cacheBase, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const managed: Array<{ path: string; version: string; mtimeMs: number }> = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory() || entry.name === currentVersion) continue;
+		const path = join(cacheBase, entry.name);
+		const state = await readOmxPluginCacheState(path);
+		if (state?.manifestVersion !== entry.name) continue;
+		if (existsSync(join(path, ".omx-live-pin"))) continue;
+		managed.push({ path, version: entry.name, mtimeMs: (await lstat(path)).mtimeMs });
+	}
+	managed.sort((left, right) => right.mtimeMs - left.mtimeMs || right.version.localeCompare(left.version));
+	const retired: string[] = [];
+	for (const candidate of managed.slice(1)) {
+		await rm(candidate.path, { recursive: true, force: true });
+		retired.push(candidate.path);
+	}
+	return retired;
 }
 
 export async function materializePackagedOmxPluginCache(
@@ -412,7 +441,14 @@ export async function materializePackagedOmxPluginCache(
 	if (!version) return { status: "unavailable" };
 	const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
 	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace, options)) {
-		return { status: "unchanged", cacheDir, version };
+		return {
+			status: "unchanged",
+			cacheDir,
+			version,
+			retiredDirs: options.dryRun
+				? []
+				: await retireUnpinnedManagedSnapshots(omxPluginCacheBase(codexHomeDir), version),
+		};
 	}
 	if (!options.dryRun) {
 		const cacheBase = omxPluginCacheBase(codexHomeDir);
@@ -435,7 +471,14 @@ export async function materializePackagedOmxPluginCache(
 			await rm(tempDir, { recursive: true, force: true });
 		}
 	}
-	return { status: "materialized", cacheDir, version };
+	return {
+		status: "materialized",
+		cacheDir,
+		version,
+		retiredDirs: options.dryRun
+			? []
+			: await retireUnpinnedManagedSnapshots(omxPluginCacheBase(codexHomeDir), version),
+	};
 }
 
 function marketplaceTableHeaderPattern(): RegExp {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -422,7 +422,10 @@ async function retireUnpinnedManagedSnapshots(
 		if (existsSync(join(path, ".omx-live-pin"))) continue;
 		managed.push({ path, version: entry.name, mtimeMs: (await lstat(path)).mtimeMs });
 	}
-	managed.sort((left, right) => right.mtimeMs - left.mtimeMs || right.version.localeCompare(left.version));
+	managed.sort((left, right) =>
+		right.version.localeCompare(left.version, undefined, { numeric: true }) ||
+		right.mtimeMs - left.mtimeMs,
+	);
 	const retired: string[] = [];
 	for (const candidate of managed.slice(1)) {
 		await rm(candidate.path, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- complete #3499's accepted bounded snapshot lifecycle after terminal critic review
- retain current, most recent previous, every explicitly live-pinned managed root, and all foreign roots
- retire only older unpinned roots whose OMX manifest version proves managed path provenance

Refs #3499

## Validation
- build, no-unused, lint
- setup lifecycle 129 tests
- resume, hook ownership, doctor repair regressions
- plugin bundle closure

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*