### PR TITLE
fix: clean orphaned HUD after detached startup failure

### DIFF
--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -331,7 +331,7 @@ describe('detached leader HUD teardown', () => {
       ]).split('\t');
       const hud = createOwnedHud(fixture, 'owner-zero');
       if (!leaderPaneId) throw new Error('invalid HUD teardown fixture');
-      cleanupDetachedHudPane(hud, 'owner-zero');
+      assert.equal(cleanupDetachedHudPane(hud, 'owner-zero'), true);
       await poll('proven HUD pane removal', () => !fixture.run(['list-panes', '-a', '-F', '#{pane_id}']).split('\n').includes(hud.paneId) ? true : undefined);
       process.kill(Number(leaderPidRaw), 'SIGTERM');
       await poll('last-pane session destruction', () => !fixture.sessionExists() ? true : undefined);
@@ -345,12 +345,12 @@ describe('detached leader HUD teardown', () => {
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
       ]);
       const staleHudProof = createOwnedHud(fixture, 'owner-user-pane');
-      cleanupDetachedHudPane(staleHudProof, 'owner-user-pane');
+      assert.equal(cleanupDetachedHudPane(staleHudProof, 'owner-user-pane'), true);
       const replacementPaneId = fixture.run([
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
       ]);
       // A stale proof must be an ordinary fail-closed preserve, never a throw.
-      assert.doesNotThrow(() => cleanupDetachedHudPane(staleHudProof, 'owner-user-pane'));
+      assert.equal(cleanupDetachedHudPane(staleHudProof, 'owner-user-pane'), false, 'a stale proof must fail closed as a boolean false');
       assert.equal(fixture.run(['display-message', '-p', '-t', replacementPaneId, '#{pane_id}']), replacementPaneId);
       process.kill(Number(leaderPidRaw), 'SIGTERM');
       await poll('unrelated pane survives leader exit', () => fixture.sessionExists() ? true : undefined);
@@ -372,11 +372,12 @@ describe('detached leader HUD teardown', () => {
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
       ]);
       const staleHudProof = createOwnedHud(fixture, 'stale-proof-owner');
-      assert.equal(cleanupDetachedHudPane(staleHudProof, 'stale-proof-owner'), undefined);
+      assert.equal(cleanupDetachedHudPane(staleHudProof, 'stale-proof-owner'), true);
       await poll('proven HUD removal', () => !paneExists(fixture, staleHudProof.paneId) ? true : undefined);
       const replacementPaneId = fixture.run([
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
       ]);
+      assert.equal(cleanupDetachedHudPane(staleHudProof, 'stale-proof-owner'), false, 'a stale proof must fail closed as a boolean false');
       assert.doesNotThrow(() => cleanupDetachedHudPane(staleHudProof, 'stale-proof-owner'));
       assert.equal(paneExists(fixture, replacementPaneId), true, 'the replacement pane must survive a stale proof');
       assert.equal(fixture.sessionExists(), true, 'the private fixture session must survive a stale proof');
@@ -387,10 +388,10 @@ describe('detached leader HUD teardown', () => {
     // Missing proof target: the proof pane id no longer exists anywhere.
     await withTempTmuxSession(async (fixture) => {
       const missingProof = createOwnedHud(fixture, 'missing-proof-owner');
-      assert.equal(cleanupDetachedHudPane(missingProof, 'missing-proof-owner'), undefined);
+      assert.equal(cleanupDetachedHudPane(missingProof, 'missing-proof-owner'), true);
       await poll('proven HUD removal', () => !paneExists(fixture, missingProof.paneId) ? true : undefined);
       const ghostProof = { ...missingProof, paneId: '%999999' };
-      assert.doesNotThrow(() => cleanupDetachedHudPane(ghostProof, 'missing-proof-owner'));
+      assert.equal(cleanupDetachedHudPane(ghostProof, 'missing-proof-owner'), false, 'a missing proof target must fail closed as a boolean false');
       assert.equal(fixture.sessionExists(), true, 'the private fixture session must survive a missing proof target');
     });
   });
@@ -403,7 +404,7 @@ describe('detached leader HUD teardown', () => {
       ]).split('\t');
       const staleProof = createOwnedHud(fixture, 'attack-owner');
       // Remove the proven HUD and let its pane id be recycled by a replacement pane.
