### PR TITLE
fix(hooks): preserve notify identity for exact cancellation

### DIFF
--- a/src/scripts/__tests__/issue-3358-ultragoal-cancel-lifecycle.test.ts
+++ b/src/scripts/__tests__/issue-3358-ultragoal-cancel-lifecycle.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { describe, it } from "node:test";
 
 import { dispatchCodexNativeHook } from "../codex-native-hook.js";
+import { normalizeSkillActiveState, syncSkillStateFromTurn } from "../notify-hook/auto-nudge.js";
 
 /**
  * Issue #3358 Ultragoal cancellation lifecycle, updated for #3497:
@@ -14,6 +16,29 @@ import { dispatchCodexNativeHook } from "../codex-native-hook.js";
 
 async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function withTrustedWorkspaceOmxCli<T>(cwd: string, run: () => Promise<T>): Promise<T> {
+  const binDir = join(cwd, "node_modules", ".bin");
+  await mkdir(binDir, { recursive: true });
+  await symlink(realpathSync(resolve(process.cwd(), "dist", "cli", "omx.js")), join(binDir, "omx"));
+  const inherited = Object.fromEntries(
+    ["PATH", "OMX_ROOT", "OMX_STATE_ROOT", "OMX_TEAM_STATE_ROOT", "OMX_SESSION_ID"]
+      .map((name) => [name, process.env[name]]),
+  );
+  process.env.PATH = `${binDir}:${dirname(process.execPath)}:/usr/bin:/bin`;
+  delete process.env.OMX_ROOT;
+  delete process.env.OMX_STATE_ROOT;
+  delete process.env.OMX_TEAM_STATE_ROOT;
+  delete process.env.OMX_SESSION_ID;
+  try {
+    return await run();
+  } finally {
+    for (const [name, value] of Object.entries(inherited)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
 }
 
 async function fixture() {
@@ -27,6 +52,16 @@ async function fixture() {
     session_id: sessionId,
     native_session_id: threadId,
     cwd,
+  });
+  await writeJson(join(stateDir, "subagent-tracking.json"), {
+    schemaVersion: 1,
+    sessions: {
+      [sessionId]: {
+        session_id: sessionId,
+        leader_thread_id: threadId,
+        threads: { [threadId]: { thread_id: threadId, kind: "leader" } },
+      },
+    },
   });
   await writeJson(join(sessionDir, "ultragoal-state.json"), {
     active: true,
@@ -57,8 +92,9 @@ function preTool(f: Awaited<ReturnType<typeof fixture>>, command: string) {
   return dispatchCodexNativeHook({
     hook_event_name: "PreToolUse",
     cwd: f.cwd,
-    session_id: f.sessionId,
+    session_id: f.threadId,
     thread_id: f.threadId,
+    agent_id: f.threadId,
     tool_name: "Bash",
     tool_input: { command },
   }, { cwd: f.cwd });
@@ -68,12 +104,71 @@ describe("issue #3358 Ultragoal cancellation lifecycle (#3497)", () => {
   it("exact omx cancel remains a PreToolUse deny path for active ultragoal", async () => {
     const f = await fixture();
     try {
-      const result = await preTool(f, "omx cancel --force");
+      const result = await withTrustedWorkspaceOmxCli(f.cwd, () => preTool(f, "omx cancel --force"));
       assert.equal(result.outputJson?.decision, "block");
       assert.match(
         JSON.stringify(result.outputJson),
         /cancelled_exact_session|invalid_command|session_binding|actor_authority|active_state/,
       );
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("cancels after notify preserves attached-tmux dual-session identity", async () => {
+    const f = await fixture();
+    try {
+      const skillPath = join(f.sessionDir, "skill-active-state.json");
+      await syncSkillStateFromTurn(f.stateDir, {
+        cwd: f.cwd,
+        "last-assistant-message": "Implementation continues.",
+      }, f.sessionId, {
+        targetSessionId: f.sessionId,
+        ownerCodexSessionId: f.sessionId,
+        allowedOwnerCodexSessionIds: [f.sessionId, f.threadId],
+        allowedStorageSessionIds: [f.sessionId, f.threadId],
+        targetRelation: "pointer-alias",
+        thread: { kind: "root-or-drift" },
+        legacyAdoption: "deny",
+        globalSideEffects: "allow",
+      });
+      const afterNotify = JSON.parse(await readFile(skillPath, "utf8"));
+      assert.equal(afterNotify.session_id, f.sessionId);
+      assert.equal(afterNotify.thread_id, f.threadId);
+      assert.equal(afterNotify.active_skills.length, 1);
+      assert.equal(afterNotify.owner_codex_session_id, f.sessionId);
+
+      const result = await withTrustedWorkspaceOmxCli(f.cwd, () => preTool(f, "omx cancel --force"));
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /cancelled_exact_session/);
+
+      const skill = JSON.parse(await readFile(skillPath, "utf8"));
+      const ultragoal = JSON.parse(await readFile(join(f.sessionDir, "ultragoal-state.json"), "utf8"));
+      assert.equal(skill.active, false);
+      assert.equal(ultragoal.active, false);
+    } finally {
+      await rm(f.cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps foreign notify owners denied without changing lifecycle state", async () => {
+    const f = await fixture();
+    try {
+      const skillPath = join(f.sessionDir, "skill-active-state.json");
+      const ultragoalPath = join(f.sessionDir, "ultragoal-state.json");
+      const stored = JSON.parse(await readFile(skillPath, "utf8"));
+      await writeJson(skillPath, normalizeSkillActiveState({
+        ...stored,
+        owner_codex_session_id: "foreign-owner",
+      }));
+      const beforeSkill = await readFile(skillPath, "utf8");
+      const beforeUltragoal = await readFile(ultragoalPath, "utf8");
+
+      const result = await withTrustedWorkspaceOmxCli(f.cwd, () => preTool(f, "omx cancel --force"));
+      assert.equal(result.outputJson?.decision, "block");
+      assert.match(JSON.stringify(result.outputJson), /active_state/);
+      assert.equal(await readFile(skillPath, "utf8"), beforeSkill);
+      assert.equal(await readFile(ultragoalPath, "utf8"), beforeUltragoal);
     } finally {
       await rm(f.cwd, { recursive: true, force: true });
     }
@@ -95,7 +190,7 @@ describe("issue #3358 Ultragoal cancellation lifecycle (#3497)", () => {
     const f = await fixture();
     try {
       const before = await readFile(join(f.sessionDir, "skill-active-state.json"), "utf8");
-      const result = await preTool(f, "omx cancel --please");
+      const result = await withTrustedWorkspaceOmxCli(f.cwd, () => preTool(f, "omx cancel --please"));
       assert.equal(result.outputJson?.decision, "block");
       assert.match(JSON.stringify(result.outputJson), /invalid_command|actor_authority|active_state|session_binding/);
       assert.equal(await readFile(join(f.sessionDir, "skill-active-state.json"), "utf8"), before);

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -3879,7 +3879,9 @@ function hookCancelOptionalSessionAliasesMatch(
     const raw = value[alias];
     if (typeof raw !== "string") return false;
     const candidate = raw.trim();
-    if (candidate && !nativeIdentityAliases.has(candidate)) return false;
+    if (candidate
+      && !nativeIdentityAliases.has(candidate)
+      && !(alias === "owner_codex_session_id" && candidate === canonicalSessionId)) return false;
   }
   if (Object.prototype.hasOwnProperty.call(value, "owner_omx_session_id")) {
     const raw = value.owner_omx_session_id;

--- a/src/scripts/notify-hook/auto-nudge.ts
+++ b/src/scripts/notify-hook/auto-nudge.ts
@@ -158,6 +158,7 @@ export function normalizeSkillActiveState(raw) {
   const skill = safeString(raw.skill);
   if (!skill) return null;
   return {
+    ...raw,
     version: asNumber(raw.version) ?? 1,
     active: raw.active !== false,
     skill,


### PR DESCRIPTION
## Summary
- preserve scoped skill identity and active workflow mirrors across notify normalization
- accept the already-bound canonical session only for `owner_codex_session_id` during exact cancellation
- add notify round-trip coverage for attached-tmux dual IDs and foreign-owner denial

## Verification
- `npm run build`
- issue #3358 lifecycle regression: 5/5
- notify session scope: 14/14
- issue #3293 callsite parity: 27/27
- issue #3293 hook-owned cancellation: 9/9
- modified-file Biome lint and `git diff --check`

## Known upstream test gaps
The broad `test:recent-bug-regressions` run retains unrelated macOS fixture failures in launch/session tests (`/private/var` aliasing and Linux process identity expectations). The changed-area and security matrices pass.