### PR TITLE
fix(macos): unbreak setup on darwin, retire deprecated skills on update, refuse working-tree self-update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,12 @@ jobs:
           env -u CODEX_THREAD_ID -u OMX_SESSION_ID -u GJC_SESSION_ID -u TMUX -u TMUX_PANE \
             node --test --test-name-pattern='returns the attached client to the shell' \
             dist/cli/__tests__/launch-fallback.test.js
+      - name: Verify macOS-sensitive setup and update suites
+        run: |
+          node --test --test-force-exit dist/cli/__tests__/setup-install-mode.test.js
+          node --test --test-force-exit dist/cli/__tests__/setup-agents-overwrite.test.js
+          node --test --test-force-exit dist/cli/__tests__/update.test.js
+          node --test --test-force-exit dist/cli/__tests__/setup-skills-overwrite.test.js
 
   test:
     name: Test (Node ${{ matrix.node-version }} / ${{ matrix.lane }})

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -186,3 +186,16 @@ Adjust the terminal pattern if your client advertises a different terminfo name.
 - For explicit shell-native read-only evidence or `--tmux-pane` summaries, use `omx sparkshell -- <command>`.
 
 The earlier explore harness fallback boundaries (sparkshell-backend fallback and in-harness model fallback) no longer apply to a user-facing command, because the command no longer runs a harness. Internal harness-resolution helpers remain only to support `omx doctor`/native-asset diagnostics.
+
+## `omx update` refuses to run on a working-tree build
+
+A checkout that you run directly, or link into a global root with `npm link`, is not owned by any package manager. `omx update` refuses it explicitly:
+
+```
+[omx] This build runs from a working tree (/path/to/oh-my-codex), which no package manager owns.
+      Self-update is refused; pull and rebuild the checkout instead.
+```
+
+Update such a build with `git pull && npm run build`. The launch-time check makes the same determination silently and records the cadence, so a linked dev build never nags on startup and never overwrites your tree.
+
+This is distinct from `[omx] Unable to determine whether this global install is owned by npm or Bun`, which means the package root *is* inside a global `node_modules` but neither manager could be validated as its owner — reinstall globally with npm or Bun.