-      assert.equal(cleanupDetachedHudPane(staleProof, 'attack-owner'), undefined);
+      assert.equal(cleanupDetachedHudPane(staleProof, 'attack-owner'), true);
       await poll('proven HUD removal', () => !paneExists(fixture, staleProof.paneId) ? true : undefined);
       const replacementPaneId = fixture.run([
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
@@ -411,7 +412,7 @@ describe('detached leader HUD teardown', () => {
       const foreignSessionName = `${fixture.sessionName}-foreign`;
       fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 120']);
       // The stale proof must fail closed without killing the server, session, or panes.
-      assert.doesNotThrow(() => cleanupDetachedHudPane(staleProof, 'attack-owner'));
+      assert.equal(cleanupDetachedHudPane(staleProof, 'attack-owner'), false, 'a stale proof must fail closed as a boolean false');
       assert.equal(fixture.sessionExists(), true, 'leader session must survive');
       assert.equal(tmuxSessionExists(foreignSessionName, fixture.serverName), true, 'foreign session must survive');
       assert.equal(paneExists(fixture, leaderPaneId), true, 'leader pane must survive');
@@ -425,6 +426,59 @@ describe('detached leader HUD teardown', () => {
     assert.ok(typeof fixtureServer === 'string');
   });
 
+  it('preserves the leader, session, and foreign panes across normal child-exit teardown with a recycled HUD proof', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-stale-seam-'));
+    // This subtest preserves every leader-session pane (remain-on-exit keeps the
+    // dead leader visible), so the HUD watcher keeps running until fixture teardown.
+    let hudPanePid: number | undefined;
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-detached-stale-seam';
+        const sessionId = 'detached-stale-seam-session';
+        const sentinel = join(wd, 'child-release');
+        // The child blocks on a sentinel so the HUD proof can be recycled before
+        // the leader reaches normal child-exit teardown.
+        const fakeChild = writeChild(wd, 'while [ ! -f child-release ]; do sleep 0.1; done\nexit 0');
+        const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'stale-seam-nonce', fakeChild);
+        hudPanePid = started.hud.panePid;
+        // Retain the dead leader pane: with remain-on-exit on, an executed
+        // `kill-pane -t leaderPaneId` destroys the pane (and the session when it
+        // is the last one), while a preserved zero-mutation teardown leaves it
+        // visible as dead. This makes the leader kill observable even after the
+        // leader process has exited normally.
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        // Remove the proven HUD out from under the leader's retained proof and
+        // recycle its pane id, exactly like the stale-proof attack, then add a
+        // replacement pane and a foreign session that must all survive teardown.
+        assert.equal(cleanupDetachedHudPane(started.hud, sessionId), true);
+        await poll('proven HUD removal', () => !paneExists(fixture, started.hud.paneId) ? true : undefined);
+        const replacementPaneId = fixture.run([
+          'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, '-c', wd, 'sleep 300',
+        ]);
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', wd, 'sleep 300']);
+        // Release the child into its normal exit and let the leader finalize.
+        writeFileSync(sentinel, 'released\n');
+        const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
+        assert.equal(terminal.finalized, true);
+        assert.equal(terminal.exitStatus, 0);
+        await poll('retained dead leader pane', () => fixture.run([
+          'display-message', '-p', '-t', started.leaderPaneId, '#{pane_dead}',
+        ]) === '1' ? true : undefined);
+
+        // Fail-closed teardown: the recycled HUD proof must suppress the leader
+        // kill entirely, leaving the leader, session, and every bystander intact.
+        assert.equal(paneExists(fixture, started.leaderPaneId), true, 'the dead leader pane must be retained, not killed');
+        assert.equal(tmuxSessionExists(sessionName, fixture.serverName), true, 'the leader session must survive zero-mutation teardown');
+        assert.equal(paneExists(fixture, replacementPaneId), true, 'the replacement pane must survive zero-mutation teardown');
+        assert.equal(tmuxSessionExists(foreignSessionName, fixture.serverName), true, 'the foreign session must survive zero-mutation teardown');
+        assert.equal(fixture.sessionExists(), true, 'the private fixture session must survive zero-mutation teardown');
+      });
+    } finally {
+      await cleanupDetachedWorkdir(wd, hudPanePid);
+    }
+  });
   it('removes only the matching bootstrap HUD after a finalized leader failure', async (t) => {
     if (!skipUnlessTmux(t)) return;
     await withTempTmuxSession(async (fixture) => {
@@ -467,10 +521,15 @@ describe('detached leader HUD teardown', () => {
         const sessionId = 'detached-zero-session';
         const fakeChild = writeChild(wd, 'sleep 1\nexit 0');
         const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'zero-nonce', fakeChild);
+        // Retain the dead leader pane: the teardown must still kill it, proving
+        // the leader kill runs when and only when HUD cleanup succeeded.
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
         const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
         assert.equal(terminal.finalized, true);
         assert.equal(terminal.exitStatus, 0);
         await poll('leader pane removal', () => !paneExists(fixture, started.leaderPaneId) ? true : undefined);
+        // Under remain-on-exit retention, only the teardown's own leader
+        // kill-pane can destroy this pane: natural exit would retain it dead.
         await poll('HUD pane removal', () => !paneExists(fixture, started.hud.paneId) ? true : undefined);
         await poll('leader session destruction', () => !tmuxSessionExists(sessionName, fixture.serverName) ? true : undefined);
         await poll('HUD process exit', () => !processAlive(started.hud.panePid) ? true : undefined);

--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -12,10 +12,9 @@ import {
   DETACHED_LEADER_READY_TIMEOUT_MS,
   cleanupDetachedPreReportSession,
   cleanupDetachedHudPane,
-  cleanupFinalizedDetachedFailureHud,
+  cleanupFinalizedDetachedHud,
   decodeDetachedLeaderPayload,
   describeDetachedLeaderFailure,
-  discoverDetachedHudAuthority,
   publishDetachedReleaseMarker,
   parseDetachedLeaderPaneIdByPid,
   isDetachedReadyReportAuthorized,
@@ -23,6 +22,7 @@ import {
   resolveDetachedAttachExitStatus,
 } from '../index.js';
 import { isRealTmuxAvailable, tmuxSessionExists, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
+import type { TempTmuxSessionFixture } from '../../team/__tests__/tmux-test-fixture.js';
 
 const TEST_TIMEOUT_MS = 45_000;
 const POLL_INTERVAL_MS = 50;
@@ -42,7 +42,9 @@ interface DetachedLeaderReport {
 interface DetachedHudAuthority {
   paneId: string;
   panePid: number;
+  sessionName: string;
   sessionId: string;
+  sessionCreated: string;
   windowId: string;
   operationMarker: string;
 }
@@ -81,6 +83,19 @@ async function readReportWhen(path: string, predicate: (report: DetachedLeaderRe
 
 function paneExists(fixture: { run: (args: string[]) => string }, paneId: string): boolean {
   return fixture.run(['list-panes', '-a', '-F', '#{pane_id}']).split('\n').includes(paneId);
+}
+
+function createOwnedHud(fixture: TempTmuxSessionFixture, ownerId: string): DetachedHudAuthority {
+  const operationMarker = randomUUID();
+  const [paneId, panePidRaw, sessionName, sessionId, sessionCreated, windowId] = fixture.run([
+    'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}',
+    '-t', fixture.sessionName, `env OMX_DETACHED_HUD_OPERATION=${operationMarker} sleep 120`,
+  ]).split('\t');
+  const panePid = Number(panePidRaw);
+  assert.ok(paneId && sessionName && sessionId && sessionCreated && windowId);
+  assert.equal(Number.isSafeInteger(panePid) && panePid > 0, true);
+  fixture.run(['set-option', '-pq', '-t', paneId, '@omx_hud_owner', ownerId]);
+  return { paneId, panePid, sessionName, sessionId, sessionCreated, windowId, operationMarker };
 }
 
 function assertProcessDead(pid: number): void {
@@ -172,8 +187,8 @@ async function startDetachedLeader(
   const splitArgs = [...splitHud.args];
   splitArgs[splitArgs.length - 1] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs.at(-1)}`;
   const hudPaneId = fixture.run(splitArgs);
-  const [paneId, panePidRaw, hudSessionId, windowId] = fixture.run([
-    'display-message', '-p', '-t', hudPaneId, '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
+  const [paneId, panePidRaw, hudSessionName, hudSessionId, sessionCreated, windowId] = fixture.run([
+    'display-message', '-p', '-t', hudPaneId, '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}',
   ]).split('\t');
   const panePid = Number(panePidRaw);
   assert.equal(paneId, hudPaneId);
@@ -185,7 +200,7 @@ async function startDetachedLeader(
   assert.equal(ready.sessionId, sessionId);
   assert.equal(ready.sessionName, sessionName);
   assert.equal(Number.isSafeInteger(ready.leaderPid) && ready.leaderPid > 0, true);
-  const hud = { paneId, panePid, sessionId: hudSessionId, windowId, operationMarker };
+  const hud = { paneId, panePid, sessionName: hudSessionName, sessionId: hudSessionId, sessionCreated, windowId, operationMarker };
   publishDetachedReleaseMarker(releaseMarkerPath, nonce, sessionId, sessionName, ready.leaderPid, hud);
 
   return { releaseMarkerPath, leaderPaneId, hud };
@@ -309,17 +324,10 @@ describe('detached leader HUD teardown', () => {
       const [leaderPaneId, leaderPidRaw] = fixture.run([
         'display-message', '-p', '-t', fixture.sessionName, '#{pane_id}\t#{pane_pid}',
       ]).split('\t');
-      const [paneId, panePidRaw, sessionId, windowId] = fixture.run([
-        'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
-        '-t', fixture.sessionName, 'sleep 120',
-      ]).split('\t');
-      if (!leaderPaneId || !paneId || !sessionId || !windowId) throw new Error('invalid HUD teardown fixture');
-      fixture.run(['set-option', '-pq', '-t', paneId, '@omx_hud_owner', 'owner-zero']);
-      const discovered = discoverDetachedHudAuthority(fixture.sessionName, 'owner-zero');
-      assert.equal(discovered?.paneId, paneId);
-      assert.equal(discovered?.panePid, Number(panePidRaw));
-      cleanupDetachedHudPane({ paneId, panePid: Number(panePidRaw), sessionId, windowId, operationMarker: randomUUID() }, 'owner-zero');
-      await poll('proven HUD pane removal', () => !fixture.run(['list-panes', '-a', '-F', '#{pane_id}']).split('\n').includes(paneId) ? true : undefined);
+      const hud = createOwnedHud(fixture, 'owner-zero');
+      if (!leaderPaneId) throw new Error('invalid HUD teardown fixture');
+      cleanupDetachedHudPane(hud, 'owner-zero');
+      await poll('proven HUD pane removal', () => !fixture.run(['list-panes', '-a', '-F', '#{pane_id}']).split('\n').includes(hud.paneId) ? true : undefined);
       process.kill(Number(leaderPidRaw), 'SIGTERM');
       await poll('last-pane session destruction', () => !fixture.sessionExists() ? true : undefined);
     });
@@ -328,17 +336,10 @@ describe('detached leader HUD teardown', () => {
       const [, leaderPidRaw] = fixture.run([
         'display-message', '-p', '-t', fixture.sessionName, '#{pane_id}\t#{pane_pid}',
       ]).split('\t');
-      const [paneId, panePidRaw, sessionId, windowId] = fixture.run([
-        'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
-        '-t', fixture.sessionName, 'sleep 120',
-      ]).split('\t');
       const userPaneId = fixture.run([
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
       ]);
-      if (!paneId || !sessionId || !windowId) throw new Error('invalid unrelated-pane fixture');
-      fixture.run(['set-option', '-pq', '-t', paneId, '@omx_hud_owner', 'owner-user-pane']);
-      assert.equal(discoverDetachedHudAuthority(fixture.sessionName, 'owner-user-pane')?.paneId, paneId);
-      const staleHudProof = { paneId, panePid: Number(panePidRaw), sessionId, windowId, operationMarker: randomUUID() };
+      const staleHudProof = createOwnedHud(fixture, 'owner-user-pane');
       cleanupDetachedHudPane(staleHudProof, 'owner-user-pane');
       const replacementPaneId = fixture.run([
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
@@ -354,38 +355,33 @@ describe('detached leader HUD teardown', () => {
   it('removes only the matching bootstrap HUD after a finalized leader failure', async (t) => {
     if (!skipUnlessTmux(t)) return;
     await withTempTmuxSession(async (fixture) => {
-      const [hudPaneId, , sessionId, windowId] = fixture.run([
-        'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
-        '-t', fixture.sessionName, 'sleep 120',
-      ]).split('\t');
-      assert.ok(hudPaneId && sessionId && windowId);
       const ownerId = 'finalized-failure-owner';
-      fixture.run(['set-option', '-pq', '-t', hudPaneId, '@omx_hud_owner', ownerId]);
-      const expected = discoverDetachedHudAuthority(fixture.sessionName, ownerId);
-      assert.ok(expected);
-      assert.equal(cleanupFinalizedDetachedFailureHud(expected, fixture.sessionName, ownerId), true);
-      await poll('bootstrap HUD removal', () => !paneExists(fixture, hudPaneId) ? true : undefined);
+      const expected = createOwnedHud(fixture, ownerId);
+      assert.equal(cleanupFinalizedDetachedHud(expected, ownerId), true);
+      await poll('bootstrap HUD removal', () => !paneExists(fixture, expected.paneId) ? true : undefined);
     });
   });
 
-  it('does not remove a mismatched bootstrap HUD during finalized failure cleanup', async (t) => {
+  it('preserves a bootstrap HUD when its proof or owner changes before finalized failure cleanup', async (t) => {
     if (!skipUnlessTmux(t)) return;
-    await withTempTmuxSession(async (fixture) => {
-      const [hudPaneId, , sessionId, windowId] = fixture.run([
-        'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
-        '-t', fixture.sessionName, 'sleep 120',
-      ]).split('\t');
-      assert.ok(hudPaneId && sessionId && windowId);
-      const ownerId = 'finalized-failure-mismatch';
-      fixture.run(['set-option', '-pq', '-t', hudPaneId, '@omx_hud_owner', ownerId]);
-      const expected = discoverDetachedHudAuthority(fixture.sessionName, ownerId);
-      assert.ok(expected);
-      assert.equal(
-        cleanupFinalizedDetachedFailureHud({ ...expected, panePid: expected.panePid + 1 }, fixture.sessionName, ownerId),
-        false,
-      );
-      assert.equal(paneExists(fixture, hudPaneId), true);
-    });
+    const mutations: Array<readonly [string, (fixture: TempTmuxSessionFixture, proof: DetachedHudAuthority) => DetachedHudAuthority]> = [
+      ['owner', (fixture, proof) => {
+        fixture.run(['set-option', '-pq', '-t', proof.paneId, '@omx_hud_owner', 'foreign-owner']);
+        return proof;
+      }],
+      ['pane PID', (_fixture, proof) => ({ ...proof, panePid: proof.panePid + 1 })],
+      ['session creation', (_fixture, proof) => ({ ...proof, sessionCreated: `${Number(proof.sessionCreated) + 1}` })],
+      ['window topology', (_fixture, proof) => ({ ...proof, windowId: '@999999' })],
+      ['operation marker', (_fixture, proof) => ({ ...proof, operationMarker: randomUUID() })],
+    ];
+    for (const [name, mutate] of mutations) {
+      await withTempTmuxSession(async (fixture) => {
+        const ownerId = `finalized-failure-${name}`;
+        const expected = createOwnedHud(fixture, ownerId);
+        assert.equal(cleanupFinalizedDetachedHud(mutate(fixture, expected), ownerId), false, name);
+        assert.equal(paneExists(fixture, expected.paneId), true, name);
+      });
+    }
   });
 
 
@@ -529,7 +525,7 @@ describe('detached leader HUD teardown', () => {
   it('publishes an optional HUD authority proof exactly', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omx-detached-release-marker-'));
     const path = join(wd, 'marker.release');
-    const hud = { paneId: '%1', panePid: 123, sessionId: '$1', windowId: '@1', operationMarker: 'operation' };
+    const hud = { paneId: '%1', panePid: 123, sessionName: 'session', sessionId: '$1', sessionCreated: '1', windowId: '@1', operationMarker: 'operation' };
     try {
       publishDetachedReleaseMarker(path, 'n', 's', 'sn', 456, hud);
       assert.deepEqual(JSON.parse(readFileSync(`${path}.release`, 'utf-8')), {

--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -90,7 +90,7 @@ function createOwnedHud(fixture: TempTmuxSessionFixture, ownerId: string): Detac
   const [paneId, panePidRaw, sessionName, sessionId, sessionCreated, windowId] = fixture.run([
     'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}',
     '-t', fixture.sessionName, `env OMX_DETACHED_HUD_OPERATION=${operationMarker} sleep 120`,
-  ]).split('\t');
+  ]).trim().split('\t');
   const panePid = Number(panePidRaw);
   assert.ok(paneId && sessionName && sessionId && sessionCreated && windowId);
   assert.equal(Number.isSafeInteger(panePid) && panePid > 0, true);
@@ -186,14 +186,19 @@ async function startDetachedLeader(
   const operationMarker = randomUUID();
   const splitArgs = [...splitHud.args];
   splitArgs[splitArgs.length - 1] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs.at(-1)}`;
-  const hudPaneId = fixture.run(splitArgs);
-  const [paneId, panePidRaw, hudSessionName, hudSessionId, sessionCreated, windowId] = fixture.run([
-    'display-message', '-p', '-t', hudPaneId, '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}',
-  ]).split('\t');
+  const splitFormatIndex = splitArgs.indexOf('-F');
+  assert.ok(splitFormatIndex >= 0 && splitArgs[splitFormatIndex + 1] === '#{pane_id}');
+  splitArgs[splitFormatIndex + 1] = '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}\tRECEIPT';
+  const splitReceipt = fixture.run(splitArgs).trim().split('\t');
+  assert.equal(splitReceipt.length, 7, 'the HUD split must return the seven-field production receipt');
+  const [paneId, panePidRaw, hudSessionName, hudSessionId, sessionCreated, windowId, observedReceipt] = splitReceipt;
+  assert.match(observedReceipt ?? '', /^RECEIPT$/, 'the HUD split receipt must terminate with the literal receipt marker');
   const panePid = Number(panePidRaw);
-  assert.equal(paneId, hudPaneId);
   assert.equal(Number.isSafeInteger(panePid) && panePid > 0, true);
   assert.notEqual(windowId, '');
+  // The production split sink tags the created HUD pane with the session owner
+  // before any finalize step runs.
+  fixture.run(['set-option', '-pq', '-t', paneId, '@omx_hud_owner', sessionId]);
 
   const ready = await readReportWhen(releaseMarkerPath, (report) => report.kind === 'ready');
   assert.equal(ready.nonce, nonce);
@@ -344,12 +349,80 @@ describe('detached leader HUD teardown', () => {
       const replacementPaneId = fixture.run([
         'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
       ]);
-      assert.throws(() => cleanupDetachedHudPane(staleHudProof, 'owner-user-pane'));
+      // A stale proof must be an ordinary fail-closed preserve, never a throw.
+      assert.doesNotThrow(() => cleanupDetachedHudPane(staleHudProof, 'owner-user-pane'));
       assert.equal(fixture.run(['display-message', '-p', '-t', replacementPaneId, '#{pane_id}']), replacementPaneId);
       process.kill(Number(leaderPidRaw), 'SIGTERM');
       await poll('unrelated pane survives leader exit', () => fixture.sessionExists() ? true : undefined);
       assert.equal(fixture.run(['display-message', '-p', '-t', userPaneId, '#{pane_id}']), userPaneId);
     });
+  });
+
+  it('treats a stale or missing HUD proof target as an ordinary preserved mismatch without destroying the server', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    // Stale proof after the proven HUD was already removed and the pane id was
+    // replaced by a new pane. The stale `-t %N` target must resolve to an
+    // ordinary fail-closed preserve result: no throw, no server/session loss,
+    // and no harm to the replacement or foreign panes.
+    await withTempTmuxSession(async (fixture) => {
+      const [, leaderPidRaw] = fixture.run([
+        'display-message', '-p', '-t', fixture.sessionName, '#{pane_id}\t#{pane_pid}',
+      ]).split('\t');
+      const userPaneId = fixture.run([
+        'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
+      ]);
+      const staleHudProof = createOwnedHud(fixture, 'stale-proof-owner');
+      assert.equal(cleanupDetachedHudPane(staleHudProof, 'stale-proof-owner'), undefined);
+      await poll('proven HUD removal', () => !paneExists(fixture, staleHudProof.paneId) ? true : undefined);
+      const replacementPaneId = fixture.run([
+        'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
+      ]);
+      assert.doesNotThrow(() => cleanupDetachedHudPane(staleHudProof, 'stale-proof-owner'));
+      assert.equal(paneExists(fixture, replacementPaneId), true, 'the replacement pane must survive a stale proof');
+      assert.equal(fixture.sessionExists(), true, 'the private fixture session must survive a stale proof');
+      assert.equal(fixture.run(['display-message', '-p', '-t', userPaneId, '#{pane_id}']), userPaneId);
+      process.kill(Number(leaderPidRaw), 'SIGTERM');
+    });
+
+    // Missing proof target: the proof pane id no longer exists anywhere.
+    await withTempTmuxSession(async (fixture) => {
+      const missingProof = createOwnedHud(fixture, 'missing-proof-owner');
+      assert.equal(cleanupDetachedHudPane(missingProof, 'missing-proof-owner'), undefined);
+      await poll('proven HUD removal', () => !paneExists(fixture, missingProof.paneId) ? true : undefined);
+      const ghostProof = { ...missingProof, paneId: '%999999' };
+      assert.doesNotThrow(() => cleanupDetachedHudPane(ghostProof, 'missing-proof-owner'));
+      assert.equal(fixture.sessionExists(), true, 'the private fixture session must survive a missing proof target');
+    });
+  });
+
+  it('preserves the tmux server, leader, replacement pane, and foreign session across a stale HUD proof attack', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const fixtureServer = await withTempTmuxSession(async (fixture) => {
+      const [leaderPaneId, leaderPidRaw] = fixture.run([
+        'display-message', '-p', '-t', fixture.sessionName, '#{pane_id}\t#{pane_pid}',
+      ]).split('\t');
+      const staleProof = createOwnedHud(fixture, 'attack-owner');
+      // Remove the proven HUD and let its pane id be recycled by a replacement pane.
+      assert.equal(cleanupDetachedHudPane(staleProof, 'attack-owner'), undefined);
+      await poll('proven HUD removal', () => !paneExists(fixture, staleProof.paneId) ? true : undefined);
+      const replacementPaneId = fixture.run([
+        'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', fixture.sessionName, 'sleep 120',
+      ]);
+      const foreignSessionName = `${fixture.sessionName}-foreign`;
+      fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 120']);
+      // The stale proof must fail closed without killing the server, session, or panes.
+      assert.doesNotThrow(() => cleanupDetachedHudPane(staleProof, 'attack-owner'));
+      assert.equal(fixture.sessionExists(), true, 'leader session must survive');
+      assert.equal(tmuxSessionExists(foreignSessionName, fixture.serverName), true, 'foreign session must survive');
+      assert.equal(paneExists(fixture, leaderPaneId), true, 'leader pane must survive');
+      assert.equal(paneExists(fixture, replacementPaneId), true, 'replacement pane must survive');
+      // The server must still be reachable for ordinary commands after the attack.
+      assert.ok(fixture.run(['list-sessions', '-F', '#{session_name}']).includes(fixture.sessionName));
+      return fixture.serverName;
+    });
+    // Server liveness must persist past the fixture scope: the cleanup kill-server
+    // in withTempTmuxSession proves termination is fixture-owned, not attack-owned.
+    assert.ok(typeof fixtureServer === 'string');
   });
 
   it('removes only the matching bootstrap HUD after a finalized leader failure', async (t) => {

--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -12,6 +12,7 @@ import {
   DETACHED_LEADER_READY_TIMEOUT_MS,
   cleanupDetachedPreReportSession,
   cleanupDetachedHudPane,
+  cleanupFinalizedDetachedFailureHud,
   decodeDetachedLeaderPayload,
   describeDetachedLeaderFailure,
   discoverDetachedHudAuthority,
@@ -347,6 +348,43 @@ describe('detached leader HUD teardown', () => {
       process.kill(Number(leaderPidRaw), 'SIGTERM');
       await poll('unrelated pane survives leader exit', () => fixture.sessionExists() ? true : undefined);
       assert.equal(fixture.run(['display-message', '-p', '-t', userPaneId, '#{pane_id}']), userPaneId);
+    });
+  });
+
+  it('removes only the matching bootstrap HUD after a finalized leader failure', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    await withTempTmuxSession(async (fixture) => {
+      const [hudPaneId, , sessionId, windowId] = fixture.run([
+        'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
+        '-t', fixture.sessionName, 'sleep 120',
+      ]).split('\t');
+      assert.ok(hudPaneId && sessionId && windowId);
+      const ownerId = 'finalized-failure-owner';
+      fixture.run(['set-option', '-pq', '-t', hudPaneId, '@omx_hud_owner', ownerId]);
+      const expected = discoverDetachedHudAuthority(fixture.sessionName, ownerId);
+      assert.ok(expected);
+      assert.equal(cleanupFinalizedDetachedFailureHud(expected, fixture.sessionName, ownerId), true);
+      await poll('bootstrap HUD removal', () => !paneExists(fixture, hudPaneId) ? true : undefined);
+    });
+  });
+
+  it('does not remove a mismatched bootstrap HUD during finalized failure cleanup', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    await withTempTmuxSession(async (fixture) => {
+      const [hudPaneId, , sessionId, windowId] = fixture.run([
+        'split-window', '-d', '-P', '-F', '#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}',
+        '-t', fixture.sessionName, 'sleep 120',
+      ]).split('\t');
+      assert.ok(hudPaneId && sessionId && windowId);
+      const ownerId = 'finalized-failure-mismatch';
+      fixture.run(['set-option', '-pq', '-t', hudPaneId, '@omx_hud_owner', ownerId]);
+      const expected = discoverDetachedHudAuthority(fixture.sessionName, ownerId);
+      assert.ok(expected);
+      assert.equal(
+        cleanupFinalizedDetachedFailureHud({ ...expected, panePid: expected.panePid + 1 }, fixture.sessionName, ownerId),
+        false,
+      );
+      assert.equal(paneExists(fixture, hudPaneId), true);
     });
   });
 

--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -624,6 +624,91 @@ describe('detached leader HUD teardown', () => {
     }
   });
 
+  it('tears down the matching HUD and leader from a non-current window while preserving foreign windows and sessions', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    const wd = mkdtempSync(join(tmpdir(), 'omx-detached-leader-cross-window-'));
+    try {
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-detached-cross-window';
+        const sessionId = 'detached-cross-window-session';
+        const sentinel = join(wd, 'child-release');
+        // Block the child on a sentinel so the session topology can change
+        // before the leader reaches normal child-exit teardown.
+        const fakeChild = writeChild(wd, 'while [ ! -f child-release ]; do sleep 0.1; done\nexit 0');
+        const started = await startDetachedLeader(fixture, wd, sessionName, sessionId, 'cross-window-nonce', fakeChild);
+        // Retain the dead leader pane so the leader kill stays observable under
+        // remain-on-exit even after the leader process exits normally.
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        // An attached user creates and selects another window in the leader
+        // session: the proven HUD stays in the original (now non-current)
+        // window while the session's current window moves to window 1.
+        const foreignWindowPaneId = fixture.run([
+          'new-window', '-d', '-P', '-F', '#{pane_id}', '-t', `${sessionName}:`, '-c', wd, 'sleep 300',
+        ]);
+        fixture.run(['select-window', '-t', `${sessionName}:1`]);
+        assert.equal(
+          fixture.run(['display-message', '-p', '-t', sessionName, '#{window_id}']),
+          fixture.run(['display-message', '-p', '-t', foreignWindowPaneId, '#{window_id}']),
+          'the selected window must be the foreign window, not the HUD window',
+        );
+        assert.equal(
+          fixture.run(['list-panes', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(started.hud.paneId),
+          false,
+          'a window-scoped listing must not see the HUD in the non-current window',
+        );
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', wd, 'sleep 300']);
+        // Release the child into its normal exit and let the leader finalize.
+        writeFileSync(sentinel, 'released\n');
+        const terminal = await readReportWhen(started.releaseMarkerPath, (report) => report.kind === 'terminal');
+        assert.equal(terminal.finalized, true);
+        assert.equal(terminal.exitStatus, 0);
+        // Session-wide proof enumeration must still authenticate the HUD in the
+        // non-current window, so teardown removes the HUD and the gated leader.
+        await poll('leader pane removal', () => !paneExists(fixture, started.leaderPaneId) ? true : undefined);
+        await poll('HUD pane removal', () => !paneExists(fixture, started.hud.paneId) ? true : undefined);
+        await poll('HUD process exit', () => !processAlive(started.hud.panePid) ? true : undefined);
+        assertProcessDead(started.hud.panePid);
+        // The user-added window keeps its live pane, so the leader session is
+        // deliberately preserved (#3266 contract): natural closure happens only
+        // when no other panes remain. The foreign window pane, the foreign
+        // session on the same server, and the private fixture session survive.
+        assert.equal(paneExists(fixture, foreignWindowPaneId), true, 'the foreign window pane must survive cross-window teardown');
+        assert.equal(tmuxSessionExists(sessionName, fixture.serverName), true, 'the leader session must survive with a preserved user pane');
+        assert.equal(tmuxSessionExists(foreignSessionName, fixture.serverName), true, 'the foreign session must survive cross-window teardown');
+        assert.equal(fixture.sessionExists(), true, 'the private fixture session must survive cross-window teardown');
+      });
+    } finally {
+      await cleanupDetachedWorkdir(wd);
+    }
+  });
+
+  it('removes the proven HUD from a non-current window without harming an impostor pane in another window', async (t) => {
+    if (!skipUnlessTmux(t)) return;
+    await withTempTmuxSession(async (fixture) => {
+      const ownerId = 'cross-window-impostor-owner';
+      const expected = createOwnedHud(fixture, ownerId);
+      // Create an impostor pane in another window carrying the same operation
+      // marker text and the same owner tag but none of the proof's pane
+      // identity: it must not become an authority match, must not be harmed,
+      // and must not stop the exact proof from authorizing the real HUD.
+      const impostorWindowPaneId = fixture.run([
+        'new-window', '-d', '-P', '-F', '#{pane_id}', '-t', `${fixture.sessionName}:`,
+        `env OMX_DETACHED_HUD_OPERATION=${expected.operationMarker} sleep 120`,
+      ]);
+      fixture.run(['set-option', '-pq', '-t', impostorWindowPaneId, '@omx_hud_owner', ownerId]);
+      fixture.run(['select-window', '-t', `${fixture.sessionName}:1`]);
+      assert.equal(
+        fixture.run(['display-message', '-p', '-t', fixture.sessionName, '#{window_id}']),
+        fixture.run(['display-message', '-p', '-t', impostorWindowPaneId, '#{window_id}']),
+        'the selected window must be the impostor window, not the HUD window',
+      );
+      assert.equal(cleanupDetachedHudPane(expected, ownerId), true, 'the exact proof must still authorize the real HUD');
+      await poll('proven HUD removal', () => !paneExists(fixture, expected.paneId) ? true : undefined);
+      assert.equal(paneExists(fixture, impostorWindowPaneId), true, 'the impostor pane in the other window must be preserved');
+    });
+  });
+
   it('applies only a matching finalized terminal exit status', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omx-detached-exit-status-'));
     const path = join(wd, 'marker.release');

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -57,6 +57,7 @@ import {
   executeDetachedLaunchStateMachine,
   isExactDetachedFinalization,
   type DetachedLaunchDependencies,
+  type DetachedReleaseFailureResolution,
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
@@ -597,6 +598,31 @@ describe("detached launch state machine", () => {
     assert.equal(finalization?.kind, "terminal");
     assert.deepEqual(events.slice(-2), ["D9", "hud-only-cleanup"]);
   });
+  for (const kind of ["malformed", "", "FAILED", "terminal ", "terminalized"] as const) {
+    it(`never grants HUD-only rollback authority when a matching report kind is "${kind}"`, async () => {
+      const events: string[] = [];
+      const deps = createDependencies(events, "D9");
+      deps.abortAndAwaitFinalization = async () => ({
+        acknowledged: true,
+        nonce: "nonce",
+        sessionId: "session",
+        sessionName: "session-name",
+        leaderPid: 123,
+        kind,
+      } as unknown as DetachedReleaseFailureResolution);
+      let observedFinalization: Parameters<typeof deps.rollback>[2];
+      deps.rollback = async (_ownedRecord, _report, finalization) => {
+        events.push("rollback");
+        observedFinalization = finalization;
+      };
+      await assert.rejects(() => executeDetachedLaunchStateMachine(
+        { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+        deps,
+      ));
+      assert.equal(observedFinalization, undefined);
+      assert.equal(events.includes("rollback"), false, `kind ${JSON.stringify(kind)} must never reach rollback`);
+    });
+  }
 
   it("finalizes and closes exactly once before D2 rollback without transport effects", async () => {
     const events: string[] = [];

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -55,6 +55,7 @@ import {
   buildMadmaxDetachedLaunchContextKey,
   withMadmaxDetachedContextLock,
   executeDetachedLaunchStateMachine,
+  isExactDetachedFinalization,
   type DetachedLaunchDependencies,
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
@@ -525,6 +526,77 @@ describe("detached launch state machine", () => {
       assert.equal(events.includes("D10"), false);
     });
   }
+
+  for (const failure of ["D3", "D4", "D5", "D6", "D7", "D9"] as const) {
+    it(`passes authenticated finalized failure authority to rollback when ${failure} fails`, async () => {
+      const events: string[] = [];
+      const deps = createDependencies(events, failure);
+      let finalization: unknown;
+      deps.rollback = async (_ownedRecord, _report, observedFinalization) => {
+        events.push("rollback");
+        finalization = observedFinalization;
+      };
+      await assert.rejects(executeDetachedLaunchStateMachine(
+        { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+        deps,
+      ));
+      assert.deepEqual(finalization, {
+        nonce: "nonce",
+        sessionId: "session",
+        sessionName: "session-name",
+        leaderPid: 123,
+        kind: "failed",
+      });
+      assert.equal(events.includes("rollback"), true);
+    });
+
+    it(`preserves the leader and does not roll back when ${failure} finalization is malformed`, async () => {
+      const events: string[] = [];
+      const deps = createDependencies(events, failure);
+      deps.abortAndAwaitFinalization = async () => ({
+        acknowledged: true,
+        nonce: "nonce",
+        sessionName: "session-name",
+        leaderPid: 123,
+        kind: "failed",
+      });
+      await assert.rejects(executeDetachedLaunchStateMachine(
+        { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+        deps,
+      ));
+      assert.equal(events.includes("rollback"), false);
+    });
+  }
+
+  it("routes an exact D9 terminal finalization to HUD-only cleanup instead of session rollback", async () => {
+    const events: string[] = [];
+    const deps = createDependencies(events, "D9");
+    deps.abortAndAwaitFinalization = async () => ({
+      acknowledged: true,
+      nonce: "nonce",
+      sessionId: "session",
+      sessionName: "session-name",
+      leaderPid: 123,
+      kind: "terminal",
+    });
+    let finalization: Parameters<typeof deps.rollback>[2];
+    deps.rollback = async (_ownedRecord, _report, observedFinalization) => {
+      events.push("hud-only-cleanup");
+      finalization = observedFinalization;
+    };
+    await assert.rejects(executeDetachedLaunchStateMachine(
+      { preflight: { kind: "available", shouldAttach: true, report: { transitions: ["D0"], rollback: { attempted: [], failures: [] } } } },
+      deps,
+    ));
+    assert.equal(isExactDetachedFinalization(finalization, {
+      nonce: "nonce",
+      sessionId: "session",
+      sessionName: "session-name",
+      leaderPid: 123,
+    }), true);
+    assert.equal(finalization?.kind, "terminal");
+    assert.deepEqual(events.slice(-2), ["D9", "hud-only-cleanup"]);
+  });
 
   it("finalizes and closes exactly once before D2 rollback without transport effects", async () => {
     const events: string[] = [];
@@ -4829,7 +4901,9 @@ exit 0
     const hud = {
       paneId: "%77",
       panePid: 7700,
+      sessionName: "omx-detached",
       sessionId: "$1",
+      sessionCreated: "1700000000",
       windowId: "@1",
       operationMarker: "operation-1",
     };

--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -142,7 +142,7 @@ if [ "$1" = "if-shell" ] && [ "$2" = "-F" ] && [ "$3" = "-t" ]; then
   esac
   [ -n "$receipt" ] || exit 1
   case "$success" in
-    *split-window*) printf '%%99\t456\t$1\t@1\t%s\n' "$receipt" ;;
+    *split-window*) printf '%%99\t456\t$1\t$2\t1\t@1\t%s\n' "$receipt" ;;
     *) printf '%s\n' "$receipt" ;;
   esac
   exit 0
@@ -266,7 +266,7 @@ if [ "$1" = "if-shell" ] && [ "$2" = "-F" ] && [ "$3" = "-t" ]; then
   esac
   [ -n "$receipt" ] || exit 1
   case "$success" in
-    *split-window*) printf '%%99\t456\t$1\t@1\t%s\n' "$receipt" ;;
+    *split-window*) printf '%%99\t456\t$1\t$2\t1\t@1\t%s\n' "$receipt" ;;
     *) printf '%s\n' "$receipt" ;;
   esac
   exit 0

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -43,9 +43,9 @@ describe('detached tmux authority contract', () => {
       cliIndex,
       /function captureDetachedLeaderAuthority[\s\S]*?#\{session_name\}\\t#\{session_id\}\\t#\{session_created\}\\t#\{window_index\}\\t#\{window_id\}\\t#\{pane_id\}\\t#\{pane_pid\}/,
     );
-    assert.match(cliIndex, /type DetachedHudAuthority = \{[\s\S]*?panePid: number;[\s\S]*?sessionId: string;[\s\S]*?windowId: string;[\s\S]*?operationMarker: string;/);
-    assert.match(cliIndex, /splitArgs\[formatIndex \+ 1\] = `#\{pane_id\}\\t#\{pane_pid\}\\t#\{session_id\}\\t#\{window_id\}\\t\$\{receipt\}`/);
-    assert.match(cliIndex, /function detachedHudAuthorityCondition[\s\S]*?#\{==:#\{pane_pid\},\$\{authority\.panePid\}\}[\s\S]*?#\{==:#\{session_id\},\$\{authority\.sessionId\}\}[\s\S]*?#\{==:#\{window_id\},\$\{authority\.windowId\}\}[\s\S]*?OMX_DETACHED_HUD_OPERATION=\$\{authority\.operationMarker\}/);
+    assert.match(cliIndex, /type DetachedHudAuthority = \{[\s\S]*?panePid: number;[\s\S]*?sessionName: string;[\s\S]*?sessionId: string;[\s\S]*?sessionCreated: string;[\s\S]*?windowId: string;[\s\S]*?operationMarker: string;/);
+    assert.match(cliIndex, /splitArgs\[formatIndex \+ 1\] = `#\{pane_id\}\\t#\{pane_pid\}\\t#\{session_name\}\\t#\{session_id\}\\t#\{session_created\}\\t#\{window_id\}\\t\$\{receipt\}`/);
+    assert.match(cliIndex, /function detachedHudAuthorityCondition[\s\S]*?#\{==:#\{pane_pid\},\$\{authority\.panePid\}\}[\s\S]*?#\{==:#\{session_name\},\$\{authority\.sessionName\}\}[\s\S]*?#\{==:#\{session_id\},\$\{authority\.sessionId\}\}[\s\S]*?#\{==:#\{session_created\},\$\{authority\.sessionCreated\}\}[\s\S]*?#\{==:#\{window_id\},\$\{authority\.windowId\}\}[\s\S]*?OMX_DETACHED_HUD_OPERATION=\$\{authority\.operationMarker\}/);
     assert.match(cliIndex, /function runDetachedHudMutation[\s\S]*?if-shell -F -t \$\{quoteShellArg\(hudAuthority\.paneId\)\}[\s\S]*?detachedLeaderAuthorityCondition\(leaderAuthority\)/);
     assert.match(cliIndex, /function guardDetachedHudDeferredMutation[\s\S]*?buildDeferredDetachedHudGuard\(leaderAuthority, hudAuthority/);
     assert.match(cliIndex, /let detachedHudAuthority: DetachedHudAuthority \| null = null;/);
@@ -53,6 +53,7 @@ describe('detached tmux authority contract', () => {
     assert.match(cliIndex, /if \(targetsHudPane\) runDetachedHudMutation\(authority, detachedHudAuthority, guardDetachedHudDeferredMutation\(authority, detachedHudAuthority, finalizeStep\.args\)\)/);
     assert.match(cliIndex, /publishDetachedReleaseMarker\(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid, detachedHudAuthority \?\? undefined\)/);
     assert.match(cliIndex, /runDetachedLeaderMutation\(detachedLeaderAuthority, step\.args\)/);
+    assert.match(cliIndex, /function removeDetachedHudPaneIfAuthorized[\s\S]*?if-shell[\s\S]*?detachedHudAuthorityCondition\(authority, true, ownerId\)[\s\S]*?kill-pane/);
     assert.ok(cliIndex.includes('splitArgs[commandIndex] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs[commandIndex]}`;'));
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1707,6 +1707,9 @@ function matchesDetachedHudAuthority(proof: DetachedHudPaneProof, authority: Det
  * missing pane proof must resolve to an ordinary fail-closed preserve result
  * instead of an `if-shell -t <stale pane>` evaluation that can tear down the
  * server with the leader and any replacement/foreign panes (#3562).
+ * `-s` widens the enumeration to every window of the session: an attached user
+ * may select another window, and a window-scoped listing would hide a fully
+ * matching HUD in the original window (#3562 review).
  *
  * Preserve (undefined) on malformed enumeration output and any tmux command
  * failure; callers preserve on zero or multiple authority matches.
@@ -1714,7 +1717,7 @@ function matchesDetachedHudAuthority(proof: DetachedHudPaneProof, authority: Det
 function listDetachedHudPaneProofsInSession(authority: DetachedHudAuthority): DetachedHudPaneProof[] | undefined {
   try {
     const output = execTmuxFileSync([
-      "list-panes", "-t", authority.sessionName, "-F", detachedHudPaneProofFormat(),
+      "list-panes", "-s", "-t", authority.sessionName, "-F", detachedHudPaneProofFormat(),
     ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
     const proofs: DetachedHudPaneProof[] = [];
     for (const line of output.split("\n")) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1649,14 +1649,106 @@ function runDetachedHudMutation(
 }
 
 
+function detachedHudPaneProofFormat(): string {
+  // The trailing literal sentinel keeps an empty @omx_hud_owner from being
+  // trimmed away as trailing whitespace by tmux's format output.
+  return "#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}\t#{pane_dead}\t#{@omx_hud_owner}\t#{pane_start_command}\tEND";
+}
+
+type DetachedHudPaneProof = {
+  paneId: string;
+  panePid: string;
+  sessionName: string;
+  sessionId: string;
+  sessionCreated: string;
+  windowId: string;
+  paneDead: string;
+  paneStartCommand: string;
+  hudOwner: string;
+};
+
+function parseDetachedHudPaneProofLine(line: string): DetachedHudPaneProof | undefined {
+  const fields = line.split("\t");
+  // Seven fixed fields, then @omx_hud_owner, then pane_start_command (which may
+  // itself contain TAB bytes), then the literal END sentinel.
+  if (fields.length < 10 || fields.at(-1) !== "END") return undefined;
+  const [paneId, panePid, sessionName, sessionId, sessionCreated, windowId, paneDead, hudOwner] = fields;
+  const paneStartCommand = fields.slice(8, -1).join("\t");
+  return {
+    paneId: paneId ?? "", panePid: panePid ?? "", sessionName: sessionName ?? "",
+    sessionId: sessionId ?? "", sessionCreated: sessionCreated ?? "", windowId: windowId ?? "",
+    paneDead: paneDead ?? "", paneStartCommand, hudOwner: hudOwner ?? "",
+  };
+}
+
+function matchesDetachedHudAuthority(proof: DetachedHudPaneProof, authority: DetachedHudAuthority, ownerId?: string): boolean {
+  if (proof.paneId !== authority.paneId) return false;
+  if (Number(proof.panePid) !== authority.panePid) return false;
+  if (proof.paneDead !== "0") return false;
+  if (proof.sessionName !== authority.sessionName) return false;
+  if (proof.sessionId !== authority.sessionId) return false;
+  if (proof.sessionCreated !== authority.sessionCreated) return false;
+  if (proof.windowId !== authority.windowId) return false;
+  // Marker non-vacuity: tmux reports pane_start_command wrapped in double
+  // quotes; the command must begin with the exact env assignment the
+  // production split sink injects. A pane whose command merely contains the
+  // marker text (e.g. an echo) is not the HUD.
+  const markerPrefix = `env OMX_DETACHED_HUD_OPERATION=${authority.operationMarker} `;
+  const startCommand = proof.paneStartCommand.replace(/^"|"$/g, "");
+  if (!startCommand.startsWith(markerPrefix)) return false;
+  if (ownerId !== undefined && proof.hudOwner !== ownerId) return false;
+  return true;
+}
+
+/**
+ * Enumerate the exact expected HUD pane inside its proven session scope and
+ * evaluate the full proof locally. The tmux enumeration target is the session
+ * name (a server-scoped stable identity), never the pane id: a stale or
+ * missing pane proof must resolve to an ordinary fail-closed preserve result
+ * instead of an `if-shell -t <stale pane>` evaluation that can tear down the
+ * server with the leader and any replacement/foreign panes (#3562).
+ *
+ * Preserve (undefined) on malformed enumeration output and any tmux command
+ * failure; callers preserve on zero or multiple authority matches.
+ */
+function listDetachedHudPaneProofsInSession(authority: DetachedHudAuthority): DetachedHudPaneProof[] | undefined {
+  try {
+    const output = execTmuxFileSync([
+      "list-panes", "-t", authority.sessionName, "-F", detachedHudPaneProofFormat(),
+    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
+    const proofs: DetachedHudPaneProof[] = [];
+    for (const line of output.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const proof = parseDetachedHudPaneProofLine(trimmed);
+      if (!proof) return undefined;
+      proofs.push(proof);
+    }
+    return proofs;
+  } catch {
+    return undefined;
+  }
+}
+
 function removeDetachedHudPaneIfAuthorized(authority: DetachedHudAuthority, ownerId?: string): boolean {
+  const proofs = listDetachedHudPaneProofsInSession(authority);
+  if (!proofs) return false;
+  const matching = proofs.filter((proof) => matchesDetachedHudAuthority(proof, authority, ownerId));
+  if (matching.length !== 1) return false;
   const receipt = detachedAuthorityReceipt();
-  const success = `kill-pane -t ${quoteShellArg(authority.paneId)} ; display-message -p ${quoteShellArg(receipt)}`;
-  const output = execTmuxFileSync([
-    "if-shell", "-F", "-t", authority.paneId, detachedHudAuthorityCondition(authority, true, ownerId),
-    success, "display-message -p ''",
-  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-  return output === receipt;
+  const killed = `killed:${receipt}`;
+  const mismatched = `mismatch:${receipt}`;
+  try {
+    const output = execTmuxFileSync([
+      "if-shell", "-F", "-t", matching[0]!.paneId,
+      detachedHudAuthorityCondition(authority, true, ownerId),
+      `kill-pane -t ${quoteShellArg(matching[0]!.paneId)} ; display-message -p ${quoteShellArg(killed)}`,
+      `display-message -p ${quoteShellArg(mismatched)}`,
+    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    return output === killed;
+  } catch {
+    return false;
+  }
 }
 
 function awaitDetachedHudPaneRemoval(paneId: string): void {
@@ -1672,7 +1764,10 @@ function awaitDetachedHudPaneRemoval(paneId: string): void {
 
 export function cleanupDetachedHudPane(authority: DetachedHudAuthority, ownerId?: string): void {
   if (!removeDetachedHudPaneIfAuthorized(authority, ownerId)) {
-    throw new Error("detached HUD authority changed before teardown");
+    // A stale, missing, or changed proof is an ordinary fail-closed preserve
+    // result. Throwing here would let callers escalate a benign mismatch into
+    // broader cleanup; the HUD pane and its session are left untouched.
+    return;
   }
   awaitDetachedHudPaneRemoval(authority.paneId);
 }
@@ -3160,7 +3255,8 @@ export function isExactDetachedFinalization(
     leaderPid: number | null;
   },
 ): boolean {
-  return finalization !== undefined && finalization.nonce === expected.nonce &&
+  return finalization !== undefined && (finalization.kind === "failed" || finalization.kind === "terminal") &&
+    finalization.nonce === expected.nonce &&
     finalization.sessionId === expected.sessionId && finalization.sessionName === expected.sessionName &&
     finalization.leaderPid === expected.leaderPid;
 }
@@ -3169,7 +3265,8 @@ function authenticatedDetachedFinalization(
   resolution: DetachedReleaseFailureResolution | undefined,
 ): DetachedFinalizationAuthority | undefined {
   if (resolution?.acknowledged !== true || !resolution.nonce || !resolution.sessionId || !resolution.sessionName ||
-    typeof resolution.leaderPid !== "number" || !Number.isSafeInteger(resolution.leaderPid) || !resolution.kind) return undefined;
+    typeof resolution.leaderPid !== "number" || !Number.isSafeInteger(resolution.leaderPid) ||
+    (resolution.kind !== "failed" && resolution.kind !== "terminal")) return undefined;
   return {
     nonce: resolution.nonce,
     sessionId: resolution.sessionId,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1762,14 +1762,15 @@ function awaitDetachedHudPaneRemoval(paneId: string): void {
   throw new Error("detached HUD topology changed before teardown");
 }
 
-export function cleanupDetachedHudPane(authority: DetachedHudAuthority, ownerId?: string): void {
+export function cleanupDetachedHudPane(authority: DetachedHudAuthority, ownerId?: string): boolean {
   if (!removeDetachedHudPaneIfAuthorized(authority, ownerId)) {
     // A stale, missing, or changed proof is an ordinary fail-closed preserve
     // result. Throwing here would let callers escalate a benign mismatch into
     // broader cleanup; the HUD pane and its session are left untouched.
-    return;
+    return false;
   }
   awaitDetachedHudPaneRemoval(authority.paneId);
+  return true;
 }
 
 /**
@@ -7163,10 +7164,11 @@ function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLea
   // Contract: only the proven HUD is removed. A pane the user added to the detached
   // session is deliberately preserved, which intentionally keeps that session (and any
   // attached client) alive; natural closure and shell return happen only when no other
-  // panes remain.
+  // panes remain. The leader pane is removed only after the proven HUD removal is
+  // confirmed; a stale, missing, or changed HUD proof leaves the leader untouched too.
   if (!hudProof) return;
   try {
-    cleanupDetachedHudPane(hudProof, payload.sessionId);
+    if (!cleanupDetachedHudPane(hudProof, payload.sessionId)) return;
     execTmuxFileSync(["kill-pane", "-t", leaderPaneId], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
   } catch (error) {
     traceDetachedLeaderPhase(`hud-teardown-error:${describeDetachedLeaderFailure(error)}`);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1660,6 +1660,30 @@ export function cleanupDetachedHudPane(authority: DetachedHudAuthority, ownerId?
   throw new Error("detached HUD topology changed before teardown");
 }
 
+/**
+ * Remove the bootstrap HUD after a finalized pre-release leader failure.
+ *
+ * The outer launcher retained the original pane snapshot while creating the
+ * HUD. Re-discover the owner-tagged pane and require the immutable tmux
+ * identity fields to match before removing it. This keeps failure cleanup
+ * fail-closed when a pane was replaced or ownership cannot be proven.
+ */
+export function cleanupFinalizedDetachedFailureHud(
+  expected: DetachedHudAuthority | null,
+  sessionName: string,
+  ownerId: string,
+): boolean {
+  if (!expected) return false;
+  const discovered = discoverDetachedHudAuthority(sessionName, ownerId);
+  if (!discovered ||
+    discovered.paneId !== expected.paneId ||
+    discovered.panePid !== expected.panePid ||
+    discovered.sessionId !== expected.sessionId ||
+    discovered.windowId !== expected.windowId) return false;
+  cleanupDetachedHudPane(discovered, ownerId);
+  return true;
+}
+
 function tagDetachedHudPane(leaderAuthority: DetachedLeaderAuthority, authority: DetachedHudAuthority, ownerId: string): void {
   runDetachedHudMutation(leaderAuthority, authority, [
     "set-option", "-pq", "-t", authority.paneId, "@omx_hud_owner", ownerId,
@@ -6558,6 +6582,7 @@ async function runCodex(
     let detachedHudAuthority: DetachedHudAuthority | null = null;
     let detachedLeaderPid: number | null = null;
     let rollbackFromPreReportAuthority = false;
+    let rollbackFinalizedFailureHud = false;
 
     let attachStep: DetachedSessionTmuxStep | null = null;
 
@@ -6653,6 +6678,7 @@ async function runCodex(
               }
               if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.sessionName === sessionName && report.leaderPid && report.kind === "failed") {
                 detachedLeaderPid = report.leaderPid;
+                rollbackFinalizedFailureHud = report.finalized === true && detachedHudAuthority !== null;
                 return { kind: "failure", operation: "session-instructions", error: new Error(report.error || "detached leader setup failed") };
               }
               if (Date.now() >= readyDeadline) return { kind: "failure", operation: "session-instructions", error: new Error("detached leader readiness timed out") };
@@ -6746,6 +6772,14 @@ async function runCodex(
             await attempt("runtime-codex-home", () => cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup));
             await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); rmSync(`${releaseMarkerPath}.abort`, { force: true }); });
             if (createdSession) {
+              if (rollbackFinalizedFailureHud) {
+                await attempt("session:kill-bootstrap-hud", () => {
+                  if (!cleanupFinalizedDetachedFailureHud(detachedHudAuthority, sessionName, sessionId)) {
+                    throw new Error("detached bootstrap HUD authority changed before failure cleanup");
+                  }
+                });
+                return;
+              }
               for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
                 await attempt(`session:${step.name}`, () => {
                   if (!detachedLeaderAuthority) throw new Error("detached leader authority missing before rollback");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1500,8 +1500,9 @@ type DetachedLeaderAuthority = {
 type DetachedHudAuthority = {
   paneId: string;
   panePid: number;
+  sessionName: string;
   sessionId: string;
-  sessionCreated?: string;
+  sessionCreated: string;
   windowId: string;
   operationMarker: string;
 };
@@ -1553,14 +1554,21 @@ function detachedLeaderAuthorityCondition(authority: DetachedLeaderAuthority, re
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
 
-function detachedHudAuthorityCondition(authority: DetachedHudAuthority, requireMarker = true): string {
+function detachedHudAuthorityCondition(
+  authority: DetachedHudAuthority,
+  requireMarker = true,
+  ownerId?: string,
+): string {
   const conditions = [
     "#{==:#{pane_dead},0}",
     `#{==:#{pane_id},${authority.paneId}}`,
     `#{==:#{pane_pid},${authority.panePid}}`,
+    `#{==:#{session_name},${authority.sessionName}}`,
     `#{==:#{session_id},${authority.sessionId}}`,
+    `#{==:#{session_created},${authority.sessionCreated}}`,
     `#{==:#{window_id},${authority.windowId}}`,
     ...(requireMarker ? [`#{m:*OMX_DETACHED_HUD_OPERATION=${authority.operationMarker}*,#{pane_start_command}}`] : []),
+    ...(ownerId ? [`#{==:#{@omx_hud_owner},${ownerId}}`] : []),
   ];
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
@@ -1641,46 +1649,48 @@ function runDetachedHudMutation(
 }
 
 
-export function cleanupDetachedHudPane(authority: DetachedHudAuthority, ownerId?: string): void {
-  if (ownerId) {
-    execTmuxFileSync(["kill-pane", "-t", authority.paneId], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
-  } else {
-    execTmuxFileSync([
-      "if-shell", "-F", "-t", authority.paneId, detachedHudAuthorityCondition(authority, false),
-      `kill-pane -t ${quoteShellArg(authority.paneId)}`, "",
-    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
-  }
+function removeDetachedHudPaneIfAuthorized(authority: DetachedHudAuthority, ownerId?: string): boolean {
+  const receipt = detachedAuthorityReceipt();
+  const success = `kill-pane -t ${quoteShellArg(authority.paneId)} ; display-message -p ${quoteShellArg(receipt)}`;
+  const output = execTmuxFileSync([
+    "if-shell", "-F", "-t", authority.paneId, detachedHudAuthorityCondition(authority, true, ownerId),
+    success, "display-message -p ''",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  return output === receipt;
+}
+
+function awaitDetachedHudPaneRemoval(paneId: string): void {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const panes = execTmuxFileSync(["list-panes", "-a", "-F", "#{pane_id}"], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     }).split("\n").map((value) => value.trim()).filter(Boolean);
-    if (!panes.includes(authority.paneId)) return;
+    if (!panes.includes(paneId)) return;
     blockMs(20);
   }
   throw new Error("detached HUD topology changed before teardown");
 }
 
+export function cleanupDetachedHudPane(authority: DetachedHudAuthority, ownerId?: string): void {
+  if (!removeDetachedHudPaneIfAuthorized(authority, ownerId)) {
+    throw new Error("detached HUD authority changed before teardown");
+  }
+  awaitDetachedHudPaneRemoval(authority.paneId);
+}
+
 /**
- * Remove the bootstrap HUD after a finalized pre-release leader failure.
+ * Remove the bootstrap HUD after an authenticated finalized leader result.
  *
- * The outer launcher retained the original pane snapshot while creating the
- * HUD. Re-discover the owner-tagged pane and require the immutable tmux
- * identity fields to match before removing it. This keeps failure cleanup
- * fail-closed when a pane was replaced or ownership cannot be proven.
+ * The outer launcher retained the original HUD proof while creating the pane.
+ * Revalidate that proof and its owner tag at the tmux mutation sink so failure
+ * cleanup stays fail-closed when a pane is replaced or taken over.
  */
-export function cleanupFinalizedDetachedFailureHud(
+export function cleanupFinalizedDetachedHud(
   expected: DetachedHudAuthority | null,
-  sessionName: string,
   ownerId: string,
 ): boolean {
   if (!expected) return false;
-  const discovered = discoverDetachedHudAuthority(sessionName, ownerId);
-  if (!discovered ||
-    discovered.paneId !== expected.paneId ||
-    discovered.panePid !== expected.panePid ||
-    discovered.sessionId !== expected.sessionId ||
-    discovered.windowId !== expected.windowId) return false;
-  cleanupDetachedHudPane(discovered, ownerId);
+  if (!removeDetachedHudPaneIfAuthorized(expected, ownerId)) return false;
+  awaitDetachedHudPaneRemoval(expected.paneId);
   return true;
 }
 
@@ -1688,22 +1698,6 @@ function tagDetachedHudPane(leaderAuthority: DetachedLeaderAuthority, authority:
   runDetachedHudMutation(leaderAuthority, authority, [
     "set-option", "-pq", "-t", authority.paneId, "@omx_hud_owner", ownerId,
   ], false);
-}
-
-
-export function discoverDetachedHudAuthority(sessionName: string, ownerId: string): DetachedHudAuthority | undefined {
-  const rows = execTmuxFileSync([
-    "list-panes", "-a", "-F",
-    "#{pane_id}\t#{pane_dead}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}\t#{@omx_hud_owner}",
-  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
-  const matches = rows.split("\n").map((line) => line.trim()).filter(Boolean).flatMap((line) => {
-    const [paneId, paneDead, panePidRaw, discoveredSessionName, sessionId, sessionCreated, windowId, owner] = line.split("\t");
-    const panePid = Number(panePidRaw);
-    if (paneDead !== "0" || discoveredSessionName !== sessionName || owner !== ownerId || !/^%\d+$/.test(paneId ?? "") || !/^\$\d+$/.test(sessionId ?? "") || !/^\d+$/.test(sessionCreated ?? "") || !/^@\d+$/.test(windowId ?? "") || !Number.isSafeInteger(panePid) || panePid <= 0) return [];
-    return [{ paneId: paneId!, panePid, sessionId: sessionId!, sessionCreated: sessionCreated!, windowId: windowId!, operationMarker: randomUUID() }];
-  });
-  if (matches.length > 1) throw new Error("multiple detached HUD ownership tags found");
-  return matches[0];
 }
 
 
@@ -1784,19 +1778,19 @@ function runDetachedLeaderSplit(authority: DetachedLeaderAuthority, args: string
   if (formatIndex < 0 || splitArgs[formatIndex + 1] !== "#{pane_id}") throw new Error("invalid detached HUD split receipt format");
   const commandIndex = splitArgs.length - 1;
   splitArgs[commandIndex] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs[commandIndex]}`;
-  splitArgs[formatIndex + 1] = `#{pane_id}\t#{pane_pid}\t#{session_id}\t#{window_id}\t${receipt}`;
+  splitArgs[formatIndex + 1] = `#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_id}\t${receipt}`;
   const output = execTmuxFileSync([
     "if-shell", "-F", "-t", authority.paneId, detachedLeaderAuthorityCondition(authority),
     splitArgs.map(quoteShellArg).join(" "), "display-message -p ''",
   ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-  const [paneId, panePid, sessionId, windowId, observedReceipt, ...extra] = output.split("\t");
-  if (!/^%[0-9]+$/.test(paneId) || !/^[1-9][0-9]*$/.test(panePid) || !/^\$[0-9]+$/.test(sessionId)
-    || !/^@[0-9]+$/.test(windowId) || observedReceipt !== receipt || extra.length !== 0) {
+  const [paneId, panePid, sessionName, sessionId, sessionCreated, windowId, observedReceipt, ...extra] = output.split("\t");
+  if (!/^%[0-9]+$/.test(paneId) || !/^[1-9][0-9]*$/.test(panePid) || !sessionName || !/^\$[0-9]+$/.test(sessionId)
+    || !/^\d+$/.test(sessionCreated) || !/^@[0-9]+$/.test(windowId) || observedReceipt !== receipt || extra.length !== 0) {
     throw new Error("detached leader authority changed before HUD split");
   }
   const parsedPid = Number(panePid);
   if (!Number.isSafeInteger(parsedPid) || parsedPid <= 0) throw new Error("malformed detached HUD authority");
-  return { paneId, panePid: parsedPid, sessionId, windowId, operationMarker };
+  return { paneId, panePid: parsedPid, sessionName, sessionId, sessionCreated, windowId, operationMarker };
 }
 
 function readTmuxEnvValueForTarget(targetPaneId: string): string | undefined {
@@ -3149,6 +3143,42 @@ export interface DetachedReleaseFailureResolution {
   kind?: "failed" | "terminal";
 }
 
+export interface DetachedFinalizationAuthority {
+  readonly nonce: string;
+  readonly sessionId: string;
+  readonly sessionName: string;
+  readonly leaderPid: number;
+  readonly kind: "failed" | "terminal";
+}
+
+export function isExactDetachedFinalization(
+  finalization: DetachedFinalizationAuthority | undefined,
+  expected: {
+    nonce: string;
+    sessionId: string;
+    sessionName: string;
+    leaderPid: number | null;
+  },
+): boolean {
+  return finalization !== undefined && finalization.nonce === expected.nonce &&
+    finalization.sessionId === expected.sessionId && finalization.sessionName === expected.sessionName &&
+    finalization.leaderPid === expected.leaderPid;
+}
+
+function authenticatedDetachedFinalization(
+  resolution: DetachedReleaseFailureResolution | undefined,
+): DetachedFinalizationAuthority | undefined {
+  if (resolution?.acknowledged !== true || !resolution.nonce || !resolution.sessionId || !resolution.sessionName ||
+    typeof resolution.leaderPid !== "number" || !Number.isSafeInteger(resolution.leaderPid) || !resolution.kind) return undefined;
+  return {
+    nonce: resolution.nonce,
+    sessionId: resolution.sessionId,
+    sessionName: resolution.sessionName,
+    leaderPid: resolution.leaderPid,
+    kind: resolution.kind,
+  };
+}
+
 
 export class DetachedTransportUnavailable extends Error {
   readonly name = "DetachedTransportUnavailable";
@@ -3189,7 +3219,11 @@ export interface DetachedLaunchDependencies<Binding = unknown, InertSession = un
    */
   abortAndAwaitFinalization?(error: unknown): Promise<DetachedReleaseFailureResolution>;
   attachOrReturn(session: InertSession, shouldAttach: boolean): Promise<void>;
-  rollback(ownedRecord: DetachedActiveRecordOwnership | undefined, report: DetachedBootstrapReport): Promise<void>;
+  rollback(
+    ownedRecord: DetachedActiveRecordOwnership | undefined,
+    report: DetachedBootstrapReport,
+    finalization: DetachedFinalizationAuthority | undefined,
+  ): Promise<void>;
   diagnostic?(error: unknown): void;
 
 }
@@ -3207,6 +3241,7 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
   let released = false;
   let retainedAuthority = false;
   let rollbackAuthorized = false;
+  let finalization: DetachedFinalizationAuthority | undefined;
   try {
     transition("D1");
     binding = await deps.establish();
@@ -3257,10 +3292,8 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
         released = true;
         throw new AggregateError([releaseError, abortError], "detached release and abort publication both failed");
       }
-      rollbackAuthorized = resolution?.acknowledged === true && Boolean(
-        resolution.nonce && resolution.sessionId && resolution.sessionName &&
-        Number.isSafeInteger(resolution.leaderPid) && resolution.kind,
-      );
+      finalization = authenticatedDetachedFinalization(resolution);
+      rollbackAuthorized = finalization !== undefined;
       if (!rollbackAuthorized) released = true;
       throw releaseError;
     }
@@ -3272,12 +3305,8 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
     if (retainedAuthority && !rollbackAuthorized && !released) {
       try {
         const resolution = await deps.abortAndAwaitFinalization?.(error);
-        rollbackAuthorized = resolution?.rollbackAuthorized === true || (
-          resolution?.acknowledged === true && Boolean(
-            resolution.nonce && resolution.sessionId && resolution.sessionName &&
-            Number.isSafeInteger(resolution.leaderPid) && resolution.kind
-          )
-        );
+        finalization = authenticatedDetachedFinalization(resolution);
+        rollbackAuthorized = resolution?.rollbackAuthorized === true || finalization !== undefined;
         if (!rollbackAuthorized) released = true;
       } catch (abortError) {
         released = true;
@@ -3287,7 +3316,7 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
     if (!released) {
       try {
         report.rollback.attempted.push("rollback");
-        await deps.rollback(ownedRecord, report);
+        await deps.rollback(ownedRecord, report, finalization);
       } catch (rollbackError) {
         report.rollback.failures.push({ step: "rollback", status: "failed", code: detachedFailureCode(rollbackError) });
         deps.diagnostic?.(rollbackError);
@@ -6582,7 +6611,6 @@ async function runCodex(
     let detachedHudAuthority: DetachedHudAuthority | null = null;
     let detachedLeaderPid: number | null = null;
     let rollbackFromPreReportAuthority = false;
-    let rollbackFinalizedFailureHud = false;
 
     let attachStep: DetachedSessionTmuxStep | null = null;
 
@@ -6678,7 +6706,6 @@ async function runCodex(
               }
               if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.sessionName === sessionName && report.leaderPid && report.kind === "failed") {
                 detachedLeaderPid = report.leaderPid;
-                rollbackFinalizedFailureHud = report.finalized === true && detachedHudAuthority !== null;
                 return { kind: "failure", operation: "session-instructions", error: new Error(report.error || "detached leader setup failed") };
               }
               if (Date.now() >= readyDeadline) return { kind: "failure", operation: "session-instructions", error: new Error("detached leader readiness timed out") };
@@ -6763,7 +6790,7 @@ async function runCodex(
             return { acknowledged: false };
           },
           attachOrReturn: async () => { if (attachStep) execTmuxFileSync(attachStep.args, { stdio: "inherit" }); },
-          rollback: async (_ownedRecord, report) => {
+          rollback: async (_ownedRecord, report, finalization) => {
             const attempt = async (step: DetachedRollbackStep, operation: () => Promise<void> | void): Promise<void> => {
               report.rollback.attempted.push(step);
               try { await operation(); } catch (error) { report.rollback.failures.push({ step, status: "failed", code: detachedFailureCode(error) }); }
@@ -6772,12 +6799,19 @@ async function runCodex(
             await attempt("runtime-codex-home", () => cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup));
             await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); rmSync(`${releaseMarkerPath}.abort`, { force: true }); });
             if (createdSession) {
-              if (rollbackFinalizedFailureHud) {
-                await attempt("session:kill-bootstrap-hud", () => {
-                  if (!cleanupFinalizedDetachedFailureHud(detachedHudAuthority, sessionName, sessionId)) {
-                    throw new Error("detached bootstrap HUD authority changed before failure cleanup");
-                  }
-                });
+              if (isExactDetachedFinalization(finalization, {
+                nonce: detachedLaunchNonce,
+                sessionId,
+                sessionName,
+                leaderPid: detachedLeaderPid,
+              })) {
+                if (detachedHudAuthority) {
+                  await attempt("session:kill-bootstrap-hud", () => {
+                    if (!cleanupFinalizedDetachedHud(detachedHudAuthority, sessionId)) {
+                      throw new Error("detached bootstrap HUD authority changed before finalized cleanup");
+                    }
+                  });
+                }
                 return;
               }
               for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
@@ -7017,10 +7051,12 @@ function parseDetachedHudAuthorityProof(value: unknown): DetachedHudAuthority | 
   const proof = value as Record<string, unknown>;
   if (typeof proof.paneId !== "string" || !/^%[0-9]+$/.test(proof.paneId)) return undefined;
   if (typeof proof.panePid !== "number" || !Number.isSafeInteger(proof.panePid) || proof.panePid <= 0) return undefined;
+  if (typeof proof.sessionName !== "string" || proof.sessionName.length === 0 || proof.sessionName.includes("\t")) return undefined;
   if (typeof proof.sessionId !== "string" || !/^\$[0-9]+$/.test(proof.sessionId)) return undefined;
+  if (typeof proof.sessionCreated !== "string" || !/^\d+$/.test(proof.sessionCreated)) return undefined;
   if (typeof proof.windowId !== "string" || !/^@[0-9]+$/.test(proof.windowId)) return undefined;
   if (typeof proof.operationMarker !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(proof.operationMarker)) return undefined;
-  return { paneId: proof.paneId, panePid: proof.panePid, sessionId: proof.sessionId, windowId: proof.windowId, operationMarker: proof.operationMarker };
+  return { paneId: proof.paneId, panePid: proof.panePid, sessionName: proof.sessionName, sessionId: proof.sessionId, sessionCreated: proof.sessionCreated, windowId: proof.windowId, operationMarker: proof.operationMarker };
 }
 
 function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLeaderPayload, hudProof: DetachedHudAuthority | undefined): void {
@@ -7031,11 +7067,9 @@ function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLea
   // session is deliberately preserved, which intentionally keeps that session (and any
   // attached client) alive; natural closure and shell return happen only when no other
   // panes remain.
-  const discovered = discoverDetachedHudAuthority(payload.sessionName, payload.sessionId);
-  const proof = discovered ?? hudProof;
-  if (!proof) return;
+  if (!hudProof) return;
   try {
-    cleanupDetachedHudPane(proof, discovered ? payload.sessionId : undefined);
+    cleanupDetachedHudPane(hudProof, payload.sessionId);
     execTmuxFileSync(["kill-pane", "-t", leaderPaneId], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
   } catch (error) {
     traceDetachedLeaderPhase(`hud-teardown-error:${describeDetachedLeaderFailure(error)}`);


### PR DESCRIPTION
## Summary

A detached leader can fail after the bootstrap HUD is created but before normal child completion. Its finalized failure path leaves the HUD watch pane alive, producing an unusable one-pane tmux session.

## Changes

- Re-discover and remove only the bootstrap-proven HUD after an authenticated finalized leader failure.
- Fail closed when the pane identity or owner tag no longer matches.
- Add real-tmux coverage for matching and mismatched authority.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] New matching/mismatched authority tests passed in the target suite.
- [ ] Full `npm test` is environment-conflicted in this active tmux/Codex session: unrelated tmux integration tests time out or fail against the interactive server.

## Focus, docs, and compatibility

- Focused change: only detached bootstrap HUD failure cleanup and its tests.
- Documentation refresh: not needed; this is internal cleanup with no CLI-contract change.
- Backward compatible: normal child-exit cleanup is unchanged; uncertain ownership is preserved.

## Related

Related to #3266. This covers the finalized pre-release failure path, which is not handled by normal child-exit teardown.