### PR TITLE
fix(cli): surface stale plugin launcher provenance instead of reporting current (#3558)

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1635,7 +1635,9 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`\\[!!\\] Native hooks: plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${cacheDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} do not match the packaged plugin; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json; run "omx setup --plugin" to refresh the plugin cache`,
+					"\\[!!\\] Native hooks: plugin-scoped hooks are enabled, but cached launcher in " +
+						cacheDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+						" is incompatible \\(.*pinned launcher target does not exist.*codex plugin remove oh-my-codex@oh-my-codex-local --json.*\\); setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json; run `codex plugin remove oh-my-codex@oh-my-codex-local --json` then rerun `omx setup --plugin`",
 				),
 			);
 			assert.doesNotMatch(res.stdout, /plugin cache native hook coverage smoke passed/);

--- a/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
+++ b/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
@@ -1,0 +1,669 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+  symlink,
+  lstat,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { setup } from "../setup.js";
+import {
+  materializePackagedOmxPluginCache,
+  resolvePackagedOmxMarketplace,
+  getPinnedLauncherIncompatibilityReason,
+  readPinnedLauncherRaw,
+  PLUGIN_LAUNCHER_RECOVERY_HINT,
+  omxPluginCacheBase,
+  upsertLocalOmxMarketplaceRegistration,
+  upsertLocalOmxPluginEnablement,
+} from "../plugin-marketplace.js";
+import { doctor } from "../doctor.js";
+
+const packageRoot = process.cwd();
+let fakeCodexBinDir: string | null = null;
+let previousPath: string | undefined;
+
+before(async () => {
+  previousPath = process.env.PATH;
+  fakeCodexBinDir = await mkdtemp(join(tmpdir(), "omx-fake-codex-3558-"));
+  const fakeCodexPath = join(fakeCodexBinDir, "codex");
+  await writeFile(
+    fakeCodexPath,
+    [
+      "#!/usr/bin/env node",
+      "if (process.argv[2] === 'features' && process.argv[3] === 'list') {",
+      "  console.log('hooks                                   stable             true');",
+      "  console.log('plugin_hooks                            experimental       true');",
+      "  console.log('goals                                   experimental       true');",
+      "  process.exit(0);",
+      "}",
+      "if (process.argv.includes('--version') || process.argv[2] === '--version') {",
+      "  console.log('codex-cli 0.999.0');",
+      "  process.exit(0);",
+      "}",
+      "process.exit(0);",
+      "",
+    ].join("\n"),
+  );
+  await import("node:fs/promises").then((m) => m.chmod(fakeCodexPath, 0o755));
+  process.env.PATH = `${fakeCodexBinDir}${process.env.PATH ? `:${process.env.PATH}` : ""}`;
+});
+
+after(async () => {
+  if (previousPath === undefined) delete process.env.PATH;
+  else process.env.PATH = previousPath;
+  if (fakeCodexBinDir)
+    await rm(fakeCodexBinDir, { recursive: true, force: true });
+});
+
+async function withIsolatedUserHome<T>(
+  wd: string,
+  fn: (codexHomeDir: string) => Promise<T>,
+): Promise<T> {
+  const prevHome = process.env.HOME;
+  const prevCodex = process.env.CODEX_HOME;
+  const homeDir = join(wd, "home");
+  const codexHomeDir = join(homeDir, ".codex");
+  await mkdir(codexHomeDir, { recursive: true });
+  process.env.HOME = homeDir;
+  process.env.CODEX_HOME = codexHomeDir;
+  try {
+    return await fn(codexHomeDir);
+  } finally {
+    if (typeof prevHome === "string") process.env.HOME = prevHome;
+    else delete process.env.HOME;
+    if (typeof prevCodex === "string") process.env.CODEX_HOME = prevCodex;
+    else delete process.env.CODEX_HOME;
+  }
+}
+
+async function withTempCwd(wd: string, fn: () => Promise<void>): Promise<void> {
+  const prev = process.cwd();
+  process.chdir(wd);
+  try {
+    await fn();
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+async function captureConsoleOutput(fn: () => Promise<void>): Promise<string> {
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const lines: string[] = [];
+  console.log = (...args: unknown[]) => lines.push(args.map(String).join(" "));
+  console.warn = (...args: unknown[]) => lines.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+    console.warn = origWarn;
+  }
+  return lines.join("\n");
+}
+
+async function packagedPluginCacheDir(codexHomeDir: string): Promise<string> {
+  const manifest = JSON.parse(
+    await readFile(
+      join(
+        packageRoot,
+        "plugins",
+        "oh-my-codex",
+        ".codex-plugin",
+        "plugin.json",
+      ),
+      "utf-8",
+    ),
+  ) as {
+    version: string;
+  };
+  return join(
+    codexHomeDir,
+    "plugins",
+    "cache",
+    "oh-my-codex-local",
+    "oh-my-codex",
+    manifest.version,
+  );
+}
+
+async function seedCurrentLauncher(codexHomeDir: string): Promise<string> {
+  const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+  await mkdir(dirname(cacheDir), { recursive: true });
+  await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+    recursive: true,
+  });
+  await writeFile(
+    join(cacheDir, "hooks", "omx-command.json"),
+    JSON.stringify(
+      {
+        command: process.execPath,
+        argsPrefix: [join(packageRoot, "dist", "cli", "omx.js")],
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  return cacheDir;
+}
+
+async function makeFakePackageRoot(
+  base: string,
+  label: string,
+): Promise<string> {
+  const fakeRoot = join(base, label);
+  await mkdir(fakeRoot, { recursive: true });
+  await cp(join(packageRoot, "plugins"), join(fakeRoot, "plugins"), {
+    recursive: true,
+  });
+  await mkdir(join(fakeRoot, ".agents", "plugins"), { recursive: true });
+  await cp(
+    join(packageRoot, ".agents", "plugins", "marketplace.json"),
+    join(fakeRoot, ".agents", "plugins", "marketplace.json"),
+  );
+  await mkdir(join(fakeRoot, "dist", "cli"), { recursive: true });
+  await writeFile(
+    join(fakeRoot, "dist", "cli", "omx.js"),
+    `// fake omx ${label}\n`,
+    "utf-8",
+  );
+  return fakeRoot;
+}
+
+describe("issue 3558 launcher provenance", () => {
+  it("reproduces exact dead-launcher case: same version different root removed -> stale-launcher, immutable preserved, recovery hint", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-repro-"));
+    const pkgBase = await mkdtemp(join(tmpdir(), "omx-3558-pkgbase-"));
+    try {
+      const oldRoot = await makeFakePackageRoot(pkgBase, "old-tmp-src");
+      const oldMarketplace = await resolvePackagedOmxMarketplace(oldRoot);
+      assert.ok(oldMarketplace);
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          // materialize from old temp root (simulates v0.21.0 from /private/tmp)
+          const r1 = await materializePackagedOmxPluginCache(
+            codexHomeDir,
+            oldMarketplace,
+          );
+          assert.equal(r1.status, "materialized");
+          const launcherPath = join(r1.cacheDir!, "hooks", "omx-command.json");
+          const launcher1 = JSON.parse(
+            await readFile(launcherPath, "utf-8"),
+          ) as { command: string; argsPrefix: string[] };
+          assert.ok(launcher1.argsPrefix[0]!.includes("old-tmp-src"));
+          // Simulate removal of temp build after global install: delete target
+          await rm(join(oldRoot, "dist", "cli", "omx.js"), { force: true });
+          assert.equal(existsSync(launcher1.argsPrefix[0]!), false);
+          // Now materialize from current (global) packageRoot — same version 0.21.0 but different root
+          const output = await captureConsoleOutput(async () => {
+            await setup({ scope: "user", installMode: "plugin" });
+          });
+          const launcher2 = JSON.parse(
+            await readFile(launcherPath, "utf-8"),
+          ) as { command: string; argsPrefix: string[] };
+          // Immutable: file not overwritten
+          assert.equal(launcher2.argsPrefix[0]!, launcher1.argsPrefix[0]!);
+          assert.equal(
+            launcher2.command,
+            launcher1.command as unknown as string,
+          );
+          // Must NOT claim current
+          assert.doesNotMatch(
+            output,
+            /Local Codex plugin cache already exposes packaged OMX skills/,
+          );
+          assert.match(output, /incompatible launcher provenance/);
+          assert.match(output, /does not exist/);
+          assert.match(
+            output,
+            /codex plugin remove oh-my-codex@oh-my-codex-local --json/,
+          );
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const r2 = await materializePackagedOmxPluginCache(
+            codexHomeDir,
+            packaged,
+          );
+          assert.equal(r2.status, "stale-launcher");
+          assert.ok(r2.reason);
+          assert.match(r2.reason!, /does not exist/);
+          assert.equal(
+            r2.cacheDir,
+            launcherPath.replace("/hooks/omx-command.json", ""),
+          );
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(pkgBase, { recursive: true, force: true });
+    }
+  });
+
+  it("same-root idempotence remains unchanged and live", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-idempotent-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          const cacheDir = await seedCurrentLauncher(codexHomeDir);
+          const output = await captureConsoleOutput(async () => {
+            await setup({ scope: "user", installMode: "plugin" });
+          });
+          assert.match(
+            output,
+            /Local Codex plugin cache already exposes packaged OMX skills/,
+          );
+          assert.doesNotMatch(output, /incompatible launcher/);
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const r = await materializePackagedOmxPluginCache(
+            codexHomeDir,
+            packaged,
+          );
+          assert.equal(r.status, "unchanged");
+          const launcher = JSON.parse(
+            await readFile(
+              join(cacheDir, "hooks", "omx-command.json"),
+              "utf-8",
+            ),
+          ) as {
+            argsPrefix: string[];
+          };
+          assert.equal(
+            launcher.argsPrefix[0],
+            join(packageRoot, "dist", "cli", "omx.js"),
+          );
+          assert.equal(existsSync(launcher.argsPrefix[0]!), true);
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("provenance mismatch with live target (different root, not deleted) is stale-launcher, not unchanged", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-provenance-live-"));
+    const pkgBase = await mkdtemp(join(tmpdir(), "omx-3558-pkgbase-live-"));
+    try {
+      const fakeRoot = await makeFakePackageRoot(pkgBase, "other-live-root");
+      const fakeMarketplace = await resolvePackagedOmxMarketplace(fakeRoot);
+      assert.ok(fakeMarketplace);
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          // seed with fake live root
+          const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+          await mkdir(dirname(cacheDir), { recursive: true });
+          await cp(join(fakeRoot, "plugins", "oh-my-codex"), cacheDir, {
+            recursive: true,
+          });
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            JSON.stringify(
+              {
+                command: process.execPath,
+                argsPrefix: [join(fakeRoot, "dist", "cli", "omx.js")],
+              },
+              null,
+              2,
+            ) + "\n",
+          );
+          assert.equal(
+            existsSync(join(fakeRoot, "dist", "cli", "omx.js")),
+            true,
+          );
+          // Now setup with current packageRoot (different but same version) — target still exists at old location
+          const output = await captureConsoleOutput(async () => {
+            await setup({ scope: "user", installMode: "plugin" });
+          });
+          assert.doesNotMatch(output, /already exposes/);
+          assert.match(output, /incompatible launcher provenance/);
+          assert.match(output, /provenance mismatch/);
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const r = await materializePackagedOmxPluginCache(
+            codexHomeDir,
+            packaged,
+          );
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /provenance mismatch/);
+          // still preserved
+          const launcher = JSON.parse(
+            await readFile(
+              join(cacheDir, "hooks", "omx-command.json"),
+              "utf-8",
+            ),
+          ) as {
+            argsPrefix: string[];
+          };
+          assert.equal(
+            launcher.argsPrefix[0],
+            join(fakeRoot, "dist", "cli", "omx.js"),
+          );
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+      await rm(pkgBase, { recursive: true, force: true });
+    }
+  });
+
+  it("live-pin does not auto-repair; stale-launcher persists and directory untouched", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-livepin-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+          await mkdir(dirname(cacheDir), { recursive: true });
+          await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+            recursive: true,
+          });
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            JSON.stringify(
+              { command: "/stale/node", argsPrefix: ["/stale/omx.js"] },
+              null,
+              2,
+            ) + "\n",
+          );
+          await writeFile(join(cacheDir, ".omx-live-pin"), "pinned\n");
+          const before = await readFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            "utf-8",
+          );
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const r = await materializePackagedOmxPluginCache(
+            codexHomeDir,
+            packaged,
+          );
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /does not exist/);
+          const after = await readFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            "utf-8",
+          );
+          assert.equal(after, before);
+          assert.equal(existsSync(join(cacheDir, ".omx-live-pin")), true);
+          const output = await captureConsoleOutput(async () => {
+            await setup({ scope: "user", installMode: "plugin" });
+          });
+          assert.doesNotMatch(output, /already exposes/);
+          assert.match(output, /incompatible launcher/);
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("malformed, missing, non-absolute and symlink cases handled", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-edge-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+
+          // malformed JSON
+          await mkdir(join(cacheDir, "hooks"), { recursive: true });
+          await mkdir(join(cacheDir, ".codex-plugin"), { recursive: true });
+          await writeFile(
+            join(cacheDir, ".codex-plugin", "plugin.json"),
+            await readFile(
+              join(
+                packageRoot,
+                "plugins",
+                "oh-my-codex",
+                ".codex-plugin",
+                "plugin.json",
+              ),
+              "utf-8",
+            ),
+          );
+          await mkdir(join(cacheDir, "skills"), { recursive: true });
+          await cp(
+            join(packageRoot, "plugins", "oh-my-codex", "hooks", "hooks.json"),
+            join(cacheDir, "hooks", "hooks.json"),
+          );
+          await cp(
+            join(
+              packageRoot,
+              "plugins",
+              "oh-my-codex",
+              "hooks",
+              "codex-native-hook.mjs",
+            ),
+            join(cacheDir, "hooks", "codex-native-hook.mjs"),
+          );
+          // need skills for state
+          await cp(
+            join(packageRoot, "plugins", "oh-my-codex", "skills"),
+            join(cacheDir, "skills"),
+            { recursive: true },
+          );
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            "{ malformed",
+            "utf-8",
+          );
+          let raw = await readPinnedLauncherRaw(cacheDir);
+          assert.match(raw.error!, /malformed/);
+          let r = await materializePackagedOmxPluginCache(
+            codexHomeDir,
+            packaged,
+          );
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /malformed/);
+          assert.match(
+            r.reason!,
+            new RegExp(
+              PLUGIN_LAUNCHER_RECOVERY_HINT.replace(
+                /[.*+?^${}()|[\]\\]/g,
+                "\\$&",
+              ),
+            ),
+          );
+
+          // missing launcher
+          await rm(join(cacheDir, "hooks", "omx-command.json"), {
+            force: true,
+          });
+          raw = await readPinnedLauncherRaw(cacheDir);
+          assert.equal(raw.raw, null);
+          r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /pinned launcher missing/);
+
+          // JSON null
+          await writeFile(join(cacheDir, "hooks", "omx-command.json"), "null\n", "utf-8");
+          raw = await readPinnedLauncherRaw(cacheDir);
+          assert.match(raw.error!, /malformed/);
+          r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /malformed/);
+          // must not throw at parsed.command access
+          const nullReason = await getPinnedLauncherIncompatibilityReason(cacheDir, packaged);
+          assert.ok(nullReason);
+
+          // JSON array
+          await writeFile(join(cacheDir, "hooks", "omx-command.json"), "[]\n", "utf-8");
+          r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /malformed/);
+
+          // dead command + live argsPrefix conflict (command validation must still fail-closed)
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            JSON.stringify({
+              command: "/stale/node",
+              argsPrefix: [join(packageRoot, "dist", "cli", "omx.js")],
+            }) + "\n",
+          );
+          r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /command.*does not exist|command provenance mismatch/);
+
+          // non-absolute target
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            JSON.stringify({
+              command: process.execPath,
+              argsPrefix: ["relative/path/omx.js"],
+            }) + "\n",
+          );
+          r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          assert.match(r.reason!, /not absolute/);
+
+          // symlink alias: packageRoot canonical alias should be considered live (unchanged)
+          const aliasRoot = join(wd, "alias-root");
+          await symlink(packageRoot, aliasRoot);
+          const aliasLauncherPath = join(aliasRoot, "dist", "cli", "omx.js");
+          // aliasLauncherPath canonical should equal packageRoot/dist/cli/omx.js
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            JSON.stringify({
+              command: process.execPath,
+              argsPrefix: [aliasLauncherPath],
+            }) + "\n",
+          );
+          // ensure file exists via alias
+          assert.equal(existsSync(aliasLauncherPath), true);
+          const incompat = await getPinnedLauncherIncompatibilityReason(
+            cacheDir,
+            packaged,
+          );
+          assert.equal(incompat, null, "symlink alias should be compatible");
+          r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(
+            r.status,
+            "unchanged",
+            "symlink alias must remain unchanged (provenance-compatible)",
+          );
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("doctor surfaces stale launcher as warn with recovery hint", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-doctor-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+          await mkdir(dirname(cacheDir), { recursive: true });
+          await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+            recursive: true,
+          });
+          await writeFile(
+            join(cacheDir, "hooks", "omx-command.json"),
+            JSON.stringify(
+              { command: "/stale/node", argsPrefix: ["/stale/omx.js"] },
+              null,
+              2,
+            ) + "\n",
+          );
+          // Also ensure doctor's expected plugin-scoped check triggers: need config that enables plugin-scoped hooks
+          // Minimal config: ensure checkPluginScopedNativeHooks path via doctor() invocation (not just helpers).
+          // Instead of full doctor (which checks many things), directly invoke the exported doctor helper via spawning logic:
+          // Call doctor() and inspect output; fallback to direct check if doctor output doesn't contain Native hooks detail in minimal fixture.
+          // First prove helper still stale
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packaged);
+          assert.ok(incompat);
+          assert.match(incompat!.reason, /codex plugin remove oh-my-codex@oh-my-codex-local --json/);
+          // Persist plugin install mode so doctor resolves plugin-scoped check deterministically
+          await mkdir(join(wd, ".omx"), { recursive: true });
+          await writeFile(join(wd, ".omx", "setup-scope.json"), JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }) + "\n", "utf-8");
+          // Now invoke actual doctor to prove it surfaces the same warn (not generic hook mismatch)
+          // MinimalDoctor invocation: we need to ensure doctor writes its Native hooks check; create a temp cwd with .codex link
+          // Easiest: invoke doctor via spawned checkNativeHooks by calling doctor() and capturing console.
+          const originalLog = console.log;
+          const logs: string[] = [];
+          console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+          try {
+            // Ensure config signals plugin-scoped hooks: create config.toml with plugin marketplace registration so doctor resolves scope correctly
+            const configPath = join(codexHomeDir, "config.toml");
+            const { getPackageRoot } = await import("../../utils/package.js");
+            const { buildLocalOmxMarketplaceRegistration } = await import("../plugin-marketplace.js");
+            let cfg = "plugin_hooks = true\ngoals = true\n";
+            cfg = upsertLocalOmxMarketplaceRegistration(cfg, getPackageRoot());
+            cfg = upsertLocalOmxPluginEnablement(cfg);
+            await writeFile(configPath, cfg, "utf-8");
+            // Need hooksPath parent
+            await mkdir(join(codexHomeDir, "agents"), { recursive: true });
+            await doctor({});
+          } catch {
+            // doctor may throw? ignore, we inspect logs below
+          } finally {
+            console.log = originalLog;
+          }
+          const output = logs.join("\n");
+          assert.match(output, /Native hooks/);
+          assert.match(output, /incompatible/);
+          assert.match(output, /codex plugin remove oh-my-codex@oh-my-codex-local --json/);
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("doctor missing omx-command.json surfaces same actionable stale-launcher warning", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3558-doctor-missing-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        await withTempCwd(wd, async () => {
+          const cacheDir = await packagedPluginCacheDir(codexHomeDir);
+          await mkdir(dirname(cacheDir), { recursive: true });
+          await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, { recursive: true });
+          await rm(join(cacheDir, "hooks", "omx-command.json"), { force: true });
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packaged);
+          assert.ok(incompat);
+          assert.match(incompat!.reason, /pinned launcher missing/);
+          assert.match(incompat!.reason, /codex plugin remove oh-my-codex@oh-my-codex-local --json/);
+          const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher");
+          // Invoke doctor and ensure missing launcher goes through stale-launcher warn, not generic "expected plugin hook file is missing" for launcher
+          const { getPackageRoot } = await import("../../utils/package.js");
+          const { buildLocalOmxMarketplaceRegistration } = await import("../plugin-marketplace.js");
+          let cfg2 = "";
+            cfg2 = upsertLocalOmxMarketplaceRegistration(cfg2, getPackageRoot());
+            cfg2 = upsertLocalOmxPluginEnablement(cfg2);
+            cfg2 = "[features]\nplugin_hooks = true\n\n" + cfg2;
+            await writeFile(join(codexHomeDir, "config.toml"), cfg2, "utf-8");
+          await mkdir(join(codexHomeDir, "agents"), { recursive: true });
+          const logs: string[] = [];
+          const origLog = console.log;
+          console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+          try {
+            await doctor({});
+          } finally {
+            console.log = origLog;
+          }
+          const output = logs.join("\n");
+          assert.match(output, /Native hooks/);
+          assert.match(output, /incompatible|cached launcher/);
+          assert.match(output, /codex plugin remove oh-my-codex@oh-my-codex-local --json/);
+          assert.match(output, /omx-command\.json|incompatible/);
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1387,10 +1387,18 @@ describe("omx setup install mode behavior", () => {
 					const launcher = JSON.parse(
 						await readFile(join(cacheDir, "hooks", "omx-command.json"), "utf-8"),
 					) as { command?: string; argsPrefix?: string[] };
+					// Immutable snapshot is preserved in place; setup must not report current when launcher is dead/provenance-incompatible
 					assert.equal(launcher.command, "/stale/node");
 					assert.deepEqual(launcher.argsPrefix, ["/stale/omx.js"]);
 					assert.doesNotMatch(output, /Invalidated .* stale Codex plugin discovery cache/);
-					assert.match(output, /Local Codex plugin cache already exposes packaged OMX skills/);
+					assert.doesNotMatch(output, /Local Codex plugin cache already exposes packaged OMX skills/);
+					assert.match(output, /incompatible launcher provenance/);
+					assert.match(output, /codex plugin remove oh-my-codex@oh-my-codex-local --json/);
+					const packagedMarketplace = await resolvePackagedOmxMarketplace(packageRoot);
+					assert.ok(packagedMarketplace);
+					const materialized = await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
+					assert.equal(materialized.status, "stale-launcher");
+					assert.ok(materialized.reason);
 				});
 			});
 		} finally {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -88,6 +88,7 @@ import {
 	OMX_LOCAL_PLUGIN_CONFIG_KEY,
 	discoverOmxPluginCacheDirs,
 	expectedPackagedOmxSkillNames,
+	getPinnedLauncherIncompatibilityReason,
 	packagedOmxPluginVersion,
 	pluginHookCacheMatchesPackaged,
 	readOmxPluginCacheState,
@@ -2425,6 +2426,17 @@ async function checkPluginScopedNativeHooks(
 
 	for (const expectedPath of [expectedHooksPath, expectedHookLauncherPath, expectedPinnedLauncherPath]) {
 		if (!existsSync(expectedPath)) {
+			if (expectedPath === expectedPinnedLauncherPath) {
+				const launcherIncompat = await getPinnedLauncherIncompatibilityReason(expectedCacheDir, packagedMarketplace);
+				if (launcherIncompat) {
+					return {
+						name: "Native hooks",
+						status: "warn",
+						message:
+							`plugin-scoped hooks are enabled, but cached launcher in ${expectedCacheDir} is incompatible (${launcherIncompat.reason}); ${setupHooksPathDescription}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\``,
+					};
+				}
+			}
 			return {
 				name: "Native hooks",
 				status: "warn",
@@ -2435,6 +2447,15 @@ async function checkPluginScopedNativeHooks(
 	}
 
 	if (!(await pluginHookCacheMatchesPackaged(expectedCacheDir, packagedMarketplace))) {
+		const launcherIncompat = await getPinnedLauncherIncompatibilityReason(expectedCacheDir, packagedMarketplace);
+		if (launcherIncompat) {
+			return {
+				name: "Native hooks",
+				status: "warn",
+				message:
+					`plugin-scoped hooks are enabled, but cached launcher in ${expectedCacheDir} is incompatible (${launcherIncompat.reason}); ${setupHooksPathDescription}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\``,
+			};
+		}
 		return {
 			name: "Native hooks",
 			status: "warn",

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -411,10 +411,103 @@ async function applyTeamModeToPluginCache(
 }
 
 export interface OmxPluginCacheMaterializeResult {
-	status: "unavailable" | "unchanged" | "materialized";
+	status: "unavailable" | "unchanged" | "materialized" | "stale-launcher";
 	cacheDir?: string;
 	version?: string;
 	retiredDirs?: string[];
+	reason?: string;
+	launcherTarget?: string;
+}
+
+export const PLUGIN_LAUNCHER_RECOVERY_HINT = "codex plugin remove oh-my-codex@oh-my-codex-local --json";
+
+async function canonicalRealpath(path: string): Promise<string | null> {
+	try {
+		return await realpath(path);
+	} catch {
+		return null;
+	}
+}
+
+export async function readPinnedLauncherRaw(cacheDir: string): Promise<{ raw: string | null; parsed: { command?: unknown; argsPrefix?: unknown } | null; error?: string }> {
+	const launcherPath = join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE);
+	try {
+		const raw = await readFile(launcherPath, "utf-8");
+		try {
+			const parsed = JSON.parse(raw) as { command?: unknown; argsPrefix?: unknown };
+			if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+				return { raw, parsed: null, error: `malformed pinned launcher JSON: expected object but got ${Array.isArray(parsed) ? "array" : String(parsed)}` };
+			}
+			return { raw, parsed, error: undefined };
+		} catch (e) {
+			return { raw, parsed: null, error: `malformed pinned launcher JSON: ${(e as Error).message}` };
+		}
+	} catch (e) {
+		if (isMissingPathError(e)) return { raw: null, parsed: null, error: "missing pinned launcher" };
+		return { raw: null, parsed: null, error: `cannot read pinned launcher: ${(e as Error).message}` };
+	}
+}
+
+export async function getPinnedLauncherIncompatibilityReason(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<{ reason: string; target?: string } | null> {
+	const launcherPath = join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE);
+	let raw: string;
+	try {
+		raw = await readFile(launcherPath, "utf-8");
+	} catch (e) {
+		if (isMissingPathError(e)) return { reason: `pinned launcher missing at ${launcherPath}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+		return { reason: `cannot read pinned launcher at ${launcherPath}: ${(e as Error).message}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw) as unknown;
+	} catch (e) {
+		return { reason: `pinned launcher at ${launcherPath} is malformed JSON (${(e as Error).message}); run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { reason: `pinned launcher at ${launcherPath} is malformed JSON (expected object but got ${Array.isArray(parsed) ? "array" : String(parsed)}); run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	const obj = parsed as { command?: unknown; argsPrefix?: unknown };
+	if (typeof obj.command !== "string" || obj.command.trim() === "") {
+		return { reason: `pinned launcher at ${launcherPath} has invalid command; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	if (!Array.isArray(obj.argsPrefix) || obj.argsPrefix.length === 0 || !obj.argsPrefix.every((v) => typeof v === "string")) {
+		return { reason: `pinned launcher at ${launcherPath} has invalid argsPrefix; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	const command = obj.command.trim();
+	const target = (obj.argsPrefix as string[])[0]!;
+	// Validate command field (generated launcher contract) — fail-closed on dead/mismatched executable
+	if (!isAbsolute(command)) {
+		return { reason: `pinned launcher command is not absolute: ${command}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`, target };
+	}
+	if (!existsSync(command)) {
+		return { reason: `pinned launcher command does not exist: ${command}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`, target };
+	}
+	const expectedCommand = process.execPath;
+	const [canonicalActualCommand, canonicalExpectedCommand] = await Promise.all([
+		canonicalRealpath(command),
+		canonicalRealpath(expectedCommand),
+	]);
+	if (canonicalActualCommand === null || canonicalExpectedCommand === null || canonicalActualCommand !== canonicalExpectedCommand) {
+		return { reason: `pinned launcher command provenance mismatch: expected ${expectedCommand} but found ${command} (different Node executable); run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`, target };
+	}
+	if (!isAbsolute(target)) {
+		return { reason: `pinned launcher target is not absolute: ${target}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`, target };
+	}
+	if (!existsSync(target)) {
+		return { reason: `pinned launcher target does not exist: ${target} (package root removed?); run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`, target };
+	}
+	const expectedTarget = join(packagedMarketplace.packageRoot, "dist", "cli", "omx.js");
+	const [canonicalActual, canonicalExpected] = await Promise.all([
+		canonicalRealpath(target),
+		canonicalRealpath(expectedTarget),
+	]);
+	if (canonicalActual === null || canonicalExpected === null || canonicalActual !== canonicalExpected) {
+		return { reason: `pinned launcher provenance mismatch: expected ${expectedTarget} but found ${target} (different package root); run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`, target };
+	}
+	return null;
 }
 
 async function retireUnpinnedManagedSnapshots(
@@ -467,13 +560,34 @@ export async function materializePackagedOmxPluginCache(
 				: await retireUnpinnedManagedSnapshots(omxPluginCacheBase(codexHomeDir), version),
 		};
 	}
+	// Same-version directory exists but is not byte-identical: distinguish immutable-preserved vs dead/provenance-incompatible launcher.
+	// Preserve #3499 immutability: never rewrite an existing same-version directory in place.
+	const rootState = await inspectCacheRoot(cacheDir);
+	if (rootState === "directory") {
+		const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packagedMarketplace);
+		if (incompat) {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: incompat.reason,
+				launcherTarget: incompat.target,
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(omxPluginCacheBase(codexHomeDir), version),
+			};
+		}
+		return {
+			status: "unchanged",
+			cacheDir,
+			version,
+			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(omxPluginCacheBase(codexHomeDir), version),
+		};
+	}
+	if (rootState === "foreign") {
+		return { status: "unavailable", cacheDir, version };
+	}
 	if (!options.dryRun) {
 		const cacheBase = omxPluginCacheBase(codexHomeDir);
 		await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
-		const rootState = await inspectCacheRoot(cacheDir);
-		if (rootState === "foreign") {
-			return { status: "unavailable", cacheDir, version };
-		}
 		const tempDir = await mkdtemp(join(tmpdir(), `omx-plugin-${version}-`));
 		try {
 			const snapshotDir = await stageCompletePluginSnapshot(
@@ -482,7 +596,6 @@ export async function materializePackagedOmxPluginCache(
 				version,
 				options.teamMode,
 			);
-			if (rootState === "directory") return { status: "unchanged", cacheDir, version };
 			await rename(snapshotDir, cacheDir);
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -139,6 +139,7 @@ import {
 } from "./setup-preferences.js";
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
+	OMX_LOCAL_PLUGIN_CONFIG_KEY,
 	OMX_PLUGIN_NAME,
 	discoverOmxPluginCacheDirs,
 	materializePackagedOmxPluginCache,
@@ -4670,6 +4671,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 		} else if (pluginCacheMaterialize.status === "unchanged") {
 			console.log("  Local Codex plugin cache already exposes packaged OMX skills.");
+		} else if (pluginCacheMaterialize.status === "stale-launcher") {
+			console.log(
+				`  warning: local Codex plugin cache at ${pluginCacheMaterialize.cacheDir} has incompatible launcher provenance (${pluginCacheMaterialize.reason}); not reporting as current.`,
+			);
+			console.log(
+				`  Run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\` to rebuild the snapshot for ${preflightMarketplace?.packageRoot ?? pkgRoot}.`,
+			);
 		}
 		if (
 			pluginCacheMaterialize.status === "materialized" ||


### PR DESCRIPTION
## Summary

Preserves #3499 immutable live-snapshot guarantees: same-version `hooks/omx-command.json` is never rewritten in place. When an existing immutable snapshot's generated launcher is dead or provenance-incompatible (removed package root, different root, malformed JSON, missing/dead `command` or `argsPrefix[0]`, non-absolute, realpath alias mismatch), setup no longer prints "already exposes packaged OMX skills". Returns distinct non-success `stale-launcher` with actionable recovery hint:

```
codex plugin remove oh-my-codex@oh-my-codex-local --json
```
then rerun `omx setup --plugin`.

Doctor routes both `pluginHookCacheMatchesPackaged` mismatch and missing `omx-command.json` through the same actionable stale-launcher warning, preserving unrelated missing-hook behavior.

Fixes #3558.

## Exact base/head

- Base: `origin/dev@00f34d8a71bac51cb7f9604e66fc9176daaf52b9` (rebased from required `cf93ebce678db578c90abe8d5d8d8e2af863c31f` due to #3560 advancement; clean rebase, focused validation re-run, no #3559 overwrite)
- Original required base: `cf93ebce678db578c90abe8d5d8d8e2af863c31f`
- Head: `2370de01de276aa382225a30371ed6914af1c9da` (1 commit after rebase, signed)

## Reproduction (isolated, no real user state touched)

Reproduced exactly via isolated HOME/CODEX_HOME/tmp roots using current dev:

1. Materialize v0.21.0 snapshot from temporary package root `/tmp/.../old-tmp-src`
2. Delete `old-tmp-src/dist/cli/omx.js` (simulate temp removal after `npm install -g`)
3. Run `materializePackagedOmxPluginCache` from new global root (same version):

Before fix: `status=unchanged`, launcher still `/tmp/old-tmp-src/dist/cli/omx.js` (dead: `existsSync=false`), setup printed "already exposes".

After fix: `status=stale-launcher`, `reason=pinned launcher target does not exist: ... (package root removed?); run codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun omx setup --plugin`, immutable snapshot preserved (file not overwritten), setup warns "incompatible launcher provenance" + recovery hint.

Also validated: `command` field validated alongside `argsPrefix[0]` (dead `/stale/node` + live target still stale), JSON `null`/`[]` fail-closed without throw, symlink alias `alias-root/dist/cli/omx.js` canonicalizes to live target -> `unchanged`, `live-pin` preserved without auto-repair.

## Product delta (6 files)

- `src/cli/plugin-marketplace.ts` — `stale-launcher` status, `PLUGIN_LAUNCHER_RECOVERY_HINT`, `canonicalRealpath` (null on failure, fail-closed), `readPinnedLauncherRaw` (null/array guard), `getPinnedLauncherIncompatibilityReason` (both command+target absolute/exists/realpath), `materialize` distinguishes stale-launcher vs unchanged, never renames over existing directory
- `src/cli/setup.ts` — handles stale-launcher with warning + recovery hint, no "already exposes" for stale
- `src/cli/doctor.ts` — surfaces stale via `getPinnedLauncherIncompatibilityReason` both after generic hook mismatch and after missing `omx-command.json` precheck
- `src/cli/__tests__/setup-install-mode.test.ts` — updated stale launcher test to assert non-current + stale-launcher
- `src/cli/__tests__/doctor-warning-copy.test.ts` — updated stale hook cache assertion to new actionable warning
- `src/cli/__tests__/plugin-launcher-provenance-3558.test.ts` (new, 7 tests) — exact repro, idempotence, live provenance mismatch, live-pin, edge cases (malformed/missing/null/array/dead-command/non-absolute/symlink alias), doctor invocation x2

`git diff --check -- src`: 0 warnings

## Validation (terminal evidence)

```
npm run build                              # tsc + chmod dist/cli/omx.js
node --test dist/cli/__tests__/plugin-launcher-provenance-3558.test.js  # 7/7 pass
  ok reproduces exact dead-launcher case -> stale-launcher
  ok same-root idempotence -> unchanged
  ok provenance mismatch live -> stale-launcher
  ok live-pin preserved
  ok malformed/missing/null/array/dead-command/symlink alias
  ok doctor surfaces stale launcher (actual doctor invocation)
  ok doctor missing launcher (actual doctor invocation)
node --test dist/cli/__tests__/setup-install-mode.test.js  # 129/129 pass
node --test dist/cli/__tests__/doctor-warning-copy.test.js # 71/71 pass
npm run lint                               # 798 files, no fixes
npm run check:no-unused                    # pass
npm run verify:plugin-bundle / verify:generated / verify:prompt-guidance / verify:capabilities-lock # pass
```

## Critic

Independent adversarial exact-diff critic (sol) `2-critic-final-okay` returned **OKAY / PASS / no block** after prior iterate fixes (canonical fail-closed, hard doctor assertions, dead-command+live-target case, JSON null/array). Product delta verified as 5 tracked files + 1 new test (6 files total), no other source changes, whitespace clean.

Closes #3558.

---
*[repo owner's gaebal-gajae (clawdbot) 🦞]*