### PR TITLE
release: prepare 0.21.0 post-epic train (#3552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,49 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+## [0.21.0] - 2026-08-22
 
+Minor release for the exact 99-commit range `v0.20.5..0f2bbb704b83f94a69622b1915f555498e0dd283` (310 files, +31,779/−69,216). This is the post-epic consolidation train: deprecated skills are removed with migration stubs, hard workflow gates are replaced by advisory guidance, state becomes a single-source-of-truth with a read-only MCP surface, and `omx autopilot` returns as the canonical staged orchestrator. Consumers invoking removed skills or MCP writer tools receive explicit migration errors — this is an intentional breaking change with migration paths.
+
+### Removed
+
+- **Deprecated skills and prompts** — 25 removed skills now fail fast through a uniform sunset-stub resolver with direct replacements: `$ralph` → `$ultragoal` (`omx ralph` CLI and persistence runtime unaffected), `$ultrawork`/`$ecomode`/`$swarm` → `$team`, `$prometheus-strict` → `$plan`, `$review`/`$security-review` → `$code-review`, `$ask-claude`/`$ask-gemini` → `$ask`, `$deepsearch` → `$analyze`, `$frontend-ui-ux` → `$design`, `$visual-verdict`/`$web-clone` → `$visual-ralph`, `$help` → `$omx-setup`; `$tdd`, `$note`, `$trace`, and `$build-fix` removed without a direct replacement. Prompts `prometheus-strict-metis`, `momus`, `oracle`, `scholastic`, and `sisyphus-lite` and their agents are deregistered (#3506, #3502, #3508).
+- **MCP state writer tools** — `state_write` and `state_clear` are removed from the MCP surface and now return explicit deprecation errors; durable writes route exclusively through the CLI/programmatic state operations (#3507, #3498).
+- **Hard workflow gates** — the Autopilot/Ralplan consensus-receipt gate and the planning-gate requirement are removed; workflow transitions no longer require a host-issued consensus receipt (#3492).
+- **Merged-away execution loops** — the standalone autopilot/pipeline loops are merged into the unified planning/execution surfaces (#3502, #3508).
+
+### Added
+
+- **`omx autopilot` canonical orchestrator** — first-class CLI command restoring the staged `$deep-interview` → `$ralplan` → `$ultragoal` orchestration as the canonical chain (#3518, #3517).
+- **Ultragoal ordinary/strict modes** — the completion cohort gate is advisory in ordinary mode and strict in strict mode (#3500, #3505).
+- **Upgrade fixture and drift tests** — a 0.20.x → 0.21 upgrade fixture plus generator `--check` surfaces are promoted into `npm test` (#3509).
+- **Setup flags** — `--disable-hooks` (disable only OMX-owned hook registrations, preserving foreign hooks) and `omx doctor --repair-state` (archive stale state projections under `.omx/archive/`) (#3497, #3507).
+
+### Changed
+
+- **State single source of truth** — a sole-writer state model with read-only MCP projection, shared handoff-carrier invariants for every writer, explicit stale-projection retirement, and fail-closed handling of corrupt or laundered carriers (#3507, #3498 follow-ups).
+- **Hooks simplified; PreToolUse advisory-only** — conductor PreToolUse write guards are replaced by advisory guidance with Codex App capability warnings (#3497, #3492).
+- **Prompt architecture slimmed** — invariants are centralized and the prompt surface reduced (#3513).
+- **Bounded plugin lifecycle** — plugin snapshots are bounded with a hook escape hatch, unpinned historical snapshots retired, and deprecated-skill retirement keyed to install badges (#3499, #3512).
+- **Team worker provenance** — team workers on external OMX state roots are authorized through evidence-returning provenance verification shared by the native hook and `omx doctor --team` (#3537).
+- **Session pointer authority split** — read semantics and write authority are separated on platforms without process-birth evidence; identity-indeterminate live pointers count as occupied evidence but never grant write authority, with bounded unproven-pointer adoption and verified-dead pointer quarantine (#3527, #3541, #3528).
+- **Dependencies** — `@biomejs/biome` 2.5.6→2.5.8 (#3532) and `@types/node` 26.1.2→26.2.0 (#3485).
+
+### Fixed
+
+- **Detached `--madmax` root identity on macOS** — path-alias canonicalization, post-create root re-resolution, and path-alias-insensitive launch-context keys; regression-locked by #3550/#3551.
+- **Detached tmux owner race** — post-tag owner mutation is retried under an unchanged authority fence (#3540, #3541).
+- **macOS arm64 runtime hydration** — `omx-runtime` hydrates and is discovered on arm64 npm installs (#3519, #3520).
+- **URL reader false truncation** — content at an exact size limit is no longer reported truncated (#3546).
+- **Notification durations** — zero and invalid durations are handled (#3544).
+- **Worker triggers** — submitted with tmux named `Enter` instead of raw `C-m`, with Claude 2.1.x prompt detection (#3531).
+- **Team scale-down claim boundary** — synchronization coverage made load-tolerant (#3548, #3549).
+- **Guarded tmux split receipts** — format-string injection is rejected (#3489).
+- **Ralplan → Ultragoal handoff** — reachable via user-authorized execution handoff (#3463, #3483).
+- **Conductor delegation lanes** — unblocked under typed, positively-supported native spawn surfaces (#3482).
+- **HUD Fish parsing** — tmux parsing no longer breaks on Fish `export` (#3480).
+- **Version display** — `OMX_VERSION_REVISION` takes precedence over `OMX_GIT_REVISION` (#3417).
+- **Canonical contracts** — workflow and hook recovery contracts aligned (#3514, #3486).
 ## [0.20.5] - 2026-08-10
 
 Patch release for the exact 68-commit range `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196`. No intentional breaking CLI or package-layout changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.20.5"
+version = "0.21.0"
 
 edition = "2021"
 rust-version = "1.73"

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,25 +1,33 @@
-# oh-my-codex 0.20.5
+# oh-my-codex 0.21.0
 
-`0.20.5` is a patch release for the exact range `v0.20.4..13c08f84cb6c27750b8f5c4a4d5105faad074196` (68 commits, 35 merged PRs). It contains no intentional breaking CLI or package-layout changes.
+`0.21.0` is a minor release for the exact range `v0.20.5..0f2bbb704b83f94a69622b1915f555498e0dd283` (99 commits, 310 files, 44 referenced PRs). It is the post-epic consolidation train and intentionally removes deprecated skills and MCP state writer tools, each with an explicit migration error.
 
 ## Highlights
 
-- **Darwin detached return-to-shell and finalization** — detached launches now bind readiness and metadata to the live pane, retain exact HUD/leader authority through teardown, release attach only after finalization, and exercise the return-to-shell path on macOS (#3472).
-- **Session and hook authority** — exact indeterminate bindings are finalized with synchronous directory-capability revalidation; trusted lock inspection is available for diagnostics; identity-indeterminate Stop handling is silent; authorization failures are no longer reinjected (#3416, #3421, #3471, #3472).
-- **Ralplan diagnostics and lifecycle** — preflight remains state-preserving, reports structured detected-version diagnostics, clears stale owner-scoped state, permits typed consensus delegation, and recognizes Codex 0.148 alpha versions (#3450, #3455, #3456, #3473).
-- **Windows and setup durability** — directory `fsync` `EPERM`, hook mode synthesis, and mode read-back are tolerated on Windows; launch repair preserves user notify/reasoning settings and project scope (#3448, #3449, #3467, #3468).
-- **Team/tmux boundaries** — foreign pane topology is explained rather than claimed, and source-authority separator argv boundaries are preserved (#3434, #3460).
-- **Plugin/runtime and packed-install fixes** — packed runtime provisioning and cwd checks are deterministic, ambient session state is scrubbed, detached OMX state is bound to launch context, and Doctor validates native process-identity readiness (#3395, #3436, #3454, #3461, #3470).
-- **Dependencies** — `windows-sys` 0.59→0.61.2, `tar-stream` 2.2.0→3.2.0, `@types/tar-stream` 2.2.3→3.1.4, `@biomejs/biome` 2.5.4→2.5.6, and `@types/node` 26.1.1→26.1.2 (#3429–#3432).
+- **Removed skills with migration stubs** — 25 removed skills fail fast through a uniform sunset-stub resolver: `$ralph` → `$ultragoal` (the `omx ralph` CLI and ralph persistence runtime are unaffected), `$ultrawork`/`$ecomode`/`$swarm` → `$team`, `$prometheus-strict` → `$plan`, `$review`/`$security-review` → `$code-review`, `$ask-claude`/`$ask-gemini` → `$ask`, `$deepsearch` → `$analyze`, `$frontend-ui-ux` → `$design`, `$visual-verdict`/`$web-clone` → `$visual-ralph`, `$help` → `$omx-setup`; `$tdd`, `$note`, `$trace`, `$build-fix` have no direct replacement (#3506, #3502, #3508).
+- **`omx autopilot` canonical orchestrator** — first-class CLI command restoring the staged `$deep-interview` → `$ralplan` → `$ultragoal` chain (#3518, #3517), with Ultragoal ordinary/strict modes and an advisory completion cohort gate in ordinary mode (#3500, #3505).
+- **Hard workflow gates removed** — no host-issued consensus receipt is required for workflow transitions; PreToolUse hooks are advisory-only with Codex App capability warnings (#3492, #3497).
+- **State single source of truth** — sole-writer state model; the MCP surface is read-only (`state_write`/`state_clear` removed with explicit deprecation errors); stale projections retire through `omx doctor --repair-state`; corrupt or laundered carriers fail closed (#3507, #3498).
+- **Bounded plugin lifecycle** — plugin snapshots are bounded with a hook escape hatch; deprecated-skill retirement is keyed to install badges (#3499, #3512).
+- **Session authority hardened** — read/write authority split for identity-indeterminate pointers, bounded unproven-pointer adoption, verified-dead pointer quarantine, and team worker provenance verification for external state roots (#3527, #3541, #3528, #3537).
 
-> **Current status / supersession (ADR 3212):** Local leader attestation and adapted role intent do not authorize. Typed routing and tracker evidence are lifecycle or diagnostic evidence only. When `role_routing_unavailable` applies to an adapted Ralplan authority attempt, installed role-intent and preflight fail closed with `unsupported_documented_leader_proof`. Ralplan consensus remains unavailable with `documented_host_consensus_receipt_unavailable` because no official host receipt verifier exists; native Architect/Critic evidence alone cannot release the transition.
+## Fixes / compatibility notes
+
+- Detached `--madmax` root identity on macOS is path-alias canonical and regression-locked (#3550, #3551); the detached tmux owner race retries under an unchanged authority fence (#3540, #3541).
+- `omx-runtime` hydrates and is discovered on macOS arm64 npm installs (#3519, #3520).
+- URL reader no longer false-truncates at the exact limit (#3546); zero/invalid notification durations are handled (#3544); HUD tolerates Fish `export` (#3480).
+- Worker triggers use tmux named `Enter` with Claude 2.1.x prompt detection (#3531); guarded split receipts reject format-string injection (#3489); team scale-down claim-boundary coverage is load-tolerant (#3548, #3549).
+- Ralplan → Ultragoal handoff is reachable via user-authorized execution handoff (#3463, #3483); Conductor delegation lanes are unblocked (#3482); workflow/hook recovery contracts are aligned (#3514, #3486).
+- Version display prefers `OMX_VERSION_REVISION` (#3417); dependencies: `@biomejs/biome` 2.5.8 (#3532), `@types/node` 26.2.0 (#3485).
+
+> **Upgrade notes for 0.20.x users:** invocations of removed skills now hard-error with the replacement name in the message; MCP clients calling `state_write`/`state_clear` must move to CLI/programmatic state operations; retire stale 0.20.x state projections with `omx doctor --repair-state` (archives under `.omx/archive/`). A 0.20→0.21 upgrade fixture and generator drift tests ship in `npm test` (#3509).
 
 ## Compatibility
 
-Patch release with no intentional breaking contract. Publication, tag, GitHub Release, and npm availability remain pending the owner-authorized promotion lane.
+Minor release with intentional, migration-pathed removals (deprecated skills; MCP state writer tools). Publication, tag, GitHub Release, and npm availability remain pending the owner-authorized promotion lane (issue #3552).
 
 ## Contributors
 
-Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with an additional contribution from @ev78394, plus @app/dependabot for dependency updates.
+Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with additional contributions from @hiSandog (#3417, #3544, #3546), @jason931225 (#3528), @NagyVikt (#3480), and the gaebal-gajae (clawdbot) release bot, plus @app/dependabot for dependency updates (#3484, #3485, #3532).
 
-**Full Changelog**: [`v0.20.4...v0.20.5`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.4...v0.20.5)
+**Full Changelog**: [`v0.20.5...v0.21.0`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.5...v0.21.0)

--- a/artifacts/release-0.21.0/inventory.md
+++ b/artifacts/release-0.21.0/inventory.md
@@ -1,0 +1,64 @@
+# Release inventory — v0.20.5..dev@0f2bbb70 (issue #3552)
+
+- PREV tag: v0.20.5 = 27b3a91c2ea630c2a82cdbcd45a1f1de30d9bb2a (tagged 2026-08-10)
+- Candidate: dev @ 0f2bbb704b83f94a69622b1915f555498e0dd283 (2026-08-22)
+- Range: exactly 99 commits (`git log --oneline v0.20.5..0f2bbb70` = 99 lines), 310 files, +31,779/−69,216
+- Ancestry: `git merge-base --is-ancestor v0.20.5 0f2bbb70` → OK (verified by leader; inventory lane independently proved via empty reverse range)
+- Merge commits: 17, every one carrying a `#NNNN` PR reference — zero unattributed merges, zero direct pushes
+- PR references in range subjects: 44 distinct (#3417 #3463 #3480 #3482 #3483 #3484 #3485 #3486 #3489 #3492 #3497 #3499 #3500 #3502 #3505 #3506 #3507 #3508 #3509 #3510 #3512 #3513 #3516 #3517 #3518 #3519 #3520 #3523 #3527 #3528 #3531 #3532 #3533 #3537 #3539 #3541 #3544 #3546 #3547 #3548 #3549 #3550 #3551)
+- Window PRs (merged ≥ tag date, 35 total): all 35 map into the range except #3503 #3511 #3524, which were merged outside `dev` (main-only release-train PRs; intentionally excluded)
+- Raw artifacts: commits.txt, prs.tsv, merge-map.tsv, range-prs.txt, window-prs.tsv, outside-range-prs.txt in this directory
+
+## PR inventory (range-referenced, grouped by train)
+
+### Epic: skill/planning/execution consolidation (0.21-class)
+- #3506 feat/issue-3493 remove deprecated skills (merge 71d2e0f6; commits 8b59cba9 98eccd21 a65635e9 d1e3365c 9adcd5ef 750dc50c df1f771c 57ef0e10 028c91cb)
+- #3502 feat/issue-3494 merge planning skills (merge a0a7093e)
+- #3508 feat(3495) merge execution loops; remove autopilot/pipeline (0de015be)
+- #3500 feat(ultragoal) ordinary/strict modes with advisory cohort gate (875851f4)
+- #3505 feat(ultragoal) ordinary/strict modes with advisory cohort gate (c86950a5, squash)
+- #3492 fix remove hard workflow gates; authority-decreasing recovery (bd1bdb13)
+- #3497 feat simplify hooks; PreToolUse advisory-only; Codex App capability warnings (57abc22f)
+- #3513 feat(prompts) centralize invariants and slim prompt architecture (213e2461)
+- #3517 feat/issue-3516 restore deep-interview (merge 12b5172f; 01c5db1f)
+- #3518 feat(autopilot) restore canonical staged orchestration (8d2adf42)
+- #3509 feat(3501) drift tests and upgrade fixture in CI (0e95f63d)
+
+### Epic: state SSOT / lifecycle / authority
+- #3507 feat(3498) State SSOT unification — sole writer, read-only MCP, stale neutralization (839b28c9; follow-ups 69449d89 259f5ab6 ee60bb77 4c05f4bd 13fbdfc7 bc3b496c b4b04ad7)
+- #3499 feat/issue-3499 slim lifecycle (merge ae903ee1; 126b24fc 2240da1b)
+- #3512 fix/issue-3499 bounded snapshot cleanup (merge 81432ce7)
+- #3514 fix/issue-3486 canonical contracts (merge dd009ba4; 8442d0f7)
+- #3537 fix/issue-3536 external team state root (merge 0555eaf8; 0d6c5414 worker-provenance)
+- #3541 fix/issue-3540 detached tmux owner race (merge 18567789; e3c40128)
+- #3527 fix(session) recover verified-dead pointers (ce3de586)
+- #3528 fix/receipt-authorized-hook-cancel (merge 5ee2193f; 9fbc5051)
+- #3482 fix(hooks) unblock Conductor delegation lanes (c4c9ecdf)
+- #3489 fix(team) guarded split receipts tmux-safe (986f877a)
+- #3463+#3483 fix(ralplan) → ultragoal user-authorized execution handoff (5ef807fd)
+- #3548/#3549 test(team) scale-down claim boundary load-tolerant (06652406)
+
+### Fixes / compatibility
+- #3550/#3551 madmax detached-root identity regression coverage (merge 0f2bbb70; 99f43e29; train 23295a35 7c53c4d6 3cd2aa2e)
+- #3546 fix(url-reader) false truncation at exact limit (merge ddad0cd1; fc1da35d b8af3a75)
+- #3547 fix(setup) capability-based wording (b8af3a75)
+- #3544 fix(notifications) zero/invalid durations (76552fcd)
+- #3531 fix(team) tmux named Enter + Claude 2.1.x prompt detection (0ec1003a)
+- #3519/#3520 fix(runtime) omx-runtime hydration on macOS arm64 npm installs (112dc381)
+- #3539 (merge 94d54e20), #3532 biome 2.5.8 (merge 3e162d1a), #3533 macOS update (merge 325347e4)
+- #3480 fix(hud) Fish export parsing (e2709a4f), #3484 biome 2.5.7, #3485 @types/node
+- #3417 fix version-revision fallback (merge 2add27ba)
+
+### Docs-only (internal-only candidates)
+- #3523 README gajae-code callout (ee3065be); f45a8529 badge comment docs
+
+## Version decision (G1)
+
+NEXT = **v0.21.0** (leader adjudication on semver-lane CLEAR recommendation):
+
+1. Docs in-range literally say "Removed in OMX 0.21" (docs/skills.html, PR #3506 train) — the range was authored as 0.21.
+2. Active+core skills removed ($ralph, $ultrawork, $ecomode, $swarm, $prometheus-strict, $review, $deepsearch, 25 sunset-stub entries) + advertised MCP API surface removed (state_write/state_clear now rejected) — breaking-for-consumers, cannot be 0.20.6.
+3. New first-class CLI command `omx autopilot` + new flags (--disable-hooks, --repair-state) — minor-grade additions.
+4. Repo precedent: 0.16.0 shipped as "minor release focused on skill deprecation" — same shape as this range.
+
+Adversarial check: "everything is compatible" fails because removed skills hard-error at invocation and removed MCP tools return errors; "patch understates" fails because additions+removals co-occur. Minor is the floor; no major (0.x convention keeps 0.21 for breaking-with-migration-path).

--- a/docs/qa/release-readiness-0.21.0.md
+++ b/docs/qa/release-readiness-0.21.0.md
@@ -1,0 +1,53 @@
+# Release readiness — 0.21.0
+
+## Release identity
+
+- Release: `0.21.0` (minor; intentional, migration-pathed removals of deprecated skills and MCP state writer tools).
+- Date: 2026-08-22.
+- Previous tag: `v0.20.5` (`27b3a91c2ea630c2a82cdbcd45a1f1de30d9bb2a`).
+- Frozen dev base: `0f2bbb704b83f94a69622b1915f555498e0dd283`.
+- Exact compare range: `v0.20.5..0f2bbb704b83f94a69622b1915f555498e0dd283`.
+- Range size: 99 commits, 310 changed files (+31,779/−69,216), 44 referenced PRs (36 merged into the range; window PRs #3503/#3511/#3524 were main-only and are intentionally excluded).
+- Merge base: `v0.20.5` itself — `git merge-base --is-ancestor v0.20.5 0f2bbb70` exits 0 (no ancestry boundary this release, unlike 0.20.5).
+- Compatibility: minor with documented removals; upgrade notes in `docs/release-notes-0.21.0.md`.
+- Tracking issue: #3552 (owner-authorized 2026-08-22).
+
+## Semver decision record
+
+`0.21.0`, not `0.20.6`: the range removes 25 catalog skills behind hard-error sunset stubs (docs in-range self-identify as "Removed in OMX 0.21"), removes the advertised MCP `state_write`/`state_clear` tools, and adds the first-class `omx autopilot` command plus `--disable-hooks`/`--repair-state` flags. Removals of reachable consumer surfaces cannot ship as a patch; additions rule out calling it merely a fix train. Repo precedent: `0.16.0` shipped as a "minor release focused on skill deprecation".
+
+## Version carriers
+
+- `package.json` → `0.21.0`
+- `package-lock.json` (top-level and `packages."`) → `0.21.0` (2-line diff)
+- `Cargo.toml` `[workspace.package]` → `0.21.0` (all six crates are `version.workspace = true`)
+- `plugins/oh-my-codex/.codex-plugin/plugin.json` → `0.21.0`
+- `packages/vscode-extension/package.json` stays `0.5.7` (independently versioned, unchanged in range)
+
+## Tag-ordering correction (2026-08-22)
+
+During G2, a **local-only** annotated `v0.21.0` tag was briefly created at the frozen dev candidate `0f2bbb70` because `dist/scripts/generate-release-body.js` requires the current-tag ref to resolve (`verifyGitCommitRef`). It was never pushed; the operator verified `origin` has no `refs/tags/v0.21.0` and deleted the local tag. Generator validation evidence from that window is preserved (`/tmp/RELEASE_BODY.generated.md`: correct Full Changelog line, `## Contributors`, all six major compare-range highlights present). **No tag will be recreated for generation.** The real annotated `v0.21.0` tag is created exactly once, only after: release collateral committed → release-prep PR merged to `dev` → frozen dev CI green → candidate promoted to `main` → exact `main` CI green; and it must point to the shipped `main` commit, not `0f2bbb70`. Recorded on issue #3552.
+
+## Required gates
+
+| Gate | Evidence | Status |
+|---|---|---|
+| Ancestry | `git merge-base --is-ancestor v0.20.5 0f2bbb70` → exit 0. | Passed locally |
+| Inventory | 99 commits; 17/17 merge commits PR-attributed; 0 unattributed/direct-push; window cross-check done. `artifacts/release-0.21.0/inventory.md`. | Passed locally |
+| Version sync | `node dist/scripts/check-version-sync.js --tag v0.21.0` (to run after build in G3). | Pending G3 |
+| Build / static / bundle | `npm run build`, `npm run check:no-unused`, `npm run lint`, native-agent + plugin-mirror + catalog checks (G3). | Pending G3 |
+| Package dry run | `npm pack --dry-run` (G3; full pack+install dogfood already passed at base 0f2bbb70 with 0.20.5 carriers — lane evidence 2026-08-22). | Pending G3 |
+| Focused high-risk tests | G3 selection: session/pointer authority, state SSOT + handoff carrier, compat upgrade fixture, team scaling, url-reader, version display. | Pending G3 |
+| Release body | `RELEASE_BODY.md` contains `## Contributors` and the Full Changelog line; generator validation runs in G3 after `dist/` build. | Pending G3 |
+| Diff hygiene | `git diff --check`. | Pending G3 |
+| CI on candidate | dev@0f2bbb70 CI green (run 32520444919, CI Status required check). Release-prep PR CI pending G4. | Base green; PR pending G4 |
+| Tag / GitHub Release / npm | Owner-authorized promotion lane (G5); v0.20.5 precedent shows npm publish may need the manual workflow if the packed-install smoke gate fails. | Pending G5 |
+
+## Known gaps
+
+- Broad cross-platform and native-build matrices are CI-authoritative (7-target cargo-dist matrix in `release.yml`).
+- No tag, GitHub Release, main merge, or npm publication is performed by this release-preparation lane; they belong to G5 under issue #3552's authorization.
+
+## Publish boundary
+
+After the release-prep PR is green on `dev` (G4), the promotion lane must merge to `main`, wait for main CI, tag `v0.21.0` (annotated), wait for the tag-triggered release workflow, verify the GitHub Release (non-draft, non-prerelease, native assets + manifest) and `npm view oh-my-codex version`, then fast-forward `dev` and bump the next development base (G6). External evidence is recorded back into this file and on issue #3552.

--- a/docs/release-notes-0.21.0.md
+++ b/docs/release-notes-0.21.0.md
@@ -1,0 +1,40 @@
+# oh-my-codex 0.21.0 release notes
+
+Release date: 2026-08-22
+
+`0.21.0` is a minor release covering the exact frozen range `v0.20.5..0f2bbb704b83f94a69622b1915f555498e0dd283`: 99 commits and 44 referenced PRs (36 merged into the range; three window PRs — #3503, #3511, #3524 — were main-only and are intentionally excluded). This is the post-epic consolidation train and it intentionally removes deprecated skills and MCP state writer tools with explicit migration errors.
+
+## Highlights
+
+- **Removed skills with migration stubs** — 25 removed skills fail fast through a uniform sunset-stub resolver: `$ralph` → `$ultragoal` (the `omx ralph` CLI and ralph persistence runtime are unaffected), `$ultrawork`/`$ecomode`/`$swarm` → `$team`, `$prometheus-strict` → `$plan`, `$review`/`$security-review` → `$code-review`, `$ask-claude`/`$ask-gemini` → `$ask`, `$deepsearch` → `$analyze`, `$frontend-ui-ux` → `$design`, `$visual-verdict`/`$web-clone` → `$visual-ralph`, `$help` → `$omx-setup`; `$tdd`, `$note`, `$trace`, `$build-fix` have no direct replacement (#3506, #3502, #3508).
+- **`omx autopilot` returns as the canonical orchestrator** — a first-class CLI command restoring the staged `$deep-interview` → `$ralplan` → `$ultragoal` chain (#3518, #3517), with Ultragoal gaining ordinary/strict modes and an advisory completion cohort gate in ordinary mode (#3500, #3505).
+- **Hard workflow gates removed** — the Autopilot/Ralplan consensus-receipt gate is gone; workflow transitions no longer require a host-issued consensus receipt, and PreToolUse hooks are advisory-only with Codex App capability warnings (#3492, #3497).
+- **State single source of truth** — sole-writer state model, read-only MCP projection (`state_write`/`state_clear` removed with explicit deprecation errors), shared handoff-carrier invariants, explicit stale-projection retirement via `omx doctor --repair-state`, and fail-closed corrupt-carrier handling (#3507, #3498).
+- **Bounded plugin lifecycle** — plugin snapshots are bounded with a hook escape hatch, and deprecated-skill retirement is keyed to install badges (#3499, #3512).
+- **Session authority hardened** — read/write authority split for identity-indeterminate pointers, bounded unproven-pointer adoption, verified-dead pointer quarantine with forensic preservation, and team worker provenance verification for external state roots (#3527, #3541, #3528, #3537).
+
+## Fixes / compatibility notes
+
+- Detached `--madmax` root identity on macOS: path-alias canonicalization, post-create re-resolution, path-alias-insensitive launch keys (#3550/#3551).
+- Detached tmux owner race retried under an unchanged authority fence (#3540, #3541); team scale-down claim-boundary coverage made load-tolerant (#3548, #3549).
+- `omx-runtime` hydration and discovery on macOS arm64 npm installs (#3519, #3520).
+- URL reader no longer false-truncates at the exact size limit (#3546); notification zero/invalid durations handled (#3544); HUD tolerates Fish `export` (#3480).
+- Worker triggers use tmux named `Enter` with Claude 2.1.x prompt detection (#3531); guarded split receipts reject format-string injection (#3489).
+- Ralplan → Ultragoal handoff reachable via user-authorized execution handoff (#3463, #3483); Conductor delegation lanes unblocked (#3482); workflow/hook recovery contracts aligned (#3514, #3486).
+- Version display prefers `OMX_VERSION_REVISION` over `OMX_GIT_REVISION` (#3417); dependencies: `@biomejs/biome` 2.5.8 (#3532), `@types/node` 26.2.0 (#3485).
+
+**Upgrade notes for 0.20.x users:** invocations of removed skills now hard-error with the replacement name in the message; MCP clients calling `state_write`/`state_clear` must move to CLI/programmatic state operations; stale 0.20.x state projections should be retired with `omx doctor --repair-state` (archives under `.omx/archive/`). A 0.20→0.21 upgrade fixture and generator drift tests ship in `npm test` (#3509).
+
+## Inventory
+
+The concise, reproducible range and PR inventory is recorded in `artifacts/release-0.21.0/inventory.md`. Merged PRs in the range: [#3417](https://github.com/Yeachan-Heo/oh-my-codex/pull/3417), [#3463](https://github.com/Yeachan-Heo/oh-my-codex/pull/3463), [#3480](https://github.com/Yeachan-Heo/oh-my-codex/pull/3480), [#3482](https://github.com/Yeachan-Heo/oh-my-codex/pull/3482), [#3483](https://github.com/Yeachan-Heo/oh-my-codex/pull/3483), [#3484](https://github.com/Yeachan-Heo/oh-my-codex/pull/3484), [#3485](https://github.com/Yeachan-Heo/oh-my-codex/pull/3485), [#3486](https://github.com/Yeachan-Heo/oh-my-codex/pull/3486), [#3489](https://github.com/Yeachan-Heo/oh-my-codex/pull/3489), [#3492](https://github.com/Yeachan-Heo/oh-my-codex/pull/3492), [#3497](https://github.com/Yeachan-Heo/oh-my-codex/pull/3497), [#3499](https://github.com/Yeachan-Heo/oh-my-codex/pull/3499), [#3502](https://github.com/Yeachan-Heo/oh-my-codex/pull/3502), [#3505](https://github.com/Yeachan-Heo/oh-my-codex/pull/3505), [#3506](https://github.com/Yeachan-Heo/oh-my-codex/pull/3506), [#3507](https://github.com/Yeachan-Heo/oh-my-codex/pull/3507), [#3508](https://github.com/Yeachan-Heo/oh-my-codex/pull/3508), [#3509](https://github.com/Yeachan-Heo/oh-my-codex/pull/3509), [#3510](https://github.com/Yeachan-Heo/oh-my-codex/pull/3510), [#3512](https://github.com/Yeachan-Heo/oh-my-codex/pull/3512), [#3513](https://github.com/Yeachan-Heo/oh-my-codex/pull/3513), [#3514](https://github.com/Yeachan-Heo/oh-my-codex/pull/3514), [#3516](https://github.com/Yeachan-Heo/oh-my-codex/pull/3516), [#3517](https://github.com/Yeachan-Heo/oh-my-codex/pull/3517), [#3518](https://github.com/Yeachan-Heo/oh-my-codex/pull/3518), [#3519](https://github.com/Yeachan-Heo/oh-my-codex/pull/3519), [#3520](https://github.com/Yeachan-Heo/oh-my-codex/pull/3520), [#3523](https://github.com/Yeachan-Heo/oh-my-codex/pull/3523), [#3527](https://github.com/Yeachan-Heo/oh-my-codex/pull/3527), [#3528](https://github.com/Yeachan-Heo/oh-my-codex/pull/3528), [#3531](https://github.com/Yeachan-Heo/oh-my-codex/pull/3531), [#3532](https://github.com/Yeachan-Heo/oh-my-codex/pull/3532), [#3533](https://github.com/Yeachan-Heo/oh-my-codex/pull/3533), [#3537](https://github.com/Yeachan-Heo/oh-my-codex/pull/3537), [#3539](https://github.com/Yeachan-Heo/oh-my-codex/pull/3539), [#3541](https://github.com/Yeachan-Heo/oh-my-codex/pull/3541), [#3544](https://github.com/Yeachan-Heo/oh-my-codex/pull/3544), [#3546](https://github.com/Yeachan-Heo/oh-my-codex/pull/3546), [#3547](https://github.com/Yeachan-Heo/oh-my-codex/pull/3547), [#3548](https://github.com/Yeachan-Heo/oh-my-codex/pull/3548), [#3549](https://github.com/Yeachan-Heo/oh-my-codex/pull/3549), [#3550](https://github.com/Yeachan-Heo/oh-my-codex/pull/3550), and [#3551](https://github.com/Yeachan-Heo/oh-my-codex/pull/3551).
+
+## Validation
+
+Local release-blocking evidence is recorded in `docs/qa/release-readiness-0.21.0.md`. Broad platform CI, tagging, GitHub Release creation, and npm publication are intentionally left to the owner-authorized promotion lane (issue #3552).
+
+## Contributors
+
+Thanks to Bellman (@Yeachan-Heo) for the majority of commits in this range, with additional contributions from @hiSandog (#3417, #3544, #3546), @jason931225 (#3528), @NagyVikt (#3480), and the gaebal-gajae (clawdbot) release bot, plus @app/dependabot for dependency updates (#3484, #3485, #3532).
+
+**Full Changelog**: [`v0.20.5...v0.21.0`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.20.5...v0.21.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.20.5",
+      "version": "0.21.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.20.5",
+  "version": "0.21.0",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",

--- a/src/team/__tests__/api-interop.test.ts
+++ b/src/team/__tests__/api-interop.test.ts
@@ -666,6 +666,7 @@ describe('executeTeamApiOperation: mailbox-mark-delivered', () => {
       if (!firstAck.ok) throw new Error('expected first acknowledgement to succeed');
       assert.equal(firstAck.data.dispatch_updated, false);
       assert.equal((await readDispatchRequest('mark-dlv-coalesced', wake.request.request_id, cwd))?.status, 'pending');
+      assert.equal((await readDispatchRequest('mark-dlv-coalesced', alternateWake.request.request_id, cwd))?.status, 'pending');
 
       const finalAck = await executeTeamApiOperation('mailbox-mark-delivered', {
         team_name: 'mark-dlv-coalesced', worker: 'worker-2', message_id: secondId,

--- a/src/team/__tests__/team-ops-contract.test.ts
+++ b/src/team/__tests__/team-ops-contract.test.ts
@@ -42,6 +42,7 @@ const EXPECTED_STATE_RE_EXPORTS = {
   teamTransitionDispatchRequest: 'transitionDispatchRequest',
   teamMarkDispatchRequestNotified: 'markDispatchRequestNotified',
   teamMarkDispatchRequestDelivered: 'markDispatchRequestDelivered',
+  teamMarkDispatchRequestFailed: 'markDispatchRequestFailed',
   teamRemoveDispatchRequestsForWorkers: 'removeDispatchRequestsForWorkers',
   teamAppendEvent: 'appendTeamEvent',
   teamReadTaskApproval: 'readTaskApproval',

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -147,26 +147,34 @@ async function markLatestMailboxDispatchDelivered(
   cwd: string,
 ): Promise<{ matched_request_id: string | null; dispatch_updated: boolean }> {
   const active = (await teamListDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: worker }))
-    .filter((request) => request.status === 'pending' || request.status === 'notified')
-    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at));
-  const latest = active[0];
-  if (!latest) return { matched_request_id: null, dispatch_updated: false };
+    .filter((request) => request.status === 'pending' || request.status === 'notified');
+  // Dispatch persistence is append-only. Keep the newest exact-message receipt
+  // when concurrent paths queued more than one wake in the same clock tick.
+  const matching = active.filter((request) => request.message_id === messageId).at(-1);
+  if (!matching) return { matched_request_id: null, dispatch_updated: false };
 
   const mailbox = await listMailboxMessages(teamName, worker, cwd);
   if (mailbox.some((message) => !message.delivered_at)) {
-    return { matched_request_id: latest.request_id, dispatch_updated: false };
+    return { matched_request_id: matching.request_id, dispatch_updated: false };
   }
 
+  const deliveredMessageIds = new Set(
+    mailbox.filter((message) => message.delivered_at).map((message) => message.message_id),
+  );
   let allDelivered = true;
   for (const request of active) {
-    if (request.status === 'pending') {
-      await teamMarkDispatchRequestNotified(teamName, request.request_id, { message_id: messageId }, cwd);
+    if (!request.message_id || !deliveredMessageIds.has(request.message_id)) {
+      allDelivered = false;
+      continue;
     }
-    const delivered = await teamMarkDispatchRequestDelivered(teamName, request.request_id, { message_id: messageId }, cwd);
+    if (request.status === 'pending') {
+      await teamMarkDispatchRequestNotified(teamName, request.request_id, { message_id: request.message_id }, cwd);
+    }
+    const delivered = await teamMarkDispatchRequestDelivered(teamName, request.request_id, { message_id: request.message_id }, cwd);
     allDelivered &&= delivered?.status === 'delivered';
   }
   return {
-    matched_request_id: latest.request_id,
+    matched_request_id: matching.request_id,
     dispatch_updated: allDelivered,
   };
 }

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -101,10 +101,9 @@ async function markImmediateDispatchFailure(params: {
   teamName: string;
   request: TeamDispatchRequest;
   reason: string;
-  messageId?: string;
   cwd: string;
 }): Promise<void> {
-  const { teamName, request, reason, messageId, cwd } = params;
+  const { teamName, request, reason, cwd } = params;
   if (request.transport_preference === 'hook_preferred_with_fallback') return;
 
   const current = await readDispatchRequest(teamName, request.request_id, cwd);
@@ -335,7 +334,6 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
       teamName: params.teamName,
       request: queued.request,
       reason: outcome.reason,
-      messageId: message.message_id,
       cwd: params.cwd,
     });
   }
@@ -435,7 +433,6 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         teamName: params.teamName,
         request: queued.request,
         reason: outcome.reason,
-        messageId: message.message_id,
         cwd: params.cwd,
       });
     }

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -7,6 +7,7 @@ import {
   teamReadDispatchRequest as readDispatchRequest,
   teamTransitionDispatchRequest as transitionDispatchRequest,
   teamMarkDispatchRequestNotified as markDispatchRequestNotified,
+  teamMarkDispatchRequestFailed as markDispatchRequestFailed,
   type TeamDispatchRequest,
   type TeamDispatchRequestInput,
 } from './team-ops.js';
@@ -110,17 +111,7 @@ async function markImmediateDispatchFailure(params: {
   if (!current) return;
   if (current.status === 'failed' || current.status === 'notified' || current.status === 'delivered') return;
 
-  await transitionDispatchRequest(
-    teamName,
-    request.request_id,
-    current.status,
-    'failed',
-    {
-      message_id: messageId ?? current.message_id,
-      last_reason: reason,
-    },
-    cwd,
-  ).catch(() => {});
+  await markDispatchRequestFailed(teamName, request.request_id, reason, cwd);
 }
 
 async function markLeaderPaneMissingDeferred(params: {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -28,6 +28,7 @@ import {
   transitionDispatchRequest as transitionDispatchRequestImpl,
   markDispatchRequestNotified as markDispatchRequestNotifiedImpl,
   markDispatchRequestDelivered as markDispatchRequestDeliveredImpl,
+  markDispatchRequestFailed as markDispatchRequestFailedImpl,
   normalizeBridgeDispatchRecord,
   normalizeDispatchRequest as normalizeDispatchRequestImpl,
 } from './state/dispatch.js';
@@ -2303,6 +2304,22 @@ export async function markDispatchRequestDelivered(
   cwd: string,
 ): Promise<TeamDispatchRequest | null> {
   return await markDispatchRequestDeliveredImpl(requestId, patch, {
+    teamName,
+    cwd,
+    validateWorkerName,
+    withDispatchLock,
+    readDispatchRequests,
+    writeDispatchRequests,
+  });
+}
+
+export async function markDispatchRequestFailed(
+  teamName: string,
+  requestId: string,
+  reason: string,
+  cwd: string,
+): Promise<void> {
+  await markDispatchRequestFailedImpl(requestId, reason, {
     teamName,
     cwd,
     validateWorkerName,

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -95,6 +95,7 @@ export { readDispatchRequest as teamReadDispatchRequest } from './state.js';
 export { transitionDispatchRequest as teamTransitionDispatchRequest } from './state.js';
 export { markDispatchRequestNotified as teamMarkDispatchRequestNotified } from './state.js';
 export { markDispatchRequestDelivered as teamMarkDispatchRequestDelivered } from './state.js';
+export { markDispatchRequestFailed as teamMarkDispatchRequestFailed } from './state.js';
 export { removeDispatchRequestsForWorkers as teamRemoveDispatchRequestsForWorkers } from './state.js';
 
 // === Events ===


### PR DESCRIPTION
## 0.21.0 release preparation

Carries the frozen post-epic release collateral/version carriers and the deterministic Team dispatch repairs found in #3552:

- associate mailbox-delivery receipts with the exact message ID and preserve unrelated pending/coalesced dispatches;
- persist notify-throw failures through the runtime bridge before retrying, preventing stale pending dispatches;
- retain strict focused regression coverage, including undelivered siblings.

Evidence: source and rebuilt-dist focused Team suites passed three consecutive runs; `tsc --noEmit`, native/generated gates, and `npm pack --dry-run` passed. The full `npm test` run exceeded the 20-minute command limit while still executing; no failure was observed before timeout.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*