### PR TITLE
fix(skills): point local-source guidance at built CLI dist/cli/omx.js (#3559)

### DIFF
--- a/omx-capabilities.lock.json
+++ b/omx-capabilities.lock.json
@@ -1417,7 +1417,7 @@
       ]
     },
     "skills": {
-      "digest": "a0ab5ecba464350ab7593a9d1c3cf711391ce9892418b930c432d56862b2643f",
+      "digest": "1cf03d84d93942785a619824cb6f34094e61a2bcc1896d7bf827d3f3624fe5f8",
       "files": [
         {
           "digest": "227c02cb4304603fae65200878acb9708bc31523d0d851ea148861a8c6f72055",
@@ -1468,7 +1468,7 @@
           "path": "skills/design/SKILL.md"
         },
         {
-          "digest": "84f4a1916054767c3c138695234e1815de0bd8ee1db5b94dac5e65b68c633b90",
+          "digest": "7c934251a6b56cdbcf0903f5cdc1420b53ee3515ebf9af046fc0350f27435dec",
           "path": "skills/doctor/SKILL.md"
         },
         {
@@ -1480,7 +1480,7 @@
           "path": "skills/hud/SKILL.md"
         },
         {
-          "digest": "e5ba47df26aa0a040f0111df216ea4068e8badb67c74a4f41901a2a30050984b",
+          "digest": "872383065b3a82a26e971881772a51c5add149f34e2d1d1a14a100e3497d2f83",
           "path": "skills/omx-setup/SKILL.md"
         },
         {

--- a/plugins/oh-my-codex/skills/doctor/SKILL.md
+++ b/plugins/oh-my-codex/skills/doctor/SKILL.md
@@ -17,7 +17,7 @@ omx doctor --force            # repair eligible repo artifact ownership issues
 omx doctor --dry-run --force  # preview eligible ownership repairs
 ```
 
-For a local source checkout, build first and invoke `node bin/omx.js doctor`. Keep command output and exact paths for the report.
+For a local source checkout, build first and invoke `node dist/cli/omx.js doctor`. Keep command output and exact paths for the report.
 
 ### Plugin cache and version
 

--- a/plugins/oh-my-codex/skills/omx-setup/SKILL.md
+++ b/plugins/oh-my-codex/skills/omx-setup/SKILL.md
@@ -48,7 +48,7 @@ omx doctor
 
 Expect doctor evidence for prompts and skills in the selected scope, project-root AGENTS.md, `.omx/state`, and CLI-first config in the scope target `config.toml`. First-party MCP and shared registry sync are omitted unless setup used `--mcp compat` (if supported by the installed CLI).
 
-If using local source, run `npm run build` before `node bin/omx.js setup --force --verbose` and `node bin/omx.js doctor`. If AGENTS was not overwritten or merged, stop the active OMX session and rerun with `--force` or `--merge-agents`; do not edit lifecycle state manually.
+If using local source, run `npm run build` before `node dist/cli/omx.js setup --force --verbose` and `node dist/cli/omx.js doctor`. If AGENTS was not overwritten or merged, stop the active OMX session and rerun with `--force` or `--merge-agents`; do not edit lifecycle state manually.
 
 ## Discovery troubleshooting
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -17,7 +17,7 @@ omx doctor --force            # repair eligible repo artifact ownership issues
 omx doctor --dry-run --force  # preview eligible ownership repairs
 ```
 
-For a local source checkout, build first and invoke `node bin/omx.js doctor`. Keep command output and exact paths for the report.
+For a local source checkout, build first and invoke `node dist/cli/omx.js doctor`. Keep command output and exact paths for the report.
 
 ### Plugin cache and version
 

--- a/skills/omx-setup/SKILL.md
+++ b/skills/omx-setup/SKILL.md
@@ -48,7 +48,7 @@ omx doctor
 
 Expect doctor evidence for prompts and skills in the selected scope, project-root AGENTS.md, `.omx/state`, and CLI-first config in the scope target `config.toml`. First-party MCP and shared registry sync are omitted unless setup used `--mcp compat` (if supported by the installed CLI).
 
-If using local source, run `npm run build` before `node bin/omx.js setup --force --verbose` and `node bin/omx.js doctor`. If AGENTS was not overwritten or merged, stop the active OMX session and rerun with `--force` or `--merge-agents`; do not edit lifecycle state manually.
+If using local source, run `npm run build` before `node dist/cli/omx.js setup --force --verbose` and `node dist/cli/omx.js doctor`. If AGENTS was not overwritten or merged, stop the active OMX session and rerun with `--force` or `--merge-agents`; do not edit lifecycle state manually.
 
 ## Discovery troubleshooting
 

--- a/src/cli/__tests__/package-bin-contract.test.ts
+++ b/src/cli/__tests__/package-bin-contract.test.ts
@@ -268,4 +268,35 @@ describe('package bin contract', () => {
     assert.equal(rootNativeAgentEntry, undefined, 'did not expect generated root native agent TOMLs in package output');
     assert.equal(pluginScopedHooksEntry, undefined, 'did not expect setup-owned hook assets inside the installable plugin bundle');
   });
+
+  it('documents local-source guidance against the declared built CLI entrypoint, never the removed bin/omx.js (#3559)', async () => {
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+    const declaredBin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.omx;
+    assert.ok(declaredBin, 'expected package.json to declare an omx bin entry');
+    assert.match(declaredBin, /^dist\/cli\/omx\.js$/, 'expected package bin to declare dist/cli/omx.js');
+
+    const localSourceSkillDocs = [
+      'skills/omx-setup/SKILL.md',
+      'skills/doctor/SKILL.md',
+      'plugins/oh-my-codex/skills/omx-setup/SKILL.md',
+      'plugins/oh-my-codex/skills/doctor/SKILL.md',
+    ];
+
+    for (const docPath of localSourceSkillDocs) {
+      const content = readFileSync(join(process.cwd(), ...docPath.split('/')), 'utf-8');
+      assert.equal(
+        content.includes('node bin/omx.js'),
+        false,
+        `${docPath} must not instruct local-source users to run the removed bin/omx.js launcher`,
+      );
+      const localSourceLine = content.split('\n').find((line) => line.includes('local source'));
+      assert.ok(localSourceLine, `${docPath} should keep its local-source checkout guidance`);
+      assert.match(
+        localSourceLine,
+        new RegExp(`node ${declaredBin.replace(/\//g, '\\/')}( setup| doctor)`),
+        `${docPath} local-source guidance must invoke the declared built CLI entrypoint`,
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Local-source users following both setup skill copies hit `MODULE_NOT_FOUND`: the guidance told them to run the removed `node bin/omx.js` launcher, while `package.json` declares the built CLI at `dist/cli/omx.js`.
- Canonical sources `skills/omx-setup/SKILL.md` and `skills/doctor/SKILL.md` now instruct `node dist/cli/omx.js setup --force --verbose` / `node dist/cli/omx.js doctor`.
- Plugin mirrors regenerated through the repository generator (`npm run sync:plugin`); `omx-capabilities.lock.json` regenerated via `omx capabilities lock`.
- Focused drift contract added to the existing package-bin contract test: the four actionable local-source docs must reference the declared package bin entrypoint and never `bin/omx.js`.

## Reproduction (exact)
- `ls bin` → `No such file or directory` (exit 2); `node bin/omx.js version` → `Error: Cannot find module '.../bin/omx.js'` with `code: 'MODULE_NOT_FOUND'`.
- After `npm install` + `npm run build`: `node dist/cli/omx.js version` → `oh-my-codex v0.21.0` (exit 0).
- Negative check: reverting one skill line to `node bin/omx.js setup` makes the new contract fail with `must not instruct local-source users to run the removed bin/omx.js launcher`; restored, it passes.

## Canonical-vs-generated ownership
- Canonical: `skills/{omx-setup,doctor}/SKILL.md`.
- Generated mirror: `plugins/oh-my-codex/skills/{omx-setup,doctor}/SKILL.md` (byte-identical via `sync-plugin-mirror`).
- Generated lock: `omx-capabilities.lock.json` (delta = aggregate skills digest + the two changed SKILL.md digests only).
- Untouched on purpose: historical CHANGELOG/QA docs and test fixtures (e.g. `src/cli/__tests__/cleanup.test.ts` mock commands, hud/tmux `/tmp/bin/omx.js` fixtures) — not user-facing setup guidance.

## Exact diff (6 files, +38/−7)
- `skills/omx-setup/SKILL.md` — one line.
- `skills/doctor/SKILL.md` — one line.
- `plugins/oh-my-codex/skills/omx-setup/SKILL.md`, `plugins/oh-my-codex/skills/doctor/SKILL.md` — mirror regen.
- `omx-capabilities.lock.json` — 3 digest lines.
- `src/cli/__tests__/package-bin-contract.test.ts` — one new focused `it(...)` block only.

## Validation
- `npm run build` — PASS.
- `npm test` (full: build + native-agents + plugin-bundle + capabilities-lock + prompt-guidance + `run-test-files dist` + catalog docs + prompt inventory) — PASS, 0 failing across the suite.
- `npm run test:plugin-boundaries:compiled` (layout 7/7, bin contract 2/2 incl. new #3559 case, shared ownership 7/7, plugin bundle SSOT 7/7) — PASS.
- `npm run verify:generated` — PASS (mirror verified, capabilities lock ok, prompt guidance ok, catalog check ok).
- `npm run lint` (biome, 797 files) — PASS. `npm run check:no-unused` — PASS.
- Independent read-only exact-diff critic — one finding (dropped `test:ci:compiled` assertion), fixed and re-verified; final verdict OKAY.
- Release/tag/publish surfaces untouched.

Fixes #3559
—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*