### PR TITLE
fix(url-reader): avoid false truncation at exact limit

### DIFF
--- a/src/url-reader/__tests__/url-reader.test.ts
+++ b/src/url-reader/__tests__/url-reader.test.ts
@@ -134,6 +134,23 @@ describe("readUrl", () => {
 		assert.equal(cancelCalled, true);
 	});
 
+	it("does not truncate a complete body that exactly matches maxBytes", async () => {
+		const result = await readUrl("http://example.test/exact", {
+			resolveHostname: publicResolver,
+			maxBytes: 4,
+			fetch: async () =>
+				response({
+					url: "http://example.test/exact",
+					bodyText: "test",
+				}),
+		});
+
+		assert.equal(result.verdict, "ok");
+		assert.equal(result.truncated, false);
+		assert.equal(result.bytes_read, 4);
+		assert.equal(result.snippet, "test");
+	});
+
 	it("rejects unsupported protocols with a blocked verdict", async () => {
 		const result = await readUrl("file:///tmp/example");
 

--- a/src/url-reader/index.ts
+++ b/src/url-reader/index.ts
@@ -449,11 +449,15 @@ async function readBoundedBody(
 	let truncated = false;
 
 	try {
-		while (bytesRead < maxBytes) {
+		while (true) {
 			const { done, value } = await reader.read();
 			if (done) break;
 			if (!value || value.byteLength === 0) continue;
 			const remaining = maxBytes - bytesRead;
+			if (remaining === 0) {
+				truncated = true;
+				break;
+			}
 			if (value.byteLength > remaining) {
 				chunks.push(value.slice(0, remaining));
 				bytesRead += remaining;
@@ -463,8 +467,6 @@ async function readBoundedBody(
 			chunks.push(value);
 			bytesRead += value.byteLength;
 		}
-
-		if (bytesRead >= maxBytes) truncated = true;
 	} finally {
 		if (truncated) {
 			await reader.cancel().catch(() => undefined);


### PR DESCRIPTION
## Summary

The bounded URL response reader marked every body that reached maxBytes as truncated, including a complete stream whose length exactly matched the configured limit. That made the result metadata report data loss when no bytes were omitted.

## Changes

- Continue reading after reaching the byte limit only to distinguish EOF from additional non-empty data.
- Mark truncated only when bytes beyond the configured limit are observed.
- Add regression coverage for a complete body exactly equal to maxBytes.

## Validation

- [x] npm run build
- [x] npm run lint — 797 files checked
- [x] npm run check:no-unused
- [ ] npm test — the URL reader target passed, but the full 418-file integration run was stopped after unrelated environment failures involving sandbox-blocked socket listeners, unavailable tmux, active-session assumptions, and macOS /var path aliases; no URL reader failure occurred.
- [x] node --test dist/url-reader/__tests__/url-reader.test.js — 25 passed
- [x] ./node_modules/.bin/tsc --noEmit
- [ ] omx doctor — not applicable; setup/config behavior is unchanged

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — no public workflow or CLI surface changed
- [x] Backward-compatibility impact considered

Document-refresh: not-needed | internal URL reader boundary flag correction with no public workflow or CLI surface change

## Related

No linked issue.