### PR TITLE
fix(team): Claude worker submits use tmux named Enter; detect Claude 2.1.x trust/bypass prompts

### DIFF
--- a/src/hooks/__tests__/notify-fallback-watcher.test.ts
+++ b/src/hooks/__tests__/notify-fallback-watcher.test.ts
@@ -390,7 +390,7 @@ if [[ "$cmd" == "if-shell" ]]; then
     exit 0
   fi
   eval "set -- \$sendCommand"
-  if [[ "\$#" -lt 4 || "\$1" != "send-keys" || "\$2" != "-t" || "\$3" != "\$paneId" || ( "\$4" != "-l" && "\$4" != "C-m" ) || ( "\$4" == "-l" && "\$#" -ne 5 ) || ( "\$4" == "C-m" && "\$#" -ne 4 ) ]]; then
+  if [[ "\$#" -lt 4 || "\$1" != "send-keys" || "\$2" != "-t" || "\$3" != "\$paneId" || ( "\$4" != "-l" && "\$4" != "C-m" && "\$4" != "Enter" ) || ( "\$4" == "-l" && "\$#" -ne 5 ) || ( ( "\$4" == "C-m" || "\$4" == "Enter" ) && "\$#" -ne 4 ) ]]; then
     printf '__omx_ralph_input_denied__\n'
     exit 0
   fi
@@ -2209,9 +2209,9 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf8');
       const typeMatches = tmuxLog.match(/send-keys -t %42 -l ping/g) || [];
       assert.equal(typeMatches.length, 1, 'fresh attempt should type once; retries with draft should be submit-only');
-      const cmMatches = tmuxLog.match(/send-keys -t %42 C-m/g) || [];
-      assert.ok(cmMatches.length > 0, 'submit should use C-m');
-      assert.ok(!/send-keys[^\n]*-l[^\n]*C-m/.test(tmuxLog), 'must keep -l payload and C-m submits isolated');
+      const enterMatches = tmuxLog.match(/send-keys -t %42 Enter/g) || [];
+      assert.ok(enterMatches.length > 0, 'submit should use the named Enter key');
+      assert.ok(!/send-keys[^\n]*-l[^\n]*Enter/.test(tmuxLog), 'must keep -l payload and Enter submits isolated');
 
       const request = await readDispatchRequest('dispatch-team', queued.request.request_id, wd);
       assert.equal(request?.status, 'pending');

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -339,9 +339,9 @@ describe('notify-hook auto-nudge', () => {
       assert.ok(existsSync(tmuxLogPath), 'tmux should have been called');
       const tmuxLog = await readFile(tmuxLogPath, 'utf-8');
       assert.match(tmuxLog, defaultAutoNudgePattern('%99'), 'should send nudge response with injection marker');
-      // Codex CLI needs C-m sent twice with a delay for reliable submission
-      const cmMatches = tmuxLog.match(/send-keys -t %99 C-m/g);
-      assert.ok(cmMatches && cmMatches.length >= 2, `should send C-m twice, got ${cmMatches?.length ?? 0}`);
+      // Codex CLI needs Enter sent twice with a delay for reliable submission
+      const enterMatches = tmuxLog.match(/send-keys -t %99 Enter/g);
+      assert.ok(enterMatches && enterMatches.length >= 2, `should send Enter twice, got ${enterMatches?.length ?? 0}`);
     });
   });
 

--- a/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-dispatch.test.ts
@@ -1574,7 +1574,7 @@ exit 0
     }
   });
 
