### PR TITLE
feat: add --provider launch shorthand with orcarouter as a known provider

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -914,6 +914,58 @@ describe("normalizeCodexLaunchArgs", () => {
     ]);
   });
 
+  it("maps --provider orcarouter to a model_provider override", () => {
+    assert.deepEqual(normalizeCodexLaunchArgs(["--provider", "orcarouter"]), [
+      "-c",
+      'model_provider="orcarouter"',
+    ]);
+  });
+
+  it("maps --provider=orcarouter to a model_provider override", () => {
+    assert.deepEqual(normalizeCodexLaunchArgs(["--provider=orcarouter"]), [
+      "-c",
+      'model_provider="orcarouter"',
+    ]);
+  });
+
+  it("passes unknown provider names through as opaque model_provider values", () => {
+    assert.deepEqual(normalizeCodexLaunchArgs(["--provider", "acme-gateway"]), [
+      "-c",
+      'model_provider="acme-gateway"',
+    ]);
+  });
+
+  it("combines --provider with --xhigh and --model", () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs([
+        "--provider",
+        "orcarouter",
+        "--xhigh",
+        "--model",
+        "o4-mini",
+      ]),
+      [
+        "--model",
+        "o4-mini",
+        "-c",
+        'model_reasoning_effort="xhigh"',
+        "-c",
+        'model_provider="orcarouter"',
+      ],
+    );
+  });
+
+  it("preserves a literal provider selector after the end-of-options marker", () => {
+    assert.deepEqual(
+      normalizeCodexLaunchArgs(["--provider", "orcarouter", "--", "--provider", "literal"]),
+      ["-c", 'model_provider="orcarouter"', "--", "--provider", "literal"],
+    );
+  });
+
+  it("drops a --provider with a missing value", () => {
+    assert.deepEqual(normalizeCodexLaunchArgs(["--provider"]), []);
+  });
+
   it("rejects pre-marker max and ultra reasoning shorthands with approved guidance", () => {
     const errors = [
       [

--- a/src/cli/constants.ts
+++ b/src/cli/constants.ts
@@ -5,6 +5,7 @@ export const HIGH_REASONING_FLAG = '--high';
 export const XHIGH_REASONING_FLAG = '--xhigh';
 export const SPARK_FLAG = '--spark';
 export const MADMAX_SPARK_FLAG = '--madmax-spark';
+export const PROVIDER_FLAG = '--provider';
 export const CONFIG_FLAG = '-c';
 export const LONG_CONFIG_FLAG = '--config';
 export const MODEL_FLAG = '--model';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -67,6 +67,7 @@ import {
   XHIGH_REASONING_FLAG,
   SPARK_FLAG,
   MADMAX_SPARK_FLAG,
+  PROVIDER_FLAG,
   CONFIG_FLAG,
   LONG_CONFIG_FLAG,
 } from "./constants.js";
@@ -103,6 +104,7 @@ import {
   isUnsupportedRootReasoningEffort,
   normalizeUnsupportedRootReasoningEffort,
 } from "../config/models.js";
+import { getKnownProvider, KNOWN_PROVIDERS } from "../config/providers.js";
 
 
 export {
@@ -312,6 +314,7 @@ Usage:
   omx status    Show active modes and state
   omx cancel    Cancel active execution modes
   omx reasoning Show or set model reasoning effort (low|medium|high|xhigh)
+  omx providers List known Codex model providers with an OMX launch shorthand
 
 Options:
   --yolo        Launch Codex in yolo mode (shorthand for: omx launch --yolo)
@@ -319,6 +322,10 @@ Options:
                 (shorthand for: -c model_reasoning_effort="high")
   --xhigh       Launch Codex with xhigh reasoning effort
                 (shorthand for: -c model_reasoning_effort="xhigh")
+  --provider <name>
+                Launch Codex with the named model provider selected
+                (shorthand for: -c model_provider="<name>"); known providers
+                include openai, openai-chatgpt, and orcarouter
   --madmax      DANGEROUS: bypass Codex approvals and sandbox
                 (alias for --dangerously-bypass-approvals-and-sandbox)
   --spark       Use the Codex spark model (~1.3x faster) for team workers only
@@ -3578,6 +3585,7 @@ export async function main(args: string[]): Promise<void> {
     "session",
     "resume",
     "version",
+    "providers",
     "tmux-hook",
     "hooks",
     "hud",
@@ -3804,6 +3812,9 @@ if (command !== "launch" && command !== "resume") {
       case "reasoning":
         await reasoningCommand(args.slice(1));
         break;
+      case "providers":
+        providersCommand();
+        break;
       case "codex-native-hook": {
         const { runCodexNativeHookCli } = await import("../scripts/codex-native-hook.js");
         await runCodexNativeHookCli();
@@ -4001,6 +4012,25 @@ async function reasoningCommand(args: string[]): Promise<void> {
   const updated = upsertTopLevelTomlString(existing, REASONING_KEY, mode);
   await writeFile(configPath, updated);
   console.log(`Set ${REASONING_KEY}="${mode}" in ${configPath}`);
+}
+
+function providersCommand(): void {
+  const rows = KNOWN_PROVIDERS.map((provider) => {
+    const parts = [provider.name];
+    if (provider.envKey) parts.push(`env=${provider.envKey}`);
+    if (provider.baseUrl) parts.push(provider.baseUrl);
+    return `  ${parts.join("  ")}`;
+  }).join("\n");
+  console.log(
+    [
+      "Known Codex model providers with an OMX launch shorthand:",
+      "",
+      rows,
+      "",
+      'Use `omx --provider <name>` (for example `omx --provider orcarouter`) to launch Codex with that provider selected.',
+      "Provider names not listed here are passed through as opaque `model_provider` values owned by config.toml.",
+    ].join("\n"),
+  );
 }
 
 export async function launchWithAuthHotswap(args: string[]): Promise<void> {
@@ -4441,8 +4471,11 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
   let wantsBypass = false;
   let hasBypass = false;
   let reasoningMode: ReasoningMode | null = null;
+  let providerName: string | null = null;
 
-  for (const arg of launchPolicyParsed.remainingArgs) {
+  for (let i = 0; i < launchPolicyParsed.remainingArgs.length; i += 1) {
+    const arg = launchPolicyParsed.remainingArgs[i];
+
     if (arg === MADMAX_FLAG) {
       wantsBypass = true;
       continue;
@@ -4482,6 +4515,21 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
       continue;
     }
 
+    if (arg === PROVIDER_FLAG) {
+      const inlineValue = launchPolicyParsed.remainingArgs[i + 1];
+      if (typeof inlineValue === "string" && !inlineValue.startsWith("-")) {
+        providerName = inlineValue.trim();
+        i += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith(`${PROVIDER_FLAG}=`)) {
+      const inlineValue = arg.slice(`${PROVIDER_FLAG}=`.length).trim();
+      if (inlineValue) providerName = inlineValue;
+      continue;
+    }
+
     normalized.push(arg);
   }
 
@@ -4491,6 +4539,18 @@ export function normalizeCodexLaunchArgs(args: string[]): string[] {
 
   if (reasoningMode) {
     normalized.push(CONFIG_FLAG, `${REASONING_KEY}="${reasoningMode}"`);
+  }
+
+  if (providerName) {
+    const known = getKnownProvider(providerName);
+    if (known) {
+      normalized.push(CONFIG_FLAG, `model_provider="${known.name}"`);
+    } else {
+      // Unknown provider names are opaque passthrough values, matching how
+      // OMX treats any non-alias model name. The launch still selects it so
+      // Codex's own config.toml `[model_providers.<name>]` table can own it.
+      normalized.push(CONFIG_FLAG, `model_provider="${providerName.replace(/"/g, '\\"')}"`);
+    }
   }
 
   return [...normalized, ...suffix];

--- a/src/config/__tests__/providers.test.ts
+++ b/src/config/__tests__/providers.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  KNOWN_PROVIDERS,
+  ORCAROUTER_PROVIDER_INFO,
+  ORCAROUTER_PROVIDER_NAME,
+  getKnownProvider,
+  isKnownProvider,
+} from "../providers.js";
+
+test("exposes orcarouter as a first-class known provider", () => {
+  assert.equal(ORCAROUTER_PROVIDER_NAME, "orcarouter");
+  assert.equal(ORCAROUTER_PROVIDER_INFO.name, "orcarouter");
+  assert.equal(ORCAROUTER_PROVIDER_INFO.envKey, "ORCAROUTER_API_KEY");
+  assert.match(ORCAROUTER_PROVIDER_INFO.baseUrl ?? "", /^https:\/\/api\.orcarouter\.ai\//);
+});
+
+test("getKnownProvider returns metadata for known providers", () => {
+  assert.equal(getKnownProvider("orcarouter")?.name, "orcarouter");
+  assert.equal(getKnownProvider("openai")?.name, "openai");
+  assert.equal(getKnownProvider("openai-chatgpt")?.name, "openai-chatgpt");
+});
+
+test("getKnownProvider returns undefined for unknown providers", () => {
+  assert.equal(getKnownProvider("acme-gateway"), undefined);
+  assert.equal(getKnownProvider(""), undefined);
+  assert.equal(getKnownProvider(undefined), undefined);
+});
+
+test("isKnownProvider distinguishes known from unknown providers", () => {
+  assert.equal(isKnownProvider("orcarouter"), true);
+  assert.equal(isKnownProvider("acme-gateway"), false);
+});
+
+test("KNOWN_PROVIDERS includes orcarouter exactly once", () => {
+  const names = KNOWN_PROVIDERS.map((provider) => provider.name);
+  assert.ok(names.includes("orcarouter"));
+  assert.equal(
+    names.filter((name) => name === "orcarouter").length,
+    1,
+  );
+});

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,0 +1,70 @@
+/**
+ * Known Codex model providers.
+ *
+ * Codex routes model traffic through the active `model_provider` selected in
+ * `config.toml` (`model_provider = "<name>"`), with each named provider
+ * described by a `[model_providers.<name>]` table. OMX does not own that table
+ * (Codex does), but it can expose first-class launch shorthands for providers
+ * it knows about, so users can select a named provider without hand-editing
+ * `config.toml`.
+ *
+ * This registry intentionally stays small: it only lists providers OMX ships
+ * a first-class `--provider` shorthand for. Any other provider name is an
+ * opaque passthrough value and carries no OMX-specific routing meaning.
+ */
+
+export interface KnownProviderInfo {
+  /** Provider name used in `config.toml` `model_provider = "<name>"`. */
+  name: string;
+  /** Short human-readable label for `omx help` and diagnostics. */
+  label: string;
+  /** Environment key that holds the provider API key, when one is expected. */
+  envKey?: string;
+  /** Base URL for OpenAI-compatible providers, when OMX knows it. */
+  baseUrl?: string;
+  /** Optional note shown by `omx providers` for this provider. */
+  description?: string;
+}
+
+export const ORCAROUTER_PROVIDER_NAME = "orcarouter";
+
+export const ORCAROUTER_PROVIDER_INFO: KnownProviderInfo = {
+  name: ORCAROUTER_PROVIDER_NAME,
+  label: "OrcaRouter",
+  envKey: "ORCAROUTER_API_KEY",
+  baseUrl: "https://api.orcarouter.ai/v1",
+  description:
+    "OpenAI-compatible gateway for models and agents: adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and gateway-level agent-tool governance.",
+};
+
+export const KNOWN_PROVIDERS: readonly KnownProviderInfo[] = [
+  {
+    name: "openai",
+    label: "OpenAI",
+    envKey: "OPENAI_API_KEY",
+    baseUrl: "https://api.openai.com/v1",
+  },
+  {
+    name: "openai-chatgpt",
+    label: "OpenAI ChatGPT (subscription)",
+  },
+  ORCAROUTER_PROVIDER_INFO,
+];
+
+const KNOWN_PROVIDER_BY_NAME = new Map<string, KnownProviderInfo>(
+  KNOWN_PROVIDERS.map((provider) => [provider.name, provider]),
+);
+
+/** Returns metadata for a provider OMX ships a first-class shorthand for. */
+export function getKnownProvider(
+  name: string | undefined,
+): KnownProviderInfo | undefined {
+  if (!name) return undefined;
+  const normalized = name.trim();
+  return normalized ? KNOWN_PROVIDER_BY_NAME.get(normalized) : undefined;
+}
+
+/** True when `name` is a provider OMX exposes a first-class shorthand for. */
+export function isKnownProvider(name: string | undefined): boolean {
+  return getKnownProvider(name) !== undefined;
+}


### PR DESCRIPTION
## Summary

oh-my-codex describes itself as "a workflow layer for OpenAI Codex CLI" that makes it easy to "start a stronger Codex session by default." Today, choosing a non-default model provider means hand-editing `config.toml` — `model_provider = "..."` plus a `[model_providers.<name>]` table and the matching env key. This PR adds a first-class launch shorthand so that same selection can be made from the CLI, and registers **OrcaRouter** as a named provider OMX knows about.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means OMX users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `src/config/providers.ts` (new): a small known-provider registry. `orcarouter` is registered with its env key (`ORCAROUTER_API_KEY`) and base URL (`https://api.orcarouter.ai/v1`), alongside `openai` and `openai-chatgpt`.
- `src/cli/index.ts`: `normalizeCodexLaunchArgs` now consumes a `--provider <name>` / `--provider=<name>` shorthand before the end-of-options marker and emits `-c model_provider="<name>"`, mirroring how `--high` maps to `-c model_reasoning_effort="high"`. Unknown provider names pass through as opaque `model_provider` values owned by `config.toml` — the same way OMX treats any non-alias model name.
- `src/cli/index.ts`: new `omx providers` list command and help-text entries for `--provider` and `omx providers`.
- `src/cli/constants.ts`: new `PROVIDER_FLAG = "--provider"`.
- Tests for the new shorthand (known provider, `=` form, opaque passthrough, combination with `--xhigh`/`--model`, end-of-options preservation, missing value) and for the provider registry.

Because the shorthand normalizes into `-c model_provider=...`, it inherits through the existing team-worker path: `collectInheritableTeamWorkerArgs` already forwards `model_provider` overrides to workers, so `omx --provider orcarouter team ...` selects the same provider for worker panes.

## Validation

- `npm run lint` — pass
- `npm run build` — pass
- `npx tsc --noEmit` — pass
- `npm test` — exit 0 (the 9 pre-existing runner timeouts are tmux/MCP-server integration files that require tmux, which is not installed in this container; none touch the changed files)
- Targeted tests: `dist/config/__tests__/providers.test.js dist/cli/__tests__/index.test.js` — 350/350 pass
- Live check against the registered OrcaRouter endpoint with `ORCAROUTER_API_KEY`:
  - `GET https://api.orcarouter.ai/v1/models` → HTTP 200 (203 models)
  - `POST https://api.orcarouter.ai/v1/chat/completions` (`orcarouter/auto`) → HTTP 200

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated (CLI help text) when behavior changed
- [x] Backward-compatibility impact considered (unknown provider names remain opaque passthrough; `--provider` was already a value-taking flag in `omx ralph`)

## Related

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
