### PR TITLE
fix(#3552): fail-closed plugin cache symlink provenance

### DIFF
--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -1,0 +1,328 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import {
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  PLUGIN_LAUNCHER_RECOVERY_HINT,
+  hasExpectedOmxPluginCache,
+  materializePackagedOmxPluginCache,
+  omxPluginCacheExecutedAssetProvenanceReason,
+  pluginHookCacheMatchesPackaged,
+  readOmxPluginCacheState,
+  resolvePackagedOmxMarketplace,
+} from "../plugin-marketplace.js";
+
+const packageRoot = process.cwd();
+
+async function withIsolatedUserHome<T>(
+  wd: string,
+  fn: (codexHomeDir: string) => Promise<T>,
+): Promise<T> {
+  const home = join(wd, "home");
+  await mkdir(home, { recursive: true });
+  const previousHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = home;
+  try {
+    return await fn(home);
+  } finally {
+    if (previousHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousHome;
+  }
+}
+
+async function packagedPluginVersion(): Promise<string> {
+  const manifest = JSON.parse(
+    await readFile(
+      join(packageRoot, "plugins", "oh-my-codex", ".codex-plugin", "plugin.json"),
+      "utf-8",
+    ),
+  ) as { version: string };
+  return manifest.version;
+}
+
+async function expectedPackagedSkillNames(): Promise<string[]> {
+  const entries = await readdir(
+    join(packageRoot, "plugins", "oh-my-codex", "skills"),
+    { withFileTypes: true },
+  );
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+}
+
+async function pinnedLauncherContent(): Promise<string> {
+  return `${JSON.stringify(
+    {
+      command: process.execPath,
+      argsPrefix: [join(packageRoot, "dist", "cli", "omx.js")],
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+/**
+ * Seeds a byte-identical regular cache snapshot for the current packageRoot,
+ * exactly like `stageCompletePluginSnapshot` + materialize would produce.
+ */
+async function seedRegularSnapshot(codexHomeDir: string): Promise<string> {
+  const version = await packagedPluginVersion();
+  const cacheDir = join(
+    codexHomeDir,
+    "plugins",
+    "cache",
+    "oh-my-codex-local",
+    "oh-my-codex",
+    version,
+  );
+  await mkdir(dirname(cacheDir), { recursive: true });
+  await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
+    recursive: true,
+  });
+  await writeFile(
+    join(cacheDir, "hooks", "omx-command.json"),
+    await pinnedLauncherContent(),
+  );
+  return cacheDir;
+}
+
+describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
+  it("control: regular immutable snapshot stays unchanged and hook-matching", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-control-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        assert.equal((await lstat(cacheDir)).isSymbolicLink(), false);
+        assert.equal(
+          await omxPluginCacheExecutedAssetProvenanceReason(cacheDir),
+          null,
+        );
+        assert.equal(await pluginHookCacheMatchesPackaged(cacheDir, packaged), true);
+        assert.equal(
+          await hasExpectedOmxPluginCache(codexHomeDir, packaged),
+          true,
+        );
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "unchanged");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("symlinked current-version cache root is rejected: no unchanged, no external mutation, stale-launcher with recovery hint", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-root-symlink-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const realCache = await seedRegularSnapshot(codexHomeDir);
+        // Attacker relocates the snapshot outside the managed namespace and
+        // replaces the <version> root with a symlink to it.
+        const externalTarget = join(wd, "external", "snapshot");
+        await mkdir(dirname(externalTarget), { recursive: true });
+        await rename(realCache, externalTarget);
+        await symlink(externalTarget, realCache);
+        assert.equal((await lstat(realCache)).isSymbolicLink(), true);
+
+        // Fast path must refuse the symlinked root instead of reading through it.
+        assert.equal(
+          await hasExpectedOmxPluginCache(codexHomeDir, packaged),
+          false,
+          "symlinked cache root must not satisfy hasExpectedOmxPluginCache",
+        );
+        assert.equal(
+          await readOmxPluginCacheState(realCache),
+          null,
+          "cache state must not be read through a symlinked root",
+        );
+        assert.equal(
+          await pluginHookCacheMatchesPackaged(realCache, packaged),
+          false,
+          "hook assets behind a symlinked root must not match",
+        );
+
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+        assert.match(r.reason!, /symlink or non-directory/);
+        assert.match(
+          r.reason!,
+          new RegExp(PLUGIN_LAUNCHER_RECOVERY_HINT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+        );
+
+        // Non-mutation proof: the external target stays exactly where the attacker
+        // put it (setup neither followed nor rewrote it), and the external copy is
+        // still attacker-writable — which is precisely why it can never be trusted.
+        const sentinel = await readFile(
+          join(externalTarget, "hooks", "hooks.json"),
+          "utf-8",
+        );
+        const packagedHook = await readFile(
+          join(packageRoot, "plugins", "oh-my-codex", "hooks", "hooks.json"),
+          "utf-8",
+        );
+        assert.equal(sentinel, packagedHook, "external target untouched by setup");
+        await writeFile(
+          join(externalTarget, "hooks", "hooks.json"),
+          "// attacker mutation\n",
+        );
+        const mutatedExternal = await readFile(
+          join(realCache, "hooks", "hooks.json"),
+          "utf-8",
+        );
+        assert.equal(
+          mutatedExternal,
+          "// attacker mutation\n",
+          "proof the pre-fix trust boundary would have followed the external target",
+        );
+        assert.equal(
+          await pluginHookCacheMatchesPackaged(realCache, packaged),
+          false,
+          "mutated external target must still never match after the mutation",
+        );
+        assert.equal(existsSync(realCache), true);
+        assert.equal((await lstat(realCache)).isSymbolicLink(), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  const assetCases = [
+    ["hooks.json", false],
+    ["codex-native-hook.mjs", false],
+    ["omx-command.json", true],
+  ] as const;
+
+  for (const [asset, isLauncher] of assetCases) {
+    it(`symlinked hooks/${asset} with byte-identical external content is rejected (unchanged fast path + materializer)`, async () => {
+      const wd = await mkdtemp(join(tmpdir(), `omx-3552-asset-${asset.replace(/[^a-z]/g, "")}-`));
+      try {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const cacheDir = await seedRegularSnapshot(codexHomeDir);
+          const assetPath = join(cacheDir, "hooks", asset);
+          const external = join(wd, "external", asset);
+          await mkdir(dirname(external), { recursive: true });
+          // Byte-identical content moved outside the managed namespace.
+          await rename(assetPath, external);
+          await symlink(external, assetPath);
+          assert.equal((await lstat(assetPath)).isSymbolicLink(), true);
+          assert.equal(
+            (await readFile(assetPath, "utf-8")) === (await readFile(external, "utf-8")),
+            true,
+            "external target is byte-identical (the pre-fix trust bypass condition)",
+          );
+
+          const reason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+          assert.ok(reason, `${asset} symlink must produce a provenance reason`);
+          assert.match(reason, new RegExp(asset.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+          assert.match(reason, /symlink or not a regular file/);
+          assert.equal(
+            await pluginHookCacheMatchesPackaged(cacheDir, packaged),
+            false,
+            `symlinked ${asset} must not satisfy hook cache matching`,
+          );
+          if (!isLauncher) {
+            // hooks.json / codex-native-hook.mjs mismatches flip hasExpectedOmxPluginCache
+            assert.equal(
+              await hasExpectedOmxPluginCache(codexHomeDir, packaged),
+              false,
+              `symlinked ${asset} must not satisfy hasExpectedOmxPluginCache`,
+            );
+          }
+          const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+          assert.match(r.reason!, /symlink or not a regular file/);
+          assert.match(
+            r.reason!,
+            new RegExp(PLUGIN_LAUNCHER_RECOVERY_HINT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+          );
+
+          // Non-mutation proof: the symlink and the external target both survive
+          // the materializer run untouched (#3499 immutability preserved), and a
+          // later external mutation never flips the verdict back to trusted.
+          assert.equal((await lstat(assetPath)).isSymbolicLink(), true);
+          await writeFile(external, "// attacker mutation\n");
+          const r2 = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r2.status, "stale-launcher", "mutated external target stays rejected");
+          assert.equal(
+            (await readFile(assetPath, "utf-8")),
+            "// attacker mutation\n",
+            "reads through the symlink follow the attacker target (why it is untrusted)",
+          );
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("symlinked hooks directory itself is rejected before any executed-asset read", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-hooks-dir-symlink-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const external = join(wd, "external", "hooks");
+        await mkdir(dirname(external), { recursive: true });
+        await rename(join(cacheDir, "hooks"), external);
+        await symlink(external, join(cacheDir, "hooks"));
+        assert.equal((await lstat(join(cacheDir, "hooks"))).isSymbolicLink(), true);
+
+        const reason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+        assert.ok(reason);
+        assert.match(reason, /symlink or not a directory/);
+        assert.equal(
+          await pluginHookCacheMatchesPackaged(cacheDir, packaged),
+          false,
+        );
+        assert.equal(
+          await hasExpectedOmxPluginCache(codexHomeDir, packaged),
+          false,
+        );
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+        assert.match(r.reason!, /symlink or not a (regular file|directory)/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("non-regular executed asset (FIFO replaced by directory) is rejected fail-closed", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-nonregular-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        await rm(join(cacheDir, "hooks", "hooks.json"), { force: true });
+        await mkdir(join(cacheDir, "hooks", "hooks.json"));
+        const reason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+        assert.ok(reason);
+        assert.match(reason, /symlink or not a regular file/);
+        assert.equal(await pluginHookCacheMatchesPackaged(cacheDir, packaged), false);
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -141,6 +141,44 @@ function isMissingPathError(error: unknown): boolean {
 }
 
 /**
+ * #3552: executed assets Codex loads from the plugin cache must be regular files inside a
+ * regular `hooks/` directory inside a regular snapshot root. `readFile`/content equality
+ * follow symlinks to their external targets before any provenance check, so a symlinked
+ * `<version>` cache root or a symlinked executed asset (hooks/hooks.json,
+ * hooks/codex-native-hook.mjs, hooks/omx-command.json) with byte-identical external
+ * content could satisfy the unchanged fast paths while the executed bytes stayed
+ * attacker-writable outside the managed namespace. Returns a human-readable reason when
+ * provenance is broken (missing/symlinked/non-regular root, hooks dir, or asset), or
+ * null when the snapshot's provenance is intact. Callers treat non-null as fail-closed.
+ */
+export async function omxPluginCacheExecutedAssetProvenanceReason(
+	cacheDir: string,
+): Promise<string | null> {
+	const expectations: Array<{ path: string; kind: "file" | "directory"; label: string }> = [
+		{ path: cacheDir, kind: "directory", label: "cache root" },
+		{ path: join(cacheDir, "hooks"), kind: "directory", label: "hooks directory" },
+		{ path: join(cacheDir, "hooks", "hooks.json"), kind: "file", label: "executed cache asset" },
+		{ path: join(cacheDir, "hooks", "codex-native-hook.mjs"), kind: "file", label: "executed cache asset" },
+		{ path: join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE), kind: "file", label: "executed cache asset" },
+	];
+	for (const { path, kind, label } of expectations) {
+		let stats;
+		try {
+			stats = await lstat(path);
+		} catch {
+			return `${label} is missing at ${path}`;
+		}
+		const shapeOk = kind === "directory"
+			? stats.isDirectory() && !stats.isSymbolicLink()
+			: stats.isFile() && !stats.isSymbolicLink();
+		if (!shapeOk) {
+			return `${label} at ${path} is a symlink or not a ${kind === "directory" ? "directory" : "regular file"}`;
+		}
+	}
+	return null;
+}
+
+/**
  * Only the namespace OMX owns below the Codex home is required to be free of symlinks; a symlinked
  * `plugins/` (or any component under the home) can redirect writes and is refused. Everything above
  * the home belongs to the platform or the user — macOS resolves TMPDIR through `/var -> /private/var`,
@@ -180,11 +218,11 @@ async function ensureManagedCacheNamespace(
 	}
 }
 
-async function inspectCacheRoot(cacheDir: string): Promise<"missing" | "directory" | "foreign"> {
+async function inspectCacheRoot(cacheDir: string): Promise<"missing" | "directory" | "foreign" | "untrusted"> {
 		try {
 			const stats = await lstat(cacheDir);
 			if (!stats.isDirectory() || stats.isSymbolicLink()) {
-				throw new Error(`Refusing to mutate non-directory OMX plugin cache root: ${cacheDir}`);
+				return "untrusted";
 			}
 			const manifest = await readPluginManifest(join(cacheDir, ".codex-plugin", "plugin.json"));
 			return manifest?.name === OMX_PLUGIN_NAME ? "directory" : "foreign";
@@ -277,6 +315,16 @@ export interface OmxPluginCacheState {
 export async function readOmxPluginCacheState(
 	cacheDir: string,
 ): Promise<OmxPluginCacheState | null> {
+	// #3552: never read cache state through a symlinked or non-directory snapshot root —
+	// readFile-based manifest reads would follow an external target before provenance checks.
+	// A missing pinned launcher is reported by the dedicated launcher checks, not here.
+	if (
+		(await omxPluginCacheExecutedAssetProvenanceReason(cacheDir))?.startsWith(
+			"cache root",
+		)
+	) {
+		return null;
+	}
 	const manifest = await readPluginManifest(
 		join(cacheDir, ".codex-plugin", "plugin.json"),
 	);
@@ -334,15 +382,24 @@ async function fileContentsEqual(leftPath: string, rightPath: string): Promise<b
 	}
 }
 
+
 /**
  * Compares only plugin-scoped hook assets that Codex executes from the cache.
  * Manifest pointers and skill lists are validated by callers before using this
  * as a hook/launcher freshness predicate.
+ *
+ * #3552: the comparison is fail-closed about provenance — every executed asset
+ * is lstat-validated as a regular file before it is read, so a symlinked asset
+ * with byte-identical external content can no longer satisfy the unchanged
+ * fast paths. `false` here means "do not trust this cache snapshot".
  */
 export async function pluginHookCacheMatchesPackaged(
 	cacheDir: string,
 	packagedMarketplace: PackagedOmxMarketplace,
 ): Promise<boolean> {
+	if ((await omxPluginCacheExecutedAssetProvenanceReason(cacheDir)) !== null) {
+		return false;
+	}
 	return await fileContentsEqual(
 		join(cacheDir, "hooks", "hooks.json"),
 		join(packagedMarketplace.pluginRoot, "hooks", "hooks.json"),
@@ -569,6 +626,16 @@ export async function materializePackagedOmxPluginCache(
 	// Same-version directory exists but is not byte-identical: distinguish immutable-preserved vs dead/provenance-incompatible launcher.
 	// Preserve #3499 immutability: never rewrite an existing same-version directory in place.
 	const rootState = await inspectCacheRoot(cacheDir);
+	if (rootState === "untrusted") {
+		return {
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: `OMX plugin cache root at ${cacheDir} is a symlink or non-directory entry; managed snapshots must be regular immutable directories; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
+			launcherTarget: undefined,
+			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+		};
+	}
 	if (rootState === "directory") {
 		const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packagedMarketplace);
 		if (incompat) {
@@ -578,6 +645,17 @@ export async function materializePackagedOmxPluginCache(
 				version,
 				reason: incompat.reason,
 				launcherTarget: incompat.target,
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+			};
+		}
+		const assetProvenanceReason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+		if (assetProvenanceReason) {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `${assetProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
+				launcherTarget: undefined,
 				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
 			};
 		}


### PR DESCRIPTION
Closes #3552

- Reject symlinked/non-regular current-version cache roots with lstat.
- Reject symlinked/non-regular hooks.json, codex-native-hook.mjs, and omx-command.json before unchanged acceptance.
- Preserve regular snapshot compatibility and external sentinel immutability.

Tests: focused #3552 regression, plugin launcher provenance, setup hook ownership, doctor warning copy, lint, tsc --noEmit, check:no-unused, build.