### PR TITLE
fix(team): authorize verified workers on external OMX state roots

### DIFF
--- a/src/cli/__tests__/doctor-team.test.ts
+++ b/src/cli/__tests__/doctor-team.test.ts
@@ -314,4 +314,88 @@ describe('omx doctor --team', () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+  it('passes a verified team worker on an external state root without a singleton session.json (#3536)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-3536-'));
+    try {
+      const leaderCwd = join(wd, 'leader');
+      const stateRoot = join(wd, 'external', '.omx', 'state');
+      const teamName = 'ext-team';
+      const workerCwd = join(leaderCwd, '.omx', 'team', teamName, 'worktrees', 'worker-1');
+      await mkdir(workerCwd, { recursive: true });
+      // External root has state but no singleton session.json.
+      await mkdir(join(stateRoot, 'sessions'), { recursive: true });
+      const teamRoot = join(stateRoot, 'team', teamName);
+      await mkdir(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+      await writeFile(join(teamRoot, 'workers', 'worker-1', 'identity.json'), JSON.stringify({
+        name: 'worker-1',
+        pane_id: '%77',
+        worktree_path: workerCwd,
+        team_state_root: stateRoot,
+      }));
+      const metadata = {
+        name: teamName,
+        leader_cwd: leaderCwd,
+        team_state_root: stateRoot,
+        leader_pane_id: '%42',
+        workers: [{ name: 'worker-1', pane_id: '%77', worktree_path: workerCwd, team_state_root: stateRoot }],
+      };
+      await writeFile(join(teamRoot, 'manifest.v2.json'), JSON.stringify({
+        ...metadata,
+        policy: { worker_launch_mode: 'prompt' },
+      }));
+      await writeFile(join(teamRoot, 'config.json'), JSON.stringify(metadata));
+
+      const res = runOmx(leaderCwd, ['doctor', '--team'], { OMX_ROOT: join(wd, 'external'), PATH: '' });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 0, res.stderr || res.stdout);
+      assert.doesNotMatch(res.stdout, /worker_policy_root_unusable/);
+      assert.match(res.stdout, /All team checks passed/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails with worker_policy_root_unusable when worker metadata cannot establish runtime authorization (#3536)', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-doctor-team-3536-bad-'));
+    try {
+      const leaderCwd = join(wd, 'leader');
+      const stateRoot = join(wd, 'external', '.omx', 'state');
+      const teamName = 'bad-team';
+      const workerCwd = join(leaderCwd, '.omx', 'team', teamName, 'worktrees', 'worker-1');
+      await mkdir(workerCwd, { recursive: true });
+      await mkdir(join(stateRoot, 'sessions'), { recursive: true });
+      const teamRoot = join(stateRoot, 'team', teamName);
+      await mkdir(join(teamRoot, 'workers', 'worker-1'), { recursive: true });
+      await writeFile(join(teamRoot, 'workers', 'worker-1', 'identity.json'), JSON.stringify({
+        name: 'worker-1',
+        pane_id: '%77',
+        worktree_path: workerCwd,
+        team_state_root: stateRoot,
+      }));
+      await writeFile(join(teamRoot, 'manifest.v2.json'), JSON.stringify({
+        name: teamName,
+        policy: { worker_launch_mode: 'prompt' },
+        leader_cwd: leaderCwd,
+        team_state_root: stateRoot,
+        leader_pane_id: '%42',
+        workers: [{ name: 'worker-1', pane_id: '%77', worktree_path: workerCwd, team_state_root: stateRoot }],
+      }));
+      // Conflicting config: leader_cwd disagrees with the manifest.
+      await writeFile(join(teamRoot, 'config.json'), JSON.stringify({
+        name: teamName,
+        leader_cwd: join(wd, 'elsewhere'),
+        team_state_root: stateRoot,
+        leader_pane_id: '%42',
+        workers: [{ name: 'worker-1', pane_id: '%77', worktree_path: workerCwd, team_state_root: stateRoot }],
+      }));
+
+      const res = runOmx(leaderCwd, ['doctor', '--team'], { OMX_ROOT: join(wd, 'external'), PATH: '' });
+      if (shouldSkipForSpawnPermissions(res.error)) return;
+      assert.equal(res.status, 1, res.stderr || res.stdout);
+      assert.match(res.stdout, /worker_policy_root_unusable/);
+      assert.match(res.stdout, /bad-team\/worker-1/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -111,8 +111,13 @@ import { readCatalogManifest } from "../catalog/reader.js";
 import {
 	defaultProcessInspectionProvider,
 	isValidProcessIdentity,
+	resolveSessionPointerContext,
 	type ProcessInspectionProvider,
 } from "../hooks/session.js";
+import {
+	resolveAuthoritativeTeamWorkerContext,
+	resolveConductorPolicyRoot,
+} from "../team/worker-provenance.js";
 
 let doctorClaimJournalDurabilityOverride: NativeHookClaimJournalDurability | undefined;
 
@@ -893,7 +898,8 @@ interface TeamDoctorIssue {
 		| "orphan_tmux_session"
 		| "resume_blocker"
 		| "prompt_resume_unavailable"
-		| "stale_leader";
+		| "stale_leader"
+		| "worker_policy_root_unusable";
 	message: string;
 	severity: "warn" | "fail";
 }
@@ -1098,6 +1104,54 @@ async function collectTeamDoctorIssues(
 					}
 				} catch {
 					// ignore malformed files
+				}
+			}
+
+			// #3536: run the same runtime preflight the native hook applies. A
+			// worker whose metadata cannot establish an authoritative context, or
+			// whose verified state root still yields an unusable Conductor policy
+			// root, would be denied at runtime while doctor reports all-pass.
+			const identityPath = join(workerDir, "identity.json");
+			if (existsSync(identityPath)) {
+				try {
+					const identity = JSON.parse(await readFile(identityPath, "utf-8")) as Record<string, unknown>;
+					const manifestForWorker = existsSync(manifestPath)
+						? JSON.parse(await readFile(manifestPath, "utf-8")) as Record<string, unknown>
+						: {};
+					const workerCwd = typeof identity.worktree_path === "string" && identity.worktree_path.trim() !== ""
+						? identity.worktree_path.trim()
+						: typeof identity.working_dir === "string" ? identity.working_dir.trim() : "";
+					const identityStateRoot = typeof identity.team_state_root === "string" && identity.team_state_root.trim() !== ""
+						? identity.team_state_root.trim()
+						: stateDir;
+					const leaderCwd = typeof manifestForWorker.leader_cwd === "string" ? manifestForWorker.leader_cwd.trim() : "";
+					if (workerCwd) {
+						const workerEnv = {
+							OMX_TEAM_INTERNAL_WORKER: `${teamName}/${worker.name}`,
+							OMX_TEAM_STATE_ROOT: identityStateRoot,
+							OMX_TEAM_LEADER_CWD: leaderCwd,
+						} as NodeJS.ProcessEnv;
+						const evidence = await resolveAuthoritativeTeamWorkerContext(workerCwd, { env: workerEnv });
+						if (!evidence) {
+							issues.push({
+								code: "worker_policy_root_unusable",
+								message: `${teamName}/${worker.name} identity/config/manifest metadata does not establish an authoritative worker context; runtime authorization would deny this worker`,
+								severity: "fail",
+							});
+						} else {
+							const selectedStateDir = resolveSessionPointerContext(workerCwd, workerEnv).baseStateDir;
+							const policyRoot = resolveConductorPolicyRoot(selectedStateDir, workerCwd, evidence);
+							if (!policyRoot.valid) {
+								issues.push({
+									code: "worker_policy_root_unusable",
+									message: `${teamName}/${worker.name} selected state root ${selectedStateDir} has no usable canonical session cwd and no verified Team-root binding; runtime authorization would deny this worker`,
+									severity: "fail",
+								});
+							}
+						}
+					}
+				} catch {
+					// ignore malformed worker metadata
 				}
 			}
 		}

--- a/src/scripts/__tests__/issue-3536-external-team-state-root.test.ts
+++ b/src/scripts/__tests__/issue-3536-external-team-state-root.test.ts
@@ -1,0 +1,216 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dispatchCodexNativeHook } from "../codex-native-hook.js";
+import { sanitizeNativeHookOutput } from "../../hooks/native/pre-tool-use-advisory.js";
+
+/**
+ * Issue #3536: a verified Team worker using an external OMX state root with no
+ * singleton session.json must not be rejected by the generic Conductor
+ * policy-root guard, while every mismatch and protected-state write stays
+ * denied. These tests exercise the effective dispatch output plus the native
+ * hook adapter sanitizer (what Codex actually consumes), not only internal
+ * classifiers.
+ */
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+const WORKER_ENV_KEYS = [
+  "TMUX",
+  "TMUX_PANE",
+  "OMX_TEAM_INTERNAL_WORKER",
+  "OMX_TEAM_WORKER",
+  "OMX_TEAM_STATE_ROOT",
+  "OMX_TEAM_LEADER_CWD",
+] as const;
+
+interface WorkerFixture {
+  root: string;
+  leaderCwd: string;
+  stateRoot: string;
+  workerCwd: string;
+  teamName: string;
+  workerName: string;
+  paneId: string;
+}
+
+async function createExternalRootWorkerFixture(): Promise<WorkerFixture> {
+  const root = realpathSync(await mkdtemp(join(tmpdir(), "omx-3536-hook-")));
+  const leaderCwd = join(root, "leader");
+  const stateRoot = join(root, "external", ".omx", "state");
+  const teamName = "ext-hook-team";
+  const workerName = "worker-1";
+  const paneId = "%78";
+  const workerCwd = join(leaderCwd, ".omx", "team", teamName, "worktrees", workerName);
+  await mkdir(workerCwd, { recursive: true });
+  // External root has state (sessions/) but deliberately no singleton session.json.
+  await mkdir(join(stateRoot, "sessions"), { recursive: true });
+  const teamRoot = join(stateRoot, "team", teamName);
+  await writeJson(join(teamRoot, "workers", workerName, "identity.json"), {
+    name: workerName,
+    index: 1,
+    role: "executor",
+    assigned_tasks: ["1"],
+    pane_id: paneId,
+    worktree_path: workerCwd,
+    team_state_root: stateRoot,
+  });
+  const metadata = {
+    name: teamName,
+    leader_cwd: leaderCwd,
+    team_state_root: stateRoot,
+    leader_pane_id: "%42",
+    workers: [{ name: workerName, pane_id: paneId, worktree_path: workerCwd, team_state_root: stateRoot }],
+  };
+  await writeJson(join(teamRoot, "manifest.v2.json"), metadata);
+  await writeJson(join(teamRoot, "config.json"), metadata);
+  return { root, leaderCwd, stateRoot, workerCwd, teamName, workerName, paneId };
+}
+
+function withWorkerEnv<T>(fixture: WorkerFixture, overrides: Record<string, string>, run: () => Promise<T>): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of WORKER_ENV_KEYS) saved[key] = process.env[key];
+  for (const key of WORKER_ENV_KEYS) delete process.env[key];
+  Object.assign(process.env, {
+    TMUX: "1",
+    TMUX_PANE: fixture.paneId,
+    OMX_TEAM_INTERNAL_WORKER: `${fixture.teamName}/${fixture.workerName}`,
+    OMX_TEAM_WORKER: `${fixture.teamName}/${fixture.workerName}`,
+    OMX_TEAM_STATE_ROOT: fixture.stateRoot,
+    OMX_TEAM_LEADER_CWD: fixture.leaderCwd,
+    ...overrides,
+  });
+  return run().finally(() => {
+    for (const key of WORKER_ENV_KEYS) {
+      if (typeof saved[key] === "string") process.env[key] = saved[key];
+      else delete process.env[key];
+    }
+  });
+}
+
+function assertNoEffectiveDeny(output: Record<string, unknown> | null, label: string): void {
+  const sanitized = sanitizeNativeHookOutput("PreToolUse", output);
+  const text = JSON.stringify(sanitized ?? {});
+  assert.equal(sanitized?.decision, undefined, `${label}: adapter must not emit a hard decision`);
+  assert.doesNotMatch(text, /PROVENANCE_DENIED/, `${label}: adapter effective output must not deny`);
+  assert.notEqual(
+    (sanitized?.hookSpecificOutput as Record<string, unknown> | undefined)?.permissionDecision,
+    "deny",
+    `${label}: adapter effective output must not be a permission deny`,
+  );
+}
+
+describe("issue #3536 external Team state root worker authorization", () => {
+  it("verified worker with external root and no singleton session.json can mutate a delegated product file", async () => {
+    const fixture = await createExternalRootWorkerFixture();
+    try {
+      await withWorkerEnv(fixture, {}, async () => {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd: fixture.workerCwd,
+          session_id: "sess-3536-product-write",
+          tool_name: "Write",
+          tool_input: { file_path: join(fixture.workerCwd, "src", "feature.ts"), content: "export const x = 1;\n" },
+        }, { cwd: fixture.workerCwd });
+        assertNoEffectiveDeny(result.outputJson, "product write");
+      });
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("verified worker product Bash write is not denied by the policy-root guard", async () => {
+    const fixture = await createExternalRootWorkerFixture();
+    try {
+      await withWorkerEnv(fixture, {}, async () => {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd: fixture.workerCwd,
+          session_id: "sess-3536-bash-write",
+          tool_name: "Bash",
+          tool_input: { command: "printf 'ok\\n' > src/feature.ts" },
+        }, { cwd: fixture.workerCwd });
+        assertNoEffectiveDeny(result.outputJson, "bash product write");
+      });
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("verified worker is not granted authority over protected team metadata", async () => {
+    const fixture = await createExternalRootWorkerFixture();
+    try {
+      await withWorkerEnv(fixture, {}, async () => {
+        for (const target of [
+          join(fixture.stateRoot, "team", fixture.teamName, "config.json"),
+          join(fixture.stateRoot, "team", fixture.teamName, "manifest.v2.json"),
+          join(fixture.stateRoot, "team", fixture.teamName, "workers", fixture.workerName, "identity.json"),
+        ]) {
+          const result = await dispatchCodexNativeHook({
+            hook_event_name: "PreToolUse",
+            cwd: fixture.workerCwd,
+            session_id: "sess-3536-protected",
+            tool_name: "Write",
+            tool_input: { file_path: target, content: "{}" },
+          }, { cwd: fixture.workerCwd });
+          const sanitized = sanitizeNativeHookOutput("PreToolUse", result.outputJson);
+          // The current authority model never affirmatively permits protected
+          // OMX orchestration metadata writes for a Team worker.
+          assert.notEqual(
+            (sanitized?.hookSpecificOutput as Record<string, unknown> | undefined)?.permissionDecision,
+            "allow",
+            `protected target must not be permitted: ${target}`,
+          );
+        }
+      });
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("unverified worker with an external root stays fail-closed", async () => {
+    const fixture = await createExternalRootWorkerFixture();
+    try {
+      // Pane identity mismatch: the declared worker cannot pass verification.
+      await withWorkerEnv(fixture, { TMUX_PANE: "%99" }, async () => {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd: fixture.workerCwd,
+          session_id: "sess-3536-unverified",
+          tool_name: "Write",
+          tool_input: { file_path: join(fixture.workerCwd, "src", "evil.ts"), content: "x" },
+        }, { cwd: fixture.workerCwd });
+        const sanitized = sanitizeNativeHookOutput("PreToolUse", result.outputJson);
+        assert.notEqual(
+          (sanitized?.hookSpecificOutput as Record<string, unknown> | undefined)?.permissionDecision,
+          "allow",
+          "unverified worker must not gain write authority",
+        );
+      });
+      // Foreign state root: no verified binding may form.
+      await withWorkerEnv(fixture, { OMX_TEAM_STATE_ROOT: join(fixture.root, "foreign") }, async () => {
+        const result = await dispatchCodexNativeHook({
+          hook_event_name: "PreToolUse",
+          cwd: fixture.workerCwd,
+          session_id: "sess-3536-foreign-root",
+          tool_name: "Write",
+          tool_input: { file_path: join(fixture.workerCwd, "src", "evil.ts"), content: "x" },
+        }, { cwd: fixture.workerCwd });
+        const sanitized = sanitizeNativeHookOutput("PreToolUse", result.outputJson);
+        assert.notEqual(
+          (sanitized?.hookSpecificOutput as Record<string, unknown> | undefined)?.permissionDecision,
+          "allow",
+          "foreign-root worker must not gain write authority",
+        );
+      });
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -36,6 +36,12 @@ import {
   resolveCanonicalTeamStateRoot,
   resolveWorkerTeamStateRootPath,
 } from "../team/state-root.js";
+import {
+  readCanonicalInternalTeamWorkerEnvironment,
+  readTeamWorkerEnvironment,
+  resolveAuthoritativeTeamWorkerContext,
+  resolveConductorPolicyRoot,
+} from "../team/worker-provenance.js";
 import { inferTerminalLifecycleOutcome } from "../runtime/run-outcome.js";
 import { syncRegularFile } from "../utils/file-durability.js";
 import {
@@ -2837,36 +2843,6 @@ function buildAdditionalContextMessage(
   return [detectedKeywordMessage, promptPriorityMessage, ultragoalPromptActivationNote, autopilotPromptActivationNote, "Follow AGENTS.md routing and preserve workflow transition and planning-safety rules."].filter(Boolean).join(" ");
 }
 
-function parseTeamWorkerEnv(rawValue: string): { teamName: string; workerName: string } | null {
-  const match = /^([a-z0-9][a-z0-9-]{0,29})\/(worker-\d+)$/.exec(rawValue.trim());
-  if (!match) return null;
-  return {
-    teamName: match[1] || "",
-    workerName: match[2] || "",
-  };
-}
-
-function readTeamWorkerEnvironment(): { teamName: string; workerName: string } | null {
-  const internalWorker = parseTeamWorkerEnv(safeString(process.env.OMX_TEAM_INTERNAL_WORKER));
-  const externalWorker = parseTeamWorkerEnv(safeString(process.env.OMX_TEAM_WORKER));
-  if (!internalWorker) return null;
-  if (externalWorker && internalWorker.workerName !== externalWorker.workerName) return null;
-  // The public Team name is a display alias; only the session-scoped internal
-  // identity is authoritative for state-root/config/manifest validation.
-  return internalWorker;
-}
-
-function readCanonicalInternalTeamWorkerEnvironment(): { teamName: string; workerName: string } | null {
-  const rawInternalWorker = safeString(process.env.OMX_TEAM_INTERNAL_WORKER).trim();
-  if (!rawInternalWorker) return null;
-  const internalWorker = parseTeamWorkerEnv(rawInternalWorker);
-  if (!internalWorker) return null;
-  const rawExternalWorker = safeString(process.env.OMX_TEAM_WORKER).trim();
-  if (!rawExternalWorker) return internalWorker;
-  const externalWorker = parseTeamWorkerEnv(rawExternalWorker);
-  if (!externalWorker || externalWorker.workerName !== internalWorker.workerName) return null;
-  return internalWorker;
-}
 
 function hasCanonicalInternalTeamWorkerDeclaration(): boolean {
   return readCanonicalInternalTeamWorkerEnvironment() !== null;
@@ -2881,63 +2857,7 @@ async function hasAuthoritativeTeamWorkerContext(
   cwd: string,
   options: { requireWorkerPane?: boolean } = {},
 ): Promise<boolean> {
-  const workerContext = readCanonicalInternalTeamWorkerEnvironment();
-  if (!workerContext) return false;
-
-  const requireWorkerPane = options.requireWorkerPane === true;
-  const currentPaneId = safeString(process.env.TMUX_PANE).trim();
-  if (requireWorkerPane && !currentPaneId) return false;
-  const stateRoot = await resolveWorkerTeamStateRootPath(cwd, workerContext, process.env).catch(() => null);
-  if (!stateRoot) return false;
-
-  const teamRoot = join(stateRoot, "team", workerContext.teamName);
-  const identity = await readJsonIfExists(join(teamRoot, "workers", workerContext.workerName, "identity.json"));
-  const manifest = await readJsonIfExists(join(teamRoot, "manifest.v2.json"));
-  const config = await readJsonIfExists(join(teamRoot, "config.json"));
-  if (!identity || !manifest || !config) return false;
-
-  const canonicalStateRoot = canonicalizeComparablePath(stateRoot);
-  const canonicalCwd = canonicalizeComparablePath(cwd);
-  const canonicalLeaderCwd = canonicalizeComparablePath(safeString(process.env.OMX_TEAM_LEADER_CWD).trim() || cwd);
-  const pathMatches = (value: unknown, expected: string): boolean => {
-    const candidate = safeString(value).trim();
-    if (!candidate) return false;
-    try {
-      return sameFilePath(candidate, expected);
-    } catch {
-      return false;
-    }
-  };
-  const matchingWorker = (state: Record<string, unknown>): Record<string, unknown> | null => {
-    const workers = Array.isArray(state.workers) ? state.workers : [];
-    return workers
-      .map((candidate) => safeObject(candidate))
-      .find((candidate) => safeString(candidate.name).trim() === workerContext.workerName) ?? null;
-  };
-  const manifestWorker = matchingWorker(manifest);
-  const configWorker = matchingWorker(config);
-  if (!manifestWorker || !configWorker) return false;
-  if (safeString(identity.name).trim() !== workerContext.workerName) return false;
-  if (requireWorkerPane && safeString(identity.pane_id).trim() !== currentPaneId) return false;
-  if (!pathMatches(identity.team_state_root, canonicalStateRoot)) return false;
-  if (!pathMatches(identity.worktree_path ?? identity.working_dir, canonicalCwd)) return false;
-  for (const state of [manifest, config]) {
-    if (safeString(state.name).trim() !== workerContext.teamName) return false;
-    if (requireWorkerPane && safeString(state.leader_pane_id).trim() === currentPaneId) return false;
-    if (!pathMatches(state.team_state_root, canonicalStateRoot)) return false;
-    if (!pathMatches(state.leader_cwd, canonicalLeaderCwd)) return false;
-  }
-  if (safeString(manifest.leader_pane_id).trim() !== safeString(config.leader_pane_id).trim()) return false;
-  for (const worker of [manifestWorker, configWorker]) {
-    if (requireWorkerPane && safeString(worker.pane_id).trim() !== currentPaneId) return false;
-    if (!pathMatches(worker.team_state_root, canonicalStateRoot)) return false;
-    const workingDir = safeString(worker.working_dir).trim();
-    const worktreePath = safeString(worker.worktree_path).trim();
-    if (!workingDir && !worktreePath) return false;
-    if (workingDir && !pathMatches(workingDir, canonicalCwd)) return false;
-    if (worktreePath && !pathMatches(worktreePath, canonicalCwd)) return false;
-  }
-  return true;
+  return (await resolveAuthoritativeTeamWorkerContext(cwd, options)) !== null;
 }
 
 async function resolveTeamStateDirForWorkerContext(
@@ -4176,43 +4096,6 @@ export async function terminalizeExactUltragoalSessionForHookCancel(input: HookC
 }
 
 
-interface ConductorPolicyRootResolution {
-  cwd: string;
-  valid: boolean;
-  statePresent: boolean;
-  externalStateRoot: boolean;
-}
-
-function resolveConductorPolicyRoot(stateDir: string, fallbackCwd: string): ConductorPolicyRootResolution {
-  const statePresent = existsSync(join(stateDir, "session.json"))
-    || existsSync(join(stateDir, "sessions"));
-  let canonicalFallback: string;
-  try {
-    canonicalFallback = realpathSync(resolve(fallbackCwd));
-  } catch {
-    canonicalFallback = resolve(fallbackCwd);
-  }
-  try {
-    const canonicalStateDir = realpathSync(stateDir);
-    const rootSession = readJsonSyncIfExists(join(canonicalStateDir, "session.json"));
-    const recordedCwd = safeString(rootSession?.cwd ?? rootSession?.workingDirectory).trim();
-    if (recordedCwd) {
-      const canonicalRecordedCwd = realpathSync(resolve(recordedCwd));
-      return {
-        cwd: canonicalRecordedCwd,
-        valid: true,
-        statePresent,
-        externalStateRoot: canonicalStateDir !== join(canonicalRecordedCwd, ".omx", "state"),
-      };
-    }
-    if (canonicalStateDir === join(canonicalFallback, ".omx", "state")) {
-      return { cwd: canonicalFallback, valid: true, statePresent, externalStateRoot: false };
-    }
-  } catch {
-    // An external state surface with an unusable pointer must not borrow execution-cwd authority.
-  }
-  return { cwd: canonicalFallback, valid: !statePresent, statePresent, externalStateRoot: statePresent };
-}
 
 
 function readPayloadAgentRole(payload: CodexHookPayload): string {
@@ -21920,7 +21803,16 @@ export async function dispatchCodexNativeHook(
   // Native hooks must use the exact pointer root selected for this dispatch.
   const pointerContext = resolveSessionPointerContext(cwd);
   const stateDir = pointerContext.baseStateDir;
-  const policyRoot = resolveConductorPolicyRoot(stateDir, cwd);
+  const declaredTeamWorker = hasRawTeamWorkerDeclaration();
+  // #3536: verify the authoritative Team-worker context BEFORE the Conductor
+  // policy-root guard runs, and hand the guard the structured evidence so a
+  // verified external Team state root can bind policy context to the verified
+  // canonical leader CWD. Unverified or mismatched workers contribute nothing.
+  const authoritativeTeamWorkerEvidence = declaredTeamWorker
+    && (hookEventName !== "Stop" || canonicalInternalTeamWorkerDeclared)
+    ? await resolveAuthoritativeTeamWorkerContext(cwd)
+    : null;
+  const policyRoot = resolveConductorPolicyRoot(stateDir, cwd, authoritativeTeamWorkerEvidence);
   const policyCwd = policyRoot.cwd;
 
   let skillState: SkillActiveState | null = null;
@@ -21931,7 +21823,6 @@ export async function dispatchCodexNativeHook(
   let teamNoticeTargetKey: string | null = null;
   let promptClassification: KeywordInputClassification | null = null;
 
-  const declaredTeamWorker = hasRawTeamWorkerDeclaration();
   const candidateWorkerPayloadSessionId = declaredTeamWorker
     ? readUnambiguousNormalizedPayloadSessionId(payload)
     : "";
@@ -21987,9 +21878,7 @@ export async function dispatchCodexNativeHook(
   let resolvedNativeSessionId = nativeSessionId;
   let skipCanonicalSessionStartContext = false;
   let isSubagentSessionStart = false;
-  const authoritativeTeamWorker = declaredTeamWorker
-    && (hookEventName !== "Stop" || canonicalInternalTeamWorkerDeclared)
-    && await hasAuthoritativeTeamWorkerContext(cwd);
+  const authoritativeTeamWorker = authoritativeTeamWorkerEvidence !== null;
   const authoritativeWorkerPayloadSessionId = authoritativeTeamWorker
     && candidateWorkerPayloadSessionId
     && (!pointer.state || !payloadMatchesSessionPointer(candidateWorkerPayloadSessionId, pointer.state))

--- a/src/team/__tests__/worker-provenance.test.ts
+++ b/src/team/__tests__/worker-provenance.test.ts
@@ -1,0 +1,283 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  resolveAuthoritativeTeamWorkerContext,
+  resolveConductorPolicyRoot,
+  type AuthoritativeTeamWorkerEvidence,
+} from "../worker-provenance.js";
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2));
+}
+
+interface TeamFixture {
+  leaderCwd: string;
+  stateRoot: string;
+  workerCwd: string;
+  teamName: string;
+  workerName: string;
+  paneId: string;
+  env: NodeJS.ProcessEnv;
+}
+
+async function createTeamFixture(options: { withSessionsDir?: boolean } = {}): Promise<{ root: string; fixture: TeamFixture }> {
+  const root = await mkdtemp(join(tmpdir(), "omx-3536-provenance-"));
+  const canonicalRoot = realpathSync(root);
+  const leaderCwd = join(canonicalRoot, "leader");
+  const stateRoot = join(canonicalRoot, "external", ".omx", "state");
+  const teamName = "ext-team";
+  const workerName = "worker-1";
+  const paneId = "%77";
+  const workerCwd = join(leaderCwd, ".omx", "team", teamName, "worktrees", workerName);
+  await mkdir(workerCwd, { recursive: true });
+  if (options.withSessionsDir !== false) {
+    await mkdir(join(stateRoot, "sessions"), { recursive: true });
+  }
+  const teamRoot = join(stateRoot, "team", teamName);
+  await writeJson(join(teamRoot, "workers", workerName, "identity.json"), {
+    name: workerName,
+    index: 1,
+    role: "executor",
+    assigned_tasks: ["1"],
+    pane_id: paneId,
+    worktree_path: workerCwd,
+    team_state_root: stateRoot,
+  });
+  const metadata = {
+    name: teamName,
+    leader_cwd: leaderCwd,
+    team_state_root: stateRoot,
+    leader_pane_id: "%42",
+    workers: [{ name: workerName, pane_id: paneId, worktree_path: workerCwd, team_state_root: stateRoot }],
+  };
+  await writeJson(join(teamRoot, "manifest.v2.json"), metadata);
+  await writeJson(join(teamRoot, "config.json"), metadata);
+  return {
+    root,
+    fixture: {
+      leaderCwd,
+      stateRoot,
+      workerCwd,
+      teamName,
+      workerName,
+      paneId,
+      env: {
+        TMUX: "1",
+        TMUX_PANE: paneId,
+        OMX_TEAM_INTERNAL_WORKER: `${teamName}/${workerName}`,
+        OMX_TEAM_WORKER: `${teamName}/${workerName}`,
+        OMX_TEAM_STATE_ROOT: stateRoot,
+        OMX_TEAM_LEADER_CWD: leaderCwd,
+      },
+    },
+  };
+}
+
+describe("resolveAuthoritativeTeamWorkerContext (#3536)", () => {
+  it("returns typed evidence for a fully verified external-root worker", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const evidence = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: fixture.env });
+      assert.ok(evidence);
+      assert.equal(evidence.teamName, fixture.teamName);
+      assert.equal(evidence.workerName, fixture.workerName);
+      assert.equal(evidence.canonicalStateRoot, realpathSync(fixture.stateRoot));
+      assert.equal(evidence.canonicalLeaderCwd, fixture.leaderCwd);
+      assert.equal(evidence.canonicalWorkerCwd, fixture.workerCwd);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies pane identity when required", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const ok = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: fixture.env, requireWorkerPane: true });
+      assert.ok(ok);
+      const denied = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, {
+        env: { ...fixture.env, TMUX_PANE: "%99" },
+        requireWorkerPane: true,
+      });
+      assert.equal(denied, null);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("denies mismatched leader CWD instead of trusting bare OMX_TEAM_LEADER_CWD", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const denied = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, {
+        env: { ...fixture.env, OMX_TEAM_LEADER_CWD: join(root, "elsewhere") },
+      });
+      assert.equal(denied, null);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("denies mismatched state root, internal identity, worktree, config, and manifest", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const foreignRoot = join(root, "foreign-state");
+      await mkdir(join(foreignRoot, "sessions"), { recursive: true });
+      assert.equal(
+        await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: { ...fixture.env, OMX_TEAM_STATE_ROOT: foreignRoot } }),
+        null,
+        "state root mismatch",
+      );
+      assert.equal(
+        await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: { ...fixture.env, OMX_TEAM_INTERNAL_WORKER: `${fixture.teamName}/worker-2` } }),
+        null,
+        "internal identity mismatch",
+      );
+      assert.equal(
+        await resolveAuthoritativeTeamWorkerContext(join(root, "other-worktree"), { env: fixture.env }),
+        null,
+        "worktree mismatch",
+      );
+
+      const teamRoot = join(fixture.stateRoot, "team", fixture.teamName);
+      const configPath = join(teamRoot, "config.json");
+      const original = JSON.parse(await readFile(configPath, "utf-8"));
+      original.leader_cwd = join(root, "tampered-leader");
+      await writeFile(configPath, JSON.stringify(original));
+      assert.equal(
+        await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: fixture.env }),
+        null,
+        "config/manifest leader_cwd conflict",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("matches canonical path aliases for the state root (symlink alias)", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const alias = join(root, "state-alias");
+      await symlink(fixture.stateRoot, alias);
+      const evidence = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, {
+        env: { ...fixture.env, OMX_TEAM_STATE_ROOT: alias },
+      });
+      assert.ok(evidence, "aliased root still verifies through canonical comparison");
+      assert.equal(evidence.canonicalStateRoot, realpathSync(fixture.stateRoot));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveConductorPolicyRoot (#3536)", () => {
+  it("binds a verified external Team state root to the verified leader CWD", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const evidence = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: fixture.env });
+      assert.ok(evidence);
+      const bound = resolveConductorPolicyRoot(fixture.stateRoot, fixture.workerCwd, evidence);
+      assert.equal(bound.valid, true);
+      assert.equal(bound.teamWorkerBound, true);
+      assert.equal(bound.externalStateRoot, true);
+      assert.equal(bound.cwd, fixture.leaderCwd);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the same external root fail-closed without verified evidence", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const resolution = resolveConductorPolicyRoot(fixture.stateRoot, fixture.workerCwd, null);
+      assert.equal(resolution.valid, false);
+      assert.equal(resolution.statePresent, true);
+      assert.equal(resolution.externalStateRoot, true);
+      assert.equal(resolution.teamWorkerBound, false);
+      assert.equal(resolution.cwd, realpathSync(fixture.workerCwd));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects verified evidence bound to a different root (no cross-root alias)", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const evidence = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: fixture.env });
+      assert.ok(evidence);
+      const otherRoot = join(root, "other-state");
+      await mkdir(join(otherRoot, "sessions"), { recursive: true });
+      const resolution = resolveConductorPolicyRoot(otherRoot, fixture.workerCwd, evidence);
+      assert.equal(resolution.valid, false);
+      assert.equal(resolution.teamWorkerBound, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps existing valid resolutions ahead of team evidence (no override)", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const evidence = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, { env: fixture.env });
+      assert.ok(evidence);
+      // Root session.json with a canonical cwd keeps precedence.
+      const sessionRoot = join(root, "session-root");
+      await mkdir(sessionRoot, { recursive: true });
+      await writeJson(join(sessionRoot, "session.json"), { cwd: fixture.leaderCwd });
+      const withSession = resolveConductorPolicyRoot(sessionRoot, fixture.workerCwd, evidence);
+      assert.equal(withSession.valid, true);
+      assert.equal(withSession.teamWorkerBound, false);
+      assert.equal(withSession.cwd, fixture.leaderCwd);
+      // Default in-repo state root behavior is unchanged.
+      const inRepo = resolveConductorPolicyRoot(join(fixture.leaderCwd, ".omx", "state"), fixture.leaderCwd, null);
+      assert.equal(inRepo.valid, true);
+      assert.equal(inRepo.externalStateRoot, false);
+      assert.equal(inRepo.teamWorkerBound, false);
+      assert.equal(inRepo.cwd, fixture.leaderCwd);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("binds through a symlink-aliased selected stateDir via canonical equality", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const alias = join(root, "state-alias");
+      await symlink(fixture.stateRoot, alias);
+      const evidence = await resolveAuthoritativeTeamWorkerContext(fixture.workerCwd, {
+        env: { ...fixture.env, OMX_TEAM_STATE_ROOT: alias },
+      });
+      assert.ok(evidence);
+      const bound = resolveConductorPolicyRoot(alias, fixture.workerCwd, evidence);
+      assert.equal(bound.valid, true);
+      assert.equal(bound.teamWorkerBound, true);
+      assert.equal(bound.cwd, fixture.leaderCwd);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats fabricated evidence for a foreign root as invalid", async () => {
+    const { root, fixture } = await createTeamFixture();
+    try {
+      const foreignRoot = join(root, "fabricated");
+      await mkdir(join(foreignRoot, "sessions"), { recursive: true });
+      const fabricated: AuthoritativeTeamWorkerEvidence = {
+        teamName: fixture.teamName,
+        workerName: fixture.workerName,
+        stateRoot: join(root, "not-the-selected-root"),
+        canonicalStateRoot: join(root, "not-the-selected-root"),
+        canonicalLeaderCwd: fixture.leaderCwd,
+        canonicalWorkerCwd: fixture.workerCwd,
+      };
+      const resolution = resolveConductorPolicyRoot(foreignRoot, fixture.workerCwd, fabricated);
+      assert.equal(resolution.valid, false);
+      assert.equal(resolution.teamWorkerBound, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/team/worker-provenance.ts
+++ b/src/team/worker-provenance.ts
@@ -1,0 +1,228 @@
+/**
+ * Shared authoritative Team-worker provenance verification and Conductor
+ * policy-root resolution (#3536).
+ *
+ * The native hook and `omx doctor --team` must evaluate the exact same
+ * worker-verification and policy-root preflight so a verified Team worker
+ * cannot be runtime-denied while doctor reports all-pass. Verification is
+ * evidence-returning (never a bare boolean plus later env re-read): policy
+ * context may only be derived from the structured result produced here.
+ */
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { canonicalizeComparablePath, sameFilePath } from "../utils/paths.js";
+import { resolveWorkerTeamStateRootPath } from "./state-root.js";
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+function safeObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+async function readJsonIfExists(path: string): Promise<Record<string, unknown> | null> {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function readJsonSyncIfExists(path: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export interface TeamWorkerEnvIdentity {
+  teamName: string;
+  workerName: string;
+}
+
+function parseTeamWorkerEnv(rawValue: string): TeamWorkerEnvIdentity | null {
+  const match = /^([a-z0-9][a-z0-9-]{0,29})\/(worker-\d+)$/.exec(rawValue.trim());
+  if (!match) return null;
+  return {
+    teamName: match[1] || "",
+    workerName: match[2] || "",
+  };
+}
+
+export function readTeamWorkerEnvironment(env: NodeJS.ProcessEnv = process.env): TeamWorkerEnvIdentity | null {
+  const internalWorker = parseTeamWorkerEnv(safeString(env.OMX_TEAM_INTERNAL_WORKER));
+  const externalWorker = parseTeamWorkerEnv(safeString(env.OMX_TEAM_WORKER));
+  if (!internalWorker) return null;
+  if (externalWorker && internalWorker.workerName !== externalWorker.workerName) return null;
+  // The public Team name is a display alias; only the session-scoped internal
+  // identity is authoritative for state-root/config/manifest validation.
+  return internalWorker;
+}
+
+export function readCanonicalInternalTeamWorkerEnvironment(env: NodeJS.ProcessEnv = process.env): TeamWorkerEnvIdentity | null {
+  const rawInternalWorker = safeString(env.OMX_TEAM_INTERNAL_WORKER).trim();
+  if (!rawInternalWorker) return null;
+  const internalWorker = parseTeamWorkerEnv(rawInternalWorker);
+  if (!internalWorker) return null;
+  const rawExternalWorker = safeString(env.OMX_TEAM_WORKER).trim();
+  if (!rawExternalWorker) return internalWorker;
+  const externalWorker = parseTeamWorkerEnv(rawExternalWorker);
+  if (!externalWorker || externalWorker.workerName !== internalWorker.workerName) return null;
+  return internalWorker;
+}
+
+/**
+ * Structured result of a fully verified authoritative Team-worker context.
+ * Every field is canonicalized and cross-checked against the worker identity,
+ * config, manifest, pane, worktree, state-root, and leader-CWD metadata; an
+ * external Team state root may contribute policy context only through this
+ * evidence, never through unverified environment values.
+ */
+export interface AuthoritativeTeamWorkerEvidence {
+  teamName: string;
+  workerName: string;
+  stateRoot: string;
+  canonicalStateRoot: string;
+  canonicalLeaderCwd: string;
+  canonicalWorkerCwd: string;
+}
+
+export async function resolveAuthoritativeTeamWorkerContext(
+  cwd: string,
+  options: { requireWorkerPane?: boolean; env?: NodeJS.ProcessEnv } = {},
+): Promise<AuthoritativeTeamWorkerEvidence | null> {
+  const env = options.env ?? process.env;
+  const workerContext = readCanonicalInternalTeamWorkerEnvironment(env);
+  if (!workerContext) return null;
+
+  const requireWorkerPane = options.requireWorkerPane === true;
+  const currentPaneId = safeString(env.TMUX_PANE).trim();
+  if (requireWorkerPane && !currentPaneId) return null;
+  const stateRoot = await resolveWorkerTeamStateRootPath(cwd, workerContext, env).catch(() => null);
+  if (!stateRoot) return null;
+
+  const teamRoot = join(stateRoot, "team", workerContext.teamName);
+  const identity = await readJsonIfExists(join(teamRoot, "workers", workerContext.workerName, "identity.json"));
+  const manifest = await readJsonIfExists(join(teamRoot, "manifest.v2.json"));
+  const config = await readJsonIfExists(join(teamRoot, "config.json"));
+  if (!identity || !manifest || !config) return null;
+
+  const canonicalStateRoot = canonicalizeComparablePath(stateRoot);
+  const canonicalCwd = canonicalizeComparablePath(cwd);
+  const canonicalLeaderCwd = canonicalizeComparablePath(safeString(env.OMX_TEAM_LEADER_CWD).trim() || cwd);
+  const pathMatches = (value: unknown, expected: string): boolean => {
+    const candidate = safeString(value).trim();
+    if (!candidate) return false;
+    try {
+      return sameFilePath(candidate, expected);
+    } catch {
+      return false;
+    }
+  };
+  const matchingWorker = (state: Record<string, unknown>): Record<string, unknown> | null => {
+    const workers = Array.isArray(state.workers) ? state.workers : [];
+    return workers
+      .map((candidate) => safeObject(candidate))
+      .find((candidate) => safeString(candidate.name).trim() === workerContext.workerName) ?? null;
+  };
+  const manifestWorker = matchingWorker(manifest);
+  const configWorker = matchingWorker(config);
+  if (!manifestWorker || !configWorker) return null;
+  if (safeString(identity.name).trim() !== workerContext.workerName) return null;
+  if (requireWorkerPane && safeString(identity.pane_id).trim() !== currentPaneId) return null;
+  if (!pathMatches(identity.team_state_root, canonicalStateRoot)) return null;
+  if (!pathMatches(identity.worktree_path ?? identity.working_dir, canonicalCwd)) return null;
+  for (const state of [manifest, config]) {
+    if (safeString(state.name).trim() !== workerContext.teamName) return null;
+    if (requireWorkerPane && safeString(state.leader_pane_id).trim() === currentPaneId) return null;
+    if (!pathMatches(state.team_state_root, canonicalStateRoot)) return null;
+    if (!pathMatches(state.leader_cwd, canonicalLeaderCwd)) return null;
+  }
+  if (safeString(manifest.leader_pane_id).trim() !== safeString(config.leader_pane_id).trim()) return null;
+  for (const worker of [manifestWorker, configWorker]) {
+    if (requireWorkerPane && safeString(worker.pane_id).trim() !== currentPaneId) return null;
+    if (!pathMatches(worker.team_state_root, canonicalStateRoot)) return null;
+    const workingDir = safeString(worker.working_dir).trim();
+    const worktreePath = safeString(worker.worktree_path).trim();
+    if (!workingDir && !worktreePath) return null;
+    if (workingDir && !pathMatches(workingDir, canonicalCwd)) return null;
+    if (worktreePath && !pathMatches(worktreePath, canonicalCwd)) return null;
+  }
+  return {
+    teamName: workerContext.teamName,
+    workerName: workerContext.workerName,
+    stateRoot,
+    canonicalStateRoot,
+    canonicalLeaderCwd,
+    canonicalWorkerCwd: canonicalCwd,
+  };
+}
+
+export interface ConductorPolicyRootResolution {
+  cwd: string;
+  valid: boolean;
+  statePresent: boolean;
+  externalStateRoot: boolean;
+  /** True when validity was established by verified Team-worker evidence. */
+  teamWorkerBound: boolean;
+}
+
+export function resolveConductorPolicyRoot(
+  stateDir: string,
+  fallbackCwd: string,
+  teamWorker: AuthoritativeTeamWorkerEvidence | null = null,
+): ConductorPolicyRootResolution {
+  const statePresent = existsSync(join(stateDir, "session.json"))
+    || existsSync(join(stateDir, "sessions"));
+  let canonicalFallback: string;
+  try {
+    canonicalFallback = realpathSync(resolve(fallbackCwd));
+  } catch {
+    canonicalFallback = resolve(fallbackCwd);
+  }
+  let canonicalStateDir: string | null = null;
+  try {
+    canonicalStateDir = realpathSync(stateDir);
+    const rootSession = readJsonSyncIfExists(join(canonicalStateDir, "session.json"));
+    const recordedCwd = safeString(rootSession?.cwd ?? rootSession?.workingDirectory).trim();
+    if (recordedCwd) {
+      const canonicalRecordedCwd = realpathSync(resolve(recordedCwd));
+      return {
+        cwd: canonicalRecordedCwd,
+        valid: true,
+        statePresent,
+        externalStateRoot: canonicalStateDir !== join(canonicalRecordedCwd, ".omx", "state"),
+        teamWorkerBound: false,
+      };
+    }
+    if (canonicalStateDir === join(canonicalFallback, ".omx", "state")) {
+      return { cwd: canonicalFallback, valid: true, statePresent, externalStateRoot: false, teamWorkerBound: false };
+    }
+  } catch {
+    // An external state surface with an unusable pointer must not borrow execution-cwd authority.
+  }
+  // #3536: only after full authoritative Team-worker verification may an
+  // external Team state root contribute policy context. The verified root must
+  // canonically match the currently selected stateDir, and the policy CWD is
+  // the already-verified canonical Team leader CWD from the evidence. Every
+  // unverified or mismatched root keeps failing closed below.
+  if (teamWorker) {
+    const selectedStateDir = canonicalStateDir ?? canonicalizeComparablePath(stateDir);
+    if (sameFilePath(teamWorker.canonicalStateRoot, selectedStateDir)) {
+      return {
+        cwd: teamWorker.canonicalLeaderCwd,
+        valid: true,
+        statePresent,
+        externalStateRoot: true,
+        teamWorkerBound: true,
+      };
+    }
+  }
+  return { cwd: canonicalFallback, valid: !statePresent, statePresent, externalStateRoot: statePresent, teamWorkerBound: false };
+}


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Verified Team workers on an external `OMX_ROOT` / `OMX_TEAM_STATE_ROOT` were denied every product-code mutation with `PROVENANCE_DENIED: the selected workflow state root has no usable canonical session cwd` whenever that root had no singleton `session.json`. Authoritative Team-worker verification already succeeded; the generic Conductor policy-root guard ran first and rejected the external root before the verified leader CWD could be bound. `omx doctor --team` reported all-pass for the same unusable authorization state.

## Changes

- Extract shared Team-worker provenance verification into `src/team/worker-provenance.ts` and return structured evidence (never a later env re-read).
- After authoritative verification, bind Conductor policy CWD only from the verified matching Team state root and canonical leader CWD.
- Keep fail-closed behavior for identity, pane, worktree, state-root, leader-CWD, fabricated-evidence, and protected-metadata mismatches.
- Existing valid `session.json` / in-repo state-root resolutions stay ahead of Team evidence (no override).
- `omx doctor --team` runs the same runtime preflight and fails with `worker_policy_root_unusable` when authorization cannot succeed.

## Validation

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npm run check:no-unused`
- [x] scoped `biome lint`
- [x] focused tests 27/27 (`doctor-team`, `issue-3536-external-team-state-root`, `worker-provenance`)
- [ ] exact-head CI (driving after open)
- [x] `omx doctor --team` coverage added for the external-root pass and metadata-conflict fail cases

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (README/DEMO/COVERAGE/AGENTS template) when needed — N/A, runtime authorization contract only
- [x] Backward-compatibility impact considered — fail-closed mismatches unchanged; only verified external roots gain a policy binding

## Related

Closes #3536