### PR TITLE
docs: add gajae-code alternative callout to README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
   <br>
   <em>Start Codex stronger, then let OMX add better prompts, workflows, and runtime help when the work grows.</em>
+  <br><br>
+  <strong>Liked OmX but find it a bit overkill? <a href="https://github.com/Yeachan-Heo/gajae-code">Try gajae-code</a>.</strong><br>
+  <sub>Keep Codex OAuth with a faster, cheaper, simpler, and more powerful SDK-based path for OpenClaw, Hermes, Grokbot, and other integrations.</sub>
 </p>
 
 [![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)


### PR DESCRIPTION
## Summary
- add a compact gajae-code alternative callout to the top README hero
- preserve Codex OAuth positioning and highlight the SDK-based OpenClaw, Hermes, and Grokbot integration path
- link directly to `Yeachan-Heo/gajae-code`

## Validation
- README-only, 3-line hero addition
- inspected Markdown/HTML structure and exact diff
- verified direct HTTPS repository link

## Authority
Owner explicitly authorized this README documentation change for immediate application to both `dev` and `main` in Discord message `1537683117593202688`.

Closes #3522

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*