-  it('retries submit with isolated C-m and does not retype when trigger already present', async () => {
+  it('retries submit with isolated named Enter and does not retype when trigger already present', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hook-team-dispatch-'));
     const fakeBinDir = join(cwd, 'fake-bin');
     const tmuxLogPath = join(cwd, 'tmux.log');
@@ -1612,9 +1612,9 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, 'utf8');
       const typeMatches = tmuxLog.match(/send-keys -t %42 -l ping/g) || [];
       assert.equal(typeMatches.length, 1, 'fresh attempt should type once; retries with draft should be submit-only');
-      const cmMatches = tmuxLog.match(/send-keys -t %42 C-m/g) || [];
-      assert.ok(cmMatches.length > 0, 'submit should use C-m');
-      assert.ok(!/send-keys[^\n]*-l[^\n]*C-m/.test(tmuxLog), 'must not mix -l payload with C-m submit');
+      const enterMatches = tmuxLog.match(/send-keys -t %42 Enter/g) || [];
+      assert.ok(enterMatches.length > 0, 'submit should use the named Enter key');
+      assert.ok(!/send-keys[^\n]*-l[^\n]*Enter/.test(tmuxLog), 'must not mix -l payload with Enter submit');
 
       const request = await readDispatchRequest('alpha', queued.request.request_id, cwd);
       assert.equal(request?.status, 'pending');
@@ -2134,7 +2134,7 @@ exit 0
       const exactGlobalPaneProof = /^list-panes -a -F #\{pane_id\}\t#\{pane_dead\}\t#\{pane_pid\}$/;
       assert.match(commands[0] || '', exactGlobalPaneProof);
       assert.match(tmuxLog, /send-keys -t %42 C-u/, 'the live proof should permit the clear effect');
-      assert.doesNotMatch(tmuxLog, /send-keys -t %42 C-m/);
+      assert.doesNotMatch(tmuxLog, /send-keys -t %42 (?:C-m|Enter)/);
       const ownerProof = 'show-option -qv -p -t %42 @omx_team_pane_owner_id';
       for (const [index, command] of commands.entries()) {
         if (!/^(send-keys|paste-buffer)\b/.test(command) || !command.includes('-t %42') || /^send-keys\b.*\s-l\s/.test(command)) continue;

--- a/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-leader-nudge.test.ts
@@ -661,9 +661,9 @@ describe('notify-hook team leader nudge', () => {
       assert.match(tmuxLog, /\[OMX\] All 2 workers idle/, 'should emit all-workers-idle nudge');
       assert.doesNotMatch(tmuxLog, /\[OMX_INTENT:/, 'should keep orchestration intent out of injected display text');
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should include injection marker');
-      const submitMatches = tmuxLog.match(/send-keys -t %99 C-m/g) || [];
-      assert.equal(submitMatches.length, 2, 'leader nudge should submit with isolated double C-m');
-      assert.ok(!/send-keys[^\n]*-l[^\n]*C-m/.test(tmuxLog), 'must not mix literal payload with submit keypresses');
+      const submitMatches = tmuxLog.match(/send-keys -t %99 Enter/g) || [];
+      assert.equal(submitMatches.length, 2, 'leader nudge should submit with isolated double Enter');
+      assert.ok(!/send-keys[^\n]*-l[^\n]*Enter/.test(tmuxLog), 'must not mix literal payload with submit keypresses');
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');
       assert.ok(existsSync(eventsPath), 'events.ndjson should exist');
@@ -1628,10 +1628,10 @@ exit 0
       assert.match(tmuxLog, /capture-pane -t %93 -p -S -80/);
       assert.match(tmuxLog, /send-keys -t %93 -l \[omx:team-notice-ledger:[a-f0-9]{24}\] Review current Team notices\./);
       assert.match(tmuxLog, /send-keys -t %93 Tab/);
-      assert.match(tmuxLog, /send-keys -t %93 C-m/);
+      assert.match(tmuxLog, /send-keys -t %93 Enter/);
       assert.ok(
-        tmuxLog.indexOf('send-keys -t %93 Tab') < tmuxLog.indexOf('send-keys -t %93 C-m'),
-        'busy leader queue path should press Tab before C-m',
+        tmuxLog.indexOf('send-keys -t %93 Tab') < tmuxLog.indexOf('send-keys -t %93 Enter'),
+        'busy leader queue path should press Tab before Enter',
       );
       assert.match(tmuxLog, /\[OMX_TMUX_INJECT\]/, 'should keep the injection marker on busy-pane sends');
       assert.doesNotMatch(tmuxLog, /send-keys -t %93 -l .*busy-live-pane/, 'busy queued wake must not retain a Team reference in model-visible input');
@@ -2091,10 +2091,10 @@ exit 0
       assert.match(tmuxLog, /capture-pane/);
       assert.match(tmuxLog, /send-keys -t %73/, 'should inject into a busy leader pane so Codex can queue the message');
       assert.match(tmuxLog, /send-keys -t %73 Tab/);
-      assert.match(tmuxLog, /send-keys -t %73 C-m/);
+      assert.match(tmuxLog, /send-keys -t %73 Enter/);
       assert.ok(
-        tmuxLog.indexOf('send-keys -t %73 Tab') < tmuxLog.indexOf('send-keys -t %73 C-m'),
-        'busy leader queue path should press Tab before C-m',
+        tmuxLog.indexOf('send-keys -t %73 Tab') < tmuxLog.indexOf('send-keys -t %73 Enter'),
+        'busy leader queue path should press Tab before Enter',
       );
 
       const eventsPath = join(teamDir, 'events', 'events.ndjson');

--- a/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
+++ b/src/hooks/__tests__/notify-hook-team-tmux-guard.test.ts
@@ -148,14 +148,14 @@ describe('notify-hook team tmux guard bridge', () => {
       const lines = log.trim().split('\n').filter(Boolean);
       assert.equal(lines.length, 3);
       assert.match(lines[0], /\[display-message\]\[-p\]\[-t\]\[%42\]\[#\{pane_start_command\}\]/);
-      assert.match(lines[1], /\[send-keys\]\[-t\]\[%42\]\[C-m\]/);
-      assert.match(lines[2], /\[send-keys\]\[-t\]\[%42\]\[C-m\]/);
+      assert.match(lines[1], /\[send-keys\]\[-t\]\[%42\]\[Enter\]/);
+      assert.match(lines[2], /\[send-keys\]\[-t\]\[%42\]\[Enter\]/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  it('queue-first submits with Tab before C-m when requested', async () => {
+  it('queue-first submits with Tab before Enter when requested', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-tmux-guard-'));
     const fakeBinDir = join(cwd, 'fake-bin');
     const tmuxLogPath = join(cwd, 'tmux.log');
@@ -190,8 +190,8 @@ describe('notify-hook team tmux guard bridge', () => {
       assert.match(lines[3], /\[send-keys\]\[-t\]\[%42\]\[C-u\]/);
       assert.match(lines[4], /\[paste-buffer\]\[-t\]\[%42\]\[-b\]\[omx-pane-input-.*\]\[-p\]\[-d\]/);
       assert.match(lines[5], /\[send-keys\]\[-t\]\[%42\]\[Tab\]/);
-      assert.match(lines[6], /\[send-keys\]\[-t\]\[%42\]\[C-m\]/);
-      assert.match(lines[7], /\[send-keys\]\[-t\]\[%42\]\[C-m\]/);
+      assert.match(lines[6], /\[send-keys\]\[-t\]\[%42\]\[Enter\]/);
+      assert.match(lines[7], /\[send-keys\]\[-t\]\[%42\]\[Enter\]/);
       assert.match(lines[8], /\[delete-buffer\]\[-b\]\[omx-pane-input-/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -232,7 +232,7 @@ describe('notify-hook team tmux guard bridge', () => {
       const lines = log.trim().split('\n').filter(Boolean);
       assert.equal(lines.length, 7);
       assert.match(lines[0], /\[display-message\]\[-p\]\[-t\]\[%42\]\[#\{pane_start_command\}\]/);
-      assert.match(lines[5], /\[send-keys\]\[-t\]\[%42\]\[C-m\]/);
+      assert.match(lines[5], /\[send-keys\]\[-t\]\[%42\]\[Enter\]/);
       assert.match(lines[6], /\[delete-buffer\]\[-b\]\[omx-pane-input-/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -291,6 +291,7 @@ exit 0
       assert.doesNotMatch(log, /show-buffer/);
       assert.doesNotMatch(log, /paste-buffer/);
       assert.doesNotMatch(log, /\[send-keys\]\[-t\]\[%42\]\[C-m\]/);
+      assert.doesNotMatch(log, /\[send-keys\]\[-t\]\[%42\]\[Enter\]/);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/src/hooks/__tests__/tmux-hook-engine.test.ts
+++ b/src/hooks/__tests__/tmux-hook-engine.test.ts
@@ -279,8 +279,8 @@ describe('buildSendKeysArgv', () => {
     }), {
       typeArgv: ['send-keys', '-t', '%3', '-l', 'continue'],
       submitArgv: [
-        ['send-keys', '-t', '%3', 'C-m'],
-        ['send-keys', '-t', '%3', 'C-m'],
+        ['send-keys', '-t', '%3', 'Enter'],
+        ['send-keys', '-t', '%3', 'Enter'],
       ],
     });
 
@@ -292,7 +292,7 @@ describe('buildSendKeysArgv', () => {
     }), {
       typeArgv: ['send-keys', '-t', '%7', '-l', 'continue'],
       submitArgv: [
-        ['send-keys', '-t', '%7', 'C-m'],
+        ['send-keys', '-t', '%7', 'Enter'],
       ],
     });
 
@@ -301,6 +301,22 @@ describe('buildSendKeysArgv', () => {
       prompt: 'continue',
       dryRun: true,
     }), null);
+  });
+
+  it('honors an explicit submit key override', () => {
+    assert.deepEqual(buildSendKeysArgv({
+      paneTarget: '%9',
+      prompt: 'continue',
+      dryRun: false,
+      submitKeyPresses: 2,
+      submitKey: 'C-m',
+    }), {
+      typeArgv: ['send-keys', '-t', '%9', '-l', 'continue'],
+      submitArgv: [
+        ['send-keys', '-t', '%9', 'C-m'],
+        ['send-keys', '-t', '%9', 'C-m'],
+      ],
+    });
   });
 });
 

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -16449,7 +16449,7 @@ exit 0
       const tmuxLog = await readFile(tmuxLogPath, "utf-8");
       assert.match(tmuxLog, /send-keys -t %42 -l \[omx:team-notice-ledger:[a-f0-9]{24}\] Review current Team notices\./);
       assert.doesNotMatch(tmuxLog, /send-keys -t %42 -l .*worker-stop-team-busy-leader|send-keys -t %42 Tab/);
-      const submits = tmuxLog.match(/send-keys -t %42 C-m/g) || [];
+      const submits = tmuxLog.match(/send-keys -t %42 Enter/g) || [];
       assert.equal(submits.length, 2, "busy worker-stop nudge should submit directly as steering, not queue via Tab");
       const nudgeState = JSON.parse(await readFile(join(workerDir, "worker-stop-nudge.json"), "utf-8"));
       assert.equal(nudgeState.delivery, "steered");

--- a/src/scripts/notify-hook/team-dispatch.ts
+++ b/src/scripts/notify-hook/team-dispatch.ts
@@ -954,6 +954,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
     expectedHudPaneId: dispatchTarget.expectedHudPaneId,
     prompt: request.trigger_message,
     submitKeyPresses,
+    submitKey: 'Enter',
     typePrompt: shouldTypePrompt,
     queueFirstSubmit: leaderTargeted,
   });
@@ -973,7 +974,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
 
   // Post-injection verification: confirm the trigger text was consumed.
   // Fixes #391: without this, dispatch marks 'notified' even when the worker
-  // pane is sitting on an unsent draft (C-m was not effectively applied).
+  // pane is sitting on an unsent draft (Enter was not effectively applied).
   const verifyNarrowArgv = buildJoinedCapturePaneArgv(resolution.paneTarget, 8);
   const verifyWideArgv = buildJoinedCapturePaneArgv(resolution.paneTarget);
   for (let round = 0; round < INJECT_VERIFY_ROUNDS; round++) {
@@ -990,7 +991,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       // full-scrollback false positives.
       narrowCap = await runProcess('tmux', verifyNarrowArgv, 2000);
     } catch {
-      // Capture failed; fall through to retry C-m.
+      // Capture failed; fall through to retry Enter.
     }
     if (narrowCap) {
       const wideProof = await verifyExplicitPane();
@@ -1000,7 +1001,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
         const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);
         const triggerNearTail = capturedPaneContainsTriggerNearTail(wideCap.stdout, request.trigger_message);
         if (triggerInNarrow || triggerNearTail) {
-          // Draft is still visible, so C-m has not actually submitted it yet.
+          // Draft is still visible, so Enter has not actually submitted it yet.
           // Do not let transient spinner/active-task text mask an unsent draft.
           const retrySend = await sendPaneInput({
             paneTarget: resolution.paneTarget,
@@ -1010,6 +1011,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
             expectedHudPaneId: dispatchTarget.expectedHudPaneId,
             prompt: request.trigger_message,
             submitKeyPresses,
+            submitKey: 'Enter',
             typePrompt: false,
           });
           if (!retrySend.ok && retrySend.reason === EXACT_PANE_UNAVAILABLE_REASON) {
@@ -1055,10 +1057,10 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
           };
         }
       } catch {
-        // Capture failed; fall through to retry C-m.
+        // Capture failed; fall through to retry Enter.
       }
     }
-    // Draft still visible and no active task — retry C-m
+    // Draft still visible and no active task — retry Enter
     const retrySend = await sendPaneInput({
       paneTarget: resolution.paneTarget,
       exactPaneId,
@@ -1067,6 +1069,7 @@ async function injectDispatchRequest(request, config, cwd, stateDir) {
       expectedHudPaneId: dispatchTarget.expectedHudPaneId,
       prompt: request.trigger_message,
       submitKeyPresses,
+      submitKey: 'Enter',
       typePrompt: false,
       queueFirstSubmit: leaderTargeted,
     });

--- a/src/scripts/notify-hook/team-tmux-guard.ts
+++ b/src/scripts/notify-hook/team-tmux-guard.ts
@@ -386,6 +386,7 @@ export async function sendPaneInput({
   expectedPanePid = undefined,
   expectedPaneOwnerId = undefined,
   expectedHudPaneId = undefined,
+  submitKey = 'Enter',
 }: any): Promise<any> {
   const target = safeString(paneTarget).trim();
   if (!target) {
@@ -447,6 +448,7 @@ export async function sendPaneInput({
       prompt: literalPrompt,
       dryRun: false,
       submitKeyPresses: normalizedSubmitKeyPresses,
+      submitKey: safeString(submitKey).trim() || 'Enter',
     })?.submitArgv;
   if (!submitArgv) {
     return { ok: false, sent: false, reason: 'send_failed', paneTarget: target, exactPaneProof };
@@ -601,7 +603,7 @@ export async function queuePaneInput({
   };
   const submitArgv = [
     ['send-keys', '-t', target, 'Tab'],
-    ['send-keys', '-t', target, 'C-m'],
+    ['send-keys', '-t', target, 'Enter'],
   ];
   const firstSubmitProof = await verifyExplicitPane();
   if (!firstSubmitProof.ok) {

--- a/src/scripts/tmux-hook-engine.ts
+++ b/src/scripts/tmux-hook-engine.ts
@@ -332,15 +332,15 @@ export function buildVisibleCapturePaneArgv(paneTarget: any): string[] {
   return ['capture-pane', '-t', paneTarget, '-p'];
 }
 
-export function buildSendKeysArgv({ paneTarget, prompt, dryRun, submitKeyPresses = 2 }: any): any {
+export function buildSendKeysArgv({ paneTarget, prompt, dryRun, submitKeyPresses = 2, submitKey = 'Enter' }: any): any {
   if (dryRun) return null;
   const pressCountRaw = Number.isFinite(submitKeyPresses) ? Math.floor(submitKeyPresses) : 2;
   const pressCount = Math.max(1, Math.min(4, pressCountRaw));
   const submitArgv = Array.from({ length: pressCount }, () => ([
-    'send-keys', '-t', paneTarget, 'C-m',
+    'send-keys', '-t', paneTarget, submitKey,
   ]));
   // Use a 2-step send for reliability:
-  // 1) literal prompt bytes, 2) explicit carriage return.
+  // 1) literal prompt bytes, 2) named Enter submit.
   return {
     typeArgv: ['send-keys', '-t', paneTarget, '-l', prompt],
     // Codex generally prefers two presses; Claude typically needs one.

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -141,6 +141,15 @@ const CLAUDE_BYPASS_PROMPT_CAPTURE = `Bypass Permissions mode
 
 Press Enter to confirm`;
 
+const CLAUDE_BYPASS_PROMPT_2_1_CAPTURE = `WARNING: Claude Code running in Bypass Permissions mode.
+
+Claude Code may make mistakes. Bypassing permissions removes safety checks.
+
+1. No, exit
+2. Yes, I accept
+
+Do you want to confirm that you want to use this mode?`;
+
 const READY_HELPER_CAPTURE = `╭────────────────────────────────────────────╮
 │ >_ OpenAI Codex (v0.114.0)                 │
 │                                            │
@@ -162,6 +171,16 @@ const VIEWPORT_WITHOUT_VISIBLE_PROMPT_CAPTURE = `╭─────────�
 const VIEWPORT_SCROLLBACK_READY_CAPTURE = `${VIEWPORT_WITHOUT_VISIBLE_PROMPT_CAPTURE}
 
 › support lane on multi-image attach`;
+
+const CLAUDE_TRUST_PROMPT_2_1_CAPTURE = `Quick safety check: Is this a project you created or one you trust?
+
+1. Yes, I trust this folder
+2. No, exit`;
+
+const CODEX_TRUST_PROMPT_CAPTURE = `Do you trust the contents of this directory?
+
+Yes, continue
+No, quit`;
 
 const QUEUED_AFTER_TOOL_CALL_CAPTURE = `• Messages to be submitted after next tool call (press esc to interrupt and send immediately)
   ↳ Read $OMX_TEAM_STATE_ROOT/team/demo/workers/worker-1/inbox.md, work now, report progress
@@ -776,6 +795,44 @@ Press enter to continue`, 'codex'), {
   });
 });
 
+describe('trust and Claude bypass prompt detection', () => {
+  it('matches Codex and pre-2.1 Claude trust wording', () => {
+    assert.equal(
+      evaluateStartupDirectTriggerSafetyCapture('Do you trust the contents of this directory?\nPress enter to continue', 'codex').reason,
+      'trust_prompt',
+    );
+    assert.equal(evaluateStartupDirectTriggerSafetyCapture(CODEX_TRUST_PROMPT_CAPTURE, 'codex').reason, 'trust_prompt');
+  });
+
+  it('matches the Claude 2.1.x quick-safety-check numbered-choice trust prompt', () => {
+    assert.equal(
+      evaluateStartupDirectTriggerSafetyCapture(CLAUDE_TRUST_PROMPT_2_1_CAPTURE, 'claude').reason,
+      'trust_prompt',
+    );
+    assert.equal(classifyWorkerStartupInjectSafety(CLAUDE_TRUST_PROMPT_2_1_CAPTURE), 'trust_prompt');
+  });
+
+  it('does not flag ordinary pane text as a trust prompt', () => {
+    assert.notEqual(evaluateStartupDirectTriggerSafetyCapture(READY_HELPER_CAPTURE, 'codex').reason, 'trust_prompt');
+    assert.notEqual(
+      evaluateStartupDirectTriggerSafetyCapture('Do you trust the contents of this directory?\n1. Something unrelated', 'codex').reason,
+      'trust_prompt',
+    );
+    assert.notEqual(
+      evaluateStartupDirectTriggerSafetyCapture('Quick safety check: unrelated banner\n1. Yes, I trust this folder\n2. No, exit', 'claude').reason,
+      'trust_prompt',
+    );
+  });
+
+  it('blocks the Claude 2.1.x bypass-permissions warning with numbered choices', () => {
+    assert.equal(
+      evaluateStartupDirectTriggerSafetyCapture(CLAUDE_BYPASS_PROMPT_2_1_CAPTURE, 'claude').reason,
+      'claude_bypass_prompt',
+    );
+    assert.equal(classifyWorkerStartupInjectSafety(CLAUDE_BYPASS_PROMPT_2_1_CAPTURE), 'claude_bypass_prompt');
+  });
+});
+
 describe('sendToWorker validation', () => {
   it('rejects text over 200 chars', async () => {
     await assert.rejects(
@@ -883,7 +940,7 @@ esac
       async ({ logPath }) => {
         await sendToWorker('omx-team-x', 1, 'check inbox');
         const log = await readFile(logPath, 'utf-8');
-        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 Enter/g) || []).length;
         assert.equal(
           enterCount,
           2,
@@ -891,6 +948,49 @@ esac
         );
         assert.match(log, /capture-pane -t omx-team-x:1 -p/);
         assert.match(log, /capture-pane -t omx-team-x:1 -p -S -80/);
+      },
+    );
+  });
+
+  it('submits claude worker triggers with the tmux named key Enter, never C-m', async () => {
+    await withMockTmuxFixture(
+      'omx-tmux-claude-submit-named-enter-',
+      (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+text_sent_file="$state_dir/text-sent"
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ -f "$text_sent_file" ]; then
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    else
+      cat <<'EOF'
+✻ Welcome to Claude Code
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "check inbox" ]; then
+      : > "$text_sent_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+      async ({ logPath }) => {
+        await sendToWorker('omx-team-x', 1, 'check inbox', undefined, 'claude');
+        const log = await readFile(logPath, 'utf-8');
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 Enter/g) || []).length;
+        assert.ok(enterCount >= 1, `expected named Enter submits for a claude worker:\n${log}`);
+        assert.doesNotMatch(log, /send-keys -t omx-team-x:1 C-m/, `claude submit must not use C-m:\n${log}`);
+        assert.doesNotMatch(log, /send-keys -t omx-team-x:1 Tab/, `claude submit must not queue via Tab:\n${log}`);
       },
     );
   });
@@ -937,7 +1037,7 @@ EOF
     if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "check inbox" ]; then
       : > "$text_sent_file"
     fi
-    if [ "\${4:-}" = "C-m" ]; then
+    if [ "\${4:-}" = "Enter" ]; then
       enter_count=0
       if [ -f "$enter_count_file" ]; then
         enter_count=$(cat "$enter_count_file")
@@ -955,7 +1055,7 @@ esac
       async ({ logPath }) => {
         await sendToWorker('omx-team-x', 1, 'check inbox');
         const log = await readFile(logPath, 'utf-8');
-        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 Enter/g) || []).length;
         assert.ok(
           enterCount >= 4,
           `expected extra submit nudges when Codex queues the trigger:\n${log}`,
@@ -1008,7 +1108,7 @@ esac
           /submit_queued_after_tool_call/,
         );
         const log = await readFile(logPath, 'utf-8');
-        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 Enter/g) || []).length;
         assert.ok(
           enterCount >= 4,
           `expected repeated submit nudges before failing closed on stuck queued banner:\n${log}`,
@@ -1059,7 +1159,7 @@ esac
           /submit_failed/,
         );
         const log = await readFile(logPath, 'utf-8');
-        const enterCount = (log.match(/send-keys -t omx-team-x:1 C-m/g) || []).length;
+        const enterCount = (log.match(/send-keys -t omx-team-x:1 Enter/g) || []).length;
         assert.ok(
           enterCount >= 4,
           `expected repeated submit nudges before failing on the still-visible wrapped draft:\n${log}`,
@@ -4180,7 +4280,7 @@ esac
         assert.equal(waitForWorkerReady('omx-team-x', 1, 5_000), true);
         const log = await readFile(logPath, 'utf-8');
         assert.match(log, /send-keys -t omx-team-x:1 -l -- 2/);
-        assert.match(log, /send-keys -t omx-team-x:1 C-m/);
+        assert.match(log, /send-keys -t omx-team-x:1 Enter/);
       },
     );
   });
@@ -4336,7 +4436,7 @@ EOF
     exit 0
     ;;
   send-keys)
-    if [ "\${4:-}" = "C-m" ]; then
+    if [ "\${4:-}" = "Enter" ]; then
       : > "$accepted_file"
     fi
     exit 0
@@ -4349,12 +4449,108 @@ esac
         async ({ logPath }) => {
           assert.equal(await waitForWorkerReadyAsync('omx-team-x', 1, 5_000), true);
           const log = await readFile(logPath, 'utf-8');
-          assert.match(log, /send-keys -t omx-team-x:1 C-m/);
+          assert.match(log, /send-keys -t omx-team-x:1 Enter/);
         },
       );
     } finally {
       if (typeof previousAutoTrust === 'string') process.env.OMX_TEAM_AUTO_TRUST = previousAutoTrust;
       else delete process.env.OMX_TEAM_AUTO_TRUST;
+    }
+  });
+  it('auto-dismisses the Claude 2.1.x quick-safety-check trust prompt with named Enter', async () => {
+    const previousAutoTrust = process.env.OMX_TEAM_AUTO_TRUST;
+    delete process.env.OMX_TEAM_AUTO_TRUST;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-worker-ready-async-claude-trust-2-1-',
+        (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+accepted_file="$state_dir/accepted"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ -f "$accepted_file" ]; then
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    else
+      cat <<'EOF'
+${CLAUDE_TRUST_PROMPT_2_1_CAPTURE}
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "Enter" ]; then
+      : > "$accepted_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          assert.equal(await waitForWorkerReadyAsync('omx-team-x', 1, 5_000), true);
+          const log = await readFile(logPath, 'utf-8');
+          assert.match(log, /send-keys -t omx-team-x:1 Enter/);
+          assert.doesNotMatch(log, /send-keys -t omx-team-x:1 C-m/);
+        },
+      );
+    } finally {
+      if (typeof previousAutoTrust === 'string') process.env.OMX_TEAM_AUTO_TRUST = previousAutoTrust;
+      else delete process.env.OMX_TEAM_AUTO_TRUST;
+    }
+  });
+
+  it('auto-accepts the Claude 2.1.x bypass-permissions warning and then observes readiness', async () => {
+    const previousAutoAccept = process.env.OMX_TEAM_AUTO_ACCEPT_BYPASS;
+    delete process.env.OMX_TEAM_AUTO_ACCEPT_BYPASS;
+    try {
+      await withMockTmuxFixture(
+        'omx-tmux-worker-ready-async-claude-bypass-2-1-',
+        (logPath) => `#!/bin/sh
+set -eu
+state_dir="$(dirname "${logPath}")"
+accepted_file="$state_dir/accepted"
+printf '%s\n' "$*" >> "${logPath}"
+case "$1" in
+  capture-pane)
+    if [ -f "$accepted_file" ]; then
+      cat <<'EOF'
+${READY_HELPER_CAPTURE}
+EOF
+    else
+      cat <<'EOF'
+${CLAUDE_BYPASS_PROMPT_2_1_CAPTURE}
+EOF
+    fi
+    exit 0
+    ;;
+  send-keys)
+    if [ "\${4:-}" = "-l" ] && [ "\${6:-}" = "2" ]; then
+      : > "$accepted_file"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`,
+        async ({ logPath }) => {
+          assert.equal(await waitForWorkerReadyAsync('omx-team-x', 1, 5_000), true);
+          const log = await readFile(logPath, 'utf-8');
+          assert.match(log, /send-keys -t omx-team-x:1 -l -- 2/);
+          assert.match(log, /send-keys -t omx-team-x:1 Enter/);
+          assert.doesNotMatch(log, /send-keys -t omx-team-x:1 C-m/);
+        },
+      );
+    } finally {
+      if (typeof previousAutoAccept === 'string') process.env.OMX_TEAM_AUTO_ACCEPT_BYPASS = previousAutoAccept;
+      else delete process.env.OMX_TEAM_AUTO_ACCEPT_BYPASS;
     }
   });
 
