### PR TITLE
ci: publish npm releases via trusted publishing in CI (#3552)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main, dev, experimental/dev]
   pull_request:
     branches: [main, dev, experimental/dev]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Immutable release tag to publish via npm trusted publishing, e.g. v0.21.0'
+        required: false
+        type: string
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -792,3 +798,85 @@ jobs:
             exit 1
           fi
           echo "All required CI checks passed for active lanes"
+
+  publish-npm-trusted:
+    name: Publish npm (trusted publishing)
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Validate release tag shape
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::refusing to publish: release_tag must be an immutable semver tag like v0.21.0, got '$RELEASE_TAG'"
+            exit 1
+          fi
+      - name: Check out the exact release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_tag }}
+      - name: Verify tag resolves to the current default branch head
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$(git rev-parse "$RELEASE_TAG^{}")" != "$(git rev-parse refs/remotes/origin/main)" ]]; then
+            echo "::error::refusing to publish: $RELEASE_TAG does not resolve to the main branch head"
+            exit 1
+          fi
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+      - name: Verify npm supports tokenless trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm --version
+          node -e "
+            const [major, minor] = require('node:child_process')
+              .execSync('npm --version')
+              .toString()
+              .trim()
+              .split('.')
+              .map(Number);
+            if (major < 11 || (major === 11 && minor < 5)) {
+              console.error('npm >= 11.5.0 is required for tokenless trusted publishing');
+              process.exit(1);
+            }
+          "
+      - run: npm ci
+      - name: Verify tag/package version and registry absence
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          test "$RELEASE_TAG" = "v$VERSION"
+          if npm view "oh-my-codex@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::oh-my-codex@$VERSION already exists on npm; refusing blind retry"
+            exit 1
+          fi
+      - run: npm pack --dry-run
+      - name: Publish to npm via trusted publishing (OIDC, no token)
+        shell: bash
+        run: npm publish --access public --provenance
+      - name: Verify npm publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          for i in $(seq 1 20); do
+            if [ "$(npm view "oh-my-codex@$VERSION" version 2>/dev/null || true)" = "$VERSION" ]; then
+              npm view oh-my-codex version dist-tags --json
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "npm did not expose oh-my-codex@$VERSION in time" >&2
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,16 +899,22 @@ jobs:
             let code = '';
             try {
               const parsed = JSON.parse(text);
-              code = String(parsed?.error?.code ?? parsed?.code ?? '');
+              const extracted = parsed?.error?.code ?? parsed?.code ?? '';
+              if (String(extracted).trim() !== '') code = String(extracted).trim();
             } catch {
-              const match = text.match(/"code"\s*:\s*"([^"]+)"/);
+              const match = text.match(/"code"\s*:\s*"([A-Z][A-Z0-9_]+)"/);
               if (match) code = match[1];
             }
+            if (!code) {
+              const match = text.match(/(?:^|\n)npm error code ([A-Z][A-Z0-9_]+)\b/);
+              if (match) code = match[1];
+            }
+            if (code) {
+              return code === 'E404' ? 'absent' : 'error';
+            }
             if (
-              code === 'E404' ||
-              /\bE404\b/.test(text) ||
-              /404 Not Found/i.test(text) ||
-              /is not in this registry/i.test(text)
+              /(?:^|\n)npm error 404 Not Found(?:\s|-|$)/.test(text) ||
+              /(?:^|\n)npm error 404\s+'[^'\n]+' is not in this registry\./.test(text)
             ) {
               return 'absent';
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,35 +822,61 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_tag }}
-      - name: Verify tag resolves to the current default branch head
+          fetch-depth: 0
+      - name: Verify tag is an ancestor of origin/main
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "$(git rev-parse "$RELEASE_TAG^{}")" != "$(git rev-parse refs/remotes/origin/main)" ]]; then
-            echo "::error::refusing to publish: $RELEASE_TAG does not resolve to the main branch head"
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git rev-parse --verify refs/remotes/origin/main
+          TAG_COMMIT=$(git rev-parse "$RELEASE_TAG^{}")
+          MAIN_COMMIT=$(git rev-parse refs/remotes/origin/main)
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" "$MAIN_COMMIT"; then
+            echo "::error::refusing to publish: $RELEASE_TAG ($TAG_COMMIT) is not an ancestor of origin/main ($MAIN_COMMIT)"
             exit 1
           fi
       - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
