### PR TITLE
docs(#3486): align workflow and hook recovery contracts

### DIFF
--- a/docs/STATE_MODEL.md
+++ b/docs/STATE_MODEL.md
@@ -172,9 +172,12 @@ entering its `ralplan` child stage. Review/QA loopbacks should keep
 `autopilot-state.json` active and set `current_phase: "ralplan"` rather than
 starting standalone `ralplan` over Autopilot.
 
-Inside Autopilot, `ralplan` consensus requires an official host-issued receipt verified through a documented host integration. No such verifier exists today, so production fails closed with `documented_host_consensus_receipt_unavailable`. Native Architect/Critic lanes, `codex_exec` outputs, trackers, and authored planning artifacts remain lifecycle or trace evidence only.
-
-Fresh default Autopilot also performs a capability-only preflight before entering `deep-interview` or launching Ralplan review work. When the installed surface deterministically has no documented host receipt verifier, Autopilot terminalizes immediately with the same exact blocker. This preflight is an expense/lifecycle decision only: an available capability does not authorize execution, active Autopilot continuations remain resumable, and direct/manual Ralplan remains inspectable.
+The hard Autopilot/Ralplan consensus-receipt gate was removed by #3492. Workflow
+transitions no longer require a host-issued receipt, and missing host provenance
+must not terminalize Autopilot or block authority-decreasing recovery. Architect,
+Critic, tracker, and artifact evidence may still inform planning and review, but
+ordinary progression follows the lightweight workflow without turning those
+local records into an authorization boundary.
 
 ## Planning-like vs execution-like
 

--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -43,6 +43,18 @@ event payload without receiving `EPIPE`.
 OMX only owns the wrapper entries that invoke `dist/scripts/codex-native-hook.js`. User-managed hook entries in the same `.codex/hooks.json` file are preserved across `omx setup` refreshes and `omx uninstall`.
 Setup-owned trust state is limited to those generated wrapper identities; user hooks and user-owned `hooks.state` entries are preserved and remain subject to Codex's normal review flow.
 
+For authority-decreasing recovery without uninstalling OMX, run one of these
+copyable commands from an external shell:
+
+```sh
+omx setup --scope user --disable-hooks
+omx setup --scope project --disable-hooks
+```
+
+The command removes only OMX-owned hook registrations and related enablement
+while preserving project `.omx` artifacts, foreign hooks, and unrelated Codex
+configuration. Re-running it is safe.
+
 ## Mapping matrix
 
 | OMC / OMX surface | Native Codex source | OMX runtime target | Status | Notes |
@@ -263,7 +275,15 @@ unsupported_documented_leader_proof: Codex hooks do not expose a documented, non
 The direct CLI result for an installed role is likewise `{"ok":false,"reason":"unsupported_documented_leader_proof"}`. An unknown role remains separately denied as `unknown_role`; it is not a fallback or an authority probe. Wrappers, assignments, compounds, redirects, malformed commands, unrelated tools, and typed native spawn payloads are outside this narrow hook boundary and retain their existing handling.
 Ordinary native planning, lifecycle, state, status, health, HUD, runtime, setup, install, sync, and unrelated delegation are outside this preflight boundary and remain governed by their existing controls; do not run this preflight merely because the surface is native or routing is unavailable.
 
-Ralplan consensus additionally requires an official host-issued receipt verified through a documented host integration. No such integration exists today, so production consensus fails closed with `documented_host_consensus_receipt_unavailable`; native Architect/Critic lifecycle evidence alone cannot release `ralplan -> ultragoal`. The packaged plugin's `OMX_CODEX_LAUNCH_ID` and `plugin-hook-routing` record are a spoofable routing-only discriminator, not a secret, signed claim, or authority source. See [ADR 3194](./adr/3194-codex-01445-documented-leader-proof.md), [ADR 3212](./adr/3212-same-user-native-child-auth-boundary.md), and the [consensus gate contract](./contracts/ralplan-consensus-gate.md).
+The former Ralplan host-consensus-receipt gate is retired. Missing host receipt
+capability no longer blocks `ralplan -> ultragoal` or terminalizes the ordinary
+workflow. Native Architect/Critic lifecycle evidence remains useful review data,
+not a host authorization token. The packaged plugin's `OMX_CODEX_LAUNCH_ID` and
+`plugin-hook-routing` record remain routing-only discriminators rather than
+secrets or signed claims. See [ADR 3194](./adr/3194-codex-01445-documented-leader-proof.md),
+[ADR 3212](./adr/3212-same-user-native-child-auth-boundary.md), and the retired
+[consensus gate contract](./contracts/ralplan-consensus-gate.md) for historical
+context.
 
 Exact Team launch therefore remains denied on Codex 0.145.0 unless a future documented host verifier supplies non-user-mintable Main-root/session/root-thread proof before any Team state, worktree, tmux, mailbox, worker, or process effect. Exact command grammar and local Ultragoal/task/session state may restrict a request, but they cannot authorize it. Native children remain limited to positively classified reads and verification/advice. Child-to-leader collaboration reporting also remains denied because 0.145.0 does not bind the caller to a host-authenticated direct parent and target; local subagent trackers cannot authorize that relation.
 

--- a/docs/contracts/multi-state-transition-contract.md
+++ b/docs/contracts/multi-state-transition-contract.md
@@ -113,4 +113,8 @@ Implementation should be considered complete only when tests prove:
 5. denial messages mention both `omx state` and `omx_state.*`
 6. HUD / overlay / stop-hook consumers honor the combined set consistently
 7. `autopilot` and `autoresearch` still reject unsupported overlap attempts; Autopilot review-driven planning loopbacks keep `autopilot` active and update its `current_phase` to `ralplan` instead of starting standalone `ralplan`
-8. `deep-interview -> ralplan` is evidence-gated: answered or handoff-cleared question obligations alone do not complete deep-interview, and Autopilot `ralplan -> ultragoal` remains blocked with `documented_host_consensus_receipt_unavailable` until an official non-user-mintable host receipt verifier exists; native lanes, trackers, `codex_exec`, and artifact approvals are non-authoritative.
+8. The retired Autopilot/Ralplan host-receipt gate must not block ordinary
+   progression or authority-decreasing recovery. Native lanes, trackers,
+   `codex_exec`, and artifacts remain planning/review evidence rather than an
+   authorization boundary; missing host provenance does not terminalize the
+   lightweight workflow.

--- a/docs/contracts/ralplan-consensus-gate.md
+++ b/docs/contracts/ralplan-consensus-gate.md
@@ -1,18 +1,17 @@
-# Ralplan Consensus Gate Contract
+# Retired Ralplan Consensus Gate Contract
 
-The `ralplan -> ultragoal` transition is fail-closed. Architect and Critic lifecycle evidence is useful diagnostic data, but cannot authorize a transition by itself.
+This contract is retained as historical context. The hard `ralplan -> ultragoal`
+host-receipt gate was removed by #3492 together with the fixed Autopilot chain.
+Ordinary workflow progression no longer depends on a host-issued consensus
+receipt, and missing host provenance must not terminalize planning or block
+authority-decreasing cancel, clear, or recovery operations.
 
 ## Authority boundary
 
-A successful transition requires a documented, versioned, official host-issued consensus receipt verified directly through an official host integration. The receipt must bind the exact transition session, installed Architect and Critic roles, distinct host thread identities, approved artifact digests, strict Architect-before-Critic order, issuer, version, and replay protection.
-
-No current official host receipt integration exists. Production consensus therefore returns the exact blocker:
-
-```text
-documented_host_consensus_receipt_unavailable
-```
-
-The gate must not read a receipt from `.omx`, repository files, user-local files, environment variables, stdin, CLI arguments, transcripts, pointers, trackers, markers, task names, prompts, or review artifact fields. Those carriers are same-user writable and are not authority.
+Local lifecycle evidence, repository files, environment variables, transcripts,
+trackers, markers, task names, prompts, and review artifacts are still not
+host-issued authority. That boundary now means they must not be promoted into a
+security claim; it does not justify a workflow-wide hard gate.
 
 ## Routing and lifecycle evidence
 
@@ -24,20 +23,27 @@ Review artifacts can describe native lifecycle observations using:
 - `thread_id`: the native lane thread id
 - `tracker_path`: `.omx/state/subagent-tracking.json`
 
-`agent_type`, `agent_role`, `provenance_kind`, session/thread IDs, tracker roles/modes/completion, task names, routing markers, transcripts, and local review artifacts are routing, lifecycle, or diagnostic data only. A same-user child can forge them. They never satisfy the receipt requirement.
+`agent_type`, `agent_role`, `provenance_kind`, session/thread IDs, tracker
+roles/modes/completion, task names, routing markers, transcripts, and local
+review artifacts are routing, lifecycle, or diagnostic data only. They may
+inform review without authorizing or denying the workflow transition.
 
-Typed `native_subagent` Architect and Critic lanes may still be tracked for diagnostics. A valid lifecycle pair uses distinct threads, completed lanes, and Architect-before-Critic ordering. A roleless legacy lane, `omx_adapted` lane, pending/bound role intent, claimant token, leader attestation, or historical routing marker is inert and cannot release consensus.
+Typed `native_subagent` Architect and Critic lanes may still be tracked for
+diagnostics and review quality. Their lifecycle does not create a host-security
+boundary around ordinary progression.
 
 ## Diagnostics
 
-When lifecycle evidence is present, the gate may render diagnostics for the expected tracker schema, current session, Architect/Critic thread IDs, session/thread existence, thread kinds, completion, distinctness, ordering, and remediation. These diagnostics explain lifecycle quality; they are not a receipt verifier.
+Lifecycle diagnostics may still report tracker schema, session/thread existence,
+completion, distinctness, ordering, and remediation. They describe review
+quality only. They must not emit a missing-receipt blocker, terminalize the
+lightweight workflow, or prevent authority-decreasing recovery.
 
-Every production result remains incomplete until the official verifier is available and validates a receipt. The unavailable result includes `blockedReason: "documented_host_consensus_receipt_unavailable"`.
+## Current contract
 
-Fresh default Autopilot checks verifier capability before starting `deep-interview` or Ralplan review lanes. Deterministic verifier absence terminalizes the fresh Autopilot run with the same exact blocker, avoiding review work that cannot advance. The capability check is not receipt verification and never authorizes a transition; direct/manual Ralplan and existing active Autopilot sessions keep their diagnostic and resumability behavior.
-
-## Future enablement
-
-Enable a positive path only after official documentation specifies a non-user-mintable host receipt channel and OMX implements direct verification for that documented version and surface. Tests must prove that injected local JSON, environment, transcript, tracker, marker, and review artifacts cannot mint or substitute the receipt. Until then, preserve the fail-closed blocker and treat typed routing/lifecycle as non-authoritative.
+Keep typed routing and lifecycle records non-authoritative, while allowing the
+ordinary lightweight workflow to proceed. Security-sensitive capabilities may
+define their own documented authority checks, but they must not reintroduce the
+retired project-wide Ralplan/Autopilot progression gate.
 
 See [ADR 3212](../adr/3212-same-user-native-child-auth-boundary.md) and [ADR 3194](../adr/3194-codex-01445-documented-leader-proof.md).

--- a/src/hooks/__tests__/autopilot-skill-contract.test.ts
+++ b/src/hooks/__tests__/autopilot-skill-contract.test.ts
@@ -89,6 +89,26 @@ describe('execution-loop sunset stub contract', () => {
     assert.doesNotMatch(gettingStartedDocs, /Choose `\$autopilot`.*`\$ultrawork`.*`\$ralph`/);
   });
 
+  it('#3486 keeps canonical workflow and recovery docs aligned with the lightweight runtime', () => {
+    const canonicalWorkflowDocs = [
+      'docs/STATE_MODEL.md',
+      'docs/contracts/ralplan-consensus-gate.md',
+      'docs/contracts/multi-state-transition-contract.md',
+      'docs/codex-native-hooks.md',
+    ];
+    for (const path of canonicalWorkflowDocs) {
+      const content = readFileSync(join(guidanceRoot, path), 'utf-8');
+      assert.doesNotMatch(content, /documented_host_consensus_receipt_unavailable/);
+      assert.doesNotMatch(content, /missing host (?:receipt|provenance) (?:terminalizes|terminalized|will terminalize)/i);
+    }
+
+    const nativeHooks = readFileSync(join(guidanceRoot, 'docs/codex-native-hooks.md'), 'utf-8');
+    assert.match(nativeHooks, /omx setup --scope user --disable-hooks/);
+    assert.match(nativeHooks, /omx setup --scope project --disable-hooks/);
+    assert.match(nativeHooks, /preserving project `\.omx` artifacts, foreign hooks/i);
+    assert.doesNotMatch(nativeHooks, /omx hooks disable/);
+  });
+
   it('autopilot stub does not preserve the old broad phase lifecycle', () => {
     assert.doesNotMatch(autopilotSkill, /All 5 phases completed/i);
     assert.doesNotMatch(autopilotSkill, /Phase 0 - Expansion/i);


### PR DESCRIPTION
## Summary
- retire stale canonical claims that missing host consensus receipts block Ralplan/Autopilot progression
- document the merged `omx setup --disable-hooks` user/project recovery commands
- add focused contract coverage preventing runtime/docs drift

## Validation
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hooks/__tests__/autopilot-skill-contract.test.js dist/state/__tests__/authority-decreasing.test.js dist/scripts/__tests__/issue-3486-pretooluse-lock-regression.test.js dist/cli/__tests__/setup-hooks-shared-ownership.test.js` (28/28)
- `npm run check:no-unused`
- `npm run lint`

Closes #3486