@@ -8593,7 +8789,7 @@ esac
           assert.match(commands[index - 1] ?? '', exactGlobalPaneProof, `fresh proof must immediately precede ${command}`);
         }
         assert.match(commands.join('\n'), /send-keys -t %9 -l -- check inbox/);
-        assert.doesNotMatch(commands.join('\n'), /send-keys -t %9 C-m/);
+        assert.doesNotMatch(commands.join('\n'), /send-keys -t %9 (?:C-m|Enter)/);
       },
     );
   });

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -555,7 +555,7 @@ async function notifyWorkerPaneOutcome(
     };
     if (!runScalePaneTransaction(
       pane,
-      `send-keys -t ${paneId} -l ${quoteTmuxCommand(message)} \\; send-keys -t ${paneId} C-m`,
+      `send-keys -t ${paneId} -l ${quoteTmuxCommand(message)} \\; send-keys -t ${paneId} Enter`,
     )) {
       throw new Error(`scale_up_final_send_authority_lost:${paneId}`);
     }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -3220,8 +3220,15 @@ function paneHasTrustPrompt(captured: string): boolean {
     .map((line) => line.replace(/\r/g, '').trim())
     .filter((line) => line.length > 0);
   const tail = lines.slice(-12);
-  const hasQuestion = tail.some((line) => /Do you trust the contents of this directory\?/i.test(line));
-  const hasActiveChoices = tail.some((line) => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(line));
+  // Codex (and pre-2.1 Claude): "Do you trust the contents of this directory?"
+  // Claude Code 2.1.x: "Quick safety check: Is this a project you created or one you trust?"
+  const hasQuestion = tail.some((line) => /Do you trust the contents of this directory\?/i.test(line))
+    || tail.some((line) => /Quick safety check:.*(?:created or one you trust)/i.test(line));
+  // Codex choices: "Yes, continue|No, quit|Press enter to continue".
+  // Claude Code 2.1.x numbered choices: "1. Yes, I trust this folder" / "2. No, exit".
+  const hasActiveChoices = tail.some((line) => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(line))
+    || (tail.some((line) => /1\.\s*Yes,\s*I\s*trust\s*this\s*folder/i.test(line))
+      && tail.some((line) => /2\.\s*No,\s*exit/i.test(line)));
   return hasQuestion && hasActiveChoices;
 }
 
