### PR TITLE
fix: serialize trusted-publish by tag and bind SHA plus native ancestry (#3552)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,13 @@ on:
         description: 'Immutable release tag to publish via npm trusted publishing, e.g. v0.21.0'
         required: false
         type: string
+      release_sha:
+        description: 'Exact peeled commit SHA the immutable release_tag must resolve to'
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && format('ci-dispatch-{0}', github.run_id) || format('ci-{0}', github.ref) }}
+  group: ${{ github.event_name == 'workflow_dispatch' && format('ci-dispatch-{0}', github.event.inputs.release_tag || github.run_id) || format('ci-{0}', github.ref) }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
@@ -801,7 +805,7 @@ jobs:
 
   publish-npm-trusted:
     name: Publish npm (trusted publishing)
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.release_tag != ''
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.release_tag != '' && inputs.release_sha != ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -809,6 +813,7 @@ jobs:
       id-token: write
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
+      RELEASE_SHA: ${{ inputs.release_sha }}
     steps:
       - name: Validate release tag shape
         shell: bash
@@ -830,6 +835,15 @@ jobs:
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           git rev-parse --verify refs/remotes/origin/main
           TAG_COMMIT=$(git rev-parse "$RELEASE_TAG^{}")
+          EXPECTED_SHA=$(printf '%s' "$RELEASE_SHA" | tr 'A-F' 'a-f')
+          if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::refusing to publish: release_sha must be a 40-character commit SHA, got '$RELEASE_SHA'"
+            exit 1
+          fi
+          if [[ "$TAG_COMMIT" != "$EXPECTED_SHA" ]]; then
+            echo "::error::refusing to publish: $RELEASE_TAG peels to $TAG_COMMIT, not the bound release_sha $EXPECTED_SHA"
+            exit 1
+          fi
           MAIN_COMMIT=$(git rev-parse refs/remotes/origin/main)
           if ! git merge-base --is-ancestor "$TAG_COMMIT" "$MAIN_COMMIT"; then
             echo "::error::refusing to publish: $RELEASE_TAG ($TAG_COMMIT) is not an ancestor of origin/main ($MAIN_COMMIT)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,18 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      - name: Verify tag is an ancestor of origin/main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git rev-parse --verify refs/remotes/origin/main
+          TAG_COMMIT=$(git rev-parse HEAD^{})
+          MAIN_COMMIT=$(git rev-parse refs/remotes/origin/main)
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" "$MAIN_COMMIT"; then
+            echo "::error::refusing to release: ${GITHUB_REF_NAME:-tag} ($TAG_COMMIT) is not an ancestor of origin/main ($MAIN_COMMIT)"
+            exit 1
+          fi
       - uses: actions/setup-node@v7
         with:
           node-version: 20

--- a/src/verification/__tests__/ci-trusted-publish.test.ts
+++ b/src/verification/__tests__/ci-trusted-publish.test.ts
@@ -52,18 +52,19 @@ const PUBLISH_JOB = 'publish-npm-trusted';
 
 describe('CI npm trusted publishing contract', () => {
 
-  it('exposes a manual dispatch input for an immutable release tag only', () => {
+  it('exposes dispatch inputs for an immutable release tag and bound commit SHA', () => {
     const workflow = readCiWorkflow();
 
     assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+release_tag:/);
-    // The dispatch input is optional so ordinary CI events never treat it as set.
     assert.match(workflow, /release_tag:\n\s+description: 'Immutable release tag to publish via npm trusted publishing, e\.g\. v0\.21\.0'\n\s+required: false\n\s+type: string/);
+    assert.match(workflow, /release_sha:\n\s+description: 'Exact peeled commit SHA the immutable release_tag must resolve to'\n\s+required: false\n\s+type: string/);
   });
+
   it('does not cancel a trusted-publish dispatch when ordinary CI shares main', () => {
     const workflow = readCiWorkflow();
     assert.match(
       workflow,
-      /group: \$\{\{ github\.event_name == 'workflow_dispatch' && format\('ci-dispatch-\{0\}', github\.run_id\) \|\| format\('ci-\{0\}', github\.ref\) \}\}/,
+      /group: \$\{\{ github\.event_name == 'workflow_dispatch' && format\('ci-dispatch-\{0\}', github\.event\.inputs\.release_tag \|\| github\.run_id\) \|\| format\('ci-\{0\}', github\.ref\) \}\}/,
     );
     assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name != 'workflow_dispatch' \}\}/);
     assert.doesNotMatch(workflow, /^\s+cancel-in-progress:\s*true$/m);
@@ -75,7 +76,7 @@ describe('CI npm trusted publishing contract', () => {
     // Ordinary push and pull_request CI must never run the publish job.
     assert.match(
       publishJob,
-      /if: github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main' && inputs\.release_tag != ''/,
+      /if: github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main' && inputs\.release_tag != '' && inputs\.release_sha != ''/,
     );
     // The publish job must not be reachable through the shared lane outputs.
     assert.doesNotMatch(publishJob, /needs\.changes/);
@@ -121,6 +122,9 @@ describe('CI npm trusted publishing contract', () => {
     assert.match(publishJob, /git fetch --no-tags origin \+refs\/heads\/main:refs\/remotes\/origin\/main/);
     assert.match(publishJob, /git rev-parse --verify refs\/remotes\/origin\/main/);
     assert.match(publishJob, /git rev-parse "\$RELEASE_TAG\^\{\}"/);
+    assert.match(publishJob, /RELEASE_SHA: \$\{\{ inputs\.release_sha \}\}/);
+    assert.match(publishJob, /EXPECTED_SHA=\$\(printf '%s' "\$RELEASE_SHA" \| tr 'A-F' 'a-f'\)/);
+    assert.match(publishJob, /TAG_COMMIT" != "\$EXPECTED_SHA"/);
     assert.match(publishJob, /git merge-base --is-ancestor "\$TAG_COMMIT" "\$MAIN_COMMIT"/);
     // Historical annotated tags on main must be publishable after main advances.
     assert.doesNotMatch(publishJob, /does not resolve to the main branch head/);
@@ -271,9 +275,11 @@ describe('CI npm trusted publishing contract', () => {
     const publishMentions = workflow.match(/npm publish[^\n]*/g) ?? [];
     assert.deepEqual(publishMentions, ['npm publish --access public --provenance']);
 
-    // No job outside the publish block may reference the dispatch input.
+    // No job outside the publish block may reference dispatch inputs.
     const withoutPublishJob = workflow.replace(jobBlock(workflow, PUBLISH_JOB), '');
-    assert.doesNotMatch(withoutPublishJob, /inputs\.release_tag/);
+    const jobsOnly = withoutPublishJob.slice(withoutPublishJob.indexOf('\njobs:'));
+    assert.doesNotMatch(jobsOnly, /inputs\.release_tag/);
+    assert.doesNotMatch(jobsOnly, /inputs\.release_sha/);
     assert.doesNotMatch(withoutPublishJob, /npm publish/);
   });
 });

--- a/src/verification/__tests__/explore-harness-release-workflow.test.ts
+++ b/src/verification/__tests__/explore-harness-release-workflow.test.ts
@@ -84,6 +84,9 @@ describe('native release workflow', () => {
     assert.doesNotMatch(workflow, /--require-no-fallback/);
 
     assert.match(workflow, /verify-version-sync:[\s\S]*Verify version sync against workspace crates[\s\S]*node --input-type=module/);
+    assert.match(workflow, /Verify tag is an ancestor of origin\/main/);
+    assert.match(workflow, /git merge-base --is-ancestor "\$TAG_COMMIT" "\$MAIN_COMMIT"/);
+    assert.match(workflow, /git fetch --no-tags origin \+refs\/heads\/main:refs\/remotes\/origin\/main/);
     assert.match(workflow, /publish-native-assets:[\s\S]*npm run build[\s\S]*node dist\/scripts\/generate-native-release-manifest\.js/);
     assert.match(workflow, /publish-native-assets:[\s\S]*Generate release body[\s\S]*node dist\/scripts\/generate-release-body\.js --template RELEASE_BODY\.md --out RELEASE_BODY\.generated\.md/);
     assert.match(workflow, /body_path:\s*RELEASE_BODY\.generated\.md/);


### PR DESCRIPTION
## Summary

Fix-forward for current-head REQUEST_CHANGES on #3568 comment 5406117365 (`dev@6cfd4ba2`):

1. Dispatch concurrency is keyed by `release_tag` (non-canceling) so two same-tag publishes cannot both observe E404 and race `npm publish`.
2. Trusted publish requires `release_sha` and refuses unless the peeled tag equals that 40-character SHA (plus existing main ancestry).
3. Native `release.yml` verifies peeled HEAD is an ancestor of `origin/main` before version-sync/native publish.

Does not mutate #3568/`main`/tags/npm. After merge, #3568 head moves and must be re-reviewed. Does not close #3552.

## Verification

- ci-trusted-publish 11/11
- native release workflow 4/4
- lint / tsc --noEmit / check:no-unused / build clean

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*