### PR TITLE
fix(session): recover verified-dead pointers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,14 @@ State writes fail closed with `Cannot resolve writable state scope: session.json
 
 ### Exact-session reconciliation (stale-dead pointer)
 
+To remove a verified-dead selected pointer and preserve its exact forensic bytes, use the official recovery command:
+
+```bash
+omx session pointer recover --cwd /path/to/project
+```
+
+The command serializes with the canonical pointer lock and moves only an authoritative, positively dead `session.json` to an adjacent no-clobber quarantine path. It refuses live or usable owners, uncertain or reused identities, malformed or foreign pointers, root/lineage mismatches, concurrent changes, I/O failures, and existing quarantine destinations. A successful recovery leaves the canonical pointer absent so an ordinary relaunch can publish a fresh pointer.
+
 When the pointer's recorded PID is definitively dead, bind the exact current session explicitly and retry the same command — no manual file surgery:
 
 ```bash

--- a/src/cli/__tests__/doctor-state-root-binding.test.ts
+++ b/src/cli/__tests__/doctor-state-root-binding.test.ts
@@ -144,12 +144,21 @@ describe('doctor state-root/session binding diagnostics', () => {
       assert.match(message, /session\.json/, status);
       assert.match(message, /bad_selectors=OMX_SESSION_ID,CODEX_SESSION_ID,SESSION_ID/, status);
       if (status === 'stale-dead') {
-        assert.match(message, /(?:omx session pointer recover|recover=omx-session-pointer-recover)/, status);
+        assert.match(message, /(?:positively dead, non-reused owner|recover=dead-nonreused-only)/, status);
+        assert.doesNotMatch(message, /recover=omx-session-pointer-recover/, status);
       } else {
         assert.match(message, /(?:terminate only verified owner if necessary|owner=terminate-verified-only-if-needed)/, status);
       }
       assert.doesNotMatch(message, /…$/, status);
     }
+  });
+  it('does not prescribe verified-dead recovery for reused or uncertain owner identity', () => {
+    const message = formatStateRootSessionBindingDiagnostic(
+      syntheticSnapshot('stale-dead', { selectedSessionJson: '/tmp/project/.omx/state/session.json' }),
+      {},
+    );
+    assert.match(message, /(?:only for a positively dead, non-reused owner|recover=dead-nonreused-only)/);
+    assert.match(message, /(?:reused or uncertain identity requires investigation|reused=investigate)/);
   });
   it('keeps all selector recovery fields atomic for owner diagnostics at the final cap fallback', () => {
     const cases = [

--- a/src/cli/__tests__/doctor-state-root-binding.test.ts
+++ b/src/cli/__tests__/doctor-state-root-binding.test.ts
@@ -143,7 +143,11 @@ describe('doctor state-root/session binding diagnostics', () => {
       assert.ok(message.length <= 240, status);
       assert.match(message, /session\.json/, status);
       assert.match(message, /bad_selectors=OMX_SESSION_ID,CODEX_SESSION_ID,SESSION_ID/, status);
-      assert.match(message, /(?:terminate only verified owner if necessary|owner=terminate-verified-only-if-needed)/, status);
+      if (status === 'stale-dead') {
+        assert.match(message, /(?:omx session pointer recover|recover=omx-session-pointer-recover)/, status);
+      } else {
+        assert.match(message, /(?:terminate only verified owner if necessary|owner=terminate-verified-only-if-needed)/, status);
+      }
       assert.doesNotMatch(message, /…$/, status);
     }
   });

--- a/src/cli/__tests__/session-search-help.test.ts
+++ b/src/cli/__tests__/session-search-help.test.ts
@@ -1,19 +1,19 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-function runOmx(cwd: string, argv: string[]) {
+function runOmx(cwd: string, argv: string[], env: NodeJS.ProcessEnv = process.env) {
   const testDir = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(testDir, '..', '..', '..');
   const omxBin = join(repoRoot, 'dist', 'cli', 'omx.js');
   return spawnSync(process.execPath, [omxBin, ...argv], {
     cwd,
     encoding: 'utf-8',
-    env: process.env,
+    env,
   });
 }
 
@@ -48,6 +48,9 @@ describe('omx session help', () => {
       const lockHelp = runOmx(cwd, ['session', 'lock', '--help']);
       assert.equal(lockHelp.status, 0, lockHelp.stderr || lockHelp.stdout);
       assert.match(lockHelp.stdout, /omx session lock <inspect\|recover>/i);
+      const pointerHelp = runOmx(cwd, ['session', 'pointer', '--help']);
+      assert.equal(pointerHelp.status, 0, pointerHelp.stderr || pointerHelp.stdout);
+      assert.match(pointerHelp.stdout, /omx session pointer recover/i);
 
       const inspection = runOmx(cwd, ['session', 'lock', 'inspect', '--cwd', cwd, '--json']);
       assert.equal(inspection.status, 0, inspection.stderr || inspection.stdout);
@@ -63,6 +66,75 @@ describe('omx session help', () => {
       assert.equal(recovery.action, 'none');
       assert.equal(recovery.recovered, false);
       assert.match(recovery.reason, /not safe to recover/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers a verified-dead pointer with deterministic JSON and human output', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-cli-'));
+    try {
+      const stateRoot = join(cwd, '.omx', 'state');
+      const pointerPath = join(stateRoot, 'session.json');
+      const runtime = join(cwd, 'runtime-no-replace.cjs');
+      const pointerBody = JSON.stringify({
+        session_id: 'dead-cli-owner',
+        started_at: '2026-08-14T00:00:00.000Z',
+        cwd,
+        state_root: stateRoot,
+        pid: 8388607,
+      });
+      await mkdir(stateRoot, { recursive: true });
+      await writeFile(pointerPath, pointerBody, 'utf-8');
+      await writeFile(runtime, [
+        '#!/usr/bin/env node',
+        'const fs = require("node:fs");',
+        'const [, , command, from, to] = process.argv;',
+        'if (command !== "fs-rename-no-replace") process.exit(2);',
+        'if (fs.existsSync(to)) console.log(JSON.stringify({ outcome: "not-moved" }));',
+        'else { fs.renameSync(from, to); console.log(JSON.stringify({ outcome: "moved" })); }',
+      ].join('\n'), 'utf-8');
+      await chmod(runtime, 0o755);
+      const env = { ...process.env, OMX_RUNTIME_BINARY: runtime };
+
+      const recovered = runOmx(cwd, ['session', 'pointer', 'recover', '--json'], env);
+      assert.equal(recovered.status, 0, recovered.stderr || recovered.stdout);
+      const result = JSON.parse(recovered.stdout) as {
+        status: string;
+        pointerPath: string;
+        recovered: boolean;
+        action: string;
+        reason: string;
+        sessionId: string;
+        quarantinePath: string;
+      };
+      assert.deepEqual({
+        status: result.status,
+        pointerPath: result.pointerPath,
+        recovered: result.recovered,
+        action: result.action,
+        reason: result.reason,
+        sessionId: result.sessionId,
+      }, {
+        status: 'recovered',
+        pointerPath,
+        recovered: true,
+        action: 'quarantined',
+        reason: 'Verified-dead selected session pointer quarantined with exact forensic bytes preserved.',
+        sessionId: 'dead-cli-owner',
+      });
+      assert.equal(await readFile(result.quarantinePath, 'utf-8'), pointerBody);
+
+      const repeated = runOmx(cwd, ['session', 'pointer', 'recover'], env);
+      assert.equal(repeated.status, 0, repeated.stderr || repeated.stdout);
+      assert.equal(repeated.stdout, [
+        'status: absent',
+        `pointer: ${pointerPath}`,
+        'action: none',
+        'recovered: no',
+        'reason: No selected session pointer exists.',
+        '',
+      ].join('\n'));
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -387,7 +387,7 @@ function bindingRecoveryAction(
     return `${selectorFix}${rootClear}inspect selected session.json path/access; relaunch`;
   }
   if (snapshot.status === "stale-dead") {
-    return `${selectorFix}${rootClear}inspect selected session.json; confirm owner state; terminate only verified owner if necessary (still-live owner only); relaunch`;
+    return `${selectorFix}${rootClear}run omx session pointer recover after confirming the selected root; relaunch`;
   }
   return `${selectorFix}${rootClear}inspect selected session.json; verify owner; terminate only verified owner if necessary; relaunch`;
 }
@@ -405,6 +405,7 @@ function compactCappedBindingRecoveryAction(
     || snapshot.status === "identity-indeterminate"
     ? "terminate only verified owner if necessary;"
     : "";
+  if (snapshot.status === "stale-dead") return `${selectorFix}${rootClear}omx session pointer recover;relaunch`;
   if (ownerTermination) return `${selectorFix}${rootClear}${ownerTermination}relaunch`;
   if (snapshot.status === "read-error") return `${selectorFix}${rootClear}inspect;relaunch`;
   return `${selectorFix}${rootClear}relaunch`;
@@ -476,6 +477,9 @@ export function formatStateRootSessionBindingDiagnostic(
       ...(compactRecovery.includes("terminate only verified owner if necessary")
         ? ["owner=terminate-verified-only-if-needed"]
         : []),
+      ...(compactRecovery.includes("omx session pointer recover")
+        ? ["recover=omx-session-pointer-recover"]
+        : []),
       ...(selectedSessionLabel ? ["selected=session.json"] : []),
       ...(badSelectorsField ? [badSelectorsField] : []),
     ];
@@ -529,6 +533,9 @@ export function formatStateRootSessionBindingDiagnostic(
     "no-mutation",
     ...(compactRecovery.includes("terminate only verified owner if necessary")
       ? ["owner=terminate-verified-only-if-needed"]
+      : []),
+    ...(compactRecovery.includes("omx session pointer recover")
+      ? ["recover=omx-session-pointer-recover"]
       : []),
     ...(selectedSessionLabel ? ["selected=session.json"] : []),
     ...(badSelectorsField ? [badSelectorsField] : []),

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -387,7 +387,7 @@ function bindingRecoveryAction(
     return `${selectorFix}${rootClear}inspect selected session.json path/access; relaunch`;
   }
   if (snapshot.status === "stale-dead") {
-    return `${selectorFix}${rootClear}run omx session pointer recover after confirming the selected root; relaunch`;
+    return `${selectorFix}${rootClear}inspect selected session.json owner identity; run omx session pointer recover only for a positively dead, non-reused owner; reused or uncertain identity requires investigation; relaunch after resolution`;
   }
   return `${selectorFix}${rootClear}inspect selected session.json; verify owner; terminate only verified owner if necessary; relaunch`;
 }
@@ -405,7 +405,7 @@ function compactCappedBindingRecoveryAction(
     || snapshot.status === "identity-indeterminate"
     ? "terminate only verified owner if necessary;"
     : "";
-  if (snapshot.status === "stale-dead") return `${selectorFix}${rootClear}omx session pointer recover;relaunch`;
+  if (snapshot.status === "stale-dead") return `${selectorFix}${rootClear}recover only verified-dead non-reused owner;investigate reused/uncertain identity;relaunch`;
   if (ownerTermination) return `${selectorFix}${rootClear}${ownerTermination}relaunch`;
   if (snapshot.status === "read-error") return `${selectorFix}${rootClear}inspect;relaunch`;
   return `${selectorFix}${rootClear}relaunch`;
@@ -477,8 +477,8 @@ export function formatStateRootSessionBindingDiagnostic(
       ...(compactRecovery.includes("terminate only verified owner if necessary")
         ? ["owner=terminate-verified-only-if-needed"]
         : []),
-      ...(compactRecovery.includes("omx session pointer recover")
-        ? ["recover=omx-session-pointer-recover"]
+      ...(snapshot.status === "stale-dead"
+        ? ["recover=dead-nonreused-only", "reused=investigate"]
         : []),
       ...(selectedSessionLabel ? ["selected=session.json"] : []),
       ...(badSelectorsField ? [badSelectorsField] : []),
@@ -534,8 +534,8 @@ export function formatStateRootSessionBindingDiagnostic(
     ...(compactRecovery.includes("terminate only verified owner if necessary")
       ? ["owner=terminate-verified-only-if-needed"]
       : []),
-    ...(compactRecovery.includes("omx session pointer recover")
-      ? ["recover=omx-session-pointer-recover"]
+    ...(snapshot.status === "stale-dead"
+      ? ["recover=dead-nonreused-only", "reused=investigate"]
       : []),
     ...(selectedSessionLabel ? ["selected=session.json"] : []),
     ...(badSelectorsField ? [badSelectorsField] : []),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -271,7 +271,7 @@ Usage:
   omx explore   DEPRECATED compatibility command; use normal repo inspection or omx sparkshell
   omx api       Run native omx-api localhost gateway commands (serve|status|stop|generate)
   omx session   Search and summarize local session history (--codex-home <path> escape hatch)
-                Includes session lock inspect/recover diagnostics
+                Includes session lock diagnostics and verified-dead pointer recovery
   omx url       Passive URL reader (read <url> --json)
   omx capabilities
                 Lock/check deterministic configured tool, skill, agent, and observation surfaces

--- a/src/cli/session-search.ts
+++ b/src/cli/session-search.ts
@@ -1,4 +1,4 @@
-import { inspectSessionPointerLock, recoverSessionPointerLock } from '../hooks/session.js';
+import { inspectSessionPointerLock, recoverDeadSessionPointer, recoverSessionPointerLock } from '../hooks/session.js';
 import { buildSessionFrictionReport, type SessionFrictionReport, type SessionFrictionOptions } from '../session-history/friction.js';
 import { searchSessionHistory, type SessionSearchReport, type SessionSearchOptions } from '../session-history/search.js';
 
@@ -8,6 +8,7 @@ Usage:
   omx session search <query> [options]
   omx session friction [options]
   omx session lock <inspect|recover> [--cwd <path>] [--json]
+  omx session pointer recover [--cwd <path>] [--json]
 
 Options for search:
   --limit <n>          Maximum results to return (default: 10)
@@ -33,6 +34,11 @@ Options for lock:
   --json               Emit structured JSON
   -h, --help           Show this help
 
+Options for pointer:
+  --cwd <path>         Recover the verified-dead selected pointer for this directory
+  --json               Emit structured JSON
+  -h, --help           Show this help
+
 Examples:
   omx session search "worker inbox path"
   omx session search all_workers_idle --since 7d --limit 5
@@ -40,6 +46,7 @@ Examples:
   omx session friction --session <id> --json
   omx session lock inspect --json
   omx session lock recover --cwd /path/to/project
+  omx session pointer recover --cwd /path/to/project
 `;
 
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
@@ -326,6 +333,32 @@ async function sessionLockCommand(args: string[]): Promise<void> {
   }
 }
 
+async function sessionPointerCommand(args: string[]): Promise<void> {
+  const operation = args[0];
+  if (!operation || HELP_TOKENS.has(operation)) {
+    console.log('Usage: omx session pointer recover [--cwd <path>] [--json]');
+    return;
+  }
+  if (operation !== 'recover') throw new Error(`Unknown session pointer operation: ${operation}`);
+  if (args.slice(1).some((token) => HELP_TOKENS.has(token))) {
+    console.log('Usage: omx session pointer recover [--cwd <path>] [--json]');
+    return;
+  }
+
+  const parsed = parseSessionLockArgs(args.slice(1));
+  const result = await recoverDeadSessionPointer(parsed.cwd);
+  console.log(parsed.json ? JSON.stringify(result, null, 2) : [
+    `status: ${result.status}`,
+    `pointer: ${result.pointerPath}`,
+    `action: ${result.action}`,
+    `recovered: ${result.recovered ? 'yes' : 'no'}`,
+    `reason: ${result.reason}`,
+    ...(result.sessionId ? [`session: ${result.sessionId}`] : []),
+    ...(result.quarantinePath ? [`quarantine: ${result.quarantinePath}`] : []),
+  ].join('\n'));
+  if (result.status !== 'absent' && result.status !== 'recovered') process.exitCode = 1;
+}
+
 export async function sessionCommand(args: string[]): Promise<void> {
   const subcommand = args[0];
   if (!subcommand || HELP_TOKENS.has(subcommand)) {
@@ -335,6 +368,11 @@ export async function sessionCommand(args: string[]): Promise<void> {
 
   if (subcommand === 'lock') {
     await sessionLockCommand(args.slice(1));
+    return;
+  }
+
+  if (subcommand === 'pointer') {
+    await sessionPointerCommand(args.slice(1));
     return;
   }
 

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1057,6 +1057,49 @@ describe('verified-dead selected session pointer recovery', { concurrency: false
     }
   });
 
+  it('preserves a canonical successor when an ambiguous outcome left the captured pointer quarantined', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-ambiguous-successor-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      const quarantinePath = `${context.sessionPath}.quarantine.dead-owner.${SUCCESSOR_TOKEN}`;
+      const successorBytes = JSON.stringify({ session_id: 'successor-owner', cwd, pid: process.pid });
+      let quarantineIdentity: { dev: number; ino: number } | undefined;
+      let successorIdentity: { dev: number; ino: number } | undefined;
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        atomicRenameNoReplace: async (from, to) => {
+          if (from === context.sessionPath) {
+            await rename(from, to);
+            const quarantined = await lstat(to);
+            quarantineIdentity = { dev: quarantined.dev, ino: quarantined.ino };
+            await writeFile(from, successorBytes);
+            const successor = await lstat(from);
+            successorIdentity = { dev: successor.dev, ino: successor.ino };
+            return 'unsupported';
+          }
+          return await defaultTestAtomicRenameNoReplace(from, to);
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'recovery-required');
+        assert.equal(result.action, 'quarantined');
+        assert.equal(result.recovered, false);
+        assert.equal(result.quarantinePath, quarantinePath);
+        assert.match(result.reason, /successor occupies the canonical path/);
+        assert.equal(await readFile(quarantinePath, 'utf-8'), pointer.body);
+        assert.equal(await readFile(context.sessionPath, 'utf-8'), successorBytes);
+        const quarantined = await lstat(quarantinePath);
+        const successor = await lstat(context.sessionPath);
+        assert.deepEqual({ dev: quarantined.dev, ino: quarantined.ino }, quarantineIdentity);
+        assert.deepEqual({ dev: successor.dev, ino: successor.ino }, successorIdentity);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('refuses a dangling pointer symlink as malformed instead of treating it as absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-dangling-'));
     try {

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -5,7 +5,7 @@ import { once } from 'node:events';
 import { existsSync } from 'node:fs';
 import { link, lstat, mkdir, mkdtemp, readFile, readdir, readlink, rename, rm, rmdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   __createDefaultPidProbeForTests,
   __releasePointerLockForTests,
@@ -24,6 +24,7 @@ import {
   readNativeSessionOwner,
   readNativeSessionOwnerEvidence,
   reconcileNativeSessionStart,
+  recoverDeadSessionPointer,
   recoverSessionPointerLock,
   resetSessionMetrics,
   resolveSessionPointerContext,
@@ -842,6 +843,397 @@ describe('isSessionStale', () => {
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('verified-dead selected session pointer recovery', { concurrency: false }, () => {
+  async function writePointer(cwd: string, overrides: Record<string, unknown> = {}): Promise<{ path: string; body: string }> {
+    const context = resolveSessionPointerContext(cwd);
+    await mkdir(context.baseStateDir, { recursive: true });
+    const body = JSON.stringify({
+      session_id: 'dead-owner',
+      started_at: '2026-08-14T00:00:00.000Z',
+      cwd,
+      state_root: context.baseStateDir,
+      pid: 8388607,
+      ...overrides,
+    });
+    await writeFile(context.sessionPath, body, 'utf-8');
+    return { path: context.sessionPath, body };
+  }
+
+  it('quarantines exact dead evidence, is idempotent, and permits relaunch', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-dead-'));
+    try {
+      const pointer = await writePointer(cwd);
+      let quarantinePath = '';
+      await withPointerDependencies({ probePid: () => 'dead', token: () => SUCCESSOR_TOKEN }, async () => {
+        const recovered = await recoverDeadSessionPointer(cwd);
+        assert.equal(recovered.status, 'recovered', recovered.reason);
+        assert.equal(recovered.recovered, true);
+        assert.equal(recovered.action, 'quarantined');
+        assert.ok(recovered.quarantinePath);
+        quarantinePath = recovered.quarantinePath;
+        assert.equal(existsSync(pointer.path), false);
+        assert.equal(await readFile(quarantinePath, 'utf-8'), pointer.body);
+        assert.deepEqual(await recoverDeadSessionPointer(cwd), {
+          status: 'absent',
+          pointerPath: pointer.path,
+          action: 'none',
+          recovered: false,
+          reason: 'No selected session pointer exists.',
+        });
+      });
+      await writeSessionStart(cwd, 'fresh-after-recovery');
+      assert.equal((await readSessionState(cwd))?.session_id, 'fresh-after-recovery');
+      assert.equal(await readFile(quarantinePath, 'utf-8'), pointer.body);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const scenario of [
+    {
+      name: 'usable owner',
+      pointer: { pid: 0 },
+      dependencies: {},
+      status: 'usable',
+    },
+    {
+      name: 'PID reuse birth mismatch',
+      pointer: { identity_schema_version: 2, process_identity: { platform: 'linux', birth: '1' }, platform: 'linux' },
+      dependencies: { runtimePlatform: 'linux' as const, probePid: () => 'alive' as const, observeProcess: () => ({ kind: 'identity' as const, identity: { platform: 'linux' as const, birth: '2' } }) },
+      status: 'reused',
+    },
+    {
+      name: 'identity-indeterminate owner',
+      pointer: {},
+      dependencies: { probePid: () => 'indeterminate' as const },
+      status: 'identity-indeterminate',
+    },
+    {
+      name: 'foreign-platform identity-less owner with locally dead PID',
+      pointer: { platform: 'darwin' },
+      dependencies: { runtimePlatform: 'linux' as const, probePid: () => 'dead' as const },
+      status: 'identity-indeterminate',
+    },
+    {
+      name: 'malformed pointer',
+      raw: '{ malformed',
+      dependencies: {},
+      status: 'malformed',
+    },
+    {
+      name: 'foreign cwd',
+      pointer: { cwd: '/tmp/foreign-project' },
+      dependencies: { probePid: () => 'dead' as const },
+      status: 'foreign-cwd',
+    },
+    {
+      name: 'foreign selected root',
+      pointer: { state_root: '/tmp/foreign-state-root' },
+      dependencies: { probePid: () => 'dead' as const },
+      status: 'foreign-root',
+    },
+    {
+      name: 'blank selected root metadata',
+      pointer: { state_root: '' },
+      dependencies: { probePid: () => 'dead' as const },
+      status: 'malformed',
+    },
+    {
+      name: 'invalid optional metadata',
+      pointer: { tmux_pane_id: 42 },
+      dependencies: { probePid: () => 'dead' as const },
+      status: 'malformed',
+    },
+    {
+      name: 'invalid launch lineage token',
+      pointer: { launch_lineage_token: 'bad' },
+      dependencies: { probePid: () => 'dead' as const },
+      status: 'malformed',
+    },
+  ] as const) it(`refuses ${scenario.name} without mutation`, async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-refuse-'));
+    try {
+      const pointer = await writePointer(cwd, 'pointer' in scenario ? scenario.pointer : {});
+      if ('raw' in scenario) await writeFile(pointer.path, scenario.raw!, 'utf-8');
+      const before = await readFile(pointer.path, 'utf-8');
+      await withPointerDependencies(scenario.dependencies, async () => {
+        const refused = await recoverDeadSessionPointer(cwd);
+        assert.equal(refused.status, scenario.status, refused.reason);
+        assert.equal(refused.recovered, false);
+        assert.equal(refused.action, 'none');
+      });
+      assert.equal(await readFile(pointer.path, 'utf-8'), before);
+      assert.equal((await readdir(dirname(pointer.path))).some((entry) => entry.includes('.quarantine.')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a fresh state root as absent without creating it', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-fresh-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      const result = await recoverDeadSessionPointer(cwd);
+      assert.equal(result.status, 'absent');
+      assert.equal(result.recovered, false);
+      assert.equal(existsSync(context.baseStateDir), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts canonical descendant cwd authority when the selected root matches the recorded owner root', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-descendant-'));
+    const nested = join(cwd, 'nested', 'project');
+    const previousRoot = process.env.OMX_ROOT;
+    try {
+      await mkdir(nested, { recursive: true });
+      process.env.OMX_ROOT = cwd;
+      const pointer = await writePointer(nested, { cwd });
+      await withPointerDependencies({ probePid: () => 'dead', token: () => SUCCESSOR_TOKEN }, async () => {
+        const result = await recoverDeadSessionPointer(nested);
+        assert.equal(result.status, 'recovered', result.reason);
+        assert.ok(result.quarantinePath);
+        assert.equal(await readFile(result.quarantinePath, 'utf-8'), pointer.body);
+      });
+    } finally {
+      if (previousRoot === undefined) delete process.env.OMX_ROOT;
+      else process.env.OMX_ROOT = previousRoot;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports unavailable atomic no-replace support without moving the pointer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-unsupported-'));
+    try {
+      const pointer = await writePointer(cwd);
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        atomicRenameNoReplace: async () => 'unsupported',
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'unsupported');
+        assert.equal(result.recovered, false);
+      });
+      assert.equal(await readFile(pointer.path, 'utf-8'), pointer.body);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses a dangling pointer symlink as malformed instead of treating it as absent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-dangling-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.baseStateDir, { recursive: true });
+      await symlink(join(cwd, 'missing-session.json'), context.sessionPath);
+      const result = await recoverDeadSessionPointer(cwd);
+      assert.equal(result.status, 'malformed');
+      assert.equal(result.recovered, false);
+      assert.equal((await lstat(context.sessionPath)).isSymbolicLink(), true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls an exact archive back when post-move liveness becomes uncertain', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-postmove-race-'));
+    try {
+      const pointer = await writePointer(cwd);
+      let probes = 0;
+      await withPointerDependencies({
+        probePid: () => ++probes > 5 ? 'indeterminate' : 'dead',
+        token: () => SUCCESSOR_TOKEN,
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'race', result.reason);
+        assert.equal(result.recovered, false);
+        assert.equal(await readFile(pointer.path, 'utf-8'), pointer.body);
+        assert.equal((await readdir(dirname(pointer.path))).some((entry) => entry.includes('.quarantine.')), false);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports pointer-lock release residue as recovery-required after preserving the archive', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-release-fail-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        fs: {
+          rename: async (from, to) => {
+            if (from === context.lockPath) throw codedError('EBUSY');
+            await rename(from, to);
+          },
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'recovery-required');
+        assert.equal(result.recovered, false);
+        assert.equal(result.action, 'quarantined');
+        assert.ok(result.quarantinePath);
+        assert.equal(await readFile(result.quarantinePath, 'utf-8'), pointer.body);
+        assert.equal(existsSync(pointer.path), false);
+        assert.equal(existsSync(context.lockPath), true);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses read I/O, concurrent changes, quarantine collisions, and held locks without moving the pointer', async () => {
+    for (const failure of ['io', 'race', 'collision', 'lock'] as const) {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-pointer-recover-${failure}-`));
+      try {
+        const pointer = await writePointer(cwd);
+        const context = resolveSessionPointerContext(cwd);
+        const before = await readFile(pointer.path, 'utf-8');
+        if (failure === 'collision') {
+          await writeFile(`${pointer.path}.quarantine.dead-owner.${SUCCESSOR_TOKEN}`, 'existing quarantine', 'utf-8');
+        }
+        if (failure === 'lock') {
+          await writeLockOwner(cwd, validLockOwner({ pid: process.pid, identity_schema_version: 2, process_identity: { platform: process.platform, birth: '1' } }));
+        }
+        let pointerReads = 0;
+        await withPointerDependencies({
+          probePid: () => 'dead',
+          token: () => SUCCESSOR_TOKEN,
+          ...(failure === 'lock' ? { nowMs: () => 10_000, sleep: async () => {} } : {}),
+          fs: failure === 'io' || failure === 'race' ? {
+            readBytes: async (path) => {
+              if (path === context.sessionPath) {
+                pointerReads += 1;
+                if (failure === 'io') throw codedError('EACCES');
+                if (pointerReads > 2) return Buffer.from(JSON.stringify({ ...JSON.parse(before), session_id: 'changed-owner' }));
+              }
+              return await readFile(path);
+            },
+          } : undefined,
+        }, async () => {
+          const refused = await recoverDeadSessionPointer(cwd);
+          assert.equal(refused.recovered, false);
+          assert.equal(refused.status, failure === 'lock' ? 'lock-unavailable' : failure === 'io' ? 'io-error' : failure);
+        });
+        assert.equal(await readFile(pointer.path, 'utf-8'), before);
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('fails closed when a regular pointer is swapped to a dangling symlink during snapshot read', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-swap-symlink-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      let reads = 0;
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        fs: {
+          readBytes: async (path) => {
+            reads += path === context.sessionPath ? 1 : 0;
+            if (path === context.sessionPath && reads === 2) {
+              await rm(path);
+              await symlink(join(cwd, 'missing-swapped-pointer.json'), path);
+            }
+            return await readFile(path);
+          },
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'io-error');
+        assert.equal(result.recovered, false);
+      });
+      assert.equal((await lstat(pointer.path)).isSymbolicLink(), true);
+      assert.equal((await readdir(dirname(pointer.path))).some((entry) => entry.includes('.quarantine.')), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('detects post-move byte mutation even when UTF-8 decoding would normalize both snapshots', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-byte-race-'));
+    try {
+      const context = resolveSessionPointerContext(cwd);
+      await mkdir(context.baseStateDir, { recursive: true });
+      const base = JSON.stringify({
+        session_id: 'dead-byte-owner',
+        started_at: '2026-08-14T00:00:00.000Z',
+        cwd,
+        state_root: context.baseStateDir,
+        pid: 8388607,
+        platform: 'linux',
+        pid_start_ticks: 1,
+      });
+      const prefix = Buffer.from(`${base.slice(0, -1)},"pid_cmdline":"`);
+      const original = Buffer.concat([prefix, Buffer.from([0x80]), Buffer.from('"}')]);
+      await writeFile(context.sessionPath, original);
+      await withPointerDependencies({
+        runtimePlatform: 'linux',
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        atomicRenameNoReplace: async (from, to) => {
+          const outcome = await defaultTestAtomicRenameNoReplace(from, to);
+          if (outcome === 'moved' && from === context.sessionPath) {
+            const changed = Buffer.from(await readFile(to));
+            changed[changed.indexOf(0x80)] = 0x81;
+            await writeFile(to, changed);
+          }
+          return outcome;
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'recovery-required');
+        assert.equal(result.recovered, false);
+        assert.equal(result.action, 'quarantined');
+        assert.ok(result.quarantinePath);
+        assert.equal(existsSync(context.sessionPath), false);
+        assert.notDeepEqual(await readFile(result.quarantinePath), original);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('restores an equal-bytes foreign symlink swapped in at the final rename seam', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-final-swap-'));
+    const foreign = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-final-foreign-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      const foreignPointer = join(foreign, 'foreign-session.json');
+      await writeFile(foreignPointer, pointer.body);
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        atomicRenameNoReplace: async (from, to) => {
+          if (from === context.sessionPath) {
+            await rm(from);
+            await symlink(foreignPointer, from);
+          }
+          return await defaultTestAtomicRenameNoReplace(from, to);
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'race');
+        assert.equal(result.recovered, false);
+        assert.equal((await lstat(context.sessionPath)).isSymbolicLink(), true);
+        assert.equal(await readlink(context.sessionPath), foreignPointer);
+        assert.equal((await readdir(dirname(context.sessionPath))).some((entry) => entry.includes('.quarantine.')), false);
+        assert.equal(await readFile(foreignPointer, 'utf-8'), pointer.body);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+      await rm(foreign, { recursive: true, force: true });
     }
   });
 });

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -986,9 +986,9 @@ describe('verified-dead selected session pointer recovery', { concurrency: false
     }
   });
 
-  it('accepts canonical descendant cwd authority when the selected root matches the recorded owner root', async () => {
+  it('accepts a ..cache-prefixed descendant when the selected root matches the recorded owner root', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-descendant-'));
-    const nested = join(cwd, 'nested', 'project');
+    const nested = join(cwd, '..cache', 'project');
     const previousRoot = process.env.OMX_ROOT;
     try {
       await mkdir(nested, { recursive: true });
@@ -1084,6 +1084,36 @@ describe('verified-dead selected session pointer recovery', { concurrency: false
         assert.equal(await readFile(result.quarantinePath, 'utf-8'), pointer.body);
         assert.equal(existsSync(pointer.path), false);
         assert.equal(existsSync(context.lockPath), true);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a committed quarantine when its first post-move lstat fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-postmove-lstat-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      const quarantinePath = `${context.sessionPath}.quarantine.dead-owner.${SUCCESSOR_TOKEN}`;
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        fs: {
+          lstat: async (path) => {
+            if (path === quarantinePath && existsSync(path)) throw codedError('EACCES');
+            return await lstat(path);
+          },
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'recovery-required');
+        assert.equal(result.action, 'quarantined');
+        assert.equal(result.recovered, false);
+        assert.equal(result.quarantinePath, quarantinePath);
+        assert.match(result.reason, /post-move verification failed \(EACCES\)/);
+        assert.equal(existsSync(pointer.path), false);
+        assert.equal(await readFile(quarantinePath, 'utf-8'), pointer.body);
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1026,6 +1026,37 @@ describe('verified-dead selected session pointer recovery', { concurrency: false
     }
   });
 
+  it('reports quarantined recovery-required when an unsupported outcome actually moved the pointer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-ambiguous-unsupported-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      const quarantinePath = `${context.sessionPath}.quarantine.dead-owner.${SUCCESSOR_TOKEN}`;
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        atomicRenameNoReplace: async (from, to) => {
+          if (from === context.sessionPath) {
+            await rename(from, to);
+            return 'unsupported';
+          }
+          return await defaultTestAtomicRenameNoReplace(from, to);
+        },
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'recovery-required');
+        assert.equal(result.action, 'quarantined');
+        assert.equal(result.recovered, false);
+        assert.equal(result.quarantinePath, quarantinePath);
+        assert.match(result.reason, /atomic move outcome was ambiguous/);
+        assert.equal(existsSync(pointer.path), false);
+        assert.equal(await readFile(quarantinePath, 'utf-8'), pointer.body);
+      });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('refuses a dangling pointer symlink as malformed instead of treating it as absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-dangling-'));
     try {

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1204,38 +1204,65 @@ describe('verified-dead selected session pointer recovery', { concurrency: false
     }
   });
 
-  it('restores an equal-bytes foreign symlink swapped in at the final rename seam', async () => {
-    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-final-swap-'));
-    const foreign = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-final-foreign-'));
-    try {
-      const pointer = await writePointer(cwd);
-      const context = resolveSessionPointerContext(cwd);
-      const foreignPointer = join(foreign, 'foreign-session.json');
-      await writeFile(foreignPointer, pointer.body);
-      await withPointerDependencies({
-        probePid: () => 'dead',
-        token: () => SUCCESSOR_TOKEN,
-        atomicRenameNoReplace: async (from, to) => {
-          if (from === context.sessionPath) {
+  for (const kind of ['file', 'symlink', 'directory'] as const) {
+    it(`preserves a foreign ${kind} inserted at quarantine after the pointer source disappears`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-session-pointer-recover-foreign-${kind}-`));
+      const foreign = await mkdtemp(join(tmpdir(), `omx-session-pointer-recover-foreign-target-${kind}-`));
+      try {
+        const pointer = await writePointer(cwd);
+        const context = resolveSessionPointerContext(cwd);
+        const quarantinePath = `${context.sessionPath}.quarantine.dead-owner.${SUCCESSOR_TOKEN}`;
+        const foreignTarget = join(foreign, 'foreign-target');
+        const foreignObject = join(foreign, 'foreign-object');
+        let insertedIdentity: { dev: number; ino: number } | undefined;
+        if (kind === 'file') await writeFile(foreignObject, 'foreign regular file');
+        else if (kind === 'symlink') {
+          await writeFile(foreignTarget, 'foreign symlink target');
+          await symlink(foreignTarget, foreignObject);
+        } else {
+          await mkdir(foreignObject);
+          await writeFile(join(foreignObject, 'marker'), 'foreign directory marker');
+        }
+        const allocated = await lstat(foreignObject);
+        insertedIdentity = { dev: allocated.dev, ino: allocated.ino };
+        await withPointerDependencies({
+          probePid: () => 'dead',
+          token: () => SUCCESSOR_TOKEN,
+          atomicRenameNoReplace: async (from, to) => {
+            if (from !== context.sessionPath) return await defaultTestAtomicRenameNoReplace(from, to);
             await rm(from);
-            await symlink(foreignPointer, from);
+            await rename(foreignObject, to);
+            return 'not-moved';
+          },
+        }, async () => {
+          const result = await recoverDeadSessionPointer(cwd);
+          assert.equal(result.status, 'race', result.reason);
+          assert.equal(result.recovered, false);
+          assert.equal(result.action, 'none');
+          assert.equal(existsSync(context.sessionPath), false);
+          const preserved = await lstat(quarantinePath);
+          if (kind === 'file') {
+            assert.equal(preserved.isFile(), true);
+            assert.equal(await readFile(quarantinePath, 'utf-8'), 'foreign regular file');
+          } else if (kind === 'symlink') {
+            assert.equal(preserved.isSymbolicLink(), true);
+            assert.equal(await readlink(quarantinePath), foreignTarget);
+            assert.equal(await readFile(foreignTarget, 'utf-8'), 'foreign symlink target');
+          } else {
+            assert.equal(preserved.isDirectory(), true);
+            assert.equal(await readFile(join(quarantinePath, 'marker'), 'utf-8'), 'foreign directory marker');
           }
-          return await defaultTestAtomicRenameNoReplace(from, to);
-        },
-      }, async () => {
-        const result = await recoverDeadSessionPointer(cwd);
-        assert.equal(result.status, 'race');
-        assert.equal(result.recovered, false);
-        assert.equal((await lstat(context.sessionPath)).isSymbolicLink(), true);
-        assert.equal(await readlink(context.sessionPath), foreignPointer);
-        assert.equal((await readdir(dirname(context.sessionPath))).some((entry) => entry.includes('.quarantine.')), false);
-        assert.equal(await readFile(foreignPointer, 'utf-8'), pointer.body);
-      });
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-      await rm(foreign, { recursive: true, force: true });
-    }
-  });
+          assert.ok(insertedIdentity);
+          assert.deepEqual({ dev: preserved.dev, ino: preserved.ino }, insertedIdentity);
+          assert.equal(existsSync(context.sessionPath), false);
+          assert.equal(await readFile(pointer.path, 'utf-8').then(() => true, () => false), false);
+        });
+      } finally {
+        await rm(cwd, { recursive: true, force: true });
+        await rm(foreign, { recursive: true, force: true });
+      }
+    });
+  }
 });
 
 describe('session pointer transaction', () => {

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -26,7 +26,7 @@ import { appendFileSync, closeSync, constants as fsConstants, fstatSync, openSyn
 import type { FileHandle } from 'fs/promises';
 import { tmpdir } from 'node:os';
 import { createHash, randomUUID } from 'crypto';
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { omxRoot, omxLogsDir, sameFilePath } from '../utils/paths.js';
 import { resolveRuntimeBinaryPath } from '../runtime/bridge.js';
 import {
@@ -1442,11 +1442,13 @@ async function moveRecoveryPathNoReplace(
   to: string,
   identity: RecoveryIdentity,
   kind: 'file' | 'directory',
+  onAtomicMove?: () => void,
 ): Promise<{ moved: boolean; unsupported?: boolean; reason?: string }> {
   try {
     const outcome = await transactionDependencies.atomicRenameNoReplace(from, to);
     if (outcome === 'unsupported') return { moved: false, unsupported: true, reason: 'Atomic no-replace recovery rename is unsupported on this platform.' };
     if (outcome === 'not-moved') return { moved: false, reason: 'Atomic recovery move left its source pathname in place.' };
+    onAtomicMove?.();
   } catch (error) {
     return { moved: false, reason: `Atomic no-replace recovery rename failed (${errorCode(error) ?? 'unknown'}).` };
   }
@@ -1641,7 +1643,7 @@ function selectedRootAuthorityFailure(
     recordedCwd = realpathSync(resolve(state.cwd));
     observedCwd = realpathSync(resolve(context.cwd));
     const cwdRelative = relative(recordedCwd, observedCwd);
-    if (cwdRelative.startsWith('..') || isAbsolute(cwdRelative)) return 'foreign-cwd';
+    if (cwdRelative === '..' || cwdRelative.startsWith(`..${sep}`) || isAbsolute(cwdRelative)) return 'foreign-cwd';
   } catch {
     return 'foreign-cwd';
   }
@@ -1865,6 +1867,7 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
       return result;
     }
     const quarantinePath = `${context.sessionPath}.quarantine.${sessionId}.${recoveryToken}`;
+    let quarantineMoveCommitted = false;
     try {
       const collision = await lstatRecoveryPath(quarantinePath);
       if (collision) {
@@ -1897,6 +1900,7 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
         quarantinePath,
         { dev: sourceStat.dev, ino: sourceStat.ino },
         'file',
+        () => { quarantineMoveCommitted = true; },
       );
       if (!moved.moved) {
         const destinationExists = await lstatRecoveryPath(quarantinePath);
@@ -1936,6 +1940,7 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
             'file',
           );
           if (rollback.moved) {
+            quarantineMoveCommitted = false;
             result = pointerRecoveryRefusal(
               context,
               'race',
@@ -1967,6 +1972,18 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
       };
       return result;
     } catch (error) {
+      if (quarantineMoveCommitted) {
+        result = {
+          status: 'recovery-required',
+          pointerPath: context.sessionPath,
+          action: 'quarantined',
+          recovered: false,
+          reason: `The selected pointer was quarantined, but post-move verification failed (${errorCode(error) ?? errorMessage(error)}); forensic residue was preserved for explicit recovery.`,
+          sessionId,
+          quarantinePath,
+        };
+        return result;
+      }
       result = pointerRecoveryRefusal(context, 'io-error', `Unable to quarantine the selected session pointer (${errorCode(error) ?? errorMessage(error)}).`, sessionId);
       return result;
     }

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1905,8 +1905,22 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
       if (!moved.moved) {
         const destinationExists = await lstatRecoveryPath(quarantinePath);
         const sourceExists = await lstatRecoveryPath(context.sessionPath);
+        const capturedDestination = destinationExists
+          && sameRecoveryIdentity(destinationExists, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file');
+        if (capturedDestination && !sourceExists) {
+          result = {
+            status: 'recovery-required',
+            pointerPath: context.sessionPath,
+            action: 'quarantined',
+            recovered: false,
+            reason: 'The atomic move outcome was ambiguous, but the captured selected pointer is present at quarantine; forensic residue was preserved for explicit recovery.',
+            sessionId,
+            quarantinePath,
+          };
+          return result;
+        }
         const foreignDestination = destinationExists
-          && !sameRecoveryIdentity(destinationExists, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file');
+          && !capturedDestination;
         result = pointerRecoveryRefusal(
           context,
           moved.unsupported ? 'unsupported' : foreignDestination && !sourceExists ? 'race' : destinationExists ? 'collision' : 'race',

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -22,11 +22,11 @@ import {
   unlink as nodeUnlink,
   writeFile as nodeWriteFile,
 } from 'fs/promises';
-import { appendFileSync, closeSync, constants as fsConstants, fstatSync, openSync, readFileSync } from 'fs';
+import { appendFileSync, closeSync, constants as fsConstants, fstatSync, openSync, readFileSync, realpathSync } from 'fs';
 import type { FileHandle } from 'fs/promises';
 import { tmpdir } from 'node:os';
 import { createHash, randomUUID } from 'crypto';
-import { basename, dirname, isAbsolute, join } from 'path';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'path';
 import { omxRoot, omxLogsDir, sameFilePath } from '../utils/paths.js';
 import { resolveRuntimeBinaryPath } from '../runtime/bridge.js';
 import {
@@ -454,6 +454,7 @@ export interface SessionPointerFsDependencies {
     isSymbolicLink(): boolean;
   }>;
   readFile(path: string, encoding: 'utf8'): Promise<string>;
+  readBytes(path: string): Promise<Buffer>;
   writeFile(path: string, data: string, options?: { mode?: number; flag?: string }): Promise<void>;
   openAndSync(
     path: string,
@@ -481,6 +482,32 @@ export interface SessionPointerLockRecovery extends SessionPointerLockInspection
   quarantinePath?: string;
 }
 
+export type SessionPointerRecoveryStatus =
+  | 'absent'
+  | 'recovered'
+  | 'usable'
+  | 'reused'
+  | 'identity-indeterminate'
+  | 'malformed'
+  | 'foreign-cwd'
+  | 'foreign-root'
+  | 'lock-unavailable'
+  | 'race'
+  | 'collision'
+  | 'unsupported'
+  | 'recovery-required'
+  | 'io-error';
+
+export interface SessionPointerRecovery {
+  status: SessionPointerRecoveryStatus;
+  pointerPath: string;
+  action: 'none' | 'quarantined';
+  recovered: boolean;
+  reason: string;
+  sessionId?: string;
+  quarantinePath?: string;
+}
+
 /** @internal Test-only deterministic transaction seam; do not use outside session tests. */
 export interface SessionPointerTransactionDependencies {
   fs: SessionPointerFsDependencies;
@@ -502,6 +529,7 @@ const defaultFsDependencies: SessionPointerFsDependencies = {
   },
   readdir: async (path) => await nodeReaddir(path),
   readFile: async (path, encoding) => await nodeReadFile(path, encoding),
+  readBytes: async (path) => await nodeReadFile(path),
   lstat: async (path) => await nodeLstat(path),
   writeFile: async (path, data, options) => {
     await nodeWriteFile(path, data, options);
@@ -1599,6 +1627,361 @@ export async function recoverSessionPointerLock(cwd: string): Promise<SessionPoi
       recovered: false,
       reason: `Unable to inspect session pointer lock recovery state (${errorCode(error) ?? errorMessage(error)}).`,
     };
+  }
+}
+
+function selectedRootAuthorityFailure(
+  context: SessionPointerContext,
+  state: SessionState,
+): 'foreign-cwd' | 'foreign-root' | undefined {
+  let recordedCwd: string;
+  let observedCwd: string;
+  try {
+    if (typeof state.cwd !== 'string' || !state.cwd.trim()) return 'foreign-cwd';
+    recordedCwd = realpathSync(resolve(state.cwd));
+    observedCwd = realpathSync(resolve(context.cwd));
+    const cwdRelative = relative(recordedCwd, observedCwd);
+    if (cwdRelative.startsWith('..') || isAbsolute(cwdRelative)) return 'foreign-cwd';
+  } catch {
+    return 'foreign-cwd';
+  }
+  try {
+    const recordedRoot = typeof state.state_root === 'string' && state.state_root.trim()
+      ? state.state_root
+      : join(recordedCwd, '.omx', 'state');
+    return sameFilePath(recordedRoot, context.baseStateDir) ? undefined : 'foreign-root';
+  } catch {
+    return 'foreign-root';
+  }
+}
+
+function classifyParsedSessionPointerForRecovery(value: unknown, raw: string): SessionPointerReadResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { status: 'malformed', raw };
+  const state = value as SessionState;
+  if (!normalizeSessionId(state.session_id)) return { status: 'malformed', raw };
+  if (state.identity_schema_version !== undefined && state.identity_schema_version !== 2) {
+    return { status: 'identity-indeterminate', raw, state };
+  }
+  if (state.process_identity !== undefined
+    && (state.identity_schema_version !== 2
+      || !isValidProcessIdentity(state.process_identity)
+      || state.platform !== undefined && state.platform !== state.process_identity.platform)) {
+    return { status: 'malformed', raw, state };
+  }
+  if (state.identity_schema_version === 2 && state.process_identity === undefined) return { status: 'malformed', raw, state };
+  return { status: classifySessionProcess(state, transactionDependencies), raw, state };
+}
+
+type SessionPointerRecoveryReadResult = SessionPointerReadResult & { bytes?: Buffer };
+
+async function readSessionPointerForRecovery(context: SessionPointerContext): Promise<SessionPointerRecoveryReadResult> {
+  let sourceStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+  try {
+    sourceStat = await transactionDependencies.fs.lstat(context.sessionPath);
+  } catch (error) {
+    if (isNotFound(error)) return { status: 'absent' };
+    throw error;
+  }
+  if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) return { status: 'malformed' };
+  const bytes = await transactionDependencies.fs.readBytes(context.sessionPath);
+  const sourceAfterRead = await transactionDependencies.fs.lstat(context.sessionPath);
+  if (!sameRecoveryIdentity(sourceAfterRead, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')) {
+    throw new Error('Selected session pointer changed while its recovery snapshot was read.');
+  }
+  const raw = bytes.toString('utf8');
+  try {
+    return { ...classifyParsedSessionPointerForRecovery(JSON.parse(raw), raw), bytes };
+  } catch (error) {
+    if (error instanceof SyntaxError) return { status: 'malformed', raw, bytes };
+    throw error;
+  }
+}
+
+function malformedRecoveryPointerReason(state: SessionState): string | undefined {
+  if (!normalizeSessionId(state.session_id)) return 'session_id is missing or invalid';
+  if (typeof state.started_at !== 'string' || !state.started_at.trim() || !Number.isFinite(Date.parse(state.started_at))) {
+    return 'started_at is missing or invalid';
+  }
+  if (typeof state.cwd !== 'string' || !state.cwd.trim()) return 'cwd is missing or invalid';
+  if (!Number.isInteger(state.pid) || state.pid <= 0) return 'pid is missing or invalid';
+  if (Object.prototype.hasOwnProperty.call(state, 'state_root')
+    && (typeof state.state_root !== 'string' || !state.state_root.trim())) return 'state_root is invalid';
+  if (state.platform !== undefined && !['linux', 'darwin', 'win32'].includes(state.platform)) return 'platform is invalid';
+  if (state.pid_start_ticks !== undefined && !isValidStartTicks(state.pid_start_ticks)) return 'pid_start_ticks is invalid';
+  if (state.pid_cmdline !== undefined && typeof state.pid_cmdline !== 'string') return 'pid_cmdline is invalid';
+  const optionalStrings: Array<keyof SessionState> = [
+    'native_session_id',
+    'previous_native_session_id',
+    'native_session_switched_at',
+    'owner_omx_session_id',
+    'owner_codex_session_id',
+    'codex_session_id',
+    'tmux_session_name',
+    'tmux_pane_id',
+  ];
+  for (const field of optionalStrings) {
+    const value = state[field];
+    if (value !== undefined && (typeof value !== 'string' || !value.trim())) return `${field} is invalid`;
+  }
+  if (state.launch_lineage_token !== undefined && !isValidToken(state.launch_lineage_token)) {
+    return 'launch_lineage_token is invalid';
+  }
+  if (recordedIdentityForState(state, transactionDependencies.runtimePlatform) === 'invalid') return 'process identity metadata is invalid';
+  return undefined;
+}
+
+function classifySessionProcessForRecovery(state: SessionState): 'usable' | 'dead' | 'reused' | 'identity-indeterminate' {
+  const hasPidMetadata = Number.isInteger(state.pid) && state.pid > 0;
+  const hasIdentityMetadata = typeof state.pid_start_ticks === 'number'
+    || typeof state.pid_cmdline === 'string'
+    || state.identity_schema_version !== undefined
+    || state.process_identity !== undefined;
+  if (!hasPidMetadata && !hasIdentityMetadata) return 'usable';
+  if (!hasPidMetadata) return 'identity-indeterminate';
+  const recordedPlatform = state.process_identity?.platform ?? state.platform;
+  if (recordedPlatform !== undefined && recordedPlatform !== transactionDependencies.runtimePlatform) {
+    return 'identity-indeterminate';
+  }
+  const recorded = recordedIdentityForState(state, transactionDependencies.runtimePlatform);
+  if (recorded === 'invalid') return 'identity-indeterminate';
+  if (!recorded) {
+    let probe: PidProbeResult;
+    try { probe = transactionDependencies.probePid(state.pid); } catch { return 'identity-indeterminate'; }
+    return probe === 'dead' ? 'dead' : 'identity-indeterminate';
+  }
+  const classification = classifyRecordedIdentity(recorded, transactionDependencies.runtimePlatform, transactionDependencies, state.pid);
+  if (classification.status === 'gone') return 'dead';
+  if (classification.status === 'birth-mismatch') return 'reused';
+  if (classification.status === 'match') return 'usable';
+  return 'identity-indeterminate';
+}
+
+function pointerRecoveryRefusal(
+  context: SessionPointerContext,
+  status: SessionPointerRecoveryStatus,
+  reason: string,
+  sessionId?: string,
+): SessionPointerRecovery {
+  return {
+    status,
+    pointerPath: context.sessionPath,
+    action: 'none',
+    recovered: false,
+    reason,
+    ...(sessionId ? { sessionId } : {}),
+  };
+}
+
+/**
+ * Explicitly quarantine one authoritative, positively dead selected pointer.
+ * The canonical pointer lock serializes the final classification and move with
+ * SessionStart/SessionEnd, while the no-replace archive preserves exact bytes.
+ */
+export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPointerRecovery> {
+  const context = resolveSessionPointerContext(cwd);
+  try {
+    if ((await readSessionPointerForRecovery(context)).status === 'absent') {
+      return pointerRecoveryRefusal(context, 'absent', 'No selected session pointer exists.');
+    }
+  } catch (error) {
+    return pointerRecoveryRefusal(context, 'io-error', `Unable to read the selected session pointer (${errorCode(error) ?? errorMessage(error)}).`);
+  }
+  const tracker: RegularFileDurabilityTracker = { degraded: false };
+  let lock: HeldPointerLock;
+  try {
+    lock = await acquirePointerLock(context, undefined, DEFAULT_POINTER_TIMEOUT_MS, process.platform, tracker);
+  } catch (error) {
+    const reason = isSessionPointerLaunchAbort(error) ? error.reason : errorMessage(error);
+    return pointerRecoveryRefusal(context, 'lock-unavailable', `Unable to acquire the selected pointer transaction lock (${reason}).`);
+  }
+
+  let result: SessionPointerRecovery | undefined;
+  try {
+    let pointer: SessionPointerRecoveryReadResult;
+    try {
+      pointer = await readSessionPointerForRecovery(context);
+    } catch (error) {
+      result = pointerRecoveryRefusal(context, 'io-error', `Unable to read the selected session pointer (${errorCode(error) ?? errorMessage(error)}).`);
+      return result;
+    }
+
+    if (pointer.status === 'absent') {
+      result = pointerRecoveryRefusal(context, 'absent', 'No selected session pointer exists.');
+      return result;
+    }
+    const sessionId = normalizeSessionId(pointer.state?.session_id);
+    if (pointer.status !== 'stale-dead' || !pointer.state || !pointer.raw || !pointer.bytes || !sessionId) {
+      const reason = pointer.status === 'usable'
+        ? 'The selected session pointer owner is usable or live.'
+        : pointer.status === 'identity-indeterminate'
+          ? 'The selected session pointer owner identity is indeterminate.'
+          : pointer.status === 'foreign-cwd'
+            ? 'The selected session pointer belongs to a different working directory.'
+            : 'The selected session pointer is malformed.';
+      const status: SessionPointerRecoveryStatus = pointer.status === 'stale-dead' ? 'malformed' : pointer.status;
+      result = pointerRecoveryRefusal(context, status, reason, sessionId);
+      return result;
+    }
+    const malformedReason = malformedRecoveryPointerReason(pointer.state);
+    if (malformedReason) {
+      result = pointerRecoveryRefusal(context, 'malformed', `The selected session pointer is malformed (${malformedReason}).`, sessionId);
+      return result;
+    }
+    const authorityFailure = selectedRootAuthorityFailure(context, pointer.state);
+    if (authorityFailure) {
+      const reason = authorityFailure === 'foreign-cwd'
+        ? 'The selected session pointer belongs to a different working-directory lineage.'
+        : 'The selected session pointer does not have exact state_root authority for the selected root.';
+      result = pointerRecoveryRefusal(context, authorityFailure, reason, sessionId);
+      return result;
+    }
+    const recoveryLiveness = classifySessionProcessForRecovery(pointer.state);
+    if (recoveryLiveness !== 'dead') {
+      const status: SessionPointerRecoveryStatus = recoveryLiveness === 'reused' ? 'reused' : recoveryLiveness;
+      const reason = recoveryLiveness === 'reused'
+        ? 'The selected session pointer PID was reused or its recorded birth identity mismatched.'
+        : recoveryLiveness === 'usable'
+          ? 'The selected session pointer owner is usable or live.'
+          : 'The selected session pointer owner identity is indeterminate.';
+      result = pointerRecoveryRefusal(context, status, reason, sessionId);
+      return result;
+    }
+
+    let sourceStat: Awaited<ReturnType<SessionPointerFsDependencies['lstat']>>;
+    try {
+      sourceStat = await transactionDependencies.fs.lstat(context.sessionPath);
+    } catch (error) {
+      result = pointerRecoveryRefusal(context, 'io-error', `Unable to inspect the selected session pointer (${errorCode(error) ?? errorMessage(error)}).`, sessionId);
+      return result;
+    }
+    if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
+      result = pointerRecoveryRefusal(context, 'malformed', 'The selected session pointer is not a regular file.', sessionId);
+      return result;
+    }
+
+    const recoveryToken = transactionDependencies.token();
+    if (!isValidToken(recoveryToken)) {
+      result = pointerRecoveryRefusal(context, 'io-error', 'Unable to create a valid selected pointer quarantine token.', sessionId);
+      return result;
+    }
+    const quarantinePath = `${context.sessionPath}.quarantine.${sessionId}.${recoveryToken}`;
+    try {
+      const collision = await lstatRecoveryPath(quarantinePath);
+      if (collision) {
+        result = pointerRecoveryRefusal(context, 'collision', 'The selected pointer quarantine destination already exists.', sessionId);
+        return result;
+      }
+      const currentStat = await transactionDependencies.fs.lstat(context.sessionPath);
+      const currentBytes = await transactionDependencies.fs.readBytes(context.sessionPath);
+      const currentAfterRead = await transactionDependencies.fs.lstat(context.sessionPath);
+      const currentRaw = currentBytes.toString('utf8');
+      let current: SessionPointerReadResult;
+      try {
+        current = classifyParsedSessionPointerForRecovery(JSON.parse(currentRaw), currentRaw);
+      } catch {
+        result = pointerRecoveryRefusal(context, 'race', 'The selected session pointer changed before quarantine.', sessionId);
+        return result;
+      }
+      if (!sameRecoveryIdentity(currentStat, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')
+        || !sameRecoveryIdentity(currentAfterRead, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')
+        || !currentBytes.equals(pointer.bytes)
+        || current.status !== 'stale-dead'
+        || !current.state
+        || selectedRootAuthorityFailure(context, current.state) !== undefined
+        || classifySessionProcessForRecovery(current.state) !== 'dead') {
+        result = pointerRecoveryRefusal(context, 'race', 'The selected session pointer changed before quarantine.', sessionId);
+        return result;
+      }
+      const moved = await moveRecoveryPathNoReplace(
+        context.sessionPath,
+        quarantinePath,
+        { dev: sourceStat.dev, ino: sourceStat.ino },
+        'file',
+      );
+      if (!moved.moved) {
+        let destinationExists = await lstatRecoveryPath(quarantinePath);
+        const sourceExists = await lstatRecoveryPath(context.sessionPath);
+        if (destinationExists && !sourceExists
+          && !sameRecoveryIdentity(destinationExists, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')) {
+          try {
+            await transactionDependencies.atomicRenameNoReplace(quarantinePath, context.sessionPath);
+          } catch { /* preserve recovery residue when the foreign replacement cannot be restored */ }
+          destinationExists = await lstatRecoveryPath(quarantinePath);
+        }
+        result = pointerRecoveryRefusal(
+          context,
+          moved.unsupported ? 'unsupported' : destinationExists ? 'collision' : 'race',
+          moved.reason ?? 'The selected session pointer could not be quarantined atomically.',
+          sessionId,
+        );
+        return result;
+      }
+      const archivedStat = await lstatRecoveryPath(quarantinePath);
+      const sourceAfterMove = await lstatRecoveryPath(context.sessionPath);
+      const archivedBytes = archivedStat && sameRecoveryIdentity(archivedStat, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')
+        ? await transactionDependencies.fs.readBytes(quarantinePath)
+        : undefined;
+      const archivedRaw = archivedBytes?.toString('utf8');
+      let archivedPointer: SessionPointerReadResult | undefined;
+      if (archivedRaw !== undefined) {
+        try { archivedPointer = classifyParsedSessionPointerForRecovery(JSON.parse(archivedRaw), archivedRaw); } catch { /* handled below */ }
+      }
+      if (sourceAfterMove
+        || !archivedBytes?.equals(pointer.bytes)
+        || archivedPointer?.status !== 'stale-dead'
+        || !archivedPointer.state
+        || selectedRootAuthorityFailure(context, archivedPointer.state) !== undefined
+        || classifySessionProcessForRecovery(archivedPointer.state) !== 'dead') {
+        if (!sourceAfterMove && archivedBytes?.equals(pointer.bytes) && archivedStat
+          && sameRecoveryIdentity(archivedStat, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')) {
+          const rollback = await moveRecoveryPathNoReplace(
+            quarantinePath,
+            context.sessionPath,
+            { dev: sourceStat.dev, ino: sourceStat.ino },
+            'file',
+          );
+          if (rollback.moved) {
+            result = pointerRecoveryRefusal(
+              context,
+              'race',
+              'The selected pointer became uncertain after quarantine and was restored without losing forensic bytes.',
+              sessionId,
+            );
+            return result;
+          }
+        }
+        result = {
+          status: 'recovery-required',
+          pointerPath: context.sessionPath,
+          action: 'quarantined',
+          recovered: false,
+          reason: 'The selected pointer changed or became uncertain after quarantine; forensic residue was preserved for explicit recovery.',
+          sessionId,
+          quarantinePath,
+        };
+        return result;
+      }
+      result = {
+        status: 'recovered',
+        pointerPath: context.sessionPath,
+        action: 'quarantined',
+        recovered: true,
+        reason: 'Verified-dead selected session pointer quarantined with exact forensic bytes preserved.',
+        sessionId,
+        quarantinePath,
+      };
+      return result;
+    } catch (error) {
+      result = pointerRecoveryRefusal(context, 'io-error', `Unable to quarantine the selected session pointer (${errorCode(error) ?? errorMessage(error)}).`, sessionId);
+      return result;
+    }
+  } finally {
+    const failures = await releasePointerLock(lock);
+    if (failures.length > 0 && result) {
+      result.status = 'recovery-required';
+      result.recovered = false;
+      result.reason = `${result.reason} Pointer lock release requires explicit lock recovery.`;
+    }
   }
 }
 

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1899,18 +1899,13 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
         'file',
       );
       if (!moved.moved) {
-        let destinationExists = await lstatRecoveryPath(quarantinePath);
+        const destinationExists = await lstatRecoveryPath(quarantinePath);
         const sourceExists = await lstatRecoveryPath(context.sessionPath);
-        if (destinationExists && !sourceExists
-          && !sameRecoveryIdentity(destinationExists, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file')) {
-          try {
-            await transactionDependencies.atomicRenameNoReplace(quarantinePath, context.sessionPath);
-          } catch { /* preserve recovery residue when the foreign replacement cannot be restored */ }
-          destinationExists = await lstatRecoveryPath(quarantinePath);
-        }
+        const foreignDestination = destinationExists
+          && !sameRecoveryIdentity(destinationExists, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file');
         result = pointerRecoveryRefusal(
           context,
-          moved.unsupported ? 'unsupported' : destinationExists ? 'collision' : 'race',
+          moved.unsupported ? 'unsupported' : foreignDestination && !sourceExists ? 'race' : destinationExists ? 'collision' : 'race',
           moved.reason ?? 'The selected session pointer could not be quarantined atomically.',
           sessionId,
         );

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -1907,13 +1907,15 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
         const sourceExists = await lstatRecoveryPath(context.sessionPath);
         const capturedDestination = destinationExists
           && sameRecoveryIdentity(destinationExists, { dev: sourceStat.dev, ino: sourceStat.ino }, 'file');
-        if (capturedDestination && !sourceExists) {
+        if (capturedDestination) {
           result = {
             status: 'recovery-required',
             pointerPath: context.sessionPath,
             action: 'quarantined',
             recovered: false,
-            reason: 'The atomic move outcome was ambiguous, but the captured selected pointer is present at quarantine; forensic residue was preserved for explicit recovery.',
+            reason: sourceExists
+              ? 'The atomic move outcome was ambiguous; the captured selected pointer is present at quarantine and a successor occupies the canonical path, so both were preserved for explicit recovery.'
+              : 'The atomic move outcome was ambiguous, but the captured selected pointer is present at quarantine; forensic residue was preserved for explicit recovery.',
             sessionId,
             quarantinePath,
           };


### PR DESCRIPTION
## Summary
- add the official `omx session pointer recover [--cwd <path>] [--json]` command
- quarantine only an authoritative, positively dead selected pointer while preserving exact bytes
- keep live, reused, identity-indeterminate, malformed, foreign-lineage/root, I/O, collision, unsupported, and concurrent-change states fail-closed
- guide stale-pointer recovery through doctor/help/troubleshooting without changing lock recovery or native Stop contracts

## Verification
- `npm run build`
- `npm run check:no-unused`
- `npx biome lint` on all changed TypeScript files
- `node --test dist/hooks/__tests__/session.test.js` — 142 passed on the final full focused run; final recovery subset 20/20 after the last race hardening
- `node --test dist/cli/__tests__/session-search-help.test.js dist/cli/__tests__/doctor-state-root-binding.test.js` — 9 passed
- `node --test dist/cli/__tests__/launch-fallback.test.js` — 36 passed
- `node --test --test-name-pattern='Stop transcript-backed recovery for a stale-dead selected pointer' dist/scripts/__tests__/codex-native-hook.test.js` — 20 passed
- `node --test dist/cli/__tests__/package-bin-contract.test.js` — 1 passed
- native runtime CLI smoke proved exact archive bytes and idempotent repeat
- final architect review: CLEAR/CLEAR/CLEAR, APPROVE
- final executor red-team QA: passed

Closes #3525

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*