@@ -3231,10 +3238,14 @@ function paneHasClaudeBypassPermissionsPrompt(captured: string): boolean {
     .map((line) => line.replace(/\r/g, '').trim())
     .filter((line) => line.length > 0);
   const tail = lines.slice(-20);
+  // Claude Code renders "WARNING: Claude Code running in Bypass Permissions mode";
+  // keep the plain fragment for older/edge renderings.
   const hasWarning = tail.some((line) => /Bypass Permissions mode/i.test(line));
   const hasChoices = tail.some((line) => /No,\s*exit/i.test(line))
     && tail.some((line) => /Yes,\s*I\s*accept/i.test(line))
-    && tail.some((line) => /Enter\s*to\s*confirm/i.test(line));
+    && (tail.some((line) => /Enter\s*to\s*confirm/i.test(line))
+      || (tail.some((line) => /1\.\s*No,\s*exit/i.test(line))
+        && tail.some((line) => /2\.\s*Yes,\s*I\s*accept/i.test(line))));
   return hasWarning && hasChoices;
 }
 
@@ -3276,7 +3287,7 @@ function acceptClaudeBypassPermissionsPrompt(resolveTarget: () => string | null)
   sleepFractionalSeconds(0.12);
   const submitTarget = resolveTarget();
   if (!submitTarget) return false;