-      - name: Verify npm supports tokenless trusted publishing
+      - name: Verify Node and npm support tokenless trusted publishing
         shell: bash
         run: |
           set -euo pipefail
+          node --version
           npm --version
-          node -e "
-            const [major, minor] = require('node:child_process')
-              .execSync('npm --version')
-              .toString()
-              .trim()
-              .split('.')
-              .map(Number);
-            if (major < 11 || (major === 11 && minor < 5)) {
-              console.error('npm >= 11.5.0 is required for tokenless trusted publishing');
-              process.exit(1);
-            }
-          "
+          node <<'NODE'
+          const { execSync } = require('node:child_process');
+
+          function nodeMeetsTrustedPublish(version) {
+            const [major, minor] = String(version).trim().replace(/^v/, '').split('.').map(Number);
+            if (![major, minor].every(Number.isFinite)) return false;
+            return major > 22 || (major === 22 && minor >= 14);
+          }
+
+          function npmMeetsTrustedPublish(version) {
+            const [major, minor, patch] = String(version).trim().replace(/^v/, '').split('.').map(Number);
+            if (![major, minor, patch].every(Number.isFinite)) return false;
+            return major > 11 || (major === 11 && minor > 5) || (major === 11 && minor === 5 && patch >= 1);
+          }
+
+          const nodeVersion = process.versions.node;
+          if (!nodeMeetsTrustedPublish(nodeVersion)) {
+            console.error(`Node >= 22.14.0 is required for tokenless trusted publishing, got ${nodeVersion}`);
+            process.exit(1);
+          }
+
+          let npmVersion = execSync('npm --version', { encoding: 'utf8' }).trim();
+          if (!npmMeetsTrustedPublish(npmVersion)) {
+            execSync('npm install -g npm@^11.5.1', { stdio: 'inherit' });
+            npmVersion = execSync('npm --version', { encoding: 'utf8' }).trim();
+          }
+          if (!npmMeetsTrustedPublish(npmVersion)) {
+            console.error(`npm >= 11.5.1 is required for tokenless trusted publishing, got ${npmVersion}`);
+            process.exit(1);
+          }
+          console.log(`trusted-publish toolchain: node ${nodeVersion}, npm ${npmVersion}`);
+          NODE
       - run: npm ci
       - name: Verify tag/package version and registry absence
         shell: bash
@@ -858,10 +884,49 @@ jobs:
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
           test "$RELEASE_TAG" = "v$VERSION"
-          if npm view "oh-my-codex@$VERSION" version >/dev/null 2>&1; then
-            echo "::error::oh-my-codex@$VERSION already exists on npm; refusing blind retry"
-            exit 1
-          fi
+          VIEW_FILE=$(mktemp)
+          trap 'rm -f "$VIEW_FILE"' EXIT
+          set +e
+          npm view "oh-my-codex@$VERSION" version --json >"$VIEW_FILE" 2>&1
+          VIEW_STATUS=$?
+          set -e
+          VIEW_STATUS="$VIEW_STATUS" VERSION="$VERSION" VIEW_FILE="$VIEW_FILE" node <<'NODE'
+          const fs = require('node:fs');
+
+          function classifyNpmViewResult(status, output) {
+            if (Number(status) === 0) return 'exists';
+            const text = String(output ?? '');
+            let code = '';
+            try {
+              const parsed = JSON.parse(text);
+              code = String(parsed?.error?.code ?? parsed?.code ?? '');
+            } catch {
+              const match = text.match(/"code"\s*:\s*"([^"]+)"/);
+              if (match) code = match[1];
+            }
+            if (
+              code === 'E404' ||
+              /\bE404\b/.test(text) ||
+              /404 Not Found/i.test(text) ||
+              /is not in this registry/i.test(text)
+            ) {
+              return 'absent';
+            }
+            return 'error';
+          }
+
+          const output = fs.readFileSync(process.env.VIEW_FILE, 'utf8');
+          const result = classifyNpmViewResult(process.env.VIEW_STATUS, output);
+          if (result === 'exists') {
+            console.error(`::error::oh-my-codex@${process.env.VERSION} already exists on npm; refusing blind retry`);
+            process.exit(1);
+          }
+          if (result === 'error') {
+            console.error('::error::npm view failed with a non-404 registry error; refusing to publish (fail closed)');
+            console.error(output);
+            process.exit(1);
+          }
+          NODE
       - run: npm pack --dry-run
       - name: Publish to npm via trusted publishing (OIDC, no token)
         shell: bash

