### PR TITLE
fix(team): restore packed skill release contract (#3552)

### DIFF
--- a/omx-capabilities.lock.json
+++ b/omx-capabilities.lock.json
@@ -1417,7 +1417,7 @@
       ]
     },
     "skills": {
-      "digest": "ddd4eff6dd7328b1bea72c20c9a567cdb47a168943c76502a0fb5d6f2c8d4bb5",
+      "digest": "a0ab5ecba464350ab7593a9d1c3cf711391ce9892418b930c432d56862b2643f",
       "files": [
         {
           "digest": "227c02cb4304603fae65200878acb9708bc31523d0d851ea148861a8c6f72055",
@@ -1508,7 +1508,7 @@
           "path": "skills/skill/SKILL.md"
         },
         {
-          "digest": "c235609d4a6c57862890b3ab1a4ee6430f5d0c1fae77988be3a2040e6e831221",
+          "digest": "f41bbba31e19ffe9c662310eb8d9ae8635052842ecff9122711fc6fa97e9d737",
           "path": "skills/team/SKILL.md"
         },
         {

--- a/plugins/oh-my-codex/skills/team/SKILL.md
+++ b/plugins/oh-my-codex/skills/team/SKILL.md
@@ -15,6 +15,8 @@ Use only for an explicit `$team` request or `omx team ...` launch that benefits 
 - Require `tmux -V`, a leader session with `$TMUX`, and the intended `omx` executable. In Codex App/plain non-tmux sessions, explain the runtime boundary instead of pretending Team is available.
 - Before launch, ground the task in a recent `.omx/context/{slug}-*.md`; create a concise snapshot when none exists. Include target, evidence, constraints, unknowns, and likely touchpoints.
 - Do not launch nested Team runs. Pick worker roles deliberately; use `OMX_TEAM_WORKER_CLI=codex|claude|auto` or `OMX_TEAM_WORKER_CLI_MAP=...` only when needed.
+- Per-agent reasoning is set by `agentReasoning`; accepted values are `low`, `medium`, `high`, `xhigh`, and `max`. `max` is passed unchanged and remains capability-dependent. `ultra` is unsupported and is not an alias for `max`.
+- Invalid configured values use the built-in role-default fallback. An explicit raw `-c model_reasoning_effort=...` is opaque and wins. When both sources are present, explicit raw reasoning wins over inherited Team reasoning and environment reasoning. Do not downgrade or retry `max` as `xhigh`; built-in role defaults remain unchanged.
 
 ## Operational steps
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -15,6 +15,8 @@ Use only for an explicit `$team` request or `omx team ...` launch that benefits 
 - Require `tmux -V`, a leader session with `$TMUX`, and the intended `omx` executable. In Codex App/plain non-tmux sessions, explain the runtime boundary instead of pretending Team is available.
 - Before launch, ground the task in a recent `.omx/context/{slug}-*.md`; create a concise snapshot when none exists. Include target, evidence, constraints, unknowns, and likely touchpoints.
 - Do not launch nested Team runs. Pick worker roles deliberately; use `OMX_TEAM_WORKER_CLI=codex|claude|auto` or `OMX_TEAM_WORKER_CLI_MAP=...` only when needed.
+- Per-agent reasoning is set by `agentReasoning`; accepted values are `low`, `medium`, `high`, `xhigh`, and `max`. `max` is passed unchanged and remains capability-dependent. `ultra` is unsupported and is not an alias for `max`.
+- Invalid configured values use the built-in role-default fallback. An explicit raw `-c model_reasoning_effort=...` is opaque and wins. When both sources are present, explicit raw reasoning wins over inherited Team reasoning and environment reasoning. Do not downgrade or retry `max` as `xhigh`; built-in role defaults remain unchanged.
 
 ## Operational steps
 


### PR DESCRIPTION
Fixes the exact release workflow failure in tag run `32555629202` / packed global-install smoke job `96990734455`: the packaged Team skill lacked the required per-agent reasoning guidance contract.

The canonical and plugin mirrors now state supported `agentReasoning` values, max/ultra semantics, fallback behavior, precedence, and no-downgrade behavior.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*