-  runTmux(['send-keys', '-t', submitTarget, 'C-m']);
+  runTmux(['send-keys', '-t', submitTarget, 'Enter']);
   return true;
 }
 
@@ -3303,7 +3314,7 @@ async function dismissClaudeBypassPermissionsPromptIfPresentAsync(
 
   const submitTarget = await resolveTarget();
   if (!submitTarget) return false;
-  const submitSend = await runTmuxAsync(['send-keys', '-t', submitTarget, 'C-m']);
+  const submitSend = await runTmuxAsync(['send-keys', '-t', submitTarget, 'Enter']);
   return submitSend.ok;
 }
 
@@ -3462,10 +3473,10 @@ async function attemptSubmitRounds(
     if (round === 0 && queueFirstRound) {
       await sendKeyAsync(resolveTarget, 'Tab');
       await sleep(80);
-      await sendKeyAsync(resolveTarget, 'C-m');
+      await sendKeyAsync(resolveTarget, 'Enter');
     } else {
       for (let press = 0; press < presses; press++) {
-        await sendKeyAsync(resolveTarget, 'C-m');
+        await sendKeyAsync(resolveTarget, 'Enter');
         if (press < presses - 1) {
           await sleep(200);
         }
@@ -3505,15 +3516,16 @@ export function waitForWorkerReady(
   const resolveTarget = createPinnedWorkerPaneTargetResolverSync(sessionName, workerIndex, workerPaneId, expectedPanePid, expectedTeamOwnerId, hudPaneId);
 
   const sendRobustEnter = (): void => {
-    // Trust + follow-up splash can require two submits in Codex TUI.
-    // Use C-m (carriage return) for raw-mode compatibility.
+    // Trust + follow-up splash can require two submits in agent TUIs.
+    // Named `Enter` submits in both Codex and Claude Code (2.1.x only accepts
+    // the named key, not the C-m byte).
     const firstTarget = resolveTarget();
     if (!firstTarget) return;
-    runTmux(['send-keys', '-t', firstTarget, 'C-m']);
+    runTmux(['send-keys', '-t', firstTarget, 'Enter']);
     sleepFractionalSeconds(0.12);
     const secondTarget = resolveTarget();
     if (!secondTarget) return;
-    runTmux(['send-keys', '-t', secondTarget, 'C-m']);
+    runTmux(['send-keys', '-t', secondTarget, 'Enter']);
   };
 
   const check = (): boolean => {
@@ -3594,15 +3606,16 @@ export async function waitForWorkerReadyDetailedAsync(
 
 
   const sendRobustEnter = async (): Promise<void> => {
-    // Trust + follow-up splash can require two submits in Codex TUI.
-    // Use C-m (carriage return) for raw-mode compatibility.
+    // Trust + follow-up splash can require two submits in agent TUIs.
+    // Named `Enter` submits in both Codex and Claude Code (2.1.x only accepts
+    // the named key, not the C-m byte).
     const firstTarget = await resolveTarget();
     if (!firstTarget) return;
-    await runTmuxAsync(['send-keys', '-t', firstTarget, 'C-m']);
+    await runTmuxAsync(['send-keys', '-t', firstTarget, 'Enter']);
     await sleep(120);
     const secondTarget = await resolveTarget();
     if (!secondTarget) return;
-    await runTmuxAsync(['send-keys', '-t', secondTarget, 'C-m']);
+    await runTmuxAsync(['send-keys', '-t', secondTarget, 'Enter']);
   };
 
   const check = async (): Promise<boolean> => {
@@ -3700,14 +3713,14 @@ export function dismissTrustPromptIfPresent(
   const result = runTmux(sharedBuildVisibleCapturePaneArgv(captureTarget));
   if (!result.ok) return false;
   if (!paneHasTrustPrompt(result.stdout)) return false;
-  // Trust prompt detected; send C-m twice to dismiss (trust + follow-up splash)
+  // Trust prompt detected; send Enter twice to dismiss (trust + follow-up splash)
   const firstTarget = resolveTarget();
   if (!firstTarget) return false;
-  runTmux(['send-keys', '-t', firstTarget, 'C-m']);
+  runTmux(['send-keys', '-t', firstTarget, 'Enter']);
   sleepFractionalSeconds(0.12);
   const secondTarget = resolveTarget();
   if (!secondTarget) return false;
-  runTmux(['send-keys', '-t', secondTarget, 'C-m']);
+  runTmux(['send-keys', '-t', secondTarget, 'Enter']);
   return true;
 }
 
@@ -3779,15 +3792,15 @@ export async function sendToWorker(
     await sleep(200);
   }
   if (paneHasTrustPrompt(capturedStr)) {
-    await sendKeyAsync(resolveTarget, 'C-m');
+    await sendKeyAsync(resolveTarget, 'Enter');
     await sleep(120);
-    await sendKeyAsync(resolveTarget, 'C-m');
+    await sendKeyAsync(resolveTarget, 'Enter');
     await sleep(200);
   }
 
   await sendLiteralTextOrThrow(resolveTarget, text);
 
-  // Allow the input buffer to settle before sending C-m
+  // Allow the input buffer to settle before submitting with Enter
   await sleep(150);
 
   const allowAutoInterruptRetry = process.env[OMX_TEAM_AUTO_INTERRUPT_RETRY_ENV] !== '0';
@@ -3799,8 +3812,8 @@ export async function sendToWorker(
   }
 
   // Submit deterministically using CLI-specific plan:
-  // - Codex: queue-first Tab+C-m when configured/busy, then double C-m rounds.
-  // - Claude: direct C-m rounds only (never queue-first Tab).
+  // - Codex: queue-first Tab+Enter when configured/busy, then double Enter rounds.
+  // - Claude: direct Enter rounds only (never queue-first Tab).
   if (await attemptSubmitRounds(
     resolveTarget,
     text,
@@ -3810,7 +3823,7 @@ export async function sendToWorker(
   )) return;
 
   // Adaptive escalation for "likely unsent trigger text at ready prompt" cases:
-  // clear line, re-send trigger, then re-submit with deterministic C-m rounds.
+  // clear line, re-send trigger, then re-submit with deterministic Enter rounds.
   const latestCapture = await capturePaneAsync(resolveTarget);
   if (shouldAttemptAdaptiveRetry(strategy, paneBusy, submitPlan.allowAdaptiveRetry, latestCapture || null, text)) {
     // Keep this branch non-interrupting to avoid canceling active turns on false positives.
@@ -3828,10 +3841,10 @@ export async function sendToWorker(
     throw new Error('sendToWorker: submit_failed (trigger text still visible after retries)');
   }
 
-  // One last best-effort double C-m nudge, then verify.
-  await sendKeyAsync(resolveTarget, 'C-m');
+  // One last best-effort double Enter nudge, then verify.
+  await sendKeyAsync(resolveTarget, 'Enter');
   await sleep(120);
-  await sendKeyAsync(resolveTarget, 'C-m');
+  await sendKeyAsync(resolveTarget, 'Enter');
 
   // Post-submit verification: wait briefly and confirm the worker consumed the
   // trigger (draft disappeared or active-task indicator appeared). Fixes #391.
@@ -3848,10 +3861,10 @@ export async function sendToWorker(
     ) {
       return;
     }
-    // Draft still visible and no active task — one more C-m attempt.
-    await sendKeyAsync(resolveTarget, 'C-m');
+    // Draft still visible and no active task — one more Enter attempt.
+    await sendKeyAsync(resolveTarget, 'Enter');
     await sleep(150);
-    await sendKeyAsync(resolveTarget, 'C-m');
+    await sendKeyAsync(resolveTarget, 'Enter');
     const finalVisibleCapture = await captureVisiblePaneAsync(resolveTarget);
     if (paneHasQueuedCodexSubmission(finalVisibleCapture)) {
       throw new Error('sendToWorker: submit_queued_after_tool_call');

--- a/src/types/tmux-hook-engine.d.ts
+++ b/src/types/tmux-hook-engine.d.ts
@@ -60,5 +60,6 @@ declare module '*tmux-hook-engine.js' {
     prompt: string;
     dryRun: boolean;
     submitKeyPresses?: number;
+    submitKey?: string;
   }): { typeArgv: string[]; submitArgv: string[][] } | null;
 }


### PR DESCRIPTION
Fixes #3529

## Problem

Team Claude workers never started their tasks (stuck pending). All worker submit paths sent Enter as `C-m` via `tmux send-keys`, but Claude Code 2.1.x's TUI only submits on the tmux **named** key `Enter`. Reporter's decisive repro: 3× `C-m` = nothing, 1× named `Enter` = submitted, 100% reproducible. Two secondary drifts made it worse:

- `paneHasTrustPrompt()` only matched pre-2.1 wording ("Do you trust the contents of this directory?" / "Yes, continue|No, quit"), so the Claude 2.1.x quick-safety-check trust screen was never auto-dismissed.
- The bypass-permissions confirm now renders as `WARNING: Claude Code running in Bypass Permissions mode` with numbered choices (`1. No, exit` / `2. Yes, I accept`), which the detector did not match.

## Fix

1. **Submit key → named `Enter`** on every worker submit path:
   - `src/team/tmux-session.ts`: `attemptSubmitRounds()` (both queue-first Tab path and per-round presses), both `sendRobustEnter()` twins, `dismissTrustPromptIfPresent()`, `sendToWorker()` trust-guard, and all best-effort/final submit nudges.
   - `src/scripts/tmux-hook-engine.ts`: `buildSendKeysArgv()` now emits the named `Enter` and accepts a `submitKey` override; `sendPaneInput`/`queuePaneInput` (`team-tmux-guard.ts`) thread it through; `team-dispatch.ts` (the default `hook_preferred_with_fallback` dispatch transport) submits with `Enter`.
   - `src/team/scaling.ts`: scale-up final send uses `Enter`.
   - Verified empirically that `Enter` and `C-m` deliver the identical `0x0d` byte to byte-oriented pty readers on tmux 3.2a, so Codex submit behavior is unchanged; multi-line double-press semantics (~200ms apart) are preserved via the existing press counts (`claude` → 1, `codex` → 2).
2. **Trust detector**: `paneHasTrustPrompt()` also matches the Claude 2.1.x wording "Quick safety check: Is this a project you created or one you trust?" with the numbered-choice layout (`1. Yes, I trust this folder` / `2. No, exit`). Both old and new wordings require question + choices, so ordinary pane text does not trip it.
3. **Bypass-permissions detector**: `paneHasClaudeBypassPermissionsPrompt()` also matches the `WARNING: Claude Code running in Bypass Permissions mode` numbered-choice layout (keeping the existing "Press Enter to confirm" variant). Auto-accept (`OMX_TEAM_AUTO_ACCEPT_BYPASS`, default on) then presses `2` + named `Enter` as before.

## Tests

- Claude worker `sendToWorker` submits with named `Enter` — never `C-m`, never queue-first `Tab`.
- Trust detector matches both Codex/pre-2.1 and Claude 2.1.x wordings; negative cases confirm no false positives on ready panes or partial text.
- `waitForWorkerReadyAsync` auto-dismisses the Claude 2.1.x trust prompt and auto-accepts the 2.1.x bypass warning, with named `Enter`.
- Hook-path submit assertions updated (`buildSendKeysArgv` default + explicit `submitKey` override, queue-first Tab-then-Enter, isolated submit argv, leader/auto-nudge paths).

Local validation: `tsc --noEmit`, `biome lint`, `check:no-unused`, full `test:node` suite (7728 tests / 0 fail), `coverage:team-critical` (87.04% lines / 80.51% branches / 94.56% functions, above gates), `verify:plugin-bundle`, `verify:capabilities-lock`, `verify:prompt-guidance`, catalog/prompt-inventory checks.