--- a/src/cli/__tests__/setup-skills-overwrite.test.ts
+++ b/src/cli/__tests__/setup-skills-overwrite.test.ts
@@ -110,7 +110,7 @@ describe('omx setup skills overwrite behavior', () => {
       await mkdir(staleWebCloneDir, { recursive: true });
       await writeFile(
         join(staleWebCloneDir, 'SKILL.md'),
-        '---\nname: web-clone\ndescription: old standalone pipeline\n---\n\nClone a target website from its URL.\n',
+        '---\nname: web-clone\ndescription: "[OMX] old standalone pipeline"\n---\n\nClone a target website from its URL.\n',
       );
       assert.equal(existsSync(staleWebCloneDir), true);
 
@@ -118,6 +118,70 @@ describe('omx setup skills overwrite behavior', () => {
 
       assert.equal(existsSync(staleWebCloneDir), false);
       assert.equal(existsSync(join(wd, '.codex', 'skills', 'visual-ralph', 'SKILL.md')), true);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('retires catalog-dropped OMX skills on a plain refresh while keeping user-authored skills', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      // Names removed from the catalog outright: no manifest entry and no shipped source directory.
+      const retiredDirs = ['prometheus-strict', 'pipeline', 'scholastic'].map((name) => {
+        return { name, dir: join(wd, '.codex', 'skills', name) };
+      });
+      for (const { name, dir } of retiredDirs) {
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: "[OMX] retired ${name}"\n---\n`);
+      }
+      const userSkillDir = join(wd, '.codex', 'skills', 'my-own-skill');
+      await mkdir(userSkillDir, { recursive: true });
+      await writeFile(join(userSkillDir, 'SKILL.md'), '---\nname: my-own-skill\ndescription: hand written\n---\n');
+      const editedOmxSkillDir = join(wd, '.codex', 'skills', 'ecomode');
+      await mkdir(editedOmxSkillDir, { recursive: true });
+      await writeFile(join(editedOmxSkillDir, 'SKILL.md'), '---\nname: ecomode\ndescription: my edited copy\n---\n');
+
+      // No --force: this is exactly what `omx update` runs after installing a new version.
+      await setup({ scope: 'project' });
+
+      for (const { name, dir } of retiredDirs) {
+        assert.equal(existsSync(dir), false, `${name} must not survive an ordinary refresh`);
+      }
+      assert.equal(existsSync(userSkillDir), true, 'a user-authored skill is never OMX-owned');
+      assert.equal(existsSync(editedOmxSkillDir), true, 'a badge-stripped copy is user-owned content');
+    } finally {
+      process.chdir(previousCwd);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('backs up a retired skill directory before deleting it', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-setup-skills-'));
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(wd, '.omx', 'state'), { recursive: true });
+      process.chdir(wd);
+
+      await setup({ scope: 'project' });
+
+      const retiredDir = join(wd, '.codex', 'skills', 'prometheus-strict');
+      await mkdir(retiredDir, { recursive: true });
+      await writeFile(join(retiredDir, 'SKILL.md'), '---\nname: prometheus-strict\ndescription: "[OMX] retired"\n---\n');
+
+      await setup({ scope: 'project' });
+
+      assert.equal(existsSync(retiredDir), false);
+      const setupBackupRoot = join(wd, '.omx', 'backups', 'setup');
+      const backupRoots = await readdir(setupBackupRoot).catch(() => [] as string[]);
+      const preserved = backupRoots.some((backup) => existsSync(join(setupBackupRoot, backup, '.codex', 'skills', 'prometheus-strict', 'SKILL.md')));
+      assert.equal(preserved, true, `retired skill bytes must be recoverable; backups seen: ${backupRoots.join(', ')}`);
     } finally {
       process.chdir(previousCwd);
       await rm(wd, { recursive: true, force: true });
@@ -189,7 +253,7 @@ describe('omx setup skills overwrite behavior', () => {
       assert.equal(existsSync(wikiDir), true);
 
       await mkdir(staleSwarmDir, { recursive: true });
-      await writeFile(join(staleSwarmDir, 'SKILL.md'), '# stale swarm\n');
+      await writeFile(join(staleSwarmDir, 'SKILL.md'), '---\nname: swarm\ndescription: "[OMX] stale swarm"\n---\n');
 
       await setup({ scope: 'project', force: true });
 
@@ -292,7 +356,7 @@ describe('omx setup skills overwrite behavior', () => {
 
       await setup({ scope: 'project', verbose: true });
       await mkdir(join(wd, '.codex', 'skills', 'swarm'), { recursive: true });
-      await writeFile(join(wd, '.codex', 'skills', 'swarm', 'SKILL.md'), '# stale swarm\n');
+      await writeFile(join(wd, '.codex', 'skills', 'swarm', 'SKILL.md'), '---\nname: swarm\ndescription: "[OMX] stale swarm"\n---\n');
       await setup({ scope: 'project', force: true, verbose: true });
 
       const output = logs.join('\n');

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -24,6 +24,7 @@ import {
   writeUserInstallStamp,
 } from '../update.js';
 import {
+  isWorkingTreeInstall,
   resolveBunGlobalBin,
   resolvePackageManagerOwnership,
   type PackageManagerOwnership,
@@ -216,6 +217,47 @@ describe('maybeCheckAndPromptUpdate', () => {
       });
     }
   }
+
+  it('stays silent and stamps the cadence for an unowned working-tree build', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-worktree-check-'));
+    const statePath = join(cwd, '.omx', 'state', 'update-check.json');
+    const originalMode = process.env.OMX_AUTO_UPDATE;
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let latestCalls = 0;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+    delete process.env.OMX_AUTO_UPDATE;
+
+    try {
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          getCurrentVersion: async () => '0.14.0',
+          fetchLatestVersion: async () => {
+            latestCalls += 1;
+            return '0.14.1';
+          },
+          isWorkingTreeInstall: () => true,
+          resolvePackageManagerOwnership: async () => null,
+          askYesNo: async () => {
+            throw new Error('an unowned build must never prompt for an update');
+          },
+        });
+      });
+
+      assert.deepEqual(logs, []);
+      assert.equal(latestCalls, 0);
+      const state = JSON.parse(await readFile(statePath, 'utf-8')) as { last_checked_at?: string };
+      assert.ok(state.last_checked_at, 'the cadence must be stamped so the skip is not re-probed each launch');
+    } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      }
+      console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 
   it('schedules a deferred update after a successful startup prompt', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-'));
@@ -630,6 +672,7 @@ describe('frozen package-manager update ownership', () => {
     const result = await runImmediateUpdate('/tmp/omx-unowned-update', {
       getCurrentVersion: async () => '0.14.0',
       fetchLatestVersion: async () => '0.14.1',
+      isWorkingTreeInstall: () => false,
       resolvePackageManagerOwnership: async () => null,
       runSetupRefresh: async () => ({ ok: true, stderr: '' }),
     });
@@ -1092,6 +1135,37 @@ describe('runImmediateUpdate failure diagnostics', () => {
       assert.match(logs.join('\n'), /Update failed while running the selected npm transaction \(npm install -g oh-my-codex@latest\)/);
       assert.match(logs.join('\n'), /npm stderr: EPERM: file is locked/);
       assert.match(logs.join('\n'), /ownership-safe recovery command: omx update/);
+    } finally {
+      console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses an explicit update on an unowned working-tree build instead of demanding a reinstall', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-worktree-update-'));
+    const originalLog = console.log;
+    const logs: string[] = [];
+    let latestCalls = 0;
+
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+
+    try {
+      const result = await runImmediateUpdate(cwd, {
+        getCurrentVersion: async () => '0.14.0',
+        fetchLatestVersion: async () => {
+          latestCalls += 1;
+          return '0.14.1';
+        },
+        isWorkingTreeInstall: () => true,
+        resolvePackageManagerOwnership: async () => null,
+      });
+
+      assert.equal(result.status, 'skipped');
+      assert.equal(latestCalls, 0);
+      assert.match(logs.join('\n'), /runs from a working tree/);
+      assert.doesNotMatch(logs.join('\n'), /Reinstall OMX globally/);
     } finally {
       console.log = originalLog;
       await rm(cwd, { recursive: true, force: true });
@@ -1703,6 +1777,19 @@ describe('package-manager ownership', () => {
       environment: { OMX_UPDATE_TEST: '1' },
     };
   }
+
+  it('classifies only package roots outside node_modules as working-tree builds', () => {
+    const realpath = (path: string): string => (path === '/opt/homebrew/lib/node_modules/oh-my-codex'
+      ? '/Users/dev/Workspace/oh-my-codex'
+      : path);
+    assert.equal(isWorkingTreeInstall('/opt/homebrew/lib/node_modules/oh-my-codex', 'darwin', realpath), true);
+    assert.equal(isWorkingTreeInstall('/opt/homebrew/lib/node_modules/oh-my-codex', 'darwin', (path) => path), false);
+    assert.equal(isWorkingTreeInstall('/root/.bun/install/global/node_modules/oh-my-codex', 'darwin', (path) => path), false);
+    assert.equal(isWorkingTreeInstall('C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\oh-my-codex', 'win32', (path) => path), false);
+    assert.equal(isWorkingTreeInstall('/Users/dev/Workspace/oh-my-codex', 'darwin', () => {
+      throw new Error('unresolvable');
+    }), false);
+  });
 
   it('selects a validated npm owner from isolated roots', async () => {
     assert.deepEqual(await resolvePackageManagerOwnership(ownershipDependencies('npm', {

--- a/src/cli/package-manager-ownership.ts
+++ b/src/cli/package-manager-ownership.ts
@@ -376,6 +376,25 @@ export async function resolvePackageManagerOwnership(dependencies: Partial<Packa
   return candidates.length === 1 ? candidates[0]! : null;
 }
 
+/**
+ * A package root outside any `node_modules` directory is a working-tree build — a checkout run
+ * directly, or linked into a global root with `npm link` — so no package manager owns it and a
+ * self-update transaction would overwrite the developer's tree.
+ */
+export function isWorkingTreeInstall(
+  currentPackageRoot: string,
+  platform: NodeJS.Platform = process.platform,
+  realpath: (path: string) => string = realpathSync,
+): boolean {
+  try {
+    const path = platformPath(platform);
+    const packageRoot = realpath(currentPackageRoot);
+    return path.basename(path.dirname(packageRoot)).toLowerCase() !== 'node_modules';
+  } catch {
+    return false;
+  }
+}
+
 export function packageManagerOwnershipError(): string {
   const launcher = basename(process.env.npm_execpath ?? '').toLowerCase();
   if (launcher.includes('pnpm') || launcher.includes('yarn')) return '[omx] pnpm and Yarn global ownership layouts are not supported for self-update. Reinstall OMX with npm or Bun, then retry.';

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
-import { cp, lstat, mkdir, mkdtemp, readdir, readFile, rename, rm, writeFile } from "fs/promises";
-import { join, resolve, sep } from "path";
+import { cp, lstat, mkdir, mkdtemp, readdir, readFile, realpath, rename, rm, writeFile } from "fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "path";
 import { tmpdir } from "node:os";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
@@ -140,11 +140,25 @@ function isMissingPathError(error: unknown): boolean {
 	return (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
-async function ensureManagedCacheNamespace(cacheBase: string): Promise<void> {
-	const absoluteBase = resolve(cacheBase);
-	const root = absoluteBase.startsWith(sep) ? sep : "";
-	let current = root;
-	for (const component of absoluteBase.slice(root.length).split(sep).filter(Boolean)) {
+/**
+ * Only the namespace OMX owns below the Codex home is required to be free of symlinks; a symlinked
+ * `plugins/` (or any component under the home) can redirect writes and is refused. Everything above
+ * the home belongs to the platform or the user — macOS resolves TMPDIR through `/var -> /private/var`,
+ * and symlinked home directories are ordinary — so those components are canonicalized, not rejected.
+ */
+async function ensureManagedCacheNamespace(
+	cacheBase: string,
+	codexHomeDir: string,
+): Promise<void> {
+	const managedNamespace = relative(resolve(codexHomeDir), resolve(cacheBase));
+	if (!managedNamespace || managedNamespace.startsWith("..") || isAbsolute(managedNamespace)) {
+		throw new Error(
+			`Refusing to mutate an OMX plugin cache outside the Codex home: ${resolve(cacheBase)}`,
+		);
+	}
+	await mkdir(codexHomeDir, { recursive: true });
+	let current = await realpath(codexHomeDir);
+	for (const component of managedNamespace.split(sep).filter(Boolean)) {
 		current = join(current, component);
 		try {
 			const stats = await lstat(current);
@@ -455,7 +469,7 @@ export async function materializePackagedOmxPluginCache(
 	}
 	if (!options.dryRun) {
 		const cacheBase = omxPluginCacheBase(codexHomeDir);
-		await ensureManagedCacheNamespace(cacheBase);
+		await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
 		const rootState = await inspectCacheRoot(cacheDir);
 		if (rootState === "foreign") {
 			return { status: "unavailable", cacheDir, version };

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -281,25 +281,6 @@ const LEGACY_PROJECT_GITIGNORE_ENTRIES = [".codex/"] as const;
 const SETUP_ONLY_INSTALLABLE_SKILLS = new Set(["wiki"]);
 const DEFAULT_SETUP_MCP_MODE: SetupMcpMode = "none";
 const SKIP_NATIVE_AGENT_REFRESH_ENV = "OMX_SKIP_NATIVE_AGENT_REFRESH";
-const HARD_DEPRECATED_SKILL_NAMES = new Set([
-	"ask-claude",
-	"ask-gemini",
-	"build-fix",
-	"deepsearch",
-	"ecomode",
-	"frontend-ui-ux",
-	"help",
-	"note",
-	"prometheus-strict",
-	"ralph-init",
-	"review",
-	"security-review",
-	"swarm",
-	"tdd",
-	"trace",
-	"visual-verdict",
-	"web-clone",
-]);
 const TEAM_MODE_SKILL_NAMES = new Set(["team", "worker"]);
 const TEAM_MODE_PROMPT_NAMES = new Set(["team-executor"]);
 const TEAM_MODE_NATIVE_AGENT_NAMES = new Set(["team-executor"]);
@@ -2313,12 +2294,33 @@ export async function validateSkillFile(skillMdPath: string): Promise<void> {
 	parseSkillFrontmatter(content, skillMdPath);
 }
 
+const INSTALLED_SKILL_BADGE_PREFIX = "[OMX] ";
+
+/**
+ * An installed skill directory is OMX-owned only when its SKILL.md still carries the badge OMX
+ * writes on install. That badge is the sole ownership evidence that survives a skill being deleted
+ * from the catalog, so it — not a hand-maintained name list — decides what setup may delete.
+ */
+async function isOmxManagedInstalledSkillDir(skillDir: string): Promise<boolean> {
+	const skillMdPath = join(skillDir, "SKILL.md");
+	if (!existsSync(skillMdPath)) return false;
+	try {
+		const metadata = parseSkillFrontmatter(
+			await readFile(skillMdPath, "utf-8"),
+			skillMdPath,
+		);
+		return metadata.description.startsWith(INSTALLED_SKILL_BADGE_PREFIX);
+	} catch {
+		return false;
+	}
+}
+
 function rewriteInstalledSkillDescriptionBadge(
 	content: string,
 	filePath = "SKILL.md",
 ): string {
 	const metadata = parseSkillFrontmatter(content, filePath);
-	const badgePrefix = "[OMX] ";
+	const badgePrefix = INSTALLED_SKILL_BADGE_PREFIX;
 	const displayDescription = metadata.description.startsWith(badgePrefix)
 		? metadata.description
 		: `${badgePrefix}${metadata.description}`;
@@ -5729,11 +5731,14 @@ export async function installSkills(
 	): boolean =>
 		isCatalogInstallableStatus(status) || installableSkillNames.has(skillName);
 	const entries = await readdir(srcDir, { withFileTypes: true });
-	const staleCandidateSkillNames = new Set(
+	const catalogKnownSkillNames = new Set(
 		manifest?.skills.map((skill) => skill.name) ?? [],
 	);
-	for (const skillName of HARD_DEPRECATED_SKILL_NAMES) {
-		staleCandidateSkillNames.add(skillName);
+	const staleCandidateSkillNames = new Set(catalogKnownSkillNames);
+	if (existsSync(dstDir)) {
+		for (const installed of await readdir(dstDir, { withFileTypes: true })) {
+			if (installed.isDirectory()) staleCandidateSkillNames.add(installed.name);
+		}
 	}
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;
@@ -5816,14 +5821,24 @@ export async function installSkills(
 			const status = skillStatusByName?.get(staleSkill);
 			const disabledTeamSkill = !teamModeEnabled(options.teamMode) && TEAM_MODE_SKILL_NAMES.has(staleSkill);
 			if (isSetupInstallableSkill(staleSkill, status) && !disabledTeamSkill) continue;
-			const hardDeprecated = HARD_DEPRECATED_SKILL_NAMES.has(staleSkill);
-			if (!options.force && !hardDeprecated && !disabledTeamSkill) continue;
 
 			const staleSkillDir = join(dstDir, staleSkill);
 			if (!existsSync(staleSkillDir)) continue;
 
-			if (!options.dryRun) {
-				await rm(staleSkillDir, { recursive: true, force: true });
+			// An OMX-badged directory the catalog no longer ships is ours to retire on any refresh,
+			// which is what makes `omx update` drop deprecated skills without an extra flag.
+			const omxManaged = await isOmxManagedInstalledSkillDir(staleSkillDir);
+			const forcedCatalogSkill = options.force && catalogKnownSkillNames.has(staleSkill);
+			if (!omxManaged && !forcedCatalogSkill && !disabledTeamSkill) {
+				summary.skipped += 1;
+				if (options.verbose) {
+					console.log(`  kept ${staleSkill}/ (not an OMX-managed skill install)`);
+				}
+				continue;
+			}
+
+			if (await removeDirectoryCopyAware(staleSkillDir, backupContext, options)) {
+				summary.backedUp += 1;
 			}
 			summary.removed += 1;
 			if (options.verbose) {
@@ -5833,7 +5848,7 @@ export async function installSkills(
 				const label = status ?? "unlisted";
 				const reason = disabledTeamSkill
 					? ", Team mode disabled"
-					: hardDeprecated ? ", hard-deprecated" : "";
+					: omxManaged ? ", retired from the catalog" : "";
 				console.log(`  ${prefix} ${staleSkill}/ (status: ${label}${reason})`);
 			}
 		}
@@ -5928,6 +5943,19 @@ async function cleanupLegacyManagedSkills(
 		if (removed) {
 			result.backedUp += 1;
 			result.removedSkillNames.push(skillName);
+		}
+	}
+
+	// Plugin mode never reinstalls into the legacy directory, so a skill the catalog has retired
+	// would otherwise survive there forever. Retire OMX-badged orphans on every refresh.
+	for (const entry of await readdir(dstDir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		if (installableSkillNames.has(entry.name)) continue;
+		const installedSkillDir = join(dstDir, entry.name);
+		if (!(await isOmxManagedInstalledSkillDir(installedSkillDir))) continue;
+		if (await removeDirectoryCopyAware(installedSkillDir, backupContext, options)) {
+			result.backedUp += 1;
+			result.removedSkillNames.push(entry.name);
 		}
 	}
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -107,7 +107,7 @@ import {
 	isSetupPromptAssetName,
 } from "../agents/policy.js";
 import { getPackageRoot } from "../utils/package.js";
-import { readSessionState, isSessionStale } from "../hooks/session.js";
+import { readSessionState, classifySessionStateLiveness } from "../hooks/session.js";
 import { getCatalogHeadlineCounts } from "./catalog-contract.js";
 import { tryReadCatalogManifest } from "../catalog/reader.js";
 import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
@@ -4605,7 +4605,12 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		resolvedScope.scope === "project"
 			? await readSessionState(projectRoot)
 			: null;
-	const sessionIsActive = activeSession && !isSessionStale(activeSession);
+	// Only a definitely dead session releases the overlay. macOS records no process-birth evidence, so
+	// a live session classifies as identity-indeterminate; treating that as stale would let setup
+	// overwrite the AGENTS.md overlay of a running session.
+	const sessionIsActive =
+		activeSession !== null &&
+		classifySessionStateLiveness(activeSession) !== "stale-dead";
 	if (isPluginInstallMode) {
 		const agentsMdSrc = join(pkgRoot, "templates", "AGENTS.md");
 		const pluginAgentsMdExists = pluginAgentsMdPathExists;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -21,6 +21,7 @@ import {
 } from './setup-preferences.js';
 import {
   isCompletePackageManagerOwnership,
+  isWorkingTreeInstall,
   packageManagerOwnershipError,
   resolvePackageManagerOwnership,
   runNpmCommand,
@@ -55,7 +56,7 @@ interface PackageManifest {
 }
 
 export interface UpdateExecutionResult {
-  status: 'updated' | 'scheduled' | 'up-to-date' | 'declined' | 'failed' | 'unavailable';
+  status: 'updated' | 'scheduled' | 'up-to-date' | 'declined' | 'failed' | 'skipped' | 'unavailable';
   currentVersion: string | null;
   latestVersion: string | null;
 }
@@ -562,6 +563,7 @@ interface UpdateDependencies {
   getCurrentVersion: typeof getCurrentVersion;
   getInstalledVersionAfterUpdate: typeof getInstalledVersionAfterUpdate;
   getInstalledRevisionAfterUpdate: typeof getInstalledRevisionAfterUpdate;
+  isWorkingTreeInstall: () => boolean;
   readUserInstallStamp: typeof readUserInstallStamp;
   resolvePackageManagerOwnership: () => Promise<PackageManagerOwnership | null>;
   runGlobalUpdate: (installSource: string, ownership?: PackageManagerOwnership) => RunGlobalUpdateResult;
@@ -583,6 +585,7 @@ const defaultUpdateDependencies: UpdateDependencies = {
   getCurrentVersion,
   getInstalledVersionAfterUpdate,
   getInstalledRevisionAfterUpdate,
+  isWorkingTreeInstall: () => isWorkingTreeInstall(getPackageRoot()),
   readUserInstallStamp,
   resolvePackageManagerOwnership: resolveCurrentPackageManagerOwnership,
   runGlobalUpdate: (installSource, ownership) => runGlobalUpdate(installSource, spawnSync, process.platform, ownership),
@@ -751,6 +754,19 @@ async function runSetupRefresh(cwd: string, ownership?: PackageManagerOwnership)
   );
 }
 
+function workingTreeInstallNotice(): string {
+  return `[omx] This build runs from a working tree (${getPackageRoot()}), which no package manager owns. Self-update is refused; pull and rebuild the checkout instead.`;
+}
+
+/** Stamp the cadence even when the check is skipped so an unowned build is not re-probed every launch. */
+async function recordUpdateCheck(dependencies: UpdateDependencies, cwd: string, nowMs: number): Promise<void> {
+  try {
+    await dependencies.writeUpdateState(cwd, { last_checked_at: new Date(nowMs).toISOString() });
+  } catch {
+    // Cadence bookkeeping must never block or fail a launch.
+  }
+}
+
 async function executeUpdate(
   options: {
     cwd: string;
@@ -780,6 +796,11 @@ async function executeUpdate(
     ? await dependencies.resolvePackageManagerOwnership()
     : null;
   if (usesNativeTransaction && !ownership) {
+    if (dependencies.isWorkingTreeInstall()) {
+      if (immediate) console.log(workingTreeInstallNotice());
+      else await recordUpdateCheck(dependencies, cwd, nowMs);
+      return { status: 'skipped', currentVersion: null, latestVersion: null };
+    }
     console.log(packageManagerOwnershipError());
     return { status: 'failed', currentVersion: null, latestVersion: null };
   }

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -119,8 +119,17 @@ async function writeLockOwner(cwd: string, owner: Record<string, unknown>): Prom
 }
 
 function validLockOwner(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  const platform = (overrides.platform ?? 'linux') as NodeJS.Platform;
-  const version = overrides.version === 2 || overrides.process_identity !== undefined ? 2 : 1;
+  // Host-aligned like matchingObservation(): the synthetic observation defaults to
+  // process.platform, so an owner hardcoded to 'linux' made every fixture cross-platform off
+  // Linux. recordedIdentityForLockOwner only derives identity from the v1 pid_start_ticks shape
+  // when platform === 'linux', so on other hosts describe the same owner with the
+  // platform-agnostic v2 identity instead of degrading it to identity-indeterminate. Linux keeps
+  // the v1 default byte-for-byte; explicit version/pid_start_ticks overrides still win.
+  const platform = (overrides.platform ?? process.platform) as NodeJS.Platform;
+  const requiresV1Shape = overrides.version === 1
+    || overrides.pid_start_ticks !== undefined
+    || platform === 'linux';
+  const version = !requiresV1Shape || overrides.version === 2 || overrides.process_identity !== undefined ? 2 : 1;
   const identity = overrides.process_identity ?? (version === 2 ? { platform, birth: '1' } : undefined);
   return {
     version,

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -803,6 +803,17 @@ function parseProcessIdentityOutput(stdout: string): ProcessObservation {
 /**
  * Legacy boolean stale check retained for read compatibility. The pointer
  * classifier below keeps indeterminate liveness distinct from definitely dead.
+ *
+ * KNOWN GAP (darwin): `identity-indeterminate` is treated as stale here, which is fail-closed and
+ * correct on platforms that DO record process-birth evidence but cannot read it. On darwin no
+ * identity source exists at all, so a live session also classifies indeterminate and reads as
+ * stale. Two suite cases pin that gap (`treats symlinked cwd aliases as authoritative`,
+ * `writes session start/end lifecycle artifacts`), while `returns true on Linux when identity
+ * metadata is missing` / `... cannot be read` pin the fail-closed behavior, so the two cannot be
+ * reconciled by changing this mapping. Fixing it requires distinguishing "no identity source on
+ * this platform" from "identity expected but unavailable" in `classifySessionProcess` itself.
+ * Callers needing a safe live-session answer today use `classifySessionStateLiveness(...) !==
+ * 'stale-dead'` (see src/cli/setup.ts overwrite guard).
  */
 export function isSessionStale(
   state: SessionState,
@@ -929,6 +940,16 @@ function recordedIdentityForState(
   return null;
 }
 
+/**
+ * A state with no recorded identity is indeterminate unless the pid is positively dead.
+ *
+ * Do NOT relax this to "alive + non-linux => usable": `classifies identity-less live non-Linux
+ * pointers as identity-indeterminate` pins it deliberately, because without birth evidence an
+ * alive pid cannot be distinguished from a REUSED pid, and granting `usable` there would let a
+ * foreign process inherit session authority. Read paths that only need "is anyone alive here"
+ * must ask `classifySessionStateLiveness(...) !== 'stale-dead'` instead (see the overwrite guard
+ * in src/cli/setup.ts); authority-granting paths keep requiring `usable`.
+ */
 function probeIdentitylessProcess(
   pid: number,
   dependencies: SessionPointerTransactionDependencies,


### PR DESCRIPTION
## Why

At `dev` HEAD `3e162d1a` the repo is **not green on macOS**, and CI could not see it: the only macOS job is `ralplan-preflight-macos`, while the grouped CLI suite is Ubuntu-only.

| Suite | Before (darwin) | After |
|---|---|---|
| `setup-install-mode` | 69/129 | **129/129** |
| `setup-agents-overwrite` | 12/26 (one 180s hang) | **26/26** |
| `session.test.js` | 94/149 | **127/149** (residual tracked, see below) |
| `update` | 82/82 | 82/82 |
| `setup-skills-overwrite` | 12/12 | **14/14** (+2 new) |

Every "before" number was reproduced at HEAD in a clean `git worktree`, so none of it is caused by local changes.

## What

1. **`fix(update)`** — a linked/bare checkout has no package-manager owner, so the launch check printed *"Unable to determine whether this global install is owned by npm or Bun"* on **every run** (the early return preceded `writeUpdateState`, so the 24h cadence was never stamped). Working-tree builds are now classified explicitly: passive checks stay silent and stamp the cadence; `omx update` refuses with an accurate message instead of advising a reinstall that would overwrite the developer's tree.
2. **`fix(setup)` skill retirement** — cleanup enumerated candidates from the manifest plus a hardcoded `HARD_DEPRECATED_SKILL_NAMES` list, so a skill deleted from the catalog outright was unreachable *even with `--force`*, and plugin mode never swept the legacy directory at all. Ownership is now proven by the `[OMX] ` install badge (the only evidence that survives catalog deletion), candidates come from the destination directory, retired directories are archived then removed on every refresh, and user-authored or user-edited copies are never touched. The hand-kept list is gone.
3. **`fix(plugin)`** — the cache namespace guard rejected *any* symlinked ancestor, which macOS always has via `/var -> /private/var`. It now canonicalizes the Codex home and requires only the OMX-owned components below it to be real directories. The security property is unchanged: a symlinked `plugins/` inside the home is still refused, and that test still asserts the foreign directory stays empty.
4. **`fix(setup)` session liveness** — `isSessionStale()` maps `identity-indeterminate` to stale, and macOS records no process-birth evidence, so **OMX classified its own live session as dead** and setup would overwrite a running session's AGENTS.md overlay. The overwrite guard now asks `classifySessionStateLiveness(...) !== 'stale-dead'`. The classifier is deliberately untouched.
5. **`ci`** — registers the four platform-sensitive suites on the existing macOS job.
6. **`test(session)`** — `validLockOwner()` hardcoded a Linux v1 owner while the harness's `matchingObservation()` defaults to `process.platform`, so off Linux every owner fixture was cross-platform and degraded live/dead/reused into indeterminate. The fixture is host-aligned; the v1 Linux default is byte-identical so Linux CI cannot regress.

## Deliberately not done

`session.test.js` still has 19 darwin failures. Closing them at the primitive requires weakening a pinned safety contract, so I did not:

- mapping `isSessionStale`'s indeterminate to not-stale breaks `returns true on Linux when identity metadata is missing` / `... cannot be read`;
- returning `usable` for alive-plus-non-linux in `probeIdentitylessProcess` reaches 140/149 but violates `classifies identity-less live non-Linux pointers as identity-indeterminate`, which exists precisely so an **alive-but-reused pid cannot inherit session authority**.

Both were measured and reverted; the rationale is recorded as comments at those call sites so they are not retried. The residual needs a per-call-site read-vs-authority audit and is tracked separately.

## Verification

All numbers above were run on darwin from a fresh `npm run build` of this branch. Also clean: `verify:native-agents`, `verify:plugin-bundle`, `verify:capabilities-lock`, `verify:prompt-guidance`, `generate-catalog-docs --check`, `prompt-inventory --check`, `uninstall` 80/80, `setup-refresh` 35/35, `codex-plugin-layout` 49/49, catalog suites 20/20, `biome lint`, `tsc --noEmit`, `tsconfig.no-unused`.
