### PR TITLE
fix(#3552): close companion metadata trust gaps

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -696,6 +696,83 @@ command = "node"
 		}
 	});
 
+	it("warns when a regular cached SKILL.md is mutated", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-cache-skill-drift-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "user", "--plugin", "--force"],
+				{ HOME: home, CODEX_HOME: codexDir },
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+			const version = await packagedPluginVersion();
+			const skillPath = join(
+				codexDir,
+				"plugins",
+				"cache",
+				"oh-my-codex-local",
+				"oh-my-codex",
+				version,
+				"skills",
+				"worker",
+				"SKILL.md",
+			);
+			await writeFile(skillPath, "# attacker-mutated skill\n");
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: expected skill file content differs/);
+			assert.match(res.stdout, /Plugin versions: expected cache directory .* has invalid plugin cache provenance: expected skill file content differs/);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("warns with pointer-specific diagnostics when the cached manifest drifts", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-cache-pointer-drift-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(codexDir, { recursive: true });
+			const setupRes = runOmx(
+				wd,
+				["setup", "--scope", "user", "--plugin", "--force"],
+				{ HOME: home, CODEX_HOME: codexDir },
+			);
+			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
+			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+			const version = await packagedPluginVersion();
+			const manifestPath = join(
+				codexDir,
+				"plugins",
+				"cache",
+				"oh-my-codex-local",
+				"oh-my-codex",
+				version,
+				".codex-plugin",
+				"plugin.json",
+			);
+			const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as Record<string, unknown>;
+			manifest.skills = "./attacker-skills/";
+			await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: plugin manifest skills pointer is not \.\/skills\//);
+			assert.match(res.stdout, /Plugin versions: expected cache directory .* has invalid plugin cache provenance: plugin manifest skills pointer is not \.\/skills\//);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("warns when plugin mode is configured but the Codex plugin cache is missing", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-cache-missing-"));
 		try {

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -431,4 +431,79 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  const companionCases = [".mcp.json", ".app.json"] as const;
+  for (const companion of companionCases) {
+    it(`${companion} content drift is rejected before unchanged acceptance`, async () => {
+      const wd = await mkdtemp(join(tmpdir(), `omx-3552-${companion.slice(1)}-drift-`));
+      try {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const cacheDir = await seedRegularSnapshot(codexHomeDir);
+          const cachedPath = join(cacheDir, companion);
+          const sentinel = `{"attacker":"${companion}"}\n`;
+          await writeFile(cachedPath, sentinel);
+
+          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+          const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+          assert.match(r.reason!, /companion file content differs/);
+          assert.equal(await readFile(cachedPath, "utf-8"), sentinel);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+
+    it(`${companion} symlink with canonical external content is rejected and preserved`, async () => {
+      const wd = await mkdtemp(join(tmpdir(), `omx-3552-${companion.slice(1)}-symlink-`));
+      try {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const cacheDir = await seedRegularSnapshot(codexHomeDir);
+          const cachedPath = join(cacheDir, companion);
+          const externalPath = join(wd, "external", companion);
+          await mkdir(dirname(externalPath), { recursive: true });
+          await rename(cachedPath, externalPath);
+          await symlink(externalPath, cachedPath);
+
+          assert.equal((await lstat(cachedPath)).isSymbolicLink(), true);
+          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+          const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+          assert.match(r.reason!, /companion file .*symlink/);
+          assert.equal((await lstat(cachedPath)).isSymbolicLink(), true);
+          await writeFile(externalPath, "{\"attacker\":true}\n");
+          const r2 = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r2.status, "stale-launcher", JSON.stringify(r2));
+          assert.equal(await readFile(cachedPath, "utf-8"), "{\"attacker\":true}\n");
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+
+    it(`${companion} non-regular entry is rejected fail-closed`, async () => {
+      const wd = await mkdtemp(join(tmpdir(), `omx-3552-${companion.slice(1)}-nonregular-`));
+      try {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const cacheDir = await seedRegularSnapshot(codexHomeDir);
+          const cachedPath = join(cacheDir, companion);
+          await rm(cachedPath, { force: true });
+          await mkdir(cachedPath);
+
+          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+          const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(r.status, "stale-launcher", JSON.stringify(r));
+          assert.match(r.reason!, /companion file .*not a regular file/);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  }
 });

--- a/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
+++ b/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
@@ -522,6 +522,14 @@ describe("issue 3558 launcher provenance", () => {
             join(cacheDir, "skills"),
             { recursive: true },
           );
+          await cp(
+            join(packageRoot, "plugins", "oh-my-codex", ".mcp.json"),
+            join(cacheDir, ".mcp.json"),
+          );
+          await cp(
+            join(packageRoot, "plugins", "oh-my-codex", ".app.json"),
+            join(cacheDir, ".app.json"),
+          );
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             "{ malformed",

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -90,6 +90,7 @@ import {
 	expectedPackagedOmxSkillNames,
 	getPinnedLauncherIncompatibilityReason,
 	packagedOmxPluginVersion,
+	omxPluginCacheProvenanceReason,
 	pluginHookCacheMatchesPackaged,
 	readOmxPluginCacheState,
 	resolvePackagedOmxMarketplace,
@@ -3410,6 +3411,29 @@ async function checkPluginMarketplaceRegistration(
 		const cacheStates = (
 			await Promise.all(cacheDirs.map((dir) => readOmxPluginCacheState(dir)))
 		).filter((state) => state !== null);
+		const expectedCacheDir = join(
+			codexHomeDir,
+			"plugins",
+			"cache",
+			OMX_LOCAL_MARKETPLACE_NAME,
+			"oh-my-codex",
+			packagedManifestVersion,
+		);
+		const currentCacheState = cacheStates.find((state) => state.cacheDir === expectedCacheDir);
+		if (currentCacheState?.manifestVersion === packagedManifestVersion) {
+			const provenanceReason = await omxPluginCacheProvenanceReason(
+				expectedCacheDir,
+				packagedMarketplace,
+				packagedManifestVersion,
+			);
+			if (provenanceReason) {
+				return {
+					name: "Skills",
+					status: "warn",
+					message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} cache provenance is invalid: ${provenanceReason}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
+				};
+			}
+		}
 		const packagedManifestSummary = {
 			manifestVersion: packagedManifestVersion,
 			skillNames: expectedSkillNames,
@@ -3517,6 +3541,18 @@ async function checkPluginVersionDiagnostics(
 			name: "Plugin versions",
 			status: "warn",
 			message: `expected cache directory ${cacheDir} is not materialized with packaged plugin manifest version ${manifestVersion}; run "omx setup --plugin --force" to refresh the plugin cache`,
+		};
+	}
+	const provenanceReason = await omxPluginCacheProvenanceReason(
+		cacheDir,
+		packagedMarketplace,
+		manifestVersion,
+	);
+	if (provenanceReason) {
+		return {
+			name: "Plugin versions",
+			status: "warn",
+			message: `expected cache directory ${cacheDir} has invalid plugin cache provenance: ${provenanceReason}; run "omx setup --plugin --force" to refresh the plugin cache`,
 		};
 	}
 

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -29,6 +29,8 @@ interface PluginManifest {
 	version?: unknown;
 	skills?: unknown;
 	hooks?: unknown;
+	mcpServers?: unknown;
+	apps?: unknown;
 }
 
 const OMX_PLUGIN_HOOK_LAUNCHER_FILE = "omx-command.json";
@@ -116,6 +118,22 @@ async function listRegularChildDirectoryNames(dir: string): Promise<string[] | n
 			.filter((entry) => entry.isDirectory())
 			.map((entry) => entry.name)
 			.sort();
+	} catch {
+		return null;
+	}
+}
+
+async function readRegularOmxPluginCacheManifest(
+	cacheDir: string,
+): Promise<PluginManifest | null> {
+	const manifestDir = join(cacheDir, ".codex-plugin");
+	const manifestPath = join(manifestDir, "plugin.json");
+	try {
+		const manifestDirStats = await lstat(manifestDir);
+		if (!manifestDirStats.isDirectory() || manifestDirStats.isSymbolicLink()) return null;
+		const manifestStats = await lstat(manifestPath);
+		if (!manifestStats.isFile() || manifestStats.isSymbolicLink()) return null;
+		return await readPluginManifest(manifestPath);
 	} catch {
 		return null;
 	}
@@ -231,6 +249,12 @@ async function omxPluginCacheManifestProvenanceReason(
 	if (manifest.hooks !== "./hooks/hooks.json") {
 		return `plugin manifest hooks pointer is not ./hooks/hooks.json at ${manifestPath}`;
 	}
+	if (manifest.mcpServers !== "./.mcp.json") {
+		return `plugin manifest mcpServers pointer is not ./.mcp.json at ${manifestPath}`;
+	}
+	if (manifest.apps !== "./.app.json") {
+		return `plugin manifest apps pointer is not ./.app.json at ${manifestPath}`;
+	}
 	return null;
 }
 
@@ -276,6 +300,45 @@ async function omxPluginCacheSkillsProvenanceReason(
 		}
 	}
 	return null;
+}
+
+async function omxPluginCacheCompanionMetadataProvenanceReason(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+): Promise<string | null> {
+	for (const [name, relativePath] of [["mcpServers", ".mcp.json"], ["apps", ".app.json"]] as const) {
+		const cachedPath = join(cacheDir, relativePath);
+		let stats;
+		try {
+			stats = await lstat(cachedPath);
+		} catch {
+			return `plugin manifest ${name} companion file is missing at ${cachedPath}`;
+		}
+		if (!stats.isFile() || stats.isSymbolicLink()) {
+			return `plugin manifest ${name} companion file at ${cachedPath} is a symlink or not a regular file`;
+		}
+		if (!(await fileContentsEqual(cachedPath, join(packagedMarketplace.pluginRoot, relativePath)))) {
+			return `plugin manifest ${name} companion file content differs at ${cachedPath}`;
+		}
+	}
+	return null;
+}
+
+export async function omxPluginCacheProvenanceReason(
+	cacheDir: string,
+	packagedMarketplace: PackagedOmxMarketplace,
+	expectedVersion?: string,
+	options: { teamMode?: SetupTeamMode } = {},
+): Promise<string | null> {
+	const manifestReason = await omxPluginCacheManifestProvenanceReason(cacheDir, expectedVersion);
+	if (manifestReason) return manifestReason;
+	const companionReason = await omxPluginCacheCompanionMetadataProvenanceReason(cacheDir, packagedMarketplace);
+	if (companionReason) return companionReason;
+	const expectedSkillNames = await expectedPackagedOmxSkillNames(packagedMarketplace, options);
+	if (!expectedSkillNames) return "packaged skill names are unavailable";
+	const skillsReason = await omxPluginCacheSkillsProvenanceReason(cacheDir, packagedMarketplace, expectedSkillNames);
+	if (skillsReason) return skillsReason;
+	return omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
 }
 
 /**
@@ -409,6 +472,8 @@ export interface OmxPluginCacheState {
 	skillsPointer: string | null;
 	skillNames: string[] | null;
 	hooksPointer: string | null;
+	mcpServersPointer: string | null;
+	appsPointer: string | null;
 	hookLauncherPinned: boolean;
 }
 
@@ -426,13 +491,9 @@ export async function readOmxPluginCacheState(
 	) {
 		return null;
 	}
-	if ((await omxPluginCacheManifestProvenanceReason(cacheDir, expectedVersion)) !== null) {
-		return null;
-	}
-	const manifest = await readPluginManifest(
-		join(cacheDir, ".codex-plugin", "plugin.json"),
-	);
+	const manifest = await readRegularOmxPluginCacheManifest(cacheDir);
 	if (manifest?.name !== OMX_PLUGIN_NAME) return null;
+	if (expectedVersion !== undefined && manifest.version !== expectedVersion) return null;
 	return {
 		cacheDir,
 		manifestVersion:
@@ -440,6 +501,8 @@ export async function readOmxPluginCacheState(
 		skillsPointer: typeof manifest.skills === "string" ? manifest.skills : null,
 		skillNames: await listRegularChildDirectoryNames(join(cacheDir, "skills")),
 		hooksPointer: typeof manifest.hooks === "string" ? manifest.hooks : null,
+		mcpServersPointer: typeof manifest.mcpServers === "string" ? manifest.mcpServers : null,
+		appsPointer: typeof manifest.apps === "string" ? manifest.apps : null,
 		hookLauncherPinned: existsSync(
 			join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
 		),
@@ -471,7 +534,7 @@ export async function hasExpectedOmxPluginCache(
 	) {
 		return false;
 	}
-	if (await omxPluginCacheSkillsProvenanceReason(state.cacheDir, packagedMarketplace, expectedSkillNames)) {
+	if (await omxPluginCacheProvenanceReason(state.cacheDir, packagedMarketplace, version, options)) {
 		return false;
 	}
 
@@ -745,22 +808,6 @@ export async function materializePackagedOmxPluginCache(
 		};
 	}
 	if (rootState === "directory") {
-		const manifestProvenanceReason = await omxPluginCacheManifestProvenanceReason(cacheDir, version);
-		const expectedSkillNames = await expectedPackagedOmxSkillNames(packagedMarketplace, options);
-		const skillsProvenanceReason = expectedSkillNames
-			? await omxPluginCacheSkillsProvenanceReason(cacheDir, packagedMarketplace, expectedSkillNames)
-			: "packaged skill names are unavailable";
-		const snapshotProvenanceReason = manifestProvenanceReason ?? skillsProvenanceReason;
-		if (snapshotProvenanceReason) {
-			return {
-				status: "stale-launcher",
-				cacheDir,
-				version,
-				reason: `${snapshotProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
-				launcherTarget: undefined,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
-			};
-		}
 		const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packagedMarketplace);
 		if (incompat) {
 			return {
@@ -769,6 +816,22 @@ export async function materializePackagedOmxPluginCache(
 				version,
 				reason: incompat.reason,
 				launcherTarget: incompat.target,
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+			};
+		}
+		const snapshotProvenanceReason = await omxPluginCacheProvenanceReason(
+			cacheDir,
+			packagedMarketplace,
+			version,
+			options,
+		);
+		if (snapshotProvenanceReason) {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `${snapshotProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
+				launcherTarget: undefined,
 				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
 			};
 		}


### PR DESCRIPTION
Closes #3552

Fixes the fresh exact-head #3568 findings after #3574:

- Enforce canonical `mcpServers: ./.mcp.json` and `apps: ./.app.json` manifest pointers.
- Require regular non-symlink `.mcp.json` and `.app.json` files with packaged byte equality on unchanged and fallback paths.
- Make doctor consume the same complete cache provenance predicate while preserving pointer-specific diagnostics.
- Add mutation, symlink, non-regular, sentinel, and doctor regressions.

Verification: focused #3552 suite, plugin provenance/setup/doctor suites, lint, tsc --noEmit, check:no-unused, and build.