### PR TITLE
fix(#3552): close manifest and skills cache trust gaps

### DIFF
--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -325,4 +325,110 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("manifest pointer drift is rejected before an existing snapshot can return unchanged", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-manifest-drift-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const manifestPath = join(cacheDir, ".codex-plugin", "plugin.json");
+        const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as Record<string, unknown>;
+        await writeFile(
+          manifestPath,
+          JSON.stringify({ ...manifest, skills: "./attacker-skills/", hooks: "./attacker-hooks/hooks.json" }),
+        );
+
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+        assert.match(r.reason!, /manifest (skills|hooks) pointer/);
+        assert.match(r.reason!, new RegExp(PLUGIN_LAUNCHER_RECOVERY_HINT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        assert.match(await readFile(manifestPath, "utf-8"), /attacker-skills/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("symlinked manifest is rejected even when its external content is canonical", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-manifest-symlink-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const manifestPath = join(cacheDir, ".codex-plugin", "plugin.json");
+        const externalManifest = join(wd, "external", "plugin.json");
+        await mkdir(dirname(externalManifest), { recursive: true });
+        await rename(manifestPath, externalManifest);
+        await symlink(externalManifest, manifestPath);
+
+        assert.equal((await lstat(manifestPath)).isSymbolicLink(), true);
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+        assert.match(r.reason!, /plugin manifest .*symlink/);
+        assert.equal((await lstat(manifestPath)).isSymbolicLink(), true);
+        assert.equal(await readFile(externalManifest, "utf-8"), await readFile(join(packaged.pluginRoot, ".codex-plugin", "plugin.json"), "utf-8"));
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("skills directory symlink with matching names and attacker content is rejected and preserved", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-skills-symlink-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const skillsPath = join(cacheDir, "skills");
+        const externalSkills = join(wd, "external", "skills");
+        await mkdir(dirname(externalSkills), { recursive: true });
+        await rename(skillsPath, externalSkills);
+        await writeFile(join(externalSkills, "worker", "SKILL.md"), "# attacker-controlled skill\n");
+        await symlink(externalSkills, skillsPath);
+
+        assert.equal((await lstat(skillsPath)).isSymbolicLink(), true);
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+        assert.match(r.reason!, /skills directory .*symlink/);
+        assert.equal((await lstat(skillsPath)).isSymbolicLink(), true);
+        assert.equal(await readFile(join(externalSkills, "worker", "SKILL.md"), "utf-8"), "# attacker-controlled skill\n");
+
+        await writeFile(join(externalSkills, "worker", "SKILL.md"), "# attacker mutation\n");
+        const r2 = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r2.status, "stale-launcher", JSON.stringify(r2));
+        assert.equal(await readFile(join(skillsPath, "worker", "SKILL.md"), "utf-8"), "# attacker mutation\n");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("regular attacker-mutated SKILL.md content is rejected before unchanged acceptance", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-skill-content-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const skillPath = join(cacheDir, "skills", "worker", "SKILL.md");
+        const sentinel = "# attacker-mutated regular skill\n";
+        await writeFile(skillPath, sentinel);
+
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+        assert.match(r.reason!, /expected skill file content differs/);
+        assert.equal(await readFile(skillPath, "utf-8"), sentinel);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -106,6 +106,21 @@ async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
 	}
 }
 
+async function listRegularChildDirectoryNames(dir: string): Promise<string[] | null> {
+	try {
+		const stats = await lstat(dir);
+		if (!stats.isDirectory() || stats.isSymbolicLink()) return null;
+		const entries = await readdir(dir, { withFileTypes: true });
+		if (entries.some((entry) => entry.isSymbolicLink())) return null;
+		return entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+			.sort();
+	} catch {
+		return null;
+	}
+}
+
 export async function packagedOmxPluginVersion(
 	packagedMarketplace: PackagedOmxMarketplace,
 ): Promise<string | null> {
@@ -173,6 +188,91 @@ export async function omxPluginCacheExecutedAssetProvenanceReason(
 			: stats.isFile() && !stats.isSymbolicLink();
 		if (!shapeOk) {
 			return `${label} at ${path} is a symlink or not a ${kind === "directory" ? "directory" : "regular file"}`;
+		}
+	}
+	return null;
+}
+
+async function omxPluginCacheManifestProvenanceReason(
+	cacheDir: string,
+	expectedVersion?: string,
+): Promise<string | null> {
+	const manifestDir = join(cacheDir, ".codex-plugin");
+	const manifestPath = join(manifestDir, "plugin.json");
+	let manifestDirStats;
+	try {
+		manifestDirStats = await lstat(manifestDir);
+	} catch {
+		return `plugin manifest directory is missing at ${manifestDir}`;
+	}
+	if (!manifestDirStats.isDirectory() || manifestDirStats.isSymbolicLink()) {
+		return `plugin manifest directory at ${manifestDir} is a symlink or not a directory`;
+	}
+	let manifestStats;
+	try {
+		manifestStats = await lstat(manifestPath);
+	} catch {
+		return `plugin manifest is missing at ${manifestPath}`;
+	}
+	if (!manifestStats.isFile() || manifestStats.isSymbolicLink()) {
+		return `plugin manifest at ${manifestPath} is a symlink or not a regular file`;
+	}
+	const manifest = await readPluginManifest(manifestPath);
+	if (!manifest) return `plugin manifest at ${manifestPath} is unreadable or invalid JSON`;
+	if (manifest.name !== OMX_PLUGIN_NAME) {
+		return `plugin manifest name is not ${OMX_PLUGIN_NAME} at ${manifestPath}`;
+	}
+	if (typeof manifest.version !== "string" || (expectedVersion !== undefined && manifest.version !== expectedVersion)) {
+		return `plugin manifest version is not ${expectedVersion ?? "a valid string"} at ${manifestPath}`;
+	}
+	if (manifest.skills !== "./skills/") {
+		return `plugin manifest skills pointer is not ./skills/ at ${manifestPath}`;
+	}
+	if (manifest.hooks !== "./hooks/hooks.json") {
+		return `plugin manifest hooks pointer is not ./hooks/hooks.json at ${manifestPath}`;
+	}
+	return null;
+}
+
+async function omxPluginCacheSkillsProvenanceReason(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+	expectedSkillNames: string[],
+): Promise<string | null> {
+	const skillsDir = join(cacheDir, "skills");
+	let skillsStats;
+	try {
+		skillsStats = await lstat(skillsDir);
+	} catch {
+		return `skills directory is missing at ${skillsDir}`;
+	}
+	if (!skillsStats.isDirectory() || skillsStats.isSymbolicLink()) {
+		return `skills directory at ${skillsDir} is a symlink or not a directory`;
+	}
+	for (const skillName of expectedSkillNames) {
+		const skillDir = join(skillsDir, skillName);
+		let skillDirStats;
+		try {
+			skillDirStats = await lstat(skillDir);
+		} catch {
+			return `expected skill directory is missing at ${skillDir}`;
+		}
+		if (!skillDirStats.isDirectory() || skillDirStats.isSymbolicLink()) {
+			return `expected skill directory at ${skillDir} is a symlink or not a directory`;
+		}
+		const cachedSkill = join(skillDir, "SKILL.md");
+		const packagedSkill = join(packagedMarketplace.pluginRoot, "skills", skillName, "SKILL.md");
+		let cachedSkillStats;
+		try {
+			cachedSkillStats = await lstat(cachedSkill);
+		} catch {
+			return `expected skill file is missing at ${cachedSkill}`;
+		}
+		if (!cachedSkillStats.isFile() || cachedSkillStats.isSymbolicLink()) {
+			return `expected skill file at ${cachedSkill} is a symlink or not a regular file`;
+		}
+		if (!(await fileContentsEqual(cachedSkill, packagedSkill))) {
+			return `expected skill file content differs at ${cachedSkill}`;
 		}
 	}
 	return null;
@@ -314,6 +414,7 @@ export interface OmxPluginCacheState {
 
 export async function readOmxPluginCacheState(
 	cacheDir: string,
+	expectedVersion?: string,
 ): Promise<OmxPluginCacheState | null> {
 	// #3552: never read cache state through a symlinked or non-directory snapshot root —
 	// readFile-based manifest reads would follow an external target before provenance checks.
@@ -325,6 +426,9 @@ export async function readOmxPluginCacheState(
 	) {
 		return null;
 	}
+	if ((await omxPluginCacheManifestProvenanceReason(cacheDir, expectedVersion)) !== null) {
+		return null;
+	}
 	const manifest = await readPluginManifest(
 		join(cacheDir, ".codex-plugin", "plugin.json"),
 	);
@@ -334,7 +438,7 @@ export async function readOmxPluginCacheState(
 		manifestVersion:
 			typeof manifest.version === "string" ? manifest.version : null,
 		skillsPointer: typeof manifest.skills === "string" ? manifest.skills : null,
-		skillNames: await listChildDirectoryNames(join(cacheDir, "skills")),
+		skillNames: await listRegularChildDirectoryNames(join(cacheDir, "skills")),
 		hooksPointer: typeof manifest.hooks === "string" ? manifest.hooks : null,
 		hookLauncherPinned: existsSync(
 			join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
@@ -354,6 +458,7 @@ export async function hasExpectedOmxPluginCache(
 	if (!version || !expectedSkillNames) return false;
 	const state = await readOmxPluginCacheState(
 		join(omxPluginCacheBase(codexHomeDir), version),
+		version,
 	);
 	if (
 		state?.manifestVersion !== version ||
@@ -364,6 +469,9 @@ export async function hasExpectedOmxPluginCache(
 		!existsSync(join(state.cacheDir, "hooks", "codex-native-hook.mjs")) ||
 		JSON.stringify(state.skillNames) !== JSON.stringify(expectedSkillNames)
 	) {
+		return false;
+	}
+	if (await omxPluginCacheSkillsProvenanceReason(state.cacheDir, packagedMarketplace, expectedSkillNames)) {
 		return false;
 	}
 
@@ -637,6 +745,22 @@ export async function materializePackagedOmxPluginCache(
 		};
 	}
 	if (rootState === "directory") {
+		const manifestProvenanceReason = await omxPluginCacheManifestProvenanceReason(cacheDir, version);
+		const expectedSkillNames = await expectedPackagedOmxSkillNames(packagedMarketplace, options);
+		const skillsProvenanceReason = expectedSkillNames
+			? await omxPluginCacheSkillsProvenanceReason(cacheDir, packagedMarketplace, expectedSkillNames)
+			: "packaged skill names are unavailable";
+		const snapshotProvenanceReason = manifestProvenanceReason ?? skillsProvenanceReason;
+		if (snapshotProvenanceReason) {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `${snapshotProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
+				launcherTarget: undefined,
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+			};
+		}
 		const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packagedMarketplace);
 		if (incompat) {
 			return {


### PR DESCRIPTION
Closes #3552

Fixes the fresh exact-head #3568 P1 findings on dev@a24b5ca4:

- Validate regular non-symlink `.codex-plugin/plugin.json` and exact canonical name/version/skills/hooks fields on existing-snapshot and unchanged paths.
- Validate regular non-symlink skills directories and expected `SKILL.md` files against packaged content.
- Reject same-name external skills trees and preserve attacker-controlled external sentinels without trusting them.
- Preserve regular immutable snapshot and setup/doctor behavior.

Verification: focused #3552 regression (10/10), plugin launcher provenance, setup hook ownership, doctor warning copy (86/86), lint, tsc --noEmit, check:no-unused, build.