### PR TITLE
docs: add gajae-code alternative callout to README hero (main application of #3522)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
   <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
   <br>
   <em>Start Codex stronger, then let OMX add better prompts, workflows, and runtime help when the work grows.</em>
+  <br><br>
+  <strong>Liked OmX but find it a bit overkill? <a href="https://github.com/Yeachan-Heo/gajae-code">Try gajae-code</a>.</strong><br>
+  <sub>Keep Codex OAuth with a faster, cheaper, simpler, and more powerful SDK-based path for OpenClaw, Hermes, Grokbot, and other integrations.</sub>
 </p>
 
 [![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)


### PR DESCRIPTION
## Summary

Applies the same README hero callout already merged to `dev` (PR #3523, merged as `dev@ee3065be7deb0cc03af0531fe0c5b70adc30bc59`) directly onto `main`, without merging or rebasing `dev` into `main` and without carrying unrelated dev history. README-only change (3 lines added, 0 deleted).

References #3522 (dev lane: #3523, merged). This PR does not use `Closes` because the issue is already referenced by the merged dev PR; closing authority stays with the owner.

## Diff scope

- `README.md` only: 3 insertions, 0 deletions — byte-identical to the three lines merged in dev PR #3523
- No version, config, generated artifacts, release state, commands, or behavior changes
- Base: `main` @ `b30127a0979c96046c8cd6312a8cd922c3516cad` (exact current main, no dev history carried)

```diff
   <em>Start Codex stronger, then let OMX add better prompts, workflows, and runtime help when the work grows.</em>
+  <br><br>
+  <strong>Liked OmX but find it a bit overkill? <a href="https://github.com/Yeachan-Heo/gajae-code">Try gajae-code</a>.</strong><br>
+  <sub>Keep Codex OAuth with a faster, cheaper, simpler, and more powerful SDK-based path for OpenClaw, Hermes, Grokbot, and other integrations.</sub>
 </p>
```

## Validation

README-only prose/link change; no broad suites apply. Evidence:

- Rendered structure inspected: identical hero block shape as dev (`main` README hero is byte-identical to dev's base hero); callout renders inside the centered `<p align="center">` as `strong` + anchor + `sub`.
- Target URL verified reachable: `https://github.com/Yeachan-Heo/gajae-code` → HTTP 200 (no redirect).
- Narrowest existing docs validation (CI `docs-check`, `git diff --check`) run locally: clean.
- Diff is the same 3 lines reviewed and approved on dev PR #3523 (cleaner PASSED, architect CLEAR/CLEAR/CLEAR + APPROVE, QA/red-team 16/16 contract coverage, 5/5 adversarial cases, terminal critic OKAY).

## Authorization

Owner-directed documentation change (Yeachan-Heo, Discord `1537682320906129469` + `1537683117593202688` + terminal continuation): the owner explicitly requires this README-only docs copy on **both `dev` and `main`**. Dev application is merged (#3523); this is the main application.

## Review note

This lane does not self-merge. Exact-head evidence for the operator's GJC review/merge path will be posted after CI.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
