### PR TITLE
docs: fix broken star history chart across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ If this happens, try:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
 
 ## License
 

--- a/docs/readme/README.el.md
+++ b/docs/readme/README.el.md
@@ -226,7 +226,7 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 
 ## Ιστορικό Αστεριών
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
 
 ## Άδεια
 

--- a/docs/readme/README.pl.md
+++ b/docs/readme/README.pl.md
@@ -219,7 +219,7 @@ Jeśli to widzisz:
 
 ## Historia gwiazdek
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
 
 ## Licencja
 

--- a/docs/readme/README.uk.md
+++ b/docs/readme/README.uk.md
@@ -264,7 +264,7 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 
 ## Історія зірок
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
 
 ## Ліцензія
 

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -226,7 +226,7 @@ Nếu gặp tình trạng này, thử:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
 
 ## Giấy phép
 


### PR DESCRIPTION
The star history chart in the main README and the localized translations no longer renders because the upstream service is broken under current GitHub stargazer API restrictions. This change repoints the chart image and its wrapping link to a working alternative so the chart is visible again.

Updated: README.md, docs/readme/README.el.md, docs/readme/README.pl.md, docs/readme/README.uk.md, docs/readme/README.vi.md.