--- a/src/verification/__tests__/ci-trusted-publish.test.ts
+++ b/src/verification/__tests__/ci-trusted-publish.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 function readCiWorkflow(): string {
   const workflowPath = join(process.cwd(), '.github', 'workflows', 'ci.yml');
@@ -18,6 +20,32 @@ function jobBlock(workflow: string, jobName: string): string {
   const nextJobOffset = workflow.slice(afterJobHeader).search(/\n  [a-z0-9-]+:\n/);
   const end = nextJobOffset === -1 ? workflow.length : afterJobHeader + nextJobOffset;
   return workflow.slice(start, end);
+}
+
+function extractNamedFunction(source: string, name: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, `missing function ${name}`);
+  const brace = source.indexOf('{', start);
+  assert.ok(brace >= 0, `missing body for ${name}`);
+  let depth = 0;
+  for (let i = brace; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  assert.fail(`unclosed function ${name}`);
+}
+
+function loadFunction<T>(source: string, name: string): T {
+  const fnSource = extractNamedFunction(source, name);
+  return new Function(`${fnSource}\nreturn ${name};`)() as T;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
 const PUBLISH_JOB = 'publish-npm-trusted';
@@ -76,22 +104,116 @@ describe('CI npm trusted publishing contract', () => {
 
     // Tag shape gate before any checkout.
     assert.match(publishJob, /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/);
-    // Checkout is pinned to the input tag, never the dispatch branch.
-    assert.match(publishJob, /uses: actions\/checkout@v7\n\s+with:\n\s+ref: \$\{\{ inputs\.release_tag \}\}/);
-    // Tag must resolve to the default branch head: no arbitrary commit publishing.
+    // Checkout is pinned to the input tag with full history so origin/main can be fetched.
+    assert.match(
+      publishJob,
+      /uses: actions\/checkout@v7\n\s+with:\n\s+ref: \$\{\{ inputs\.release_tag \}\}\n\s+fetch-depth: 0\n/,
+    );
+    assert.match(publishJob, /git fetch --no-tags origin \+refs\/heads\/main:refs\/remotes\/origin\/main/);
+    assert.match(publishJob, /git rev-parse --verify refs\/remotes\/origin\/main/);
     assert.match(publishJob, /git rev-parse "\$RELEASE_TAG\^\{\}"/);
-    assert.match(publishJob, /git rev-parse refs\/remotes\/origin\/main/);
+    assert.match(publishJob, /git merge-base --is-ancestor "\$TAG_COMMIT" "\$MAIN_COMMIT"/);
+    // Historical annotated tags on main must be publishable after main advances.
+    assert.doesNotMatch(publishJob, /does not resolve to the main branch head/);
+    assert.doesNotMatch(
+      publishJob,
+      /git rev-parse "\$RELEASE_TAG\^\{\}"\)" != "\$\(git rev-parse refs\/remotes\/origin\/main\)"/,
+    );
     // Package version must equal the tag.
     assert.match(publishJob, /test "\$RELEASE_TAG" = "v\$VERSION"/);
+  });
+
+  it('treats an immutable tag on historical main as an ancestor, not current-head equality', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'omx-trusted-publish-ancestry-'));
+    try {
+      git(cwd, ['init', '-b', 'main']);
+      git(cwd, ['config', 'user.email', 'trusted-publish@example.test']);
+      git(cwd, ['config', 'user.name', 'trusted-publish']);
+      writeFileSync(join(cwd, 'README'), 'first\n');
+      git(cwd, ['add', 'README']);
+      git(cwd, ['commit', '-m', 'first']);
+      const tagged = git(cwd, ['rev-parse', 'HEAD']);
+      git(cwd, ['tag', '-a', 'v0.21.0', '-m', 'v0.21.0']);
+      writeFileSync(join(cwd, 'README'), 'first\nsecond\n');
+      git(cwd, ['add', 'README']);
+      git(cwd, ['commit', '-m', 'second']);
+      const mainHead = git(cwd, ['rev-parse', 'HEAD']);
+      const peeledTag = git(cwd, ['rev-parse', 'v0.21.0^{}']);
+
+      assert.equal(peeledTag, tagged);
+      assert.notEqual(peeledTag, mainHead);
+      git(cwd, ['merge-base', '--is-ancestor', peeledTag, mainHead]);
+
+      git(cwd, ['checkout', '-q', '-b', 'unmerged']);
+      writeFileSync(join(cwd, 'README'), 'first\nsecond\nside\n');
+      git(cwd, ['add', 'README']);
+      git(cwd, ['commit', '-m', 'side']);
+      const side = git(cwd, ['rev-parse', 'HEAD']);
+      assert.throws(() => git(cwd, ['merge-base', '--is-ancestor', side, mainHead]));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('enforces npm >= 11.5.1 and Node >= 22.14.0, rejecting 11.5.0', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+    assert.match(publishJob, /node-version: 24/);
+    assert.match(publishJob, /npm install -g npm@\^11\.5\.1/);
+    assert.match(publishJob, /npm >= 11\.5\.1 is required for tokenless trusted publishing/);
+    assert.match(publishJob, /Node >= 22\.14\.0 is required for tokenless trusted publishing/);
+    assert.doesNotMatch(publishJob, /npm >= 11\.5\.0 is required/);
+
+    const nodeMeetsTrustedPublish = loadFunction<(version: string) => boolean>(
+      publishJob,
+      'nodeMeetsTrustedPublish',
+    );
+    const npmMeetsTrustedPublish = loadFunction<(version: string) => boolean>(
+      publishJob,
+      'npmMeetsTrustedPublish',
+    );
+
+    assert.equal(npmMeetsTrustedPublish('11.5.0'), false);
+    assert.equal(npmMeetsTrustedPublish('11.4.2'), false);
+    assert.equal(npmMeetsTrustedPublish('11.5.1'), true);
+    assert.equal(npmMeetsTrustedPublish('11.6.0'), true);
+    assert.equal(npmMeetsTrustedPublish('12.0.0'), true);
+    assert.equal(nodeMeetsTrustedPublish('20.19.0'), false);
+    assert.equal(nodeMeetsTrustedPublish('22.13.1'), false);
+    assert.equal(nodeMeetsTrustedPublish('22.14.0'), true);
+    assert.equal(nodeMeetsTrustedPublish('24.4.0'), true);
   });
 
   it('verifies the version is absent from the registry before publishing and refuses blind retries', () => {
     const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
 
-    assert.match(publishJob, /if npm view "oh-my-codex@\$VERSION" version >\/dev\/null 2>&1; then/);
+    assert.match(publishJob, /npm view "oh-my-codex@\$VERSION" version --json/);
     assert.match(publishJob, /already exists on npm; refusing blind retry/);
+    assert.match(publishJob, /npm view failed with a non-404 registry error; refusing to publish \(fail closed\)/);
+    assert.doesNotMatch(publishJob, /if npm view "oh-my-codex@\$VERSION" version >\/dev\/null 2>&1; then/);
     // Pack is a dry run only: no artifact publication outside npm publish.
     assert.match(publishJob, /run: npm pack --dry-run\n/);
+
+    const classifyNpmViewResult = loadFunction<(status: number | string, output: string) => string>(
+      publishJob,
+      'classifyNpmViewResult',
+    );
+
+    assert.equal(classifyNpmViewResult(0, '"0.21.0"'), 'exists');
+    assert.equal(
+      classifyNpmViewResult(1, JSON.stringify({ error: { code: 'E404', summary: 'Not Found' } })),
+      'absent',
+    );
+    assert.equal(
+      classifyNpmViewResult(
+        1,
+        "npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/oh-my-codex/0.21.0\nnpm error 404  'oh-my-codex@0.21.0' is not in this registry.\n",
+      ),
+      'absent',
+    );
+    assert.equal(classifyNpmViewResult(1, 'npm error code EAI_AGAIN\nnpm error request to https://registry.npmjs.org failed'), 'error');
+    assert.equal(classifyNpmViewResult(1, 'npm error code E401\nnpm error Unable to authenticate'), 'error');
+    assert.equal(classifyNpmViewResult(1, 'npm error code ETIMEDOUT'), 'error');
+    assert.equal(classifyNpmViewResult(2, 'ENOTFOUND registry.npmjs.org'), 'error');
   });
 
   it('verifies registry publication with bounded retries after publishing', () => {

--- a/src/verification/__tests__/ci-trusted-publish.test.ts
+++ b/src/verification/__tests__/ci-trusted-publish.test.ts
@@ -189,7 +189,9 @@ describe('CI npm trusted publishing contract', () => {
     assert.match(publishJob, /npm view "oh-my-codex@\$VERSION" version --json/);
     assert.match(publishJob, /already exists on npm; refusing blind retry/);
     assert.match(publishJob, /npm view failed with a non-404 registry error; refusing to publish \(fail closed\)/);
+    assert.match(publishJob, /if \(code\) \{\n\s+return code === 'E404' \? 'absent' : 'error';/);
     assert.doesNotMatch(publishJob, /if npm view "oh-my-codex@\$VERSION" version >\/dev\/null 2>&1; then/);
+    assert.doesNotMatch(publishJob, /code === 'E404' \|\|/);
     // Pack is a dry run only: no artifact publication outside npm publish.
     assert.match(publishJob, /run: npm pack --dry-run\n/);
 
@@ -210,10 +212,33 @@ describe('CI npm trusted publishing contract', () => {
       ),
       'absent',
     );
+    assert.equal(
+      classifyNpmViewResult(
+        1,
+        "npm error 404 Not Found - GET https://registry.npmjs.org/oh-my-codex/0.21.0\nnpm error 404  'oh-my-codex@0.21.0' is not in this registry.\n",
+      ),
+      'absent',
+    );
+    assert.equal(
+      classifyNpmViewResult(1, JSON.stringify({ error: { code: 'E401', summary: '404 Not Found' } })),
+      'error',
+    );
+    assert.equal(
+      classifyNpmViewResult(1, 'npm error code E401\nnpm error 404 Not Found - GET https://registry.npmjs.org/oh-my-codex/0.21.0'),
+      'error',
+    );
+    assert.equal(
+      classifyNpmViewResult(
+        1,
+        'npm error code E403\nnpm error 404  \'oh-my-codex@0.21.0\' is not in this registry.\n',
+      ),
+      'error',
+    );
     assert.equal(classifyNpmViewResult(1, 'npm error code EAI_AGAIN\nnpm error request to https://registry.npmjs.org failed'), 'error');
     assert.equal(classifyNpmViewResult(1, 'npm error code E401\nnpm error Unable to authenticate'), 'error');
     assert.equal(classifyNpmViewResult(1, 'npm error code ETIMEDOUT'), 'error');
     assert.equal(classifyNpmViewResult(2, 'ENOTFOUND registry.npmjs.org'), 'error');
+    assert.equal(classifyNpmViewResult(1, 'HTTP 404 Not Found from a proxy during E401'), 'error');
   });
 
   it('verifies registry publication with bounded retries after publishing', () => {

--- a/src/verification/__tests__/ci-trusted-publish.test.ts
+++ b/src/verification/__tests__/ci-trusted-publish.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function readCiWorkflow(): string {
+  const workflowPath = join(process.cwd(), '.github', 'workflows', 'ci.yml');
+  assert.equal(existsSync(workflowPath), true, `missing workflow: ${workflowPath}`);
+  return readFileSync(workflowPath, 'utf-8').replace(/\r\n/g, '\n');
+}
+
+function jobBlock(workflow: string, jobName: string): string {
+  const startMatch = workflow.match(new RegExp(`(^|\n)  ${jobName}:\n`));
+  assert.ok(startMatch?.index !== undefined, `missing CI job block for ${jobName}`);
+
+  const start = startMatch.index + startMatch[1].length;
+  const afterJobHeader = start + `  ${jobName}:\n`.length;
+  const nextJobOffset = workflow.slice(afterJobHeader).search(/\n  [a-z0-9-]+:\n/);
+  const end = nextJobOffset === -1 ? workflow.length : afterJobHeader + nextJobOffset;
+  return workflow.slice(start, end);
+}
+
+const PUBLISH_JOB = 'publish-npm-trusted';
+
+describe('CI npm trusted publishing contract', () => {
+
+  it('exposes a manual dispatch input for an immutable release tag only', () => {
+    const workflow = readCiWorkflow();
+
+    assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+release_tag:/);
+    // The dispatch input is optional so ordinary CI events never treat it as set.
+    assert.match(workflow, /release_tag:\n\s+description: 'Immutable release tag to publish via npm trusted publishing, e\.g\. v0\.21\.0'\n\s+required: false\n\s+type: string/);
+  });
+
+  it('runs the publish job only on an explicit dispatch from main with a tag input', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+
+    // Ordinary push and pull_request CI must never run the publish job.
+    assert.match(
+      publishJob,
+      /if: github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main' && inputs\.release_tag != ''/,
+    );
+    // The publish job must not be reachable through the shared lane outputs.
+    assert.doesNotMatch(publishJob, /needs\.changes/);
+    assert.doesNotMatch(publishJob, /needs:/);
+  });
+
+  it('grants only the OIDC and read permissions trusted publishing needs', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+
+    assert.match(publishJob, /permissions:\n\s+contents: read\n\s+id-token: write/);
+    // No write surface beyond the OIDC token: contents stays read-only.
+    assert.doesNotMatch(publishJob, /contents:\s*write/);
+    assert.doesNotMatch(publishJob, /packages:\s*write/);
+  });
+
+  it('publishes tokenlessly with provenance and no secret or OTP fallback', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+
+    assert.match(publishJob, /run: npm publish --access public --provenance\n/);
+
+    // No npm token, no OTP, no non-provenance retry path.
+    assert.doesNotMatch(publishJob, /NODE_AUTH_TOKEN/);
+    assert.doesNotMatch(publishJob, /NPM_TOKEN/);
+    assert.doesNotMatch(publishJob, /secrets\./);
+    assert.doesNotMatch(publishJob, /_authToken/);
+    assert.doesNotMatch(publishJob, /npm whoami/);
+    assert.doesNotMatch(publishJob, /--otp/i);
+    // The publish step must be the single tokenless attempt: no conditional retry.
+    const publishSteps = publishJob.match(/npm publish[^\n]*/g) ?? [];
+    assert.deepEqual(publishSteps, ['npm publish --access public --provenance']);
+  });
+
+  it('binds publication to the exact release tag and refuses mismatches', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+
+    // Tag shape gate before any checkout.
+    assert.match(publishJob, /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/);
+    // Checkout is pinned to the input tag, never the dispatch branch.
+    assert.match(publishJob, /uses: actions\/checkout@v7\n\s+with:\n\s+ref: \$\{\{ inputs\.release_tag \}\}/);
+    // Tag must resolve to the default branch head: no arbitrary commit publishing.
+    assert.match(publishJob, /git rev-parse "\$RELEASE_TAG\^\{\}"/);
+    assert.match(publishJob, /git rev-parse refs\/remotes\/origin\/main/);
+    // Package version must equal the tag.
+    assert.match(publishJob, /test "\$RELEASE_TAG" = "v\$VERSION"/);
+  });
+
+  it('verifies the version is absent from the registry before publishing and refuses blind retries', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+
+    assert.match(publishJob, /if npm view "oh-my-codex@\$VERSION" version >\/dev\/null 2>&1; then/);
+    assert.match(publishJob, /already exists on npm; refusing blind retry/);
+    // Pack is a dry run only: no artifact publication outside npm publish.
+    assert.match(publishJob, /run: npm pack --dry-run\n/);
+  });
+
+  it('verifies registry publication with bounded retries after publishing', () => {
+    const publishJob = jobBlock(readCiWorkflow(), PUBLISH_JOB);
+
+    assert.match(publishJob, /for i in \$\(seq 1 20\); do/);
+    assert.match(publishJob, /npm view "oh-my-codex@\$VERSION" version 2>\/dev\/null \|\| true/);
+    assert.match(publishJob, /npm view oh-my-codex version dist-tags --json/);
+    assert.match(publishJob, /sleep 15/);
+    assert.match(publishJob, /npm did not expose oh-my-codex@\$VERSION in time/);
+  });
+
+  it('keeps ordinary push and pull_request CI free of any publish surface', () => {
+    const workflow = readCiWorkflow();
+
+    // The workflow still triggers on the same ordinary CI events.
+    assert.match(workflow, /push:\n\s+branches: \[main, dev, experimental\/dev\]/);
+    assert.match(workflow, /pull_request:\n\s+branches: \[main, dev, experimental\/dev\]/);
+
+    // Only the dedicated publish job may run npm publish, and only via dispatch.
+    const publishMentions = workflow.match(/npm publish[^\n]*/g) ?? [];
+    assert.deepEqual(publishMentions, ['npm publish --access public --provenance']);
+
+    // No job outside the publish block may reference the dispatch input.
+    const withoutPublishJob = workflow.replace(jobBlock(workflow, PUBLISH_JOB), '');
+    assert.doesNotMatch(withoutPublishJob, /inputs\.release_tag/);
+    assert.doesNotMatch(withoutPublishJob, /npm publish/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a narrowly gated `publish-npm-trusted` job to `.github/workflows/ci.yml` so `oh-my-codex` npm releases publish through GitHub Actions **OIDC trusted publishing** (npm trusted publisher identity = `ci.yml` per owner configuration), replacing the superseded legacy `NPM_TOKEN` manual path that failed `EOTP`.
- The job runs **only** on an explicit `workflow_dispatch` from `main` with an immutable semver `release_tag` input; it checks out exactly that tag, requires the tag to resolve to the `main` branch head, requires `release_tag == v`+package.json version, confirms the version is absent from the registry (no blind retry), runs `npm ci` + `npm pack --dry-run`, then publishes `npm publish --access public --provenance` **tokenlessly** — no `NODE_AUTH_TOKEN`, no `NPM_TOKEN`, no OTP, no non-provenance fallback.
- Permissions are scoped to the minimum: `contents: read` + `id-token: write` on the job only.
- Registry publication is verified with bounded retries (20 × 15s) and dist-tags printed.
- Ordinary push/PR CI never reaches the publish job: every other job is untouched and no other job references `inputs.release_tag` or `npm publish`.
- New contract tests `src/verification/__tests__/ci-trusted-publish.test.ts` pin the OIDC/no-secret/tag-binding contract and prevent accidental publish on push/PR.

## Verification

- `node --test dist/verification/__tests__/ci-trusted-publish.test.js` — 8/8 pass
- `node --test dist/verification/__tests__/ci-rust-gates.test.js` — 18/18 pass (existing CI workflow contracts unaffected)
- `node --test dist/verification/__tests__/dev-merge-issue-close-workflow.test.js dist/verification/__tests__/explore-harness-release-workflow.test.js dist/verification/__tests__/pr-check-workflow.test.js` — 13/13 pass
- `npm run lint` clean, `npx tsc --noEmit` clean, `npm run check:no-unused` clean, `npm run build` clean
- Workflow YAML parses with the expected trigger set and job list

## Notes for reviewers

- After merge to `dev`, this needs promotion to `main` (the configured default branch where the trusted-publisher workflow identity must live) before dispatching for `v0.21.0`.
- No tag movement, no release/asset replacement, no secret usage.

Closes #3552

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*