### PR TITLE
fix(notifications): handle zero and invalid durations

### DIFF
--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -69,6 +69,16 @@ describe('formatSessionEnd', () => {
     assert.ok(result.includes('2m 5s'));
   });
 
+  it('should format a zero duration instead of reporting it as unknown', () => {
+    const result = formatSessionEnd({ ...basePayload, event: 'session-end', durationMs: 0 });
+    assert.ok(result.includes('**Duration:** 0s'));
+  });
+
+  it('should report invalid durations as unknown', () => {
+    const result = formatSessionEnd({ ...basePayload, event: 'session-end', durationMs: -1 });
+    assert.ok(result.includes('**Duration:** unknown'));
+  });
+
   it('should include agents count', () => {
     const result = formatSessionEnd({ ...basePayload, event: 'session-end', agentsSpawned: 5, agentsCompleted: 3 });
     assert.ok(result.includes('3/5 completed'));

--- a/src/notifications/__tests__/template-engine.test.ts
+++ b/src/notifications/__tests__/template-engine.test.ts
@@ -52,6 +52,16 @@ describe('computeTemplateVariables', () => {
     assert.equal(vars.duration, '2m 5s');
   });
 
+  it('computes a zero duration as 0s', () => {
+    const vars = computeTemplateVariables(makePayload({ durationMs: 0 }));
+    assert.equal(vars.duration, '0s');
+  });
+
+  it('reports invalid durations as unknown', () => {
+    const vars = computeTemplateVariables(makePayload({ durationMs: Number.POSITIVE_INFINITY }));
+    assert.equal(vars.duration, 'unknown');
+  });
+
   it('computes iterationDisplay when both present', () => {
     const vars = computeTemplateVariables(makePayload({ iteration: 3, maxIterations: 10 }));
     assert.equal(vars.iterationDisplay, '3/10');

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -106,7 +106,7 @@ export function parseTmuxTail(raw: string): string {
 }
 
 function formatDuration(ms?: number): string {
-  if (!ms) return "unknown";
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "unknown";
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);
   const hours = Math.floor(minutes / 60);

--- a/src/notifications/template-engine.ts
+++ b/src/notifications/template-engine.ts
@@ -32,7 +32,7 @@ const KNOWN_VARIABLES = new Set<string>([
  * Mirrors formatDuration() in formatter.ts.
  */
 function formatDuration(ms?: number): string {
-  if (!ms) return "unknown";
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "unknown";
   const seconds = Math.floor(ms / 1000);
   const minutes = Math.floor(seconds / 60);
   const hours = Math.floor(minutes / 60);


### PR DESCRIPTION
## Summary

Notification duration formatting treated a valid `durationMs` value of zero as missing and displayed `unknown`. Negative or non-finite runtime values could also produce misleading duration text.

## Changes

- Format zero milliseconds as `0s` in both standard and template-based notifications
- Treat negative and non-finite duration values as `unknown`
- Add regression coverage for both formatting paths

## Validation

- [x] `npm run build`
- [x] `node --test dist/notifications/__tests__/formatter.test.js dist/notifications/__tests__/template-engine.test.js` (68 passed)
- [x] Biome lint on the four changed files
- [ ] Full `npm test` (not run; targeted notification tests were used)
- [ ] `omx doctor` (not applicable; no setup or configuration behavior changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs reviewed; no update needed for this edge-case formatting correction
- [x] Backward-compatibility impact considered

## Related

No related issue.