### PR TITLE
fix(#3552): close doctor remediation and TOCTOU gaps

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -892,6 +892,10 @@ command = "node"
 				res.stdout,
 				/Plugin versions: expected cache directory .* is not materialized with packaged plugin manifest version .*; run "omx setup --plugin --force" to refresh the plugin cache/,
 			);
+			assert.match(
+				res.stdout,
+				/Native hooks: plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin/,
+			);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -680,16 +680,17 @@ command = "node"
 			});
 			if (shouldSkipForSpawnPermissions(res.error)) return;
 			assert.equal(res.status, 0, res.stderr || res.stdout);
+			const escapedVersion = version.replaceAll(".", String.fromCharCode(92) + ".");
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`Skills: plugin marketplace oh-my-codex-local is registered, but installed Codex plugin cache manifest version 0\\.0\\.0-stale does not match packaged version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
+					`Skills: plugin marketplace oh-my-codex-local is registered, but installed Codex plugin cache manifest version 0\\.0\\.0-stale does not match packaged version ${escapedVersion}; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin.*so /skills can discover OMX plugin skills`,
 				),
 			);
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`Plugin versions: expected cache directory .*${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} is not materialized with packaged plugin manifest version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin`,
+					`Plugin versions: expected cache directory .*${escapedVersion} is not materialized with packaged plugin manifest version ${escapedVersion}; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin`,
 				),
 			);
 		} finally {
@@ -873,6 +874,11 @@ command = "node"
 			);
 			if (shouldSkipForSpawnPermissions(setupRes.error)) return;
 			assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+			const configPath = join(codexDir, "config.toml");
+			const configContent = await readFile(configPath, "utf-8");
+			if (!/^\s*plugin_hooks\s*=/m.test(configContent)) {
+				await writeFile(configPath, `plugin_hooks = true\n${configContent}`);
+			}
 			await rm(join(codexDir, "plugins", "cache"), {
 				recursive: true,
 				force: true,
@@ -886,7 +892,7 @@ command = "node"
 			assert.equal(res.status, 0, res.stderr || res.stdout);
 			assert.match(
 				res.stdout,
-				/Skills: plugin marketplace oh-my-codex-local is registered, but no installed Codex plugin cache was found; run "omx setup --plugin --force" so \/skills can discover OMX plugin skills/,
+				/Skills: plugin marketplace oh-my-codex-local is registered, but no installed Codex plugin cache was found; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin.*so \/skills can discover OMX plugin skills/,
 			);
 			assert.match(
 				res.stdout,

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -684,7 +684,7 @@ command = "node"
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`Skills: plugin marketplace oh-my-codex-local is registered, but installed Codex plugin cache manifest version 0\\.0\\.0-stale does not match packaged version ${escapedVersion}; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin.*so /skills can discover OMX plugin skills`,
+					`Skills: plugin marketplace oh-my-codex-local is registered, but (?:installed Codex plugin cache manifest version 0\\.0\\.0-stale does not match packaged version ${escapedVersion}|no installed Codex plugin cache was found); run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin.*so /skills can discover OMX plugin skills`,
 				),
 			);
 			assert.match(

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -689,7 +689,7 @@ command = "node"
 			assert.match(
 				res.stdout,
 				new RegExp(
-					`Plugin versions: expected cache directory .*${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} is not materialized with packaged plugin manifest version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run "omx setup --plugin --force" to refresh the plugin cache`,
+					`Plugin versions: expected cache directory .*${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} is not materialized with packaged plugin manifest version ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin`,
 				),
 			);
 		} finally {
@@ -890,7 +890,7 @@ command = "node"
 			);
 			assert.match(
 				res.stdout,
-				/Plugin versions: expected cache directory .* is not materialized with packaged plugin manifest version .*; run "omx setup --plugin --force" to refresh the plugin cache/,
+				/Plugin versions: expected cache directory .* is not materialized with packaged plugin manifest version .*; run .*codex plugin remove oh-my-codex@oh-my-codex-local --json.*omx setup --plugin/,
 			);
 			assert.match(
 				res.stdout,

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -42,6 +42,7 @@ import {
 	buildManagedCodexNativeHookCommand,
 	buildManagedCodexNativeHookWindowsShimContent,
 } from "../../config/codex-hooks.js";
+import { computeOmxPluginCacheClaimDigest } from "../plugin-marketplace.js";
 
 const MANAGED_HOOK_EVENTS = [
 	"SessionStart",
@@ -137,7 +138,8 @@ async function installPluginCacheFixture(codexDir: string): Promise<string> {
 			2,
 		)}\n`,
 	);
-	await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
+	const claimDigest = await computeOmxPluginCacheClaimDigest(cacheDir);
+	await writeFile(join(cacheDir, ".omx-complete"), `${JSON.stringify({ claimDigest })}\n`);
 	return cacheDir;
 }
 

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -137,6 +137,7 @@ async function installPluginCacheFixture(codexDir: string): Promise<string> {
 			2,
 		)}\n`,
 	);
+	await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
 	return cacheDir;
 }
 
@@ -727,8 +728,8 @@ command = "node"
 			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
 			if (shouldSkipForSpawnPermissions(res.error)) return;
 			assert.equal(res.status, 0, res.stderr || res.stdout);
-			assert.match(res.stdout, /Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: expected skill file content differs/);
-			assert.match(res.stdout, /Plugin versions: expected cache directory .* has invalid plugin cache provenance: expected skill file content differs/);
+			assert.match(res.stdout, /Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: expected skill file content differs.*codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun "omx setup --plugin"/);
+			assert.match(res.stdout, /Plugin versions: expected cache directory .* has invalid plugin cache provenance: expected skill file content differs.*codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun "omx setup --plugin"/);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}
@@ -766,10 +767,92 @@ command = "node"
 			const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
 			if (shouldSkipForSpawnPermissions(res.error)) return;
 			assert.equal(res.status, 0, res.stderr || res.stdout);
-			assert.match(res.stdout, /Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: plugin manifest skills pointer is not \.\/skills\//);
-			assert.match(res.stdout, /Plugin versions: expected cache directory .* has invalid plugin cache provenance: plugin manifest skills pointer is not \.\/skills\//);
+			assert.match(res.stdout, /Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: plugin manifest skills pointer is not \.\/skills\/.*codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun "omx setup --plugin"/);
+			assert.match(res.stdout, /Plugin versions: expected cache directory .* has invalid plugin cache provenance: plugin manifest skills pointer is not \.\/skills\/.*codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun "omx setup --plugin"/);
 		} finally {
 			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("warns with pointer-specific diagnostics for companion metadata drift", async () => {
+		for (const [field, pointer] of [["mcpServers", "./attacker-mcp.json"], ["apps", "./attacker-app.json"]] as const) {
+			const wd = await mkdtemp(join(tmpdir(), `omx-doctor-plugin-cache-${field}-drift-`));
+			try {
+				const home = join(wd, "home");
+				const codexDir = join(home, ".codex");
+				await mkdir(codexDir, { recursive: true });
+				const setupRes = runOmx(
+					wd,
+					["setup", "--scope", "user", "--plugin", "--force"],
+					{ HOME: home, CODEX_HOME: codexDir },
+				);
+				if (shouldSkipForSpawnPermissions(setupRes.error)) continue;
+				assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+				const version = await packagedPluginVersion();
+				const manifestPath = join(
+					codexDir,
+					"plugins",
+					"cache",
+					"oh-my-codex-local",
+					"oh-my-codex",
+					version,
+					".codex-plugin",
+					"plugin.json",
+				);
+				const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as Record<string, unknown>;
+				manifest[field] = pointer;
+				await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+				const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+				if (shouldSkipForSpawnPermissions(res.error)) continue;
+				assert.equal(res.status, 0, res.stderr || res.stdout);
+				assert.match(res.stdout, new RegExp(`Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: plugin manifest ${field} pointer is not [^;]+; run codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun "omx setup --plugin"`));
+				assert.match(res.stdout, new RegExp(`Plugin versions: expected cache directory .* has invalid plugin cache provenance: plugin manifest ${field} pointer is not [^;]+; run codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun "omx setup --plugin"`));
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("warns with remediation when companion cache files mutate or symlink", async () => {
+		for (const companion of [".mcp.json", ".app.json"] as const) {
+			for (const mode of ["mutated", "symlinked"] as const) {
+				const wd = await mkdtemp(join(tmpdir(), `omx-doctor-plugin-cache-${companion.slice(1)}-${mode}-`));
+				try {
+					const home = join(wd, "home");
+					const codexDir = join(home, ".codex");
+					await mkdir(codexDir, { recursive: true });
+					const setupRes = runOmx(
+						wd,
+						["setup", "--scope", "user", "--plugin", "--force"],
+						{ HOME: home, CODEX_HOME: codexDir },
+					);
+					if (shouldSkipForSpawnPermissions(setupRes.error)) continue;
+					assert.equal(setupRes.status, 0, setupRes.stderr || setupRes.stdout);
+
+					const version = await packagedPluginVersion();
+					const cachedPath = join(codexDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex", version, companion);
+					if (mode === "mutated") {
+						await writeFile(cachedPath, `{"attacker":"${companion}"}\n`);
+					} else {
+						const externalPath = join(wd, "external", companion);
+						await mkdir(dirname(externalPath), { recursive: true });
+						await rename(cachedPath, externalPath);
+						await symlink(externalPath, cachedPath);
+					}
+
+					const res = runOmx(wd, ["doctor"], { HOME: home, CODEX_HOME: codexDir });
+					if (shouldSkipForSpawnPermissions(res.error)) continue;
+					assert.equal(res.status, 0, res.stderr || res.stdout);
+					const reason = mode === "mutated" ? ".*companion file content differs" : ".*companion file .*symlink";
+					const guidance = "codex plugin remove oh-my-codex@oh-my-codex-local --json then rerun \\\"omx setup --plugin\\\"";
+					assert.match(res.stdout, new RegExp(`Skills: plugin marketplace oh-my-codex-local cache provenance is invalid: ${reason}.*${guidance}`));
+					assert.match(res.stdout, new RegExp(`Plugin versions: expected cache directory .* has invalid plugin cache provenance: ${reason}.*${guidance}`));
+				} finally {
+					await rm(wd, { recursive: true, force: true });
+				}
+			}
 		}
 	});
 

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3686,7 +3686,7 @@ describe("project launch scope helpers", () => {
     try {
       const lockPath = join(wd, ".omx-history.lock");
       const ownerPath = join(lockPath, "owner.json");
-      await mkdir(lockPath);
+      await mkdir(lockPath, { mode: 0o700 });
       await writeFile(ownerPath, JSON.stringify({ token: "old", pid: process.pid, startIdentity: "reused" }));
       utimesSync(ownerPath, new Date(Date.now() - 1_000), new Date(Date.now() - 1_000));
       const lease = await acquireHistoryPersistenceLock(wd, { staleMs: 30 });

--- a/src/cli/__tests__/plugin-cache-stale-lock.test.ts
+++ b/src/cli/__tests__/plugin-cache-stale-lock.test.ts
@@ -51,4 +51,30 @@ describe("issue 3552 stale publication lock recovery", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("uses inode age when a lock heartbeat is materially in the future", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-future-heartbeat-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        await writeFile(lockPath, JSON.stringify({
+          pid: 99999999,
+          createdAt: Date.now() - 600_000,
+          heartbeatAt: Date.now() + 3_600_000,
+          processToken: "implausible-future",
+        }));
+        const expired = new Date(Date.now() - 10 * 60_000);
+        await utimes(lockPath, expired, expired);
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "materialized", JSON.stringify(result));
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/plugin-cache-stale-lock.test.ts
+++ b/src/cli/__tests__/plugin-cache-stale-lock.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  hasExpectedOmxPluginCache,
+  materializePackagedOmxPluginCache,
+  omxPluginCacheBase,
+  packagedOmxPluginVersion,
+  resolvePackagedOmxMarketplace,
+} from "../plugin-marketplace.js";
+
+const packageRoot = process.cwd();
+
+async function withIsolatedUserHome<T>(wd: string, fn: (codexHomeDir: string) => Promise<T>): Promise<T> {
+  const home = join(wd, "home");
+  await mkdir(home, { recursive: true });
+  const previousHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = home;
+  try {
+    return await fn(home);
+  } finally {
+    if (previousHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousHome;
+  }
+}
+
+describe("issue 3552 stale publication lock recovery", () => {
+  it("reclaims an expired malformed publication lock after age fencing", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-malformed-lock-age-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        await writeFile(lockPath, JSON.stringify({ pid: "not-a-number", heartbeatAt: "bad" }));
+        const expired = new Date(Date.now() - 10 * 60_000);
+        await utimes(lockPath, expired, expired);
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "materialized", JSON.stringify(result));
+        assert.equal(existsSync(lockPath), false);
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+        assert.equal(typeof await packagedOmxPluginVersion(packaged), "string");
+        assert.equal(await readFile(join(result.cacheDir!, ".omx-complete"), "utf-8").then((value) => value.length > 0), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -12,10 +12,11 @@ import {
   rename,
   rm,
   symlink,
+
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   PLUGIN_LAUNCHER_RECOVERY_HINT,
   hasExpectedOmxPluginCache,
@@ -29,9 +30,15 @@ import {
   readOmxPluginCacheState,
   discoverOmxPluginCacheDirs,
   resolvePackagedOmxMarketplace,
+  setPluginCacheMutationHooksForTest,
 } from "../plugin-marketplace.js";
 
 const packageRoot = process.cwd();
+
+function parseLastPublicationLockRecord(bytes: string): Record<string, unknown> {
+  const lines = bytes.split("\n").map((line) => line.trim()).filter(Boolean);
+  return JSON.parse(lines.at(-1) ?? "") as Record<string, unknown>;
+}
 
 async function withIsolatedUserHome<T>(
   wd: string,
@@ -1109,7 +1116,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
           onCacheDirPrepared: async () => {
             const bytes = await readFile(lockPath);
-            const before = JSON.parse(bytes.toString("utf-8")) as { heartbeatAt?: number };
+            const before = parseLastPublicationLockRecord(bytes.toString("utf-8")) as { heartbeatAt?: number };
             assert.ok(typeof before.heartbeatAt === "number");
             // Concurrent claimant while critical section is still held.
             const concurrent = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
@@ -1120,7 +1127,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
             // interval has kept the real lease non-expired (done via the interval).
             await new Promise<void>((r) => setTimeout(r, 50));
             const afterBytes = await readFile(lockPath);
-            const after = JSON.parse(afterBytes.toString("utf-8")) as { heartbeatAt?: number };
+            const after = parseLastPublicationLockRecord(afterBytes.toString("utf-8")) as { heartbeatAt?: number };
             assert.ok(typeof after.heartbeatAt === "number");
           },
         });
@@ -1177,6 +1184,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           const dir = join(cacheBase, v);
           await mkdir(dir, { recursive: true });
           await writeFile(join(dir, ".omx-complete"), "ok\n");
+          await writeFile(join(dir, ".omx-managed"), "fixture\n");
           await mkdir(join(dir, ".codex-plugin"), { recursive: true });
           await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: v, skills: "./skills/", hooks: "./hooks/hooks.json" }));
         }
@@ -1197,12 +1205,12 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
-  it("retirement replacement after validation is restored (P2 3861490875)", async () => {
+  it("retirement replacement after validation is preserved (P2 3861490875)", async () => {
     // Deterministic identity-bound test: stat, replace directory with foreign
     // inode, then call removeChildIfIdentity with stale original stats.
-    // The helper must restore the foreign replacement to its canonical version
-    // path (or keep it in quarantine if a successor now occupies the name)
-    // and must not delete foreign content.
+    // The helper must preserve the foreign replacement at its canonical version
+    // path or in quarantine, because portable directory restoration cannot be
+    // made atomic no-replace, and must not delete foreign content.
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-replacement-restore-"));
     try {
       await withIsolatedUserHome(wd, async (codexHomeDir) => {
@@ -1249,4 +1257,386 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("preserves both artifacts when retirement is interposed before quarantine", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-retirement-interpose-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        await mkdir(cacheBase, { recursive: true });
+        const victim = "0.20.0";
+        const victimPath = join(cacheBase, victim);
+        await mkdir(victimPath, { recursive: true });
+        await writeFile(join(victimPath, "victim.txt"), "victim\n");
+        const originalStats = await lstat(victimPath);
+        const originalPath = join(cacheBase, `${victim}.original`);
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRename: async (sourcePath) => {
+            if (interposed || basename(sourcePath) !== victim) return;
+            interposed = true;
+            await rename(victimPath, originalPath);
+            await mkdir(victimPath, { recursive: true });
+            await writeFile(join(victimPath, "successor.txt"), "successor\n");
+          },
+        });
+        try {
+          const { removeChildIfIdentity } = await import("../plugin-marketplace.js") as unknown as {
+            removeChildIfIdentity: (baseRef: unknown, name: string, stats: import("fs").Stats, opts: unknown) => Promise<void>;
+          };
+          const { open } = await import("fs/promises");
+          const { constants } = await import("fs");
+          const fd = await open(cacheBase, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+          const baseRef: unknown = {
+            handle: fd,
+            path: cacheBase,
+            operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+          };
+          try {
+            await assert.rejects(
+              removeChildIfIdentity(baseRef, victim, originalStats, { recursive: true, force: true }),
+              /preserved quarantine/,
+            );
+          } finally {
+            await fd.close();
+          }
+        } finally {
+          resetHooks();
+        }
+        assert.equal(await readFile(join(originalPath, "victim.txt"), "utf-8"), "victim\n");
+        const quarantined = (await readdir(cacheBase)).find((name) => name.includes(".reclaim-"));
+        assert.ok(quarantined, "interposed successor must remain quarantined for bounded cleanup");
+        const successorAtVersion = existsSync(join(victimPath, "successor.txt"));
+        const successorInQuarantine = existsSync(join(cacheBase, quarantined!, "successor.txt"));
+        assert.equal(successorAtVersion || successorInQuarantine, true, "interposed successor must remain reachable");
+        if (successorInQuarantine) {
+          assert.equal(await readFile(join(cacheBase, quarantined!, "successor.txt"), "utf-8"), "successor\n");
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when staging destination appears between no-replace checks", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-staging-interpose-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+        let destinationName: string | undefined;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeMkdirExclusive: async (parentPath, name) => {
+            if (destinationName || parentPath !== cacheDir || name === ".omx-incomplete") return;
+            destinationName = name;
+            await writeFile(join(parentPath, name), "staging successor\n");
+          },
+          beforeExclusiveCreate: async (parentPath, name) => {
+            if (destinationName || parentPath !== cacheDir || name === ".omx-incomplete") return;
+            destinationName = name;
+            await writeFile(join(parentPath, name), "staging successor\n");
+          },
+        });
+        try {
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        } finally {
+          resetHooks();
+        }
+        assert.ok(destinationName);
+        assert.equal(await readFile(join(cacheDir, destinationName!), "utf-8"), "staging successor\n");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when a staged source changes after its bytes are read", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-staged-source-race-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          afterStagedFileRead: async (path) => {
+            if (interposed || (!path.includes("/snapshot/hooks/") && !path.includes("\\snapshot\\hooks\\")) || !path.endsWith("hooks.json")) return;
+            interposed = true;
+            await writeFile(path, "{\"attacker\":true}\n");
+          },
+        });
+        try {
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        } finally {
+          resetHooks();
+        }
+        assert.equal(existsSync(join(cacheDir, ".omx-complete")), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("validates the final claim before publishing the complete marker", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-final-claim-validation-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeCompleteMarker: async (claimPath) => {
+            await writeFile(join(claimPath, "hooks", "hooks.json"), "{\"attacker\":true}\n");
+          },
+        });
+        try {
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        } finally {
+          resetHooks();
+        }
+        assert.equal(existsSync(join(cacheDir, ".omx-complete")), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a replacement interposed between quarantine lstat and recursive removal", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-removal-interpose-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        await mkdir(cacheBase, { recursive: true });
+        const victim = "0.20.0";
+        const victimPath = join(cacheBase, victim);
+        await mkdir(victimPath, { recursive: true });
+        await writeFile(join(victimPath, "victim.txt"), "victim\n");
+        const originalStats = await lstat(victimPath);
+        const preservedPath = join(cacheBase, `${victim}.preserved`);
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRemove: async (path) => {
+            if (interposed || !path.includes(".reclaim-")) return;
+            interposed = true;
+            await rename(path, preservedPath);
+            await mkdir(path, { recursive: true });
+            await writeFile(join(path, "replacement.txt"), "replacement\n");
+          },
+        });
+        try {
+          const { removeChildIfIdentity } = await import("../plugin-marketplace.js") as unknown as {
+            removeChildIfIdentity: (baseRef: unknown, name: string, stats: import("fs").Stats, opts: unknown) => Promise<void>;
+          };
+          const { open } = await import("fs/promises");
+          const { constants } = await import("fs");
+          const fd = await open(cacheBase, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+          const baseRef: unknown = {
+            handle: fd,
+            path: cacheBase,
+            operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+          };
+          try {
+            await assert.rejects(
+              removeChildIfIdentity(baseRef, victim, originalStats, { recursive: true, force: true, preserveRecursive: false }),
+              /changed before deletion/,
+            );
+          } finally {
+            await fd.close();
+          }
+        } finally {
+          resetHooks();
+        }
+        assert.equal(await readFile(join(preservedPath, "victim.txt"), "utf-8"), "victim\n");
+        const replacementAtVersion = existsSync(join(cacheBase, victim, "replacement.txt"));
+        const quarantined = (await readdir(cacheBase)).find((name) => name.includes(".reclaim-"));
+        const replacementInQuarantine = quarantined
+          ? existsSync(join(cacheBase, quarantined, "replacement.txt"))
+          : false;
+        assert.equal(replacementAtVersion || replacementInQuarantine, true, "replacement must remain reachable");
+        if (replacementInQuarantine) {
+          assert.equal(await readFile(join(cacheBase, quarantined!, "replacement.txt"), "utf-8"), "replacement\n");
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a replacement interposed after the final removal identity check", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-removal-final-fence-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        await mkdir(cacheBase, { recursive: true });
+        const victim = "0.20.0";
+        const victimPath = join(cacheBase, victim);
+        await mkdir(victimPath, { recursive: true });
+        await writeFile(join(victimPath, "victim.txt"), "victim\n");
+        const originalStats = await lstat(victimPath);
+        const preservedPath = join(cacheBase, `${victim}.preserved`);
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRemoveSyscall: async (path) => {
+            if (interposed || !path.includes(".reclaim-")) return;
+            interposed = true;
+            await rename(path, preservedPath);
+            await mkdir(path, { recursive: true });
+            await writeFile(join(path, "replacement.txt"), "replacement\n");
+          },
+        });
+        try {
+          const { removeChildIfIdentity } = await import("../plugin-marketplace.js") as unknown as {
+            removeChildIfIdentity: (baseRef: unknown, name: string, stats: import("fs").Stats, opts: unknown) => Promise<void>;
+          };
+          const { open } = await import("fs/promises");
+          const { constants } = await import("fs");
+          const fd = await open(cacheBase, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+          const baseRef: unknown = {
+            handle: fd,
+            path: cacheBase,
+            operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+          };
+          try {
+            await assert.rejects(
+              removeChildIfIdentity(baseRef, victim, originalStats, { recursive: true, force: true, preserveRecursive: false }),
+              /changed before removal syscall/,
+            );
+          } finally {
+            await fd.close();
+          }
+        } finally {
+          resetHooks();
+        }
+        assert.equal(await readFile(join(preservedPath, "victim.txt"), "utf-8"), "victim\n");
+        const quarantined = (await readdir(cacheBase)).find((name) => name.includes(".reclaim-"));
+        const replacementAtVersion = existsSync(join(cacheBase, victim, "replacement.txt"));
+        const replacementInQuarantine = quarantined
+          ? existsSync(join(cacheBase, quarantined, "replacement.txt"))
+          : false;
+        assert.equal(replacementAtVersion || replacementInQuarantine, true, "replacement must remain reachable");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a successor during interposed stale-lock cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-stale-lock-interpose-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        const originalPath = join(cacheBase, ".omx-publish.lock.original");
+        await mkdir(cacheBase, { recursive: true });
+        await writeFile(lockPath, JSON.stringify({ pid: 99999999, createdAt: Date.now() - 60_000 }));
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRename: async (sourcePath) => {
+            if (interposed || basename(sourcePath) !== ".omx-publish.lock") return;
+            interposed = true;
+            await rename(lockPath, originalPath);
+            await writeFile(lockPath, JSON.stringify({
+              pid: process.pid,
+              createdAt: Date.now(),
+              heartbeatAt: Date.now(),
+              processToken: "successor",
+            }));
+          },
+        });
+        try {
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        } finally {
+          resetHooks();
+        }
+        const successor = parseLastPublicationLockRecord(await readFile(lockPath, "utf-8")) as { processToken?: string };
+        assert.equal(successor.processToken, "successor");
+        assert.equal(existsSync(originalPath), true);
+        assert.ok((await readdir(cacheBase)).some((name) => name.includes(".reclaim-")), "raced lock quarantine must remain for bounded cleanup");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("re-reads a same-inode heartbeat before stale-lock quarantine", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-heartbeat-recheck-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        await writeFile(lockPath, `${JSON.stringify({ pid: 99999999, createdAt: Date.now() - 600_000, heartbeatAt: Date.now() - 600_000, processToken: "old" })}\n`);
+        let refreshed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeStaleLockReclaim: async (path) => {
+            if (refreshed) return;
+            refreshed = true;
+            await writeFile(path, `${JSON.stringify({ pid: process.pid, createdAt: Date.now(), heartbeatAt: Date.now(), processToken: "same-inode-live" })}\n`, { flag: "a" });
+          },
+        });
+        try {
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        } finally {
+          resetHooks();
+        }
+        const record = parseLastPublicationLockRecord(await readFile(lockPath, "utf-8")) as { processToken?: string };
+        assert.equal(record.processToken, "same-inode-live");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts stale-lock cleanup when the quarantined owner heartbeats late", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-late-heartbeat-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        await writeFile(lockPath, `${JSON.stringify({ pid: 99999999, createdAt: Date.now() - 600_000, heartbeatAt: Date.now() - 600_000, processToken: "old" })}\n`);
+        let heartbeated = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRemoveSyscall: async (path) => {
+            if (heartbeated || !path.includes(".reclaim-")) return;
+            heartbeated = true;
+            await writeFile(path, `${JSON.stringify({ pid: process.pid, createdAt: Date.now(), heartbeatAt: Date.now(), processToken: "late-owner" })}\n`);
+          },
+        });
+        try {
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        } finally {
+          resetHooks();
+        }
+        const successor = parseLastPublicationLockRecord(await readFile(lockPath, "utf-8")) as { processToken?: string };
+        assert.equal(successor.processToken, "late-owner");
+        assert.ok((await readdir(cacheBase)).some((name) => name.includes(".reclaim-")), "late-heartbeat quarantine must remain bounded");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -158,7 +158,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
-  it("fails closed on Darwin where descriptor-relative mutation paths are unavailable", async () => {
+  it("keeps Darwin publication on identity-gated visible-path mutations", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-darwin-publication-"));
     try {
       await withPlatform("darwin", async () => {
@@ -166,9 +166,11 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           const packaged = await resolvePackagedOmxMarketplace(packageRoot);
           assert.ok(packaged);
           const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
-          assert.equal(first.status, "stale-launcher", JSON.stringify(first));
-          assert.match(first.reason ?? "", /ENOTSUP|descriptor-relative/);
-          assert.equal(existsSync(omxPluginCacheBase(codexHomeDir)), false);
+          assert.equal(first.status, "materialized", JSON.stringify(first));
+          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+          // Mutations stay reachable (no blanket ENOTSUP) because every one is
+          // exclusive-create or inode-gated through the validated anchor.
+          assert.equal(existsSync(omxPluginCacheBase(codexHomeDir)), true);
         });
       });
     } finally {
@@ -835,8 +837,31 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           },
         });
         assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        assert.match(result.reason ?? "", /already exists|refusing to replace/);
         assert.equal(await readFile(join(cacheDir, "attacker-sentinel"), "utf-8"), "preserve\n");
         assert.equal(existsSync(join(cacheDir, ".omx-complete")), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on a foreign .omx-incomplete directory instead of reclaiming it", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-foreign-incomplete-claim-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+        await mkdir(cacheDir, { recursive: true });
+        await writeFile(join(cacheDir, "foreign-sentinel"), "preserve\n");
+        await writeFile(join(cacheDir, ".omx-incomplete"), "crashed publisher\n");
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        assert.match(result.reason ?? "", /already exists|refusing to replace|symlink or non-directory/);
+        assert.equal(await readFile(join(cacheDir, "foreign-sentinel"), "utf-8"), "preserve\n");
+        assert.equal(existsSync(join(cacheDir, ".omx-incomplete")), true);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -860,7 +885,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           },
         });
         assert.equal(result.status, "stale-launcher", JSON.stringify(result));
-        assert.match(result.reason ?? "", /appeared concurrently|refusing to replace/);
+        assert.match(result.reason ?? "", /already exists|refusing to replace/);
         // The claimant (empty directory) survives untouched.
         assert.equal((await lstat(cacheDir)).isDirectory(), true);
         assert.equal((await readdir(cacheDir)).length, 0);

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -1764,4 +1764,41 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
+  it("preserves a live pin inserted after quarantine before recursive cleanup", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-live-pin-late-cleanup-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const seed = async (version: string) => {
+          const dir = join(cacheBase, version);
+          await mkdir(join(dir, ".codex-plugin"), { recursive: true });
+          await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version }));
+          await writeFile(join(dir, ".omx-managed"), "fixture\n");
+          await writeFile(join(dir, ".omx-complete"), `${JSON.stringify({ version, claimDigest: await computeOmxPluginCacheClaimDigest(dir) })}\n`);
+        };
+        await seed("0.20.0");
+        await seed("0.20.1");
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRemoveSyscall: async (path) => {
+            if (interposed || !path.includes(".reclaim-")) return;
+            interposed = true;
+            await writeFile(join(path, ".omx-live-pin"), "late pin\n");
+          },
+        });
+        try {
+          const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js");
+          const preservedDirs: string[] = [];
+          assert.deepEqual(await retireUnpinnedManagedSnapshots(codexHomeDir, "0.21.0", undefined, false, preservedDirs), []);
+          assert.equal(interposed, true);
+          assert.ok(preservedDirs.some((path) => existsSync(join(path, ".omx-live-pin"))));
+        } finally {
+          resetHooks();
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -23,6 +23,7 @@ import {
   readOmxPluginCacheFileNoFollow,
   omxPluginCacheProvenanceReason,
   omxPluginCacheExecutedAssetProvenanceReason,
+  omxPluginCacheBase,
   pluginHookCacheMatchesPackaged,
   readOmxPluginCacheState,
   discoverOmxPluginCacheDirs,
@@ -44,6 +45,16 @@ async function withIsolatedUserHome<T>(
   } finally {
     if (previousHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = previousHome;
+  }
+}
+
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", { configurable: true, value: original });
   }
 }
 
@@ -103,6 +114,41 @@ async function seedRegularSnapshot(codexHomeDir: string): Promise<string> {
 }
 
 describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
+  it("publishes, validates, and retires snapshots without descendant /dev/fd paths", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-darwin-publication-"));
+    try {
+      await withPlatform("darwin", async () => {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(first.status, "materialized", JSON.stringify(first));
+          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+
+          const oldVersions = ["0.0.1", "0.0.2"];
+          for (const oldVersion of oldVersions) {
+            const oldDir = join(omxPluginCacheBase(codexHomeDir), oldVersion);
+            await mkdir(dirname(oldDir), { recursive: true });
+            await cp(join(packageRoot, "plugins", "oh-my-codex"), oldDir, { recursive: true });
+            const oldManifestPath = join(oldDir, ".codex-plugin", "plugin.json");
+            const oldManifest = JSON.parse(await readFile(oldManifestPath, "utf-8")) as Record<string, unknown>;
+            await writeFile(oldManifestPath, `${JSON.stringify({ ...oldManifest, version: oldVersion })}\n`);
+            await writeFile(join(oldDir, "hooks", "omx-command.json"), await pinnedLauncherContent());
+            await writeFile(join(oldDir, ".omx-complete"), "fixture\n");
+          }
+
+          const second = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.equal(second.status, "unchanged", JSON.stringify(second));
+          assert.deepEqual(second.retiredDirs, [join(omxPluginCacheBase(codexHomeDir), "0.0.1")]);
+          assert.equal(existsSync(join(omxPluginCacheBase(codexHomeDir), "0.0.1")), false);
+          assert.equal(existsSync(join(first.cacheDir!, ".omx-incomplete")), false);
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("control: regular immutable snapshot stays unchanged and hook-matching", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-control-"));
     try {

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -1684,4 +1684,47 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
+  it("preserves a live pin inserted before retirement quarantine", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-live-pin-race-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const victim = join(cacheBase, "0.20.0");
+        await mkdir(join(victim, ".codex-plugin"), { recursive: true });
+        await writeFile(join(victim, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: "0.20.0" }));
+        await writeFile(join(victim, ".omx-complete"), "fixture\n");
+        await writeFile(join(victim, ".omx-managed"), "fixture\n");
+        const newer = join(cacheBase, "0.20.1");
+        await mkdir(join(newer, ".codex-plugin"), { recursive: true });
+        await writeFile(join(newer, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: "0.20.1" }));
+        await writeFile(join(newer, ".omx-complete"), "fixture\n");
+        await writeFile(join(newer, ".omx-managed"), "fixture\n");
+        let interposed = false;
+        const resetHooks = setPluginCacheMutationHooksForTest({
+          beforeRename: async (sourcePath) => {
+            if (interposed || !sourcePath.includes("0.20.0")) return;
+            interposed = true;
+            await writeFile(join(sourcePath, ".omx-live-pin"), "late pin\n");
+          },
+        });
+        try {
+          const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js");
+          let retirementError: unknown;
+          try {
+            await retireUnpinnedManagedSnapshots(codexHomeDir, "0.21.0");
+          } catch (error) {
+            retirementError = error;
+          }
+          assert.equal(interposed, true, "retirement interposition did not reach the candidate quarantine rename");
+          assert.match(String((retirementError as Error | undefined)?.message ?? ""), /managed cache ownership changed during reclamation/);
+        } finally {
+          resetHooks();
+        }
+        assert.ok((await readdir(cacheBase)).some((name) => name.includes(".reclaim-") && existsSync(join(cacheBase, name, ".omx-live-pin"))));
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -29,6 +29,7 @@ import {
   packagedOmxPluginVersion,
   readOmxPluginCacheState,
   discoverOmxPluginCacheDirs,
+  computeOmxPluginCacheClaimDigest,
   resolvePackagedOmxMarketplace,
   setPluginCacheMutationHooksForTest,
 } from "../plugin-marketplace.js";
@@ -117,7 +118,8 @@ async function seedRegularSnapshot(codexHomeDir: string): Promise<string> {
     join(cacheDir, "hooks", "omx-command.json"),
     await pinnedLauncherContent(),
   );
-  await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
+  const claimDigest = await computeOmxPluginCacheClaimDigest(cacheDir);
+  await writeFile(join(cacheDir, ".omx-complete"), `${JSON.stringify({ version, claimDigest })}\n`);
   return cacheDir;
 }
 
@@ -1223,10 +1225,10 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         for (const v of ["0.20.0", "0.20.1", "0.20.2"]) {
           const dir = join(cacheBase, v);
           await mkdir(dir, { recursive: true });
-          await writeFile(join(dir, ".omx-complete"), "ok\n");
           await writeFile(join(dir, ".omx-managed"), "fixture\n");
           await mkdir(join(dir, ".codex-plugin"), { recursive: true });
           await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: v, skills: "./skills/", hooks: "./hooks/hooks.json" }));
+          await writeFile(join(dir, ".omx-complete"), `${JSON.stringify({ version: v, claimDigest: await computeOmxPluginCacheClaimDigest(dir) })}\n`);
         }
         const version = await packagedPluginVersion();
         const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js") as unknown as { retireUnpinnedManagedSnapshots: (a: string, b: string) => Promise<string[]> };
@@ -1714,7 +1716,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         const foreign = join(cacheBase, "0.20.0");
         await mkdir(join(foreign, ".codex-plugin"), { recursive: true });
         await writeFile(join(foreign, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: "0.20.0" }));
-        await writeFile(join(foreign, ".omx-complete"), "foreign\n");
+        await writeFile(join(foreign, ".omx-complete"), `${JSON.stringify({ version: "0.20.0", claimDigest: await computeOmxPluginCacheClaimDigest(foreign) })}\n`);
         const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js");
         assert.deepEqual(await retireUnpinnedManagedSnapshots(codexHomeDir, "0.21.0"), []);
         assert.equal(existsSync(foreign), true);
@@ -1732,13 +1734,13 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         const victim = join(cacheBase, "0.20.0");
         await mkdir(join(victim, ".codex-plugin"), { recursive: true });
         await writeFile(join(victim, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: "0.20.0" }));
-        await writeFile(join(victim, ".omx-complete"), "fixture\n");
         await writeFile(join(victim, ".omx-managed"), "fixture\n");
+        await writeFile(join(victim, ".omx-complete"), `${JSON.stringify({ version: "0.20.0", claimDigest: await computeOmxPluginCacheClaimDigest(victim) })}\n`);
         const newer = join(cacheBase, "0.20.1");
         await mkdir(join(newer, ".codex-plugin"), { recursive: true });
         await writeFile(join(newer, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: "0.20.1" }));
-        await writeFile(join(newer, ".omx-complete"), "fixture\n");
         await writeFile(join(newer, ".omx-managed"), "fixture\n");
+        await writeFile(join(newer, ".omx-complete"), `${JSON.stringify({ version: "0.20.1", claimDigest: await computeOmxPluginCacheClaimDigest(newer) })}\n`);
         let interposed = false;
         const resetHooks = setPluginCacheMutationHooksForTest({
           beforeRename: async (sourcePath) => {
@@ -1749,18 +1751,13 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         });
         try {
           const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js");
-          let retirementError: unknown;
-          try {
-            await retireUnpinnedManagedSnapshots(codexHomeDir, "0.21.0");
-          } catch (error) {
-            retirementError = error;
-          }
+          const preservedDirs: string[] = [];
+          assert.deepEqual(await retireUnpinnedManagedSnapshots(codexHomeDir, "0.21.0", undefined, false, preservedDirs), []);
           assert.equal(interposed, true, "retirement interposition did not reach the candidate quarantine rename");
-          assert.match(String((retirementError as Error | undefined)?.message ?? ""), /managed cache ownership changed during reclamation/);
+          assert.ok(preservedDirs.some((path) => existsSync(join(path, ".omx-live-pin"))));
         } finally {
           resetHooks();
         }
-        assert.ok((await readdir(cacheBase)).some((name) => name.includes(".reclaim-") && existsSync(join(cacheBase, name, ".omx-live-pin"))));
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -25,6 +25,7 @@ import {
   omxPluginCacheExecutedAssetProvenanceReason,
   pluginHookCacheMatchesPackaged,
   readOmxPluginCacheState,
+  discoverOmxPluginCacheDirs,
   resolvePackagedOmxMarketplace,
 } from "../plugin-marketplace.js";
 
@@ -178,6 +179,37 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
+  it("fails closed when state surfaces have invalid pointers, companions, skills, or launcher", async () => {
+    const cases = [
+      ["pointer", async (cacheDir: string) => {
+        const manifestPath = join(cacheDir, ".codex-plugin", "plugin.json");
+        const manifest = JSON.parse(await readFile(manifestPath, "utf-8")) as Record<string, unknown>;
+        await writeFile(manifestPath, JSON.stringify({ ...manifest, skills: "./attacker-skills/" }));
+      }],
+      ["companion", async (cacheDir: string) => {
+        await writeFile(join(cacheDir, ".mcp.json"), "not-json\n");
+      }],
+      ["skill", async (cacheDir: string) => {
+        await rm(join(cacheDir, "skills", "worker", "SKILL.md"), { force: true });
+      }],
+      ["launcher", async (cacheDir: string) => {
+        await writeFile(join(cacheDir, "hooks", "omx-command.json"), "{}\n");
+      }],
+    ] as const;
+    for (const [label, mutate] of cases) {
+      const wd = await mkdtemp(join(tmpdir(), `omx-3552-state-${label}-`));
+      try {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const cacheDir = await seedRegularSnapshot(codexHomeDir);
+          await mutate(cacheDir);
+          assert.equal(await readOmxPluginCacheState(cacheDir), null, `${label} state failure was trusted`);
+        });
+      } finally {
+        await rm(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it("rejects an anchored parent replacement before reading a managed asset", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-parent-barrier-"));
     try {
@@ -198,6 +230,28 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
+  it("rejects a symlinked intermediate skills directory during descriptor-bound reads", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-intermediate-skills-symlink-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const skillsDir = join(cacheDir, "skills");
+        const externalSkills = join(wd, "external-skills");
+        await rename(skillsDir, externalSkills);
+        await symlink(externalSkills, skillsDir);
+        assert.equal(
+          await readOmxPluginCacheFileNoFollow(
+            join(cacheDir, "skills", "worker", "SKILL.md"),
+            { anchorDir: cacheDir },
+          ),
+          null,
+        );
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("rejects an interrupted publication without a committed marker", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-publication-interrupt-"));
     try {
@@ -209,6 +263,19 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         await writeFile(join(cacheDir, ".omx-incomplete"), "interrupted\n");
         assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
         assert.equal(await readOmxPluginCacheState(cacheDir), null);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not discover a manifest without a committed publication marker", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-discovery-marker-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        await rm(join(cacheDir, ".omx-complete"), { force: true });
+        assert.deepEqual(await discoverOmxPluginCacheDirs(codexHomeDir), []);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -647,6 +714,72 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       });
     } finally {
       await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a same-version directory claimed at the publication barrier", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-publication-barrier-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        const cacheDir = join(
+          codexHomeDir,
+          "plugins",
+          "cache",
+          "oh-my-codex-local",
+          "oh-my-codex",
+          version,
+        );
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
+          onCacheDirPrepared: async (preparedCacheDir) => {
+            assert.equal(preparedCacheDir, cacheDir);
+            await mkdir(preparedCacheDir, { recursive: true });
+            await writeFile(join(preparedCacheDir, "attacker-sentinel"), "preserve\n");
+          },
+        });
+        assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        assert.equal(await readFile(join(cacheDir, "attacker-sentinel"), "utf-8"), "preserve\n");
+        assert.equal(existsSync(join(cacheDir, ".omx-complete")), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers a publication lock owned by a dead process", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-stale-publication-lock-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = join(codexHomeDir, "plugins", "cache", "oh-my-codex-local", "oh-my-codex");
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        await writeFile(lockPath, JSON.stringify({ pid: 99999999, createdAt: Date.now() - 60_000 }));
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "materialized", JSON.stringify(result));
+        assert.equal(existsSync(lockPath), false);
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps direct materialization dry-run read-only when the cache namespace is absent", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-dry-run-read-only-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged, { dryRun: true });
+        assert.equal(result.status, "materialized", JSON.stringify(result));
+        assert.equal(existsSync(join(codexHomeDir, "plugins")), false);
+      });
+    } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -1089,4 +1089,74 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("long live publication lease is renewed while holding the lock (P2 heartbeat)", async () => {
+    // Slow publisher on a slow filesystem would exceed PUBLICATION_LOCK_LEASE_MS.
+    // The holder must refresh heartbeatAt on the open fd so a concurrent claimant
+    // never sees an expired live lease. This exercises the real publication path
+    // via a staged onCacheDirPrepared delay.
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-heartbeat-live-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        // Seed a fresh live lock then run a publication that holds it: inject a
+        // short delay inside the critical section; second concurrent attempt must
+        // still see the live owner as active.
+        const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
+          onCacheDirPrepared: async () => {
+            const bytes = await readFile(lockPath);
+            const before = JSON.parse(bytes.toString("utf-8")) as { heartbeatAt?: number };
+            assert.ok(typeof before.heartbeatAt === "number");
+            // Concurrent claimant while critical section is still held.
+            const concurrent = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+            assert.equal(concurrent.status, "stale-launcher");
+            assert.match(concurrent.reason ?? "", /another OMX plugin cache publication is active|cannot claim/);
+            // Write a stale-looking heartbeat under a reused PID would previously
+            // have been considered stale even for a live owner; ensure the holder's
+            // interval has kept the real lease non-expired (done via the interval).
+            await new Promise<void>((r) => setTimeout(r, 50));
+            const afterBytes = await readFile(lockPath);
+            const after = JSON.parse(afterBytes.toString("utf-8")) as { heartbeatAt?: number };
+            assert.ok(typeof after.heartbeatAt === "number");
+          },
+        });
+        assert.equal(first.status, "materialized", JSON.stringify(first));
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("cleanup does not quarantine a successor lock (P2 successor)", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-successor-lock-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        // First publisher materializes and releases; immediately after, a second
+        // publisher claims a new lock. Verify the first publisher's cleanup did not
+        // quarantine the successor (dev/ino fencing in the finally block).
+        const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(first.status, "materialized", JSON.stringify(first));
+        // Lock is removed on success path; seed a successor and ensure materialize
+        // still respects it, then that successor's own lifecycle is intact.
+        await writeFile(lockPath, JSON.stringify({ pid: process.pid, createdAt: Date.now(), heartbeatAt: Date.now(), processToken: "successor" }));
+        const second = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(second.status, "stale-launcher", JSON.stringify(second));
+        assert.match(second.reason ?? "", /another OMX plugin cache publication is active|cannot claim/);
+        const successorBytes = await readFile(lockPath, "utf-8");
+        const successor = JSON.parse(successorBytes) as { processToken?: string };
+        assert.equal(successor.processToken, "successor");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import {
   cp,
   lstat,
+  link,
   mkdir,
   mkdtemp,
   readFile,
@@ -19,6 +20,8 @@ import {
   PLUGIN_LAUNCHER_RECOVERY_HINT,
   hasExpectedOmxPluginCache,
   materializePackagedOmxPluginCache,
+  readOmxPluginCacheFileNoFollow,
+  omxPluginCacheProvenanceReason,
   omxPluginCacheExecutedAssetProvenanceReason,
   pluginHookCacheMatchesPackaged,
   readOmxPluginCacheState,
@@ -94,6 +97,7 @@ async function seedRegularSnapshot(codexHomeDir: string): Promise<string> {
     join(cacheDir, "hooks", "omx-command.json"),
     await pinnedLauncherContent(),
   );
+  await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
   return cacheDir;
 }
 
@@ -117,6 +121,94 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         );
         const r = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
         assert.equal(r.status, "unchanged");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the committed publication marker is removed", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-marker-loss-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(first.status, "materialized");
+        await rm(join(first.cacheDir!, ".omx-complete"), { force: true });
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "stale-launcher");
+        assert.match(result.reason ?? "", /managed snapshots|publication marker|codex plugin remove/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects extra skill directories from immutable provenance", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-extra-skill-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        await mkdir(join(cacheDir, "skills", "attacker"), { recursive: true });
+        await writeFile(join(cacheDir, "skills", "attacker", "SKILL.md"), "attacker\n");
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "stale-launcher");
+        assert.match(result.reason ?? "", /skills directory contents differ/);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed at the state boundary for missing managed assets", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-state-boundary-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        await rm(join(cacheDir, "hooks", "hooks.json"), { force: true });
+        assert.equal(await readOmxPluginCacheState(cacheDir), null);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an anchored parent replacement before reading a managed asset", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-parent-barrier-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        const hooksDir = join(cacheDir, "hooks");
+        const externalDir = join(wd, "external-hooks");
+        await rename(hooksDir, externalDir);
+        await symlink(externalDir, hooksDir);
+        const bytes = await readOmxPluginCacheFileNoFollow(
+          join(cacheDir, "hooks", "hooks.json"),
+          { anchorDir: cacheDir },
+        );
+        assert.equal(bytes, null);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an interrupted publication without a committed marker", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-publication-interrupt-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        await rm(join(cacheDir, ".omx-complete"), { force: true });
+        await writeFile(join(cacheDir, ".omx-incomplete"), "interrupted\n");
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false);
+        assert.equal(await readOmxPluginCacheState(cacheDir), null);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -506,4 +598,123 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       }
     });
   }
+
+  it("rejects companion symlink swaps during descriptor-bound provenance validation", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-companion-toctou-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        for (const companion of companionCases) {
+          const cachedPath = join(cacheDir, companion);
+          const externalPath = join(wd, "external", companion);
+          const canonical = await readFile(cachedPath);
+          await mkdir(dirname(externalPath), { recursive: true });
+			await writeFile(externalPath, `{"attacker":"${companion}"}\n`);
+			for (let iteration = 0; iteration < 2000; iteration += 1) {
+				await rm(cachedPath, { force: true });
+				await symlink(externalPath, cachedPath);
+				const reason = await omxPluginCacheProvenanceReason(cacheDir, packaged);
+				assert.match(reason ?? "", /companion file .*symlink/);
+				await rm(cachedPath, { force: true });
+				await writeFile(cachedPath, canonical);
+			}
+          assert.equal(await readFile(externalPath, "utf-8"), `{"attacker":"${companion}"}\n`);
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not replace a same-version cache claimed concurrently", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-cache-claim-race-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const results = await Promise.all([
+          materializePackagedOmxPluginCache(codexHomeDir, packaged),
+          materializePackagedOmxPluginCache(codexHomeDir, packaged),
+        ]);
+        assert.ok(results.every((result) => result.status !== "unavailable"));
+        assert.ok(results.some((result) => result.status === "materialized" || result.status === "unchanged"));
+        const cacheDir = results.find((result) => result.cacheDir)?.cacheDir;
+        assert.ok(cacheDir);
+        assert.equal(existsSync(join(cacheDir, ".omx-incomplete")), false);
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+      });
+    } finally {
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not accept attacker bytes after companion replacement", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-companion-concurrent-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheDir = await seedRegularSnapshot(codexHomeDir);
+        for (const companion of companionCases) {
+          const cachedPath = join(cacheDir, companion);
+          const externalPath = join(wd, "external", companion);
+          const canonical = await readFile(cachedPath);
+          await mkdir(dirname(externalPath), { recursive: true });
+          await writeFile(externalPath, canonical);
+          for (let iteration = 0; iteration < 2000; iteration += 1) {
+            await rm(cachedPath, { force: true });
+            await symlink(externalPath, cachedPath);
+            await writeFile(externalPath, `{"attacker":"${companion}"}\n`);
+            const rejected = await readOmxPluginCacheFileNoFollow(cachedPath);
+            assert.equal(rejected, null, `${companion} accepted attacker-controlled symlink bytes`);
+            await rm(cachedPath, { force: true });
+            await writeFile(cachedPath, canonical);
+            await writeFile(externalPath, canonical);
+          }
+          assert.equal((await readFile(externalPath)).equals(canonical), true);
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects hard-linked cache provenance files across shared surfaces", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-hardlink-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const surfaces = [
+          ".mcp.json",
+          ".app.json",
+          ".codex-plugin/plugin.json",
+          "skills/worker/SKILL.md",
+          "hooks/hooks.json",
+          "hooks/codex-native-hook.mjs",
+          "hooks/omx-command.json",
+        ];
+        for (const surface of surfaces) {
+          const cacheDir = await seedRegularSnapshot(codexHomeDir);
+          const cachedPath = join(cacheDir, surface);
+          const externalPath = join(wd, "hardlinks", surface.replaceAll("/", "-"));
+          await mkdir(dirname(externalPath), { recursive: true });
+          await link(cachedPath, externalPath);
+          await rm(cachedPath, { force: true });
+          await link(externalPath, cachedPath);
+
+          const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          assert.notEqual(result.status, "unchanged", `${surface} hardlink was trusted`);
+          assert.equal((await lstat(cachedPath)).nlink > 1, true);
+          assert.equal((await readFile(externalPath)).equals(await readFile(cachedPath)), true);
+          await rm(cacheDir, { recursive: true, force: true });
+        }
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -1159,4 +1159,94 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
       await rm(wd, { recursive: true, force: true });
     }
   });
+
+  it("standalone retirement holds heartbeat for >120s scan (P2 3861490863)", async () => {
+    // retireUnpinnedManagedSnapshots acquires its own publication lock when
+    // called standalone (publicationLockHeld=false). A scan/removal that
+    // lasts beyond PUBLICATION_LOCK_LEASE_MS must not be reclaimable
+    // mid-retirement. The standalone path must refresh heartbeatAt on the
+    // open fd (same lifecycle as publication).
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-long-retirement-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        await mkdir(cacheBase, { recursive: true });
+        for (const v of ["0.20.0", "0.20.1", "0.20.2"]) {
+          const dir = join(cacheBase, v);
+          await mkdir(dir, { recursive: true });
+          await writeFile(join(dir, ".omx-complete"), "ok\n");
+          await mkdir(join(dir, ".codex-plugin"), { recursive: true });
+          await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: v, skills: "./skills/", hooks: "./hooks/hooks.json" }));
+        }
+        const version = await packagedPluginVersion();
+        const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js") as unknown as { retireUnpinnedManagedSnapshots: (a: string, b: string) => Promise<string[]> };
+        const retirement = retireUnpinnedManagedSnapshots(codexHomeDir, version);
+        await new Promise<void>((r) => setTimeout(r, 20));
+        const concurrent = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.ok(concurrent.status === "stale-launcher" || concurrent.status === "materialized" || concurrent.status === "unchanged");
+        if (concurrent.status === "stale-launcher") {
+          assert.match(concurrent.reason ?? "", /another OMX plugin cache publication is active|cannot claim/);
+        }
+        const retired = await retirement;
+        assert.ok(Array.isArray(retired));
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("retirement replacement after validation is restored (P2 3861490875)", async () => {
+    // Deterministic identity-bound test: stat, replace directory with foreign
+    // inode, then call removeChildIfIdentity with stale original stats.
+    // The helper must restore the foreign replacement to its canonical version
+    // path (or keep it in quarantine if a successor now occupies the name)
+    // and must not delete foreign content.
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-replacement-restore-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        await mkdir(cacheBase, { recursive: true });
+        const victim = "0.20.0";
+        const victimPath = join(cacheBase, victim);
+        await mkdir(victimPath, { recursive: true });
+        await writeFile(join(victimPath, "victim.txt"), "victim\n");
+        const { lstat: lstatP } = await import("fs/promises");
+        const originalStats = await lstatP(victimPath);
+        // Keep original inode alive so the foreign replacement gets a different inode
+        // (immediate rm+mkdir can reuse the same inode on this fs, which would
+        // make the dev/ino check pass and the helper would incorrectly delete foreign).
+        const keepPath = join(cacheBase, victim + ".keep-" + process.pid);
+        await rm(keepPath, { recursive: true, force: true }).catch(() => {});
+        const { rename: renameP } = await import("fs/promises");
+        await renameP(victimPath, keepPath);
+        await mkdir(victimPath, { recursive: true });
+        const foreignSentinel = join(victimPath, "foreign.txt");
+        await writeFile(foreignSentinel, "foreign\n");
+        // keepPath holds the original inode; clean it up after the check
+
+        const { removeChildIfIdentity } = await import("../plugin-marketplace.js") as unknown as { removeChildIfIdentity: (baseRef: unknown, name: string, stats: import("fs").Stats, opts: unknown) => Promise<void> };
+        // Build a minimal DirectoryRef over cacheBase using the same helper
+        // the production code uses (open via fs/promises so lstat/dev/ino match).
+        const { open } = await import("fs/promises");
+        const { constants } = await import("fs");
+        const fd = await open(cacheBase, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+        const baseRef: unknown = { handle: fd, path: cacheBase, operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`, scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`, mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}` };
+        try {
+          await removeChildIfIdentity(baseRef, victim, originalStats, { recursive: true, force: true });
+        } catch (e) {
+          assert.match((e as Error).message, /identity-bound removal target changed/);
+        } finally {
+          try { await (fd as unknown as { close: () => Promise<void> }).close(); } catch {}
+        }
+        await rm(keepPath, { recursive: true, force: true }).catch(() => {});
+        const foreignAtVersion = existsSync(foreignSentinel) && (await readFile(foreignSentinel, "utf-8")) === "foreign\n";
+        const quarantineWithForeign = (await readdir(cacheBase)).some((n) => n.includes(".reclaim-") && existsSync(join(cacheBase, n, "foreign.txt")));
+        assert.equal(foreignAtVersion || quarantineWithForeign, true, "foreign replacement was deleted");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -25,6 +25,7 @@ import {
   omxPluginCacheExecutedAssetProvenanceReason,
   omxPluginCacheBase,
   pluginHookCacheMatchesPackaged,
+  packagedOmxPluginVersion,
   readOmxPluginCacheState,
   discoverOmxPluginCacheDirs,
   resolvePackagedOmxMarketplace,
@@ -114,7 +115,50 @@ async function seedRegularSnapshot(codexHomeDir: string): Promise<string> {
 }
 
 describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
-  it("publishes, validates, and retires snapshots without descendant /dev/fd paths", async () => {
+  it("rejects unsafe packaged versions before constructing cache paths", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-unsafe-version-"));
+    try {
+      const manifestPath = join(wd, "plugin.json");
+      await writeFile(manifestPath, JSON.stringify({ version: "../escape" }));
+      const packaged = {
+        marketplacePath: join(wd, "marketplace.json"),
+        packageRoot,
+        pluginRoot: packageRoot,
+        pluginManifestPath: manifestPath,
+      };
+      assert.equal(await packagedOmxPluginVersion(packaged), null);
+      const result = await materializePackagedOmxPluginCache(join(wd, "codex"), packaged);
+      assert.equal(result.status, "unavailable", JSON.stringify(result));
+      assert.equal(existsSync(join(wd, "codex")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not publish a snapshot missing a required plugin surface", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-incomplete-snapshot-"));
+    try {
+      const fakePluginRoot = join(wd, "plugin");
+      await cp(join(packageRoot, "plugins", "oh-my-codex"), fakePluginRoot, { recursive: true });
+      await rm(join(fakePluginRoot, ".mcp.json"), { force: true });
+      const packaged = {
+        marketplacePath: join(wd, "marketplace.json"),
+        packageRoot,
+        pluginRoot: fakePluginRoot,
+        pluginManifestPath: join(fakePluginRoot, ".codex-plugin", "plugin.json"),
+      };
+      const codexHomeDir = join(wd, "codex");
+      const version = await packagedPluginVersion();
+      const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+      assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+      assert.match(result.reason ?? "", /required surface|companion file/);
+      assert.equal(existsSync(join(omxPluginCacheBase(codexHomeDir), version)), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on Darwin where descriptor-relative mutation paths are unavailable", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-darwin-publication-"));
     try {
       await withPlatform("darwin", async () => {
@@ -122,26 +166,30 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           const packaged = await resolvePackagedOmxMarketplace(packageRoot);
           assert.ok(packaged);
           const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
-          assert.equal(first.status, "materialized", JSON.stringify(first));
-          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+          assert.equal(first.status, "stale-launcher", JSON.stringify(first));
+          assert.match(first.reason ?? "", /ENOTSUP|descriptor-relative/);
+          assert.equal(existsSync(omxPluginCacheBase(codexHomeDir)), false);
+        });
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
 
-          const oldVersions = ["0.0.1", "0.0.2"];
-          for (const oldVersion of oldVersions) {
-            const oldDir = join(omxPluginCacheBase(codexHomeDir), oldVersion);
-            await mkdir(dirname(oldDir), { recursive: true });
-            await cp(join(packageRoot, "plugins", "oh-my-codex"), oldDir, { recursive: true });
-            const oldManifestPath = join(oldDir, ".codex-plugin", "plugin.json");
-            const oldManifest = JSON.parse(await readFile(oldManifestPath, "utf-8")) as Record<string, unknown>;
-            await writeFile(oldManifestPath, `${JSON.stringify({ ...oldManifest, version: oldVersion })}\n`);
-            await writeFile(join(oldDir, "hooks", "omx-command.json"), await pinnedLauncherContent());
-            await writeFile(join(oldDir, ".omx-complete"), "fixture\n");
+  it("keeps the Windows reparse-safe publication path available", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-win32-publication-"));
+    try {
+      await withPlatform("win32", async () => {
+        await withIsolatedUserHome(wd, async (codexHomeDir) => {
+          const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+          assert.ok(packaged);
+          const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+          if (process.platform === "win32") {
+            assert.equal(first.status, "materialized", JSON.stringify(first));
+            assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+          } else {
+            assert.notEqual(first.status, "unavailable");
           }
-
-          const second = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
-          assert.equal(second.status, "unchanged", JSON.stringify(second));
-          assert.deepEqual(second.retiredDirs, [join(omxPluginCacheBase(codexHomeDir), "0.0.1")]);
-          assert.equal(existsSync(join(omxPluginCacheBase(codexHomeDir), "0.0.1")), false);
-          assert.equal(existsSync(join(first.cacheDir!, ".omx-incomplete")), false);
         });
       });
     } finally {
@@ -789,6 +837,126 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         assert.equal(result.status, "stale-launcher", JSON.stringify(result));
         assert.equal(await readFile(join(cacheDir, "attacker-sentinel"), "utf-8"), "preserve\n");
         assert.equal(existsSync(join(cacheDir, ".omx-complete")), false);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not replace an EMPTY same-version directory claimed concurrently (no-replace publication)", async () => {
+    // Blocker 3: POSIX rename() silently replaces an empty directory, so the
+    // empty-destination case must be covered separately from the sentinel case.
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-empty-claim-barrier-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
+          onCacheDirPrepared: async (preparedCacheDir) => {
+            assert.equal(preparedCacheDir, cacheDir);
+            await mkdir(preparedCacheDir, { recursive: true });
+          },
+        });
+        assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        assert.match(result.reason ?? "", /appeared concurrently|refusing to replace/);
+        // The claimant (empty directory) survives untouched.
+        assert.equal((await lstat(cacheDir)).isDirectory(), true);
+        assert.equal((await readdir(cacheDir)).length, 0);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not clobber a newly claimed lock during stale-lock restore", async () => {
+    // Blocker 4: the restore path must use a no-clobber primitive (link) so a
+    // replacement lock acquired by another publisher is never overwritten.
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-lock-restore-noclobber-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        // Seed a stale lock from a dead pid; another publisher concurrently
+        // re-claims the name after the reclaimer quarantines it.
+        await writeFile(lockPath, JSON.stringify({ pid: 99999999, createdAt: Date.now() - 60_000 }));
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
+          onCacheDirPrepared: async () => {
+            // Simulate the restore-gap claimant: replace the (now removed)
+            // lock name with fresh content while publication holds staging.
+            const entries = await readdir(cacheBase);
+            if (!entries.includes(".omx-publish.lock")) {
+              await writeFile(lockPath, JSON.stringify({ pid: process.pid, createdAt: Date.now(), heartbeatAt: Date.now() }), { flag: "wx" });
+            }
+          },
+        });
+        // Either this publisher lost the race (stale-launcher) or it completed
+        // after removing its own lock; in both cases a live claimant's lock
+        // content must never be overwritten by the restore path.
+        const finalLock = existsSync(lockPath) ? await readFile(lockPath, "utf-8") : null;
+        if (finalLock !== null) {
+          const record = JSON.parse(finalLock) as { pid?: number };
+          assert.ok(record.pid, "surviving lock must keep its claimant record");
+        }
+        assert.ok(result.status === "materialized" || result.status === "stale-launcher");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("never discovers a marker-committed staging snapshot before publication", async () => {
+    // Blocker 5: discovery must exclude staging trees, so a snapshot that has
+    // its .omx-complete marker committed while still staged is invisible.
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-staging-invisible-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const version = await packagedPluginVersion();
+        let observedDuringStaging = false;
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
+          onCacheDirPrepared: async () => {
+            const discovered = await discoverOmxPluginCacheDirs(codexHomeDir);
+            if (discovered.some((dir) => dir.includes(".omx-plugin-"))) observedDuringStaging = true;
+          },
+        });
+        assert.equal(result.status, "materialized", JSON.stringify(result));
+        assert.equal(observedDuringStaging, false, "discovery observed a staging path");
+        const published = await discoverOmxPluginCacheDirs(codexHomeDir);
+        assert.ok(published.some((dir) => dir === join(omxPluginCacheBase(codexHomeDir), version)));
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a PID-reused live owner as a stale lock while its lease is valid", async () => {
+    // Blocker 6: a crashed publisher's pid can be reused by a live process;
+    // the lock must remain held while the recorded lease is fresh.
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-pid-reuse-lease-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        await mkdir(cacheBase, { recursive: true });
+        // Live process pid + fresh heartbeat: lock is held regardless of PID reuse.
+        await writeFile(lockPath, JSON.stringify({ pid: process.pid, createdAt: Date.now(), heartbeatAt: Date.now(), processToken: "other" }));
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        assert.match(result.reason ?? "", /another OMX plugin cache publication is active|cannot claim/);
+        assert.equal(existsSync(lockPath), true);
+        // An expired lease with a live-but-unrelated pid (PID reuse) is stale.
+        await writeFile(lockPath, JSON.stringify({ pid: process.pid, createdAt: Date.now() - 600_000, heartbeatAt: Date.now() - 600_000, processToken: "crashed" }));
+        const recovered = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(recovered.status, "materialized", JSON.stringify(recovered));
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
       });
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -1639,4 +1639,49 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
+  it("aborts a publisher when its retained lock fd loses the pathname", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-lock-path-loss-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const lockPath = join(cacheBase, ".omx-publish.lock");
+        let interposed = false;
+        const result = await materializePackagedOmxPluginCache(codexHomeDir, packaged, {
+          onCacheDirPrepared: async () => {
+            if (interposed) return;
+            interposed = true;
+            await rm(lockPath, { force: true });
+            await writeFile(lockPath, `${JSON.stringify({ pid: process.pid, createdAt: Date.now(), heartbeatAt: Date.now(), processToken: "successor" })}\n`, { flag: "wx" });
+          },
+        });
+        assert.equal(result.status, "stale-launcher", JSON.stringify(result));
+        assert.match(result.reason ?? "", /publication lock ownership lost/);
+        const successor = parseLastPublicationLockRecord(await readFile(lockPath, "utf-8")) as { processToken?: string };
+        assert.equal(successor.processToken, "successor");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retire a same-name cache without the managed ownership marker", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-foreign-managed-name-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const cacheBase = omxPluginCacheBase(codexHomeDir);
+        const foreign = join(cacheBase, "0.20.0");
+        await mkdir(join(foreign, ".codex-plugin"), { recursive: true });
+        await writeFile(join(foreign, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version: "0.20.0" }));
+        await writeFile(join(foreign, ".omx-complete"), "foreign\n");
+        const { retireUnpinnedManagedSnapshots } = await import("../plugin-marketplace.js");
+        assert.deepEqual(await retireUnpinnedManagedSnapshots(codexHomeDir, "0.21.0"), []);
+        assert.equal(existsSync(foreign), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -250,6 +250,46 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
     }
   });
 
+  it("fails closed on malformed completion markers and ignores the mutable live pin", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-marker-integrity-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(first.status, "materialized");
+        const completePath = join(first.cacheDir!, ".omx-complete");
+        for (const marker of ["{\n", "not-json\n"]) {
+          await writeFile(completePath, marker);
+          assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), false, marker);
+        }
+        const second = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(second.status, "stale-launcher");
+
+        const clean = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(clean.status, "stale-launcher");
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not invalidate a healthy claim when a live pin is added", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-3552-live-pin-digest-"));
+    try {
+      await withIsolatedUserHome(wd, async (codexHomeDir) => {
+        const packaged = await resolvePackagedOmxMarketplace(packageRoot);
+        assert.ok(packaged);
+        const first = await materializePackagedOmxPluginCache(codexHomeDir, packaged);
+        assert.equal(first.status, "materialized");
+        await writeFile(join(first.cacheDir!, ".omx-live-pin"), "pinned\n");
+        assert.equal(await hasExpectedOmxPluginCache(codexHomeDir, packaged), true);
+      });
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("rejects extra skill directories from immutable provenance", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-3552-extra-skill-"));
     try {

--- a/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
+++ b/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
@@ -23,6 +23,7 @@ import {
   omxPluginCacheBase,
   upsertLocalOmxMarketplaceRegistration,
   upsertLocalOmxPluginEnablement,
+  computeOmxPluginCacheClaimDigest,
 } from "../plugin-marketplace.js";
 import { doctor } from "../doctor.js";
 
@@ -140,7 +141,6 @@ async function seedCurrentLauncher(codexHomeDir: string): Promise<string> {
   await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
     recursive: true,
   });
-  await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
   await writeFile(
     join(cacheDir, "hooks", "omx-command.json"),
     JSON.stringify(
@@ -152,7 +152,14 @@ async function seedCurrentLauncher(codexHomeDir: string): Promise<string> {
       2,
     ) + "\n",
   );
+  const claimDigest = await computeOmxPluginCacheClaimDigest(cacheDir);
+  await writeFile(join(cacheDir, ".omx-complete"), `${JSON.stringify({ claimDigest })}\n`);
   return cacheDir;
+}
+
+async function writeBoundCompletionMarker(cacheDir: string): Promise<void> {
+	const claimDigest = await computeOmxPluginCacheClaimDigest(cacheDir);
+	await writeFile(join(cacheDir, ".omx-complete"), `${JSON.stringify({ claimDigest })}\n`);
 }
 
 async function makeFakePackageRoot(
@@ -303,7 +310,6 @@ describe("issue 3558 launcher provenance", () => {
           await cp(join(fakeRoot, "plugins", "oh-my-codex"), cacheDir, {
             recursive: true,
           });
-          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             JSON.stringify(
@@ -315,6 +321,7 @@ describe("issue 3558 launcher provenance", () => {
               2,
             ) + "\n",
           );
+          await writeBoundCompletionMarker(cacheDir);
           assert.equal(
             existsSync(join(fakeRoot, "dist", "cli", "omx.js")),
             true,
@@ -439,7 +446,6 @@ describe("issue 3558 launcher provenance", () => {
           await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
             recursive: true,
           });
-          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             JSON.stringify(
@@ -449,6 +455,7 @@ describe("issue 3558 launcher provenance", () => {
             ) + "\n",
           );
           await writeFile(join(cacheDir, ".omx-live-pin"), "pinned\n");
+          await writeBoundCompletionMarker(cacheDir);
           const before = await readFile(
             join(cacheDir, "hooks", "omx-command.json"),
             "utf-8",
@@ -533,12 +540,12 @@ describe("issue 3558 launcher provenance", () => {
             join(packageRoot, "plugins", "oh-my-codex", ".app.json"),
             join(cacheDir, ".app.json"),
           );
-          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             "{ malformed",
             "utf-8",
           );
+          await writeBoundCompletionMarker(cacheDir);
           let raw = await readPinnedLauncherRaw(cacheDir);
           assert.match(raw.error!, /malformed/);
           let r = await materializePackagedOmxPluginCache(
@@ -620,6 +627,7 @@ describe("issue 3558 launcher provenance", () => {
               argsPrefix: [aliasLauncherPath],
             }) + "\n",
           );
+          await writeBoundCompletionMarker(cacheDir);
           // ensure file exists via alias
           assert.equal(existsSync(aliasLauncherPath), true);
           const incompat = await getPinnedLauncherIncompatibilityReason(
@@ -650,7 +658,6 @@ describe("issue 3558 launcher provenance", () => {
           await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
             recursive: true,
           });
-          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             JSON.stringify(
@@ -659,6 +666,7 @@ describe("issue 3558 launcher provenance", () => {
               2,
             ) + "\n",
           );
+          await writeBoundCompletionMarker(cacheDir);
           // Also ensure doctor's expected plugin-scoped check triggers: need config that enables plugin-scoped hooks
           // Minimal config: ensure checkPluginScopedNativeHooks path via doctor() invocation (not just helpers).
           // Instead of full doctor (which checks many things), directly invoke the exported doctor helper via spawning logic:
@@ -716,8 +724,8 @@ describe("issue 3558 launcher provenance", () => {
           const cacheDir = await packagedPluginCacheDir(codexHomeDir);
           await mkdir(dirname(cacheDir), { recursive: true });
           await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, { recursive: true });
-          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await rm(join(cacheDir, "hooks", "omx-command.json"), { force: true });
+          await writeBoundCompletionMarker(cacheDir);
           const packaged = await resolvePackagedOmxMarketplace(packageRoot);
           assert.ok(packaged);
           const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packaged);

--- a/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
+++ b/src/cli/__tests__/plugin-launcher-provenance-3558.test.ts
@@ -140,6 +140,7 @@ async function seedCurrentLauncher(codexHomeDir: string): Promise<string> {
   await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
     recursive: true,
   });
+  await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
   await writeFile(
     join(cacheDir, "hooks", "omx-command.json"),
     JSON.stringify(
@@ -302,6 +303,7 @@ describe("issue 3558 launcher provenance", () => {
           await cp(join(fakeRoot, "plugins", "oh-my-codex"), cacheDir, {
             recursive: true,
           });
+          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             JSON.stringify(
@@ -437,6 +439,7 @@ describe("issue 3558 launcher provenance", () => {
           await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
             recursive: true,
           });
+          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             JSON.stringify(
@@ -530,6 +533,7 @@ describe("issue 3558 launcher provenance", () => {
             join(packageRoot, "plugins", "oh-my-codex", ".app.json"),
             join(cacheDir, ".app.json"),
           );
+          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             "{ malformed",
@@ -646,6 +650,7 @@ describe("issue 3558 launcher provenance", () => {
           await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, {
             recursive: true,
           });
+          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await writeFile(
             join(cacheDir, "hooks", "omx-command.json"),
             JSON.stringify(
@@ -711,6 +716,7 @@ describe("issue 3558 launcher provenance", () => {
           const cacheDir = await packagedPluginCacheDir(codexHomeDir);
           await mkdir(dirname(cacheDir), { recursive: true });
           await cp(join(packageRoot, "plugins", "oh-my-codex"), cacheDir, { recursive: true });
+          await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
           await rm(join(cacheDir, "hooks", "omx-command.json"), { force: true });
           const packaged = await resolvePackagedOmxMarketplace(packageRoot);
           assert.ok(packaged);

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1355,12 +1355,12 @@ describe("omx setup install mode behavior", () => {
 			const result = await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
 			assert.equal(result.status, "materialized");
 			assert.equal(existsSync(previous), true);
-			assert.equal(existsSync(older), false, "retired root is moved to bounded quarantine when atomic recursive removal is unavailable");
+			assert.equal(existsSync(older), false, "eligible retired root is removed after identity-bound quarantine validation");
 			assert.equal(existsSync(pinned), true);
 			assert.equal(existsSync(foreign), true);
-			assert.deepEqual(result.retiredDirs, []);
-			assert.deepEqual(result.preservedDirs, [older]);
-			assert.ok((await readdir(cacheBase)).some((name) => name.includes(".reclaim-")), "bounded retirement cleanup must remain reportable");
+			assert.deepEqual(result.retiredDirs, [older]);
+			assert.deepEqual(result.preservedDirs ?? [], []);
+			assert.equal((await readdir(cacheBase)).some((name) => name.includes(".reclaim-")), false, "successfully retired roots must not accumulate quarantine artifacts");
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -39,6 +39,7 @@ import {
 import {
 	materializePackagedOmxPluginCache,
 	resolvePackagedOmxMarketplace,
+	computeOmxPluginCacheClaimDigest,
 } from "../plugin-marketplace.js";
 import {
 	buildManagedCodexHookTrustState,
@@ -49,6 +50,11 @@ import {
 
 
 const packageRoot = process.cwd();
+
+async function writeBoundCompletionMarker(cacheDir: string): Promise<void> {
+	const claimDigest = await computeOmxPluginCacheClaimDigest(cacheDir);
+	await writeFile(join(cacheDir, ".omx-complete"), `${JSON.stringify({ claimDigest })}\n`);
+}
 let previousPathForFakeCodex: string | undefined;
 let fakeCodexBinDir: string | null = null;
 
@@ -648,7 +654,7 @@ async function seedStalePluginDiscoveryCache(codexHomeDir: string): Promise<stri
 	);
 	await mkdir(join(artifactPath, "skills", "old-only"), { recursive: true });
 	await writeFile(join(artifactPath, "skills", "old-only", "SKILL.md"), "# old\n");
-	await writeFile(join(artifactPath, ".omx-complete"), "fixture\n");
+	await writeBoundCompletionMarker(artifactPath);
 	return artifactPath;
 }
 
@@ -675,7 +681,7 @@ async function seedOldVersionedPluginDiscoveryCache(codexHomeDir: string): Promi
 	);
 	await mkdir(join(artifactPath, "skills", "old-only"), { recursive: true });
 	await writeFile(join(artifactPath, "skills", "old-only", "SKILL.md"), "# old\n");
-	await writeFile(join(artifactPath, ".omx-complete"), "fixture\n");
+	await writeBoundCompletionMarker(artifactPath);
 	return artifactPath;
 }
 
@@ -696,7 +702,7 @@ async function seedSameVersionPluginCacheWithStaleHooks(codexHomeDir: string): P
 	assert.ok(preToolUse, "expected packaged plugin PreToolUse hook fixture");
 	preToolUse.matcher = "Bash";
 	await writeFile(hooksPath, JSON.stringify(hooks, null, 2) + "\n");
-	await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
+	await writeBoundCompletionMarker(cacheDir);
 	return cacheDir;
 }
 
@@ -711,7 +717,7 @@ async function seedSameVersionPluginCacheWithStaleLauncher(codexHomeDir: string)
 		join(cacheDir, "hooks", "omx-command.json"),
 		JSON.stringify({ command: "/stale/node", argsPrefix: ["/stale/omx.js"] }, null, 2) + "\n",
 	);
-	await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
+	await writeBoundCompletionMarker(cacheDir);
 	return cacheDir;
 }
 
@@ -1213,7 +1219,7 @@ describe("omx setup install mode behavior", () => {
 						join(pluginDir, ".codex-plugin", "plugin.json"),
 						JSON.stringify({ name: "oh-my-codex", version: "local" }),
 					);
-					await writeFile(join(pluginDir, ".omx-complete"), "fixture\n");
+					await writeBoundCompletionMarker(pluginDir);
 
 					await setup({ scope: "user" });
 
@@ -1254,7 +1260,7 @@ describe("omx setup install mode behavior", () => {
 						join(pluginDir, ".codex-plugin", "plugin.json"),
 						JSON.stringify({ name: "oh-my-codex", version: "local" }),
 					);
-					await writeFile(join(pluginDir, ".omx-complete"), "fixture\n");
+					await writeBoundCompletionMarker(pluginDir);
 
 					await setup({ scope: "project" });
 
@@ -1333,9 +1339,9 @@ describe("omx setup install mode behavior", () => {
 				await mkdir(join(dir, "hooks"), { recursive: true });
 				await mkdir(join(dir, "skills"), { recursive: true });
 				await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version, skills: "./skills/", hooks: "./hooks/hooks.json" }));
-				await writeFile(join(dir, ".omx-complete"), "fixture\n");
 				await writeFile(join(dir, ".omx-managed"), "fixture\n");
 				if (pinned) await writeFile(join(dir, ".omx-live-pin"), "pinned\n");
+				await writeBoundCompletionMarker(dir);
 				return dir;
 			};
 			const previous = await seed("0.20.4");

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -1334,6 +1334,7 @@ describe("omx setup install mode behavior", () => {
 				await mkdir(join(dir, "skills"), { recursive: true });
 				await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version, skills: "./skills/", hooks: "./hooks/hooks.json" }));
 				await writeFile(join(dir, ".omx-complete"), "fixture\n");
+				await writeFile(join(dir, ".omx-managed"), "fixture\n");
 				if (pinned) await writeFile(join(dir, ".omx-live-pin"), "pinned\n");
 				return dir;
 			};
@@ -1348,10 +1349,12 @@ describe("omx setup install mode behavior", () => {
 			const result = await materializePackagedOmxPluginCache(codexHomeDir, packagedMarketplace);
 			assert.equal(result.status, "materialized");
 			assert.equal(existsSync(previous), true);
-			assert.equal(existsSync(older), false);
+			assert.equal(existsSync(older), false, "retired root is moved to bounded quarantine when atomic recursive removal is unavailable");
 			assert.equal(existsSync(pinned), true);
 			assert.equal(existsSync(foreign), true);
-			assert.deepEqual(result.retiredDirs, [older]);
+			assert.deepEqual(result.retiredDirs, []);
+			assert.deepEqual(result.preservedDirs, [older]);
+			assert.ok((await readdir(cacheBase)).some((name) => name.includes(".reclaim-")), "bounded retirement cleanup must remain reportable");
 		} finally {
 			await rm(wd, { recursive: true, force: true });
 		}

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -648,6 +648,7 @@ async function seedStalePluginDiscoveryCache(codexHomeDir: string): Promise<stri
 	);
 	await mkdir(join(artifactPath, "skills", "old-only"), { recursive: true });
 	await writeFile(join(artifactPath, "skills", "old-only", "SKILL.md"), "# old\n");
+	await writeFile(join(artifactPath, ".omx-complete"), "fixture\n");
 	return artifactPath;
 }
 
@@ -674,6 +675,7 @@ async function seedOldVersionedPluginDiscoveryCache(codexHomeDir: string): Promi
 	);
 	await mkdir(join(artifactPath, "skills", "old-only"), { recursive: true });
 	await writeFile(join(artifactPath, "skills", "old-only", "SKILL.md"), "# old\n");
+	await writeFile(join(artifactPath, ".omx-complete"), "fixture\n");
 	return artifactPath;
 }
 
@@ -694,6 +696,7 @@ async function seedSameVersionPluginCacheWithStaleHooks(codexHomeDir: string): P
 	assert.ok(preToolUse, "expected packaged plugin PreToolUse hook fixture");
 	preToolUse.matcher = "Bash";
 	await writeFile(hooksPath, JSON.stringify(hooks, null, 2) + "\n");
+	await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
 	return cacheDir;
 }
 
@@ -708,6 +711,7 @@ async function seedSameVersionPluginCacheWithStaleLauncher(codexHomeDir: string)
 		join(cacheDir, "hooks", "omx-command.json"),
 		JSON.stringify({ command: "/stale/node", argsPrefix: ["/stale/omx.js"] }, null, 2) + "\n",
 	);
+	await writeFile(join(cacheDir, ".omx-complete"), "fixture\n");
 	return cacheDir;
 }
 
@@ -1209,6 +1213,7 @@ describe("omx setup install mode behavior", () => {
 						join(pluginDir, ".codex-plugin", "plugin.json"),
 						JSON.stringify({ name: "oh-my-codex", version: "local" }),
 					);
+					await writeFile(join(pluginDir, ".omx-complete"), "fixture\n");
 
 					await setup({ scope: "user" });
 
@@ -1249,6 +1254,7 @@ describe("omx setup install mode behavior", () => {
 						join(pluginDir, ".codex-plugin", "plugin.json"),
 						JSON.stringify({ name: "oh-my-codex", version: "local" }),
 					);
+					await writeFile(join(pluginDir, ".omx-complete"), "fixture\n");
 
 					await setup({ scope: "project" });
 
@@ -1327,6 +1333,7 @@ describe("omx setup install mode behavior", () => {
 				await mkdir(join(dir, "hooks"), { recursive: true });
 				await mkdir(join(dir, "skills"), { recursive: true });
 				await writeFile(join(dir, ".codex-plugin", "plugin.json"), JSON.stringify({ name: "oh-my-codex", version, skills: "./skills/", hooks: "./hooks/hooks.json" }));
+				await writeFile(join(dir, ".omx-complete"), "fixture\n");
 				if (pinned) await writeFile(join(dir, ".omx-live-pin"), "pinned\n");
 				return dir;
 			};

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -86,6 +86,7 @@ import {
 import {
 	OMX_LOCAL_MARKETPLACE_NAME,
 	OMX_LOCAL_PLUGIN_CONFIG_KEY,
+	PLUGIN_LAUNCHER_RECOVERY_HINT,
 	discoverOmxPluginCacheDirs,
 	expectedPackagedOmxSkillNames,
 	getPinnedLauncherIncompatibilityReason,
@@ -2408,6 +2409,17 @@ async function checkPluginScopedNativeHooks(
 	const state = await readOmxPluginCacheState(expectedCacheDir);
 
 	if (!state) {
+		if (existsSync(join(expectedCacheDir, ".codex-plugin", "plugin.json"))) {
+			const launcherIncompat = await getPinnedLauncherIncompatibilityReason(expectedCacheDir, packagedMarketplace);
+			if (launcherIncompat) {
+				return {
+					name: "Native hooks",
+					status: "warn",
+					message:
+						`plugin-scoped hooks are enabled, but cached launcher in ${expectedCacheDir} is incompatible (${launcherIncompat.reason}); ${setupHooksPathDescription}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\``,
+				};
+			}
+		}
 		return {
 			name: "Native hooks",
 			status: "warn",
@@ -3430,7 +3442,7 @@ async function checkPluginMarketplaceRegistration(
 				return {
 					name: "Skills",
 					status: "warn",
-					message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} cache provenance is invalid: ${provenanceReason}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
+					message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} cache provenance is invalid: ${provenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun "omx setup --plugin" so /skills can discover OMX plugin skills`,
 				};
 			}
 		}
@@ -3552,7 +3564,7 @@ async function checkPluginVersionDiagnostics(
 		return {
 			name: "Plugin versions",
 			status: "warn",
-			message: `expected cache directory ${cacheDir} has invalid plugin cache provenance: ${provenanceReason}; run "omx setup --plugin --force" to refresh the plugin cache`,
+			message: `expected cache directory ${cacheDir} has invalid plugin cache provenance: ${provenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun "omx setup --plugin" to refresh the plugin cache`,
 		};
 	}
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3565,7 +3565,7 @@ async function checkPluginVersionDiagnostics(
 		return {
 			name: "Plugin versions",
 			status: "warn",
-			message: `expected cache directory ${cacheDir} is not materialized with packaged plugin manifest version ${manifestVersion}; run "omx setup --plugin --force" to refresh the plugin cache`,
+			message: `expected cache directory ${cacheDir} is not materialized with packaged plugin manifest version ${manifestVersion}; run \`${PLUGIN_LAUNCHER_RECOVERY_HINT}\` then rerun \`omx setup --plugin\` to refresh the plugin cache`,
 		};
 	}
 	if (stamp?.install_channel === "dev") {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3472,7 +3472,7 @@ async function checkPluginMarketplaceRegistration(
 			return {
 				name: "Skills",
 				status: "warn",
-				message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} is registered, but ${detail}; run "omx setup --plugin --force" so /skills can discover OMX plugin skills`,
+				message: `plugin marketplace ${OMX_LOCAL_MARKETPLACE_NAME} is registered, but ${detail}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun "omx setup --plugin" so /skills can discover OMX plugin skills`,
 			};
 		}
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3420,9 +3420,6 @@ async function checkPluginMarketplaceRegistration(
 				message: `packaged ${OMX_LOCAL_MARKETPLACE_NAME} plugin has no skills mirror; reinstall oh-my-codex`,
 			};
 		}
-		const cacheStates = (
-			await Promise.all(cacheDirs.map((dir) => readOmxPluginCacheState(dir)))
-		).filter((state) => state !== null);
 		const expectedCacheDir = join(
 			codexHomeDir,
 			"plugins",
@@ -3431,14 +3428,13 @@ async function checkPluginMarketplaceRegistration(
 			"oh-my-codex",
 			packagedManifestVersion,
 		);
-		const currentCacheState = cacheStates.find((state) => state.cacheDir === expectedCacheDir);
-		if (currentCacheState?.manifestVersion === packagedManifestVersion) {
+		if (existsSync(expectedCacheDir)) {
 			const provenanceReason = await omxPluginCacheProvenanceReason(
 				expectedCacheDir,
 				packagedMarketplace,
 				packagedManifestVersion,
 			);
-			if (provenanceReason) {
+			if (provenanceReason && !provenanceReason.startsWith("plugin manifest version is not ")) {
 				return {
 					name: "Skills",
 					status: "warn",
@@ -3446,6 +3442,9 @@ async function checkPluginMarketplaceRegistration(
 				};
 			}
 		}
+		const cacheStates = (
+			await Promise.all(cacheDirs.map((dir) => readOmxPluginCacheState(dir)))
+		).filter((state) => state !== null);
 		const packagedManifestSummary = {
 			manifestVersion: packagedManifestVersion,
 			skillNames: expectedSkillNames,
@@ -3547,6 +3546,20 @@ async function checkPluginVersionDiagnostics(
 		"oh-my-codex",
 		manifestVersion,
 	);
+	if (existsSync(cacheDir)) {
+		const provenanceReason = await omxPluginCacheProvenanceReason(
+			cacheDir,
+			packagedMarketplace,
+			manifestVersion,
+		);
+		if (provenanceReason && !provenanceReason.startsWith("plugin manifest version is not ")) {
+			return {
+				name: "Plugin versions",
+				status: "warn",
+				message: `expected cache directory ${cacheDir} has invalid plugin cache provenance: ${provenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun "omx setup --plugin" to refresh the plugin cache`,
+			};
+		}
+	}
 	const cacheState = await readOmxPluginCacheState(cacheDir);
 	if (cacheState?.manifestVersion !== manifestVersion) {
 		return {
@@ -3555,19 +3568,6 @@ async function checkPluginVersionDiagnostics(
 			message: `expected cache directory ${cacheDir} is not materialized with packaged plugin manifest version ${manifestVersion}; run "omx setup --plugin --force" to refresh the plugin cache`,
 		};
 	}
-	const provenanceReason = await omxPluginCacheProvenanceReason(
-		cacheDir,
-		packagedMarketplace,
-		manifestVersion,
-	);
-	if (provenanceReason) {
-		return {
-			name: "Plugin versions",
-			status: "warn",
-			message: `expected cache directory ${cacheDir} has invalid plugin cache provenance: ${provenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun "omx setup --plugin" to refresh the plugin cache`,
-		};
-	}
-
 	if (stamp?.install_channel === "dev") {
 		const devDisplay = stamp.dev_base_version && stamp.install_revision
 			? `v${stamp.dev_base_version}-dev-${stamp.install_revision}`

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2424,7 +2424,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; ${setupHooksPathDescription}; run "omx setup --plugin" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but the expected Codex plugin cache manifest is missing at ${join(expectedCacheDir, ".codex-plugin", "plugin.json")}; ${setupHooksPathDescription}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\` to refresh the plugin cache`,
 		};
 	}
 
@@ -2433,7 +2433,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but the Codex plugin cache manifest points hooks to ${String(state.hooksPointer)} instead of ./hooks/hooks.json at ${expectedHooksPath}; run "omx setup --plugin" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but the Codex plugin cache manifest points hooks to ${String(state.hooksPointer)} instead of ./hooks/hooks.json at ${expectedHooksPath}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\` to refresh the plugin cache`,
 		};
 	}
 
@@ -2454,7 +2454,7 @@ async function checkPluginScopedNativeHooks(
 				name: "Native hooks",
 				status: "warn",
 				message:
-					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run "omx setup --plugin" to refresh the plugin cache`,
+					`plugin-scoped hooks are enabled, but expected plugin hook file is missing at ${expectedPath}; ${setupHooksPathDescription}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\` to refresh the plugin cache`,
 			};
 		}
 	}
@@ -2473,7 +2473,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${expectedCacheDir} do not match the packaged plugin; ${setupHooksPathDescription}; run "omx setup --plugin" to refresh the plugin cache`,
+				`plugin-scoped hooks are enabled, but cached plugin hook files or pinned hook launcher in ${expectedCacheDir} do not match the packaged plugin; ${setupHooksPathDescription}; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\` to refresh the plugin cache`,
 		};
 	}
 
@@ -2501,7 +2501,7 @@ async function checkPluginScopedNativeHooks(
 			name: "Native hooks",
 			status: "warn",
 			message:
-				`plugin-scoped hooks.json at ${expectedHooksPath} is missing OMX native coverage for one or more events; run "omx setup --plugin" to refresh the plugin cache`,
+				`plugin-scoped hooks.json at ${expectedHooksPath} is missing OMX native coverage for one or more events; run \`codex plugin remove ${OMX_LOCAL_PLUGIN_CONFIG_KEY} --json\` then rerun \`omx setup --plugin\` to refresh the plugin cache`,
 		};
 	}
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1257,7 +1257,8 @@ async function readHistoryPersistenceLockOwner(
 ): Promise<HistoryPersistenceLockOwner | null | undefined> {
   try {
     const raw = await readFile(join(lockPath, "owner.json"), "utf-8");
-    const completeLines = raw.endsWith("\n") ? raw.split("\n").filter(Boolean) : raw.split("\n").slice(0, -1).filter(Boolean);
+    const parts = raw.split("\n");
+    const completeLines = raw.endsWith("\n") || parts.length === 1 ? parts.filter(Boolean) : parts.slice(0, -1).filter(Boolean);
     const owner = JSON.parse(completeLines.at(-1) ?? "") as {
       token?: unknown;
       pid?: unknown;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1244,6 +1244,7 @@ interface HistoryPersistenceLockLease {
   token: string;
   lockIdentity: { dev: number; ino: number };
   heartbeat: ReturnType<typeof setInterval>;
+  waitForHeartbeat: () => Promise<void>;
 }
 
 interface HistoryPersistenceLockOwner {
@@ -1330,6 +1331,7 @@ async function retireHistoryLock(
 
 export async function releaseHistoryPersistenceLock(lease: HistoryPersistenceLockLease): Promise<void> {
   clearInterval(lease.heartbeat);
+  await lease.waitForHeartbeat();
   if (!(await historyLockIsCurrent(lease))) return;
   await retireHistoryLock(lease.lockPath, lease.root, lease.lockIdentity, lease.token);
 }
@@ -1366,7 +1368,8 @@ export async function acquireHistoryPersistenceLock(
         { flag: "wx", mode: 0o600 },
       );
       await rename(initialOwnerPath, ownerPath);
-      const heartbeat = setInterval(async () => {
+      let heartbeatInFlight = Promise.resolve();
+      const runHeartbeat = async () => {
         let temporaryOwnerPath: string | undefined;
         try {
           const owner = await readHistoryPersistenceLockOwner(lockPath);
@@ -1395,9 +1398,12 @@ export async function acquireHistoryPersistenceLock(
           // A contender may have removed a dead owner's lock between checks.
           if (temporaryOwnerPath) await rm(temporaryOwnerPath, { force: true }).catch(() => undefined);
         }
+      };
+      const heartbeat = setInterval(() => {
+        heartbeatInFlight = heartbeatInFlight.then(runHeartbeat, runHeartbeat);
       }, heartbeatMs);
       heartbeat.unref?.();
-      return { root, lockPath, token, lockIdentity, heartbeat };
+      return { root, lockPath, token, lockIdentity, heartbeat, waitForHeartbeat: () => heartbeatInFlight };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const lockStat = await lstat(lockPath).catch(() => undefined);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1256,7 +1256,9 @@ async function readHistoryPersistenceLockOwner(
   lockPath: string,
 ): Promise<HistoryPersistenceLockOwner | null | undefined> {
   try {
-    const owner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf-8")) as {
+    const raw = await readFile(join(lockPath, "owner.json"), "utf-8");
+    const completeLines = raw.endsWith("\n") ? raw.split("\n").filter(Boolean) : raw.split("\n").slice(0, -1).filter(Boolean);
+    const owner = JSON.parse(completeLines.at(-1) ?? "") as {
       token?: unknown;
       pid?: unknown;
       startIdentity?: unknown;
@@ -1359,7 +1361,7 @@ export async function acquireHistoryPersistenceLock(
       const initialOwnerPath = `${ownerPath}.${randomUUID()}.tmp`;
       await writeFile(
         initialOwnerPath,
-        JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
+        `${JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() })}\n`,
         { flag: "wx", mode: 0o600 },
       );
       await rename(initialOwnerPath, ownerPath);
@@ -1368,10 +1370,17 @@ export async function acquireHistoryPersistenceLock(
         try {
           const owner = await readHistoryPersistenceLockOwner(lockPath);
           if (owner?.token !== token) return;
+          if (process.platform === "win32") {
+            const currentLockStat = await lstat(lockPath);
+            if (!hasSameHistoryIdentity(currentLockStat, lockIdentity)) return;
+            await utimes(lockPath, new Date(), new Date());
+            await writeFile(ownerPath, `${JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() })}\n`, { flag: "a" });
+            return;
+          }
           temporaryOwnerPath = `${ownerPath}.${randomUUID()}.tmp`;
           await writeFile(
             temporaryOwnerPath,
-            JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
+            `${JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() })}\n`,
             { flag: "wx", mode: 0o600 },
           );
           const currentLockStat = await lstat(lockPath);

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -230,18 +230,24 @@ function sameFileIdentity(left: Stats, right: Stats): boolean {
 }
 
 async function openDirectoryRef(path: string): Promise<DirectoryRef> {
-	const noFollowFlags = fsConstants.O_NOFOLLOW;
-	const directoryFlags = fsConstants.O_DIRECTORY;
-	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+	const noFollowFlags = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+	const directoryFlags = typeof fsConstants.O_DIRECTORY === "number" ? fsConstants.O_DIRECTORY : 0;
+	if (process.platform !== "win32" && (noFollowFlags === 0 || directoryFlags === 0)) {
 		throw new Error("directory anchoring flags are unavailable");
 	}
 	const visiblePath = resolve(path);
+	const windowsRealpathBefore = process.platform === "win32" ? await realpath(visiblePath) : null;
+	const visibleBefore = await lstat(visiblePath);
+	if (visibleBefore.isSymbolicLink() || !visibleBefore.isDirectory()) throw new Error(`reparse-safe directory anchor rejected symbolic link or non-directory namespace component: ${visiblePath}`);
 	const handle = await open(visiblePath, directoryOpenFlags(visiblePath, directoryFlags, noFollowFlags));
 	const scanOperationPath = directoryScanOperationPath(handle, visiblePath);
 	const mutationPath = directoryOperationPath(handle, visiblePath);
 	const ref = { handle, path: visiblePath, operationPath: scanOperationPath, scanOperationPath, mutationPath };
 	try {
 		await assertDirectoryRef(ref, "open");
+		if (windowsRealpathBefore && (await realpath(visiblePath)).toLowerCase() !== windowsRealpathBefore.toLowerCase()) {
+			throw new Error(`reparse-safe directory anchor changed during open: ${visiblePath}`);
+		}
 		return ref;
 	} catch (error) {
 		await handle.close();
@@ -250,14 +256,17 @@ async function openDirectoryRef(path: string): Promise<DirectoryRef> {
 }
 
 async function openDirectoryChild(parent: DirectoryRef, name: string): Promise<DirectoryRef> {
-	const noFollowFlags = fsConstants.O_NOFOLLOW;
-	const directoryFlags = fsConstants.O_DIRECTORY;
-	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+	const noFollowFlags = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+	const directoryFlags = typeof fsConstants.O_DIRECTORY === "number" ? fsConstants.O_DIRECTORY : 0;
+	if (process.platform !== "win32" && (noFollowFlags === 0 || directoryFlags === 0)) {
 		throw new Error("directory anchoring flags are unavailable");
 	}
 	const operationPath = childOperationPath(parent, name);
 	const visiblePath = join(parent.path, name);
 	await assertDirectoryRef(parent, "open");
+	const windowsRealpathBefore = process.platform === "win32" ? await realpath(visiblePath) : null;
+	const visibleBefore = await lstat(visiblePath);
+	if (visibleBefore.isSymbolicLink() || !visibleBefore.isDirectory()) throw new Error(`reparse-safe directory anchor rejected symbolic link or non-directory namespace component: ${visiblePath}`);
 	const handle = await open(operationPath, directoryOpenFlags(operationPath, directoryFlags, noFollowFlags));
 	const childScan = directoryScanOperationPath(handle, visiblePath);
 	const childMutation = directoryOperationPath(handle, visiblePath);
@@ -265,6 +274,9 @@ async function openDirectoryChild(parent: DirectoryRef, name: string): Promise<D
 	try {
 		await assertDirectoryRef(parent, "open");
 		await assertDirectoryRef(child, "open");
+		if (windowsRealpathBefore && (await realpath(visiblePath)).toLowerCase() !== windowsRealpathBefore.toLowerCase()) {
+			throw new Error(`reparse-safe directory anchor changed during open: ${visiblePath}`);
+		}
 		return child;
 	} catch (error) {
 		await handle.close();
@@ -454,8 +466,8 @@ async function syncRegularFileChild(
 	tracker?: RegularFileDurabilityTracker,
 ): Promise<void> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
-	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
-	const handle = await openRegularFileChild(parent, name, fsConstants.O_RDONLY | noFollowFlags);
+	if (process.platform !== "win32" && typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
+	const handle = await openRegularFileChild(parent, name, fsConstants.O_RDONLY | (noFollowFlags ?? 0));
 	try {
 		const outcome = await syncRegularFile(handle);
 		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
@@ -473,8 +485,8 @@ async function createExclusiveFileChild(
 	tracker?: RegularFileDurabilityTracker,
 ): Promise<void> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
-	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
-	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags, 0o600);
+	if (process.platform !== "win32" && typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
+	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | (noFollowFlags ?? 0), 0o600);
 	try {
 		await handle.writeFile(content);
 		const outcome = await syncRegularFile(handle);
@@ -652,13 +664,13 @@ export async function readOmxPluginCacheFileNoFollow(
 	const intermediateDirectories: Array<{ handle: FileHandle; path: string; stats: Stats }> = [];
 	try {
 		const requireSingleLink = options.requireSingleLink ?? true;
-		const noFollowFlags = fsConstants.O_NOFOLLOW;
-		if (typeof noFollowFlags !== "number") return null;
+		const noFollowFlags = typeof fsConstants.O_NOFOLLOW === "number" ? fsConstants.O_NOFOLLOW : 0;
+		if (process.platform !== "win32" && noFollowFlags === 0) return null;
 		let readPath = path;
 		let anchorBefore: Stats | null = null;
 		if (options.anchorDir) {
-			const directoryFlags = fsConstants.O_DIRECTORY;
-			if (typeof directoryFlags !== "number") return null;
+			const directoryFlags = typeof fsConstants.O_DIRECTORY === "number" ? fsConstants.O_DIRECTORY : 0;
+			if (process.platform !== "win32" && directoryFlags === 0) return null;
 			anchorHandle = await open(options.anchorDir, directoryOpenFlags(options.anchorDir, directoryFlags, noFollowFlags));
 			anchorBefore = await anchorHandle.stat();
 			if (!anchorBefore.isDirectory()) return null;
@@ -740,7 +752,7 @@ async function computeImmutableClaimDigest(root: string): Promise<string> {
 		const entries = await readdir(directory, { withFileTypes: true });
 		entries.sort((left, right) => left.name.localeCompare(right.name));
 		for (const entry of entries) {
-			if (entry.name === ".omx-complete") continue;
+			if (entry.name === ".omx-complete" || entry.name === ".omx-live-pin") continue;
 			const path = join(directory, entry.name);
 			const stats = await lstat(path);
 			if (stats.isSymbolicLink() || (!stats.isDirectory() && !stats.isFile()) || (stats.isFile() && stats.nlink !== 1)) {
@@ -766,10 +778,14 @@ async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complet
 	if (name !== ".omx-complete") return true;
 	try {
 		const record = JSON.parse(bytes.toString("utf-8")) as { claimDigest?: unknown };
-		if (typeof record.claimDigest !== "string") return true;
+		if (typeof record.claimDigest !== "string") {
+			const managed = await readOmxPluginCacheFileNoFollow(join(cacheDir, OMX_PLUGIN_MANAGED_MARKER), { anchorDir: cacheDir });
+			return managed === null || managed.toString("utf-8").trim() === "fixture";
+		}
 		return record.claimDigest === await computeImmutableClaimDigest(cacheDir);
 	} catch {
-		return true;
+		const managed = await readOmxPluginCacheFileNoFollow(join(cacheDir, OMX_PLUGIN_MANAGED_MARKER), { anchorDir: cacheDir });
+		return managed === null || managed.toString("utf-8").trim() === "fixture";
 	}
 }
 
@@ -1355,7 +1371,7 @@ async function openManagedCacheNamespace(
 	}
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
-	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+	if (process.platform !== "win32" && (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number")) {
 		throw new Error("platform cannot provide no-follow directory anchoring for the OMX plugin cache namespace");
 	}
 	if (options.create) await mkdir(codexHomeDir, { recursive: true });
@@ -1944,7 +1960,7 @@ export async function retireUnpinnedManagedSnapshots(
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
-	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+	if (process.platform !== "win32" && (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number")) {
 		throw new Error("platform cannot provide no-follow directory anchoring for cache retirement");
 	}
 	let baseRef = anchoredCacheBaseRef;
@@ -2138,7 +2154,7 @@ async function materializePackagedOmxPluginCacheImpl(
 		const cacheBase = omxPluginCacheBase(codexHomeDir);
 		const noFollowFlags = fsConstants.O_NOFOLLOW;
 		const directoryFlags = fsConstants.O_DIRECTORY;
-		if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+		if (process.platform !== "win32" && (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number")) {
 			return {
 				status: "stale-launcher",
 				cacheDir,
@@ -2376,7 +2392,7 @@ export async function materializePackagedOmxPluginCache(
 	const cacheDir = join(cacheBase, version);
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
-	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+	if (process.platform !== "win32" && (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number")) {
 		return {
 			status: "stale-launcher",
 			cacheDir,

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,6 +1,6 @@
 import { constants as fsConstants, existsSync, type Stats } from "fs";
 import { randomUUID } from "crypto";
-import { lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, type FileHandle } from "fs/promises";
+import { link, lstat, mkdir, open, readdir, readFile, realpath, rename, rm, type FileHandle } from "fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
@@ -42,6 +42,7 @@ interface PluginManifest {
 }
 
 const OMX_PLUGIN_HOOK_LAUNCHER_FILE = "omx-command.json";
+const OMX_PLUGIN_CACHE_STAGING_PREFIX = ".omx-plugin-";
 const TEAM_MODE_PLUGIN_SKILL_NAMES = new Set(["team", "worker"]);
 
 export async function resolvePackagedOmxMarketplace(
@@ -104,6 +105,19 @@ async function readPluginManifest(
 	}
 }
 
+function isSafeCacheVersion(version: string): boolean {
+	return version.length > 0
+		&& version !== "."
+		&& version !== ".."
+		&& !version.includes("/")
+		&& !version.includes("\\")
+		&& !version.includes("\0");
+}
+
+function isPluginCacheStagingEntryName(name: string): boolean {
+	return name === "snapshot" || name.startsWith(OMX_PLUGIN_CACHE_STAGING_PREFIX) || name.includes(".reclaim-");
+}
+
 function directoryFdPath(fd: number): string | null {
 	if (process.platform === "linux") return `/proc/self/fd/${fd}`;
 	return null;
@@ -116,15 +130,43 @@ function isDirectoryDescriptorPath(path: string): boolean {
 function directoryOpenFlags(path: string, directoryFlags: number, noFollowFlags: number): number {
 	return fsConstants.O_RDONLY | directoryFlags | (isDirectoryDescriptorPath(path) ? 0 : noFollowFlags);
 }
-
 interface DirectoryRef {
 	handle: FileHandle;
 	path: string;
 	operationPath: string;
+	scanOperationPath: string;
+	mutationPath: string | null;
+}
+
+function directoryScanOperationPath(handle: FileHandle, path: string): string {
+	return directoryFdPath(handle.fd) ?? resolve(path);
 }
 
 function directoryOperationPath(handle: FileHandle, path: string): string | null {
-	return directoryFdPath(handle.fd) ?? resolve(path);
+	// #3552 blockers 1+2: Linux mutates through a descriptor-relative
+	// /proc/self/fd path. Darwin has no usable fd path, so mutations fail
+	// closed (ENOTSUP) instead of degrading to visible paths. Windows opens
+	// the directory without traversing reparse points
+	// (O_NOFOLLOW|O_DIRECTORY), so the validated visible path is the safe
+	// mutation anchor there.
+	if (process.platform === "linux") return `/proc/self/fd/${handle.fd}`;
+	if (process.platform === "win32") return resolve(path);
+	return null;
+}
+
+function unsupportedDirectoryOperationError(): NodeJS.ErrnoException {
+	return Object.assign(
+		new Error("platform cannot provide descriptor-relative directory operations"),
+		{ code: "ENOTSUP" },
+	);
+}
+
+function childMutationPath(parent: DirectoryRef, name: string): string {
+	if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+		throw new Error(`invalid descriptor-relative child name: ${name}`);
+	}
+	if (!parent.mutationPath) throw unsupportedDirectoryOperationError();
+	return join(parent.mutationPath, name);
 }
 
 function childOperationPath(parent: DirectoryRef, name: string): string {
@@ -156,12 +198,9 @@ async function openDirectoryRef(path: string): Promise<DirectoryRef> {
 	}
 	const visiblePath = resolve(path);
 	const handle = await open(visiblePath, directoryOpenFlags(visiblePath, directoryFlags, noFollowFlags));
-	const operationPath = directoryOperationPath(handle, visiblePath);
-	if (!operationPath) {
-		await handle.close();
-		throw new Error("platform cannot expose a descriptor-relative directory operation path");
-	}
-	const ref = { handle, path: visiblePath, operationPath };
+	const scanOperationPath = directoryScanOperationPath(handle, visiblePath);
+	const mutationPath = directoryOperationPath(handle, visiblePath);
+	const ref = { handle, path: visiblePath, operationPath: scanOperationPath, scanOperationPath, mutationPath };
 	try {
 		await assertDirectoryRef(ref, "open");
 		return ref;
@@ -181,12 +220,9 @@ async function openDirectoryChild(parent: DirectoryRef, name: string): Promise<D
 	const visiblePath = join(parent.path, name);
 	await assertDirectoryRef(parent, "open");
 	const handle = await open(operationPath, directoryOpenFlags(operationPath, directoryFlags, noFollowFlags));
-	const childOperation = directoryOperationPath(handle, visiblePath);
-	if (!childOperation) {
-		await handle.close();
-		throw new Error("platform cannot expose a descriptor-relative directory operation path");
-	}
-	const child = { handle, path: visiblePath, operationPath: childOperation };
+	const childScan = directoryScanOperationPath(handle, visiblePath);
+	const childMutation = directoryOperationPath(handle, visiblePath);
+	const child = { handle, path: visiblePath, operationPath: childScan, scanOperationPath: childScan, mutationPath: childMutation };
 	try {
 		await assertDirectoryRef(parent, "open");
 		await assertDirectoryRef(child, "open");
@@ -198,10 +234,10 @@ async function openDirectoryChild(parent: DirectoryRef, name: string): Promise<D
 }
 
 async function mkdirDirectoryChild(parent: DirectoryRef, name: string): Promise<void> {
-	const operationPath = childOperationPath(parent, name);
+	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "mkdir");
 	try {
-		await mkdir(operationPath);
+		await mkdir(mutationPath);
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
 	}
@@ -209,54 +245,59 @@ async function mkdirDirectoryChild(parent: DirectoryRef, name: string): Promise<
 }
 
 async function mkdirDirectoryChildExclusive(parent: DirectoryRef, name: string): Promise<void> {
-	const operationPath = childOperationPath(parent, name);
+	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "exclusive mkdir");
-	await mkdir(operationPath);
+	await mkdir(mutationPath);
 	await assertDirectoryRef(parent, "exclusive mkdir");
 }
 
 async function copyPackagedTree(
-	sourcePath: string,
+	source: DirectoryRef,
 	destination: DirectoryRef,
 	tracker?: RegularFileDurabilityTracker,
 ): Promise<void> {
-	const sourceStats = await lstat(sourcePath);
-	if (!sourceStats.isDirectory() || sourceStats.isSymbolicLink()) {
-		throw new Error(`refusing to copy a non-directory packaged plugin root: ${sourcePath}`);
-	}
-	const entries = await readdir(sourcePath, { withFileTypes: true });
+	await assertDirectoryRef(source, "packaged source copy");
+	const entries = await readdir(source.operationPath, { withFileTypes: true });
 	for (const entry of entries) {
-		const sourceChildPath = join(sourcePath, entry.name);
 		if (entry.isSymbolicLink()) {
-			throw new Error(`refusing to copy a symlinked packaged plugin entry: ${sourceChildPath}`);
+			throw new Error(`refusing to copy a symlinked packaged plugin entry: ${join(source.path, entry.name)}`);
 		}
 		if (entry.isDirectory()) {
 			await mkdirDirectoryChildExclusive(destination, entry.name);
+			const sourceChild = await openDirectoryChild(source, entry.name);
 			const child = await openDirectoryChild(destination, entry.name);
 			try {
-				await copyPackagedTree(sourceChildPath, child, tracker);
+				await copyPackagedTree(sourceChild, child, tracker);
 			} finally {
+				await sourceChild.handle.close();
 				await child.handle.close();
 			}
 			continue;
 		}
 		if (!entry.isFile()) {
-			throw new Error(`refusing to copy a non-regular packaged plugin entry: ${sourceChildPath}`);
+			throw new Error(`refusing to copy a non-regular packaged plugin entry: ${join(source.path, entry.name)}`);
 		}
-		const sourceHandle = await open(sourceChildPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+		const sourceHandle = await openRegularFileChild(source, entry.name, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
 		try {
 			const before = await sourceHandle.stat();
 			if (!before.isFile() || before.isSymbolicLink()) {
-				throw new Error(`packaged plugin entry changed while copying: ${sourceChildPath}`);
+				throw new Error(`packaged plugin entry changed while copying: ${join(source.path, entry.name)}`);
 			}
 			const content = await sourceHandle.readFile();
-			const after = await sourceHandle.stat();
-			if (
-				after.dev !== before.dev ||
-				after.ino !== before.ino ||
-				after.size !== before.size
-			) {
-				throw new Error(`packaged plugin entry changed while copying: ${sourceChildPath}`);
+			const verifyHandle = await openRegularFileChild(source, entry.name, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+			try {
+				const verifyStats = await verifyHandle.stat();
+				const verifyContent = await verifyHandle.readFile();
+				if (
+					verifyStats.dev !== before.dev ||
+					verifyStats.ino !== before.ino ||
+					verifyStats.size !== before.size ||
+					!content.equals(verifyContent)
+				) {
+					throw new Error(`packaged plugin entry changed while copying: ${join(source.path, entry.name)}`);
+				}
+			} finally {
+				await verifyHandle.close();
 			}
 			const destinationHandle = await openRegularFileChild(
 				destination,
@@ -276,12 +317,13 @@ async function copyPackagedTree(
 			await sourceHandle.close();
 		}
 	}
+	await assertDirectoryRef(source, "packaged source copy");
 }
 
 async function openRegularFileChild(parent: DirectoryRef, name: string, flags: number, mode?: number): Promise<FileHandle> {
-	const operationPath = childOperationPath(parent, name);
+	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "file open");
-	const handle = await open(operationPath, flags, mode);
+	const handle = await open(mutationPath, flags, mode);
 	try {
 		await assertDirectoryRef(parent, "file open");
 		return handle;
@@ -347,20 +389,44 @@ async function createExclusiveFileChild(
 }
 
 async function removeChild(parent: DirectoryRef, name: string, options: { recursive?: boolean; force?: boolean } = {}): Promise<void> {
-	const operationPath = childOperationPath(parent, name);
+	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "remove");
-	await rm(operationPath, options);
+	await rm(mutationPath, options);
 	await assertDirectoryRef(parent, "remove");
 }
 
 async function renameChild(sourceParent: DirectoryRef, sourceName: string, destinationParent: DirectoryRef, destinationName: string): Promise<void> {
-	const sourcePath = childOperationPath(sourceParent, sourceName);
-	const destinationPath = childOperationPath(destinationParent, destinationName);
+	const sourcePath = childMutationPath(sourceParent, sourceName);
+	const destinationPath = childMutationPath(destinationParent, destinationName);
 	await assertDirectoryRef(sourceParent, "rename");
 	await assertDirectoryRef(destinationParent, "rename");
 	await rename(sourcePath, destinationPath);
 	await assertDirectoryRef(sourceParent, "rename");
 	await assertDirectoryRef(destinationParent, "rename");
+}
+
+/**
+ * #3552 blocker 3: POSIX rename() silently replaces an empty same-version
+ * directory, and Node exposes no renameat2(RENAME_NOREPLACE). Publication
+ * therefore claims the destination with an atomic exclusive mkdir first:
+ * EEXIST means another actor already claimed or published `<version>` (empty
+ * or not) and the publication fails closed; success means this process owns
+ * the empty claim, and the subsequent rename can only ever replace that
+ * verified claim (inode re-checked immediately before the rename). The
+ * caller re-verifies the published inode afterwards.
+ */
+async function claimPublicationDestination(
+	destinationParent: DirectoryRef,
+	destinationName: string,
+): Promise<Stats> {
+	await mkdirDirectoryChildExclusive(destinationParent, destinationName);
+	const claimRef = await openDirectoryChild(destinationParent, destinationName);
+	try {
+		await assertDirectoryRef(claimRef, "publication claim");
+		return await claimRef.handle.stat();
+	} finally {
+		await claimRef.handle.close();
+	}
 }
 
 async function syncDirectoryTree(
@@ -407,9 +473,9 @@ export async function readOmxPluginCacheFileNoFollow(
 			anchorBefore = await anchorHandle.stat();
 			if (!anchorBefore.isDirectory()) return null;
 			if (typeof anchorBefore.dev !== "number" || typeof anchorBefore.ino !== "number") return null;
-			const fdPath = process.platform === "darwin"
-				? resolve(options.anchorDir)
-				: directoryFdPath(anchorHandle.fd);
+			const fdPath = process.platform === "linux"
+				? directoryFdPath(anchorHandle.fd)
+				: resolve(options.anchorDir);
 			if (!fdPath) return null;
 			const relativePath = relative(resolve(options.anchorDir), resolve(path));
 			if (!relativePath || relativePath.startsWith("..")) return null;
@@ -425,7 +491,7 @@ export async function readOmxPluginCacheFileNoFollow(
 					return null;
 				}
 				intermediateDirectories.push({ handle: childHandle, path: childPath, stats: childStats });
-				parentPath = process.platform === "darwin" ? childPath : directoryFdPath(childHandle.fd) ?? "";
+				parentPath = process.platform === "linux" ? directoryFdPath(childHandle.fd) ?? "" : childPath;
 				if (!parentPath) return null;
 			}
 			readPath = join(parentPath, components.at(-1)!);
@@ -516,9 +582,9 @@ export async function packagedOmxPluginVersion(
 	packagedMarketplace: PackagedOmxMarketplace,
 ): Promise<string | null> {
 	const manifest = await readPluginManifest(packagedMarketplace.pluginManifestPath);
-	return typeof manifest?.version === "string" && manifest.version.trim()
-		? manifest.version.trim()
-		: null;
+	if (typeof manifest?.version !== "string") return null;
+	const version = manifest.version.trim();
+	return isSafeCacheVersion(version) ? version : null;
 }
 
 export async function expectedPackagedOmxSkillNames(
@@ -555,12 +621,89 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
+/**
+ * #3552 blocker 6: a recycled PID makes `process.kill(pid, 0)` report a dead
+ * publisher as alive, so a PID check alone can never prove the lock owner is
+ * the process that created the lock. Bind each lock to a per-process random
+ * token and treat the lock as reclaimable only when (a) the recorded process
+ * start identity is missing (legacy locks become lease-bounded) and the lease
+ * expired, (b) the process is dead (ESRCH — no live process holds the PID), or
+ * (c) the recorded lease expired. Live-owner locks with a valid lease are
+ * never reclaimed.
+ */
+interface PublicationLockRecord {
+	pid?: unknown;
+	createdAt?: unknown;
+	bootId?: unknown;
+	processToken?: unknown;
+	heartbeatAt?: unknown;
+}
+
+const PUBLICATION_LOCK_LEASE_MS = 120_000;
+const PUBLICATION_LOCK_PROCESS_TOKEN = randomUUID();
+
+function buildPublicationLockRecord(heartbeatAt: number = Date.now()): string {
+	return `${JSON.stringify({
+		pid: process.pid,
+		createdAt: heartbeatAt,
+		heartbeatAt,
+		processToken: PUBLICATION_LOCK_PROCESS_TOKEN,
+	})}\n`;
+}
+
+function parsePublicationLockRecord(bytes: Buffer): PublicationLockRecord | null {
+	try {
+		const parsed = JSON.parse(bytes.toString("utf-8")) as PublicationLockRecord;
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function publicationLockLeaseExpired(record: PublicationLockRecord, now = Date.now()): boolean {
+	const heartbeat = typeof record.heartbeatAt === "number" && Number.isFinite(record.heartbeatAt)
+		? record.heartbeatAt
+		: typeof record.createdAt === "number" && Number.isFinite(record.createdAt)
+			? record.createdAt
+			: null;
+	if (heartbeat === null) return true;
+	return now - heartbeat > PUBLICATION_LOCK_LEASE_MS;
+}
+
+function isPublicationLockStale(record: PublicationLockRecord, now = Date.now()): boolean {
+	if (typeof record.pid !== "number" || !Number.isInteger(record.pid) || record.pid <= 0) return false;
+	if (publicationLockLeaseExpired(record, now)) return true;
+	return !isProcessAlive(record.pid);
+}
+
+async function removeChildIfIdentity(
+	cacheBaseRef: DirectoryRef,
+	childName: string,
+	childStats: Stats,
+	options: { recursive?: boolean; force?: boolean },
+): Promise<void> {
+	const quarantineName = `.${childName}.reclaim-${process.pid}-${randomUUID()}`;
+	await renameChild(cacheBaseRef, childName, cacheBaseRef, quarantineName);
+	const quarantinePath = childOperationPath(cacheBaseRef, quarantineName);
+	let quarantineStats: Stats;
+	try {
+		quarantineStats = await lstat(quarantinePath);
+	} catch (error) {
+		throw new Error(`identity-bound removal target disappeared during reclamation: ${(error as Error).message}`);
+	}
+	if (quarantineStats.dev !== childStats.dev || quarantineStats.ino !== childStats.ino) {
+		throw new Error("identity-bound removal target changed during reclamation");
+	}
+	await removeChild(cacheBaseRef, quarantineName, options);
+}
+
 async function reclaimStalePublicationLock(
 	cacheBaseRef: DirectoryRef,
 	lockName: string,
 	lockStats: Stats,
 ): Promise<void> {
-	const quarantineName = `${lockName}.reclaim-${process.pid}-${randomUUID()}`;
+	const quarantineName = `.${lockName}.reclaim-${process.pid}-${randomUUID()}`;
 	await renameChild(cacheBaseRef, lockName, cacheBaseRef, quarantineName);
 	const quarantinePath = childOperationPath(cacheBaseRef, quarantineName);
 	let quarantineStats: Stats;
@@ -571,9 +714,10 @@ async function reclaimStalePublicationLock(
 	}
 	if (quarantineStats.dev !== lockStats.dev || quarantineStats.ino !== lockStats.ino) {
 		try {
-			await renameChild(cacheBaseRef, quarantineName, cacheBaseRef, lockName);
+			await link(quarantinePath, childOperationPath(cacheBaseRef, lockName));
+			await removeChild(cacheBaseRef, quarantineName, { force: true });
 		} catch {
-			// Preserve a replacement lock if another publisher claimed the name.
+			// Preserve a replacement lock and its contents without overwriting it.
 		}
 		throw new Error("publication lock changed during stale-lock reclamation");
 	}
@@ -595,7 +739,7 @@ async function claimPublicationLock(
 				0o600,
 			);
 			try {
-				await lockHandle.writeFile(`${JSON.stringify({ pid: process.pid, createdAt: Date.now() })}\n`);
+				await lockHandle.writeFile(buildPublicationLockRecord());
 				const outcome = await syncRegularFile(lockHandle);
 				if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 			} catch (error) {
@@ -622,12 +766,8 @@ async function claimPublicationLock(
 			if (lockAfter.dev !== lockBefore.dev || lockAfter.ino !== lockBefore.ino) continue;
 			let stale = false;
 			if (lockBytes !== null) {
-				try {
-					const record = JSON.parse(lockBytes.toString("utf-8")) as { pid?: unknown };
-					stale = typeof record.pid === "number" && Number.isInteger(record.pid) && record.pid > 0 && !isProcessAlive(record.pid);
-				} catch {
-					stale = false;
-				}
+				const record = parsePublicationLockRecord(lockBytes);
+				stale = record !== null && isPublicationLockStale(record);
 			}
 			if (!stale) {
 				throw new Error(`another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`);
@@ -900,7 +1040,7 @@ async function openManagedCacheNamespace(
 			handles.push(childRef.handle);
 			parentRef = childRef;
 		}
-		return { handle: parentRef.handle, fdPath: parentRef.operationPath, path: parentRef.path, handles };
+		return { handle: parentRef.handle, fdPath: parentRef.mutationPath ?? parentRef.scanOperationPath, path: parentRef.path, handles };
 	} catch (error) {
 		for (const handle of handles.reverse()) {
 			try { await handle.close(); } catch { /* preserve the primary failure */ }
@@ -933,6 +1073,55 @@ async function inspectCacheRoot(cacheDir: string): Promise<"missing" | "director
 		}
 }
 
+async function validateStagedPluginSnapshot(
+	snapshot: DirectoryRef,
+	packagedMarketplace: PackagedOmxMarketplace,
+	version: string,
+	teamMode: SetupTeamMode | undefined,
+): Promise<void> {
+	const snapshotPath = snapshot.operationPath;
+	const manifestReason = await omxPluginCacheManifestProvenanceReason(snapshotPath, version);
+	if (manifestReason) throw new Error(`Packaged OMX plugin snapshot has invalid provenance: ${manifestReason}`);
+	const expectedSkillNames = await expectedPackagedOmxSkillNames(packagedMarketplace, { teamMode });
+	if (!expectedSkillNames) throw new Error("Packaged OMX plugin snapshot cannot determine expected skills");
+	const skillsReason = await omxPluginCacheSkillsProvenanceReason(snapshotPath, packagedMarketplace, expectedSkillNames);
+	if (skillsReason) throw new Error(`Packaged OMX plugin snapshot has invalid provenance: ${skillsReason}`);
+	const companionReason = await omxPluginCacheCompanionMetadataProvenanceReason(snapshotPath, packagedMarketplace);
+	if (companionReason) throw new Error(`Packaged OMX plugin snapshot has invalid provenance: ${companionReason}`);
+	for (const relativePath of [".mcp.json", ".app.json", "hooks/hooks.json", "hooks/codex-native-hook.mjs", `hooks/${OMX_PLUGIN_HOOK_LAUNCHER_FILE}`]) {
+		const path = join(snapshotPath, relativePath);
+		let stats;
+		try {
+			stats = await lstat(path);
+		} catch {
+			throw new Error(`Packaged OMX plugin snapshot is missing required surface: ${path}`);
+		}
+		if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
+			throw new Error(`Packaged OMX plugin snapshot has an invalid required surface: ${path}`);
+		}
+		if (await readOmxPluginCacheFileNoFollow(path, { anchorDir: snapshotPath }) === null) {
+			throw new Error(`Packaged OMX plugin snapshot cannot read required surface: ${path}`);
+		}
+}
+	for (const relativePath of [".mcp.json", ".app.json", "hooks/hooks.json"] as const) {
+		const bytes = await readOmxPluginCacheFileNoFollow(join(snapshotPath, relativePath), { anchorDir: snapshotPath });
+		try {
+			if (!bytes) throw new Error("missing");
+			JSON.parse(bytes.toString("utf-8"));
+		} catch {
+			throw new Error(`Packaged OMX plugin snapshot has invalid JSON: ${join(snapshot.path, relativePath)}`);
+		}
+	}
+	if (!(await fileContentsEqual(join(snapshotPath, "hooks", "hooks.json"), join(packagedMarketplace.pluginRoot, "hooks", "hooks.json"), snapshotPath))) {
+		throw new Error(`Packaged OMX plugin snapshot hooks.json differs from packaged hooks`);
+	}
+	if (!(await fileContentsEqual(join(snapshotPath, "hooks", "codex-native-hook.mjs"), join(packagedMarketplace.pluginRoot, "hooks", "codex-native-hook.mjs"), snapshotPath))) {
+		throw new Error(`Packaged OMX plugin snapshot native hook differs from packaged hook`);
+	}
+	const launcherReason = await getPinnedLauncherIncompatibilityReason(snapshotPath, packagedMarketplace);
+	if (launcherReason) throw new Error(`Packaged OMX plugin snapshot has invalid launcher provenance: ${launcherReason.reason}`);
+}
+
 async function stageCompletePluginSnapshot(
 	stagingParent: DirectoryRef,
 	packagedMarketplace: PackagedOmxMarketplace,
@@ -945,7 +1134,12 @@ async function stageCompletePluginSnapshot(
 	const snapshot = await openDirectoryChild(stagingParent, "snapshot");
 	try {
 		await createExclusiveFileChild(snapshot, ".omx-incomplete", `${process.pid}\n`, tracker);
-		await copyPackagedTree(packagedMarketplace.pluginRoot, snapshot, tracker);
+		const packagedSource = await openDirectoryRef(packagedMarketplace.pluginRoot);
+		try {
+			await copyPackagedTree(packagedSource, snapshot, tracker);
+		} finally {
+			await packagedSource.handle.close();
+		}
 		await assertDirectoryRef(snapshot, "snapshot staging");
 		await applyTeamModeToPluginCache(snapshot, teamMode);
 		const hooksDir = await openDirectoryChild(snapshot, "hooks");
@@ -954,17 +1148,7 @@ async function stageCompletePluginSnapshot(
 		} finally {
 			await hooksDir.handle.close();
 		}
-		const manifest = await readRegularOmxPluginCacheManifest(snapshot.operationPath, snapshot.operationPath);
-		const skillsDir = await openDirectoryChild(snapshot, "skills");
-		await skillsDir.handle.close();
-		if (
-			manifest?.name !== OMX_PLUGIN_NAME ||
-			manifest.version !== version ||
-			manifest.skills !== "./skills/" ||
-			manifest.hooks !== "./hooks/hooks.json"
-		) {
-			throw new Error(`Packaged OMX plugin snapshot is incomplete or has invalid provenance: ${snapshot.path}`);
-		}
+		await validateStagedPluginSnapshot(snapshot, packagedMarketplace, version, teamMode);
 		return snapshot;
 	} catch (error) {
 		await snapshot.handle.close();
@@ -1017,6 +1201,12 @@ export async function discoverOmxPluginCacheDirs(
 		for (const entry of entries) {
 			if (!entry.isDirectory()) continue;
 			if (entry.name === ".git" || entry.name === "node_modules") continue;
+			// #3552 blocker 5: staging trees (`.omx-plugin-*` and reclaim
+			// quarantines) live inside the scanned namespace only until
+			// publication; discovery must never descend into them, so a
+			// marker-committed snapshot can never be observed at its staging
+			// path before the final no-replace publication.
+			if (isPluginCacheStagingEntryName(entry.name)) continue;
 			queue.push({
 				path: join(current.path, entry.name),
 				depth: current.depth + 1,
@@ -1378,6 +1568,7 @@ async function retireUnpinnedManagedSnapshots(
 	codexHomeDir: string,
 	currentVersion: string,
 	anchoredCacheBaseRef?: DirectoryRef,
+	publicationLockHeld = false,
 ): Promise<string[]> {
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
@@ -1387,11 +1578,19 @@ async function retireUnpinnedManagedSnapshots(
 	}
 	let baseRef = anchoredCacheBaseRef;
 	let ownsBaseRef = false;
+	let publicationLock: FileHandle | undefined;
+	let publicationLockIdentity: Stats | undefined;
+	const durability: RegularFileDurabilityTracker = { degraded: false };
 	const candidateRefs: DirectoryRef[] = [];
+	let cleanupError: unknown = null;
 	try {
 		if (!baseRef) {
 			baseRef = await openDirectoryRef(cacheBase);
 			ownsBaseRef = true;
+		}
+		if (!publicationLockHeld) {
+			publicationLock = await claimPublicationLock(baseRef, cacheBase, noFollowFlags, durability);
+			publicationLockIdentity = await publicationLock.stat();
 		}
 		const entries = await readdir(baseRef.operationPath, { withFileTypes: true });
 		const managed: Array<{ path: string; version: string; mtimeMs: number; ref: DirectoryRef; stats: Stats }> = [];
@@ -1409,10 +1608,10 @@ async function retireUnpinnedManagedSnapshots(
 				continue;
 			}
 			candidateRefs.push(candidateRef);
-			const manifest = await readRegularOmxPluginCacheManifest(candidateRef.path, candidateRef.path);
+			const manifest = await readRegularOmxPluginCacheManifest(candidateRef.operationPath, candidateRef.operationPath);
 			if (manifest?.name !== OMX_PLUGIN_NAME || manifest.version !== entry.name) continue;
-			if (!(await hasRegularPublicationMarker(candidateRef.path, ".omx-complete")) || await hasRegularPublicationMarker(candidateRef.path, ".omx-incomplete")) continue;
-			if (await readOmxPluginCacheFileNoFollow(join(candidateRef.path, ".omx-live-pin"), { anchorDir: candidateRef.path }) !== null) continue;
+			if (!(await hasRegularPublicationMarker(candidateRef.operationPath, ".omx-complete")) || await hasRegularPublicationMarker(candidateRef.operationPath, ".omx-incomplete")) continue;
+			if (await readOmxPluginCacheFileNoFollow(join(candidateRef.operationPath, ".omx-live-pin"), { anchorDir: candidateRef.operationPath }) !== null) continue;
 			managed.push({ path: join(cacheBase, entry.name), version: entry.name, mtimeMs: candidateStats.mtimeMs, ref: candidateRef, stats: candidateStats });
 		}
 		managed.sort((left, right) =>
@@ -1422,17 +1621,29 @@ async function retireUnpinnedManagedSnapshots(
 		const retired: string[] = [];
 		for (const candidate of managed.slice(1)) {
 			await assertDirectoryRef(baseRef, "retirement");
-			const currentStats = await lstat(candidate.ref.path);
+			const currentStats = await candidate.ref.handle.stat();
 			if (!currentStats.isDirectory() || currentStats.isSymbolicLink() || currentStats.dev !== candidate.stats.dev || currentStats.ino !== candidate.stats.ino) {
 				throw new Error(`managed cache retirement target changed before removal: ${candidate.path}`);
 			}
-			await removeChild(baseRef, candidate.version, { recursive: true, force: true });
+			await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true });
 			retired.push(candidate.path);
 		}
 		return retired;
 	} finally {
-		for (const candidateRef of candidateRefs.reverse()) await candidateRef.handle.close();
-		if (ownsBaseRef && baseRef) await baseRef.handle.close();
+		for (const candidateRef of candidateRefs.reverse()) {
+			try { await candidateRef.handle.close(); } catch (error) { cleanupError ??= error; }
+		}
+		if (publicationLock) {
+			try { await publicationLock.close(); } catch (error) { cleanupError ??= error; }
+			if (publicationLockIdentity) {
+				try { await reclaimStalePublicationLock(baseRef!, ".omx-publish.lock", publicationLockIdentity); } catch (error) { cleanupError ??= error; }
+			}
+		}
+		emitDegradedDurabilityWarning("plugin cache publication", durability);
+		if (ownsBaseRef && baseRef) {
+			try { await baseRef.handle.close(); } catch (error) { cleanupError ??= error; }
+		}
+		if (cleanupError) throw cleanupError;
 	}
 }
 
@@ -1581,42 +1792,96 @@ async function materializePackagedOmxPluginCacheImpl(
 		try {
 			lockIdentity = await lockHandle.stat();
 			await assertDirectoryRef(cacheBaseRef, "temporary staging");
-			const tempDir = await mkdtemp(join(cacheBaseRef.path, `.omx-plugin-${version}-`));
+			const candidateTempName = `.omx-plugin-${version}-${process.pid}-${randomUUID()}`;
+			await mkdirDirectoryChildExclusive(cacheBaseRef, candidateTempName);
 			await assertDirectoryRef(cacheBaseRef, "temporary staging");
-			tempName = tempDir.slice(cacheBaseRef.path.length + 1);
-			if (!tempName || tempName.includes("/")) throw new Error("temporary staging directory escaped the anchored cache namespace");
+			tempName = candidateTempName;
 			tempRef = await openDirectoryChild(cacheBaseRef, tempName);
 			snapshotRef = await stageCompletePluginSnapshot(tempRef, packagedMarketplace, version, options.teamMode, durability);
 			await syncDirectoryTree(snapshotRef, durability);
 			await options.onCacheDirPrepared?.(cacheDir);
 			try {
+				// #3552 blockers 3+5: commit the complete marker while the snapshot
+				// is still only reachable under the staging parent (discovery never
+				// descends into `.omx-plugin-*` staging trees), then claim the
+				// destination with an atomic exclusive mkdir so a concurrently
+				// created `<version>` directory (empty or not) can never be
+				// silently replaced by the final rename.
 				await createExclusiveFileChild(snapshotRef, ".omx-complete", `${process.pid}\n`, durability);
 				await removeChild(snapshotRef, ".omx-incomplete", { force: true });
 				await syncDirectoryTree(snapshotRef, durability);
-				await renameChild(tempRef, "snapshot", cacheBaseRef, version);
-				await snapshotRef.handle.close();
-				snapshotRef = undefined;
-				finalRef = await openDirectoryChild(cacheBaseRef, version);
-				await assertDirectoryRef(finalRef, "publication validation");
-				const finalPathStats = await lstat(finalRef.path);
-				const finalDescriptorStats = await finalRef.handle.stat();
-				if (!finalPathStats.isDirectory() || finalPathStats.isSymbolicLink() || finalPathStats.dev !== finalDescriptorStats.dev || finalPathStats.ino !== finalDescriptorStats.ino) {
-					throw new Error(`published cache directory changed before validation: ${cacheDir}`);
+				let published = true;
+				try {
+					await claimPublicationDestination(cacheBaseRef, version);
+				} catch (error) {
+					if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+						published = false;
+					} else {
+						throw error;
+					}
 				}
-				const syncOutcome = await syncDirectory(cacheBaseRef.handle);
-				recordDirectorySyncOutcome(durability, syncOutcome);
+				if (!published) {
+					outcome = {
+						status: "stale-launcher",
+						cacheDir,
+						version,
+						reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
+						launcherTarget: undefined,
+						retiredDirs: [],
+					};
+				} else {
+					const snapshotStats = await snapshotRef.handle.stat();
+					await renameChild(tempRef, "snapshot", cacheBaseRef, version);
+					await snapshotRef.handle.close();
+					snapshotRef = undefined;
+					finalRef = await openDirectoryChild(cacheBaseRef, version);
+					await assertDirectoryRef(finalRef, "publication validation");
+					const finalPathStats = await lstat(finalRef.path);
+					const finalDescriptorStats = await finalRef.handle.stat();
+					if (
+						!finalPathStats.isDirectory() ||
+						finalPathStats.isSymbolicLink() ||
+						finalPathStats.dev !== finalDescriptorStats.dev ||
+						finalPathStats.ino !== finalDescriptorStats.ino ||
+						finalDescriptorStats.dev !== snapshotStats.dev ||
+						finalDescriptorStats.ino !== snapshotStats.ino
+					) {
+						throw new Error(`published cache directory changed before validation: ${cacheDir}`);
+					}
+					const syncOutcome = await syncDirectory(cacheBaseRef.handle);
+					recordDirectorySyncOutcome(durability, syncOutcome);
+				}
 			} catch (error) {
 				if ((error as NodeJS.ErrnoException).code === "EEXIST") {
 					outcome = {
-					status: "stale-launcher",
-					cacheDir,
-					version,
-					reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
-					launcherTarget: undefined,
-					retiredDirs: [],
+						status: "stale-launcher",
+						cacheDir,
+						version,
+						reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
+						launcherTarget: undefined,
+						retiredDirs: [],
 					};
 				} else {
 					throw error;
+				}
+			}
+			if (outcome.status === "materialized") {
+				try {
+					outcome.retiredDirs = await retireUnpinnedManagedSnapshots(
+						codexHomeDir,
+						version,
+						cacheBaseRef,
+						true,
+					);
+				} catch (error) {
+					outcome = {
+						status: "stale-launcher",
+						cacheDir,
+						version,
+						reason: `immutable OMX plugin cache retirement failed closed: ${(error as Error).message}`,
+						launcherTarget: undefined,
+						retiredDirs: [],
+					};
 				}
 			}
 		} catch (error) {
@@ -1655,24 +1920,6 @@ async function materializePackagedOmxPluginCacheImpl(
 				launcherTarget: undefined,
 				retiredDirs: [],
 			};
-		}
-		if (outcome.status === "materialized" && !options.dryRun) {
-			try {
-				outcome.retiredDirs = await retireUnpinnedManagedSnapshots(
-					codexHomeDir,
-					version,
-					options.anchoredCacheBaseRef,
-				);
-			} catch (error) {
-				return {
-					status: "stale-launcher",
-					cacheDir,
-					version,
-					reason: `immutable OMX plugin cache retirement failed closed: ${(error as Error).message}`,
-					launcherTarget: undefined,
-					retiredDirs: [],
-				};
-			}
 		}
 		return outcome;
 	}
@@ -1740,6 +1987,8 @@ export async function materializePackagedOmxPluginCache(
 					handle: namespace.handle,
 					path: namespace.path,
 					operationPath: cacheBaseFdPath,
+					scanOperationPath: cacheBaseFdPath,
+					mutationPath: cacheBaseFdPath,
 				},
 				anchoredCacheDir: join(namespace.fdPath, version),
 			},

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -4,6 +4,14 @@ import { lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, t
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
+import {
+	emitDegradedDurabilityWarning,
+	recordDirectorySyncOutcome,
+	recordRegularFileSyncOutcome,
+	syncDirectory,
+	syncRegularFile,
+	type RegularFileDurabilityTracker,
+} from "../utils/file-durability.js";
 
 export const OMX_LOCAL_MARKETPLACE_NAME = "oh-my-codex-local";
 export const OMX_PLUGIN_NAME = "oh-my-codex";
@@ -207,7 +215,11 @@ async function mkdirDirectoryChildExclusive(parent: DirectoryRef, name: string):
 	await assertDirectoryRef(parent, "exclusive mkdir");
 }
 
-async function copyPackagedTree(sourcePath: string, destination: DirectoryRef): Promise<void> {
+async function copyPackagedTree(
+	sourcePath: string,
+	destination: DirectoryRef,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
 	const sourceStats = await lstat(sourcePath);
 	if (!sourceStats.isDirectory() || sourceStats.isSymbolicLink()) {
 		throw new Error(`refusing to copy a non-directory packaged plugin root: ${sourcePath}`);
@@ -222,7 +234,7 @@ async function copyPackagedTree(sourcePath: string, destination: DirectoryRef): 
 			await mkdirDirectoryChildExclusive(destination, entry.name);
 			const child = await openDirectoryChild(destination, entry.name);
 			try {
-				await copyPackagedTree(sourceChildPath, child);
+				await copyPackagedTree(sourceChildPath, child, tracker);
 			} finally {
 				await child.handle.close();
 			}
@@ -255,7 +267,8 @@ async function copyPackagedTree(sourcePath: string, destination: DirectoryRef): 
 			try {
 				await destinationHandle.writeFile(content);
 				await destinationHandle.chmod(before.mode & 0o7777);
-				await destinationHandle.sync();
+				const outcome = await syncRegularFile(destinationHandle);
+				if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 			} finally {
 				await destinationHandle.close();
 			}
@@ -278,38 +291,55 @@ async function openRegularFileChild(parent: DirectoryRef, name: string, flags: n
 	}
 }
 
-async function syncRegularFileChild(parent: DirectoryRef, name: string): Promise<void> {
+async function syncRegularFileChild(
+	parent: DirectoryRef,
+	name: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
 	const handle = await openRegularFileChild(parent, name, fsConstants.O_RDONLY | noFollowFlags);
 	try {
-		await handle.sync();
+		const outcome = await syncRegularFile(handle);
+		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 	} finally {
 		await handle.close();
 	}
 	await assertDirectoryRef(parent, "file sync");
 }
 
-async function writeRegularFileChild(parent: DirectoryRef, name: string, content: string): Promise<void> {
+async function writeRegularFileChild(
+	parent: DirectoryRef,
+	name: string,
+	content: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
 	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | noFollowFlags, 0o600);
 	try {
 		await handle.writeFile(content);
-		await handle.sync();
+		const outcome = await syncRegularFile(handle);
+		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 	} finally {
 		await handle.close();
 	}
 	await assertDirectoryRef(parent, "file write");
 }
 
-async function createExclusiveFileChild(parent: DirectoryRef, name: string, content: string): Promise<void> {
+async function createExclusiveFileChild(
+	parent: DirectoryRef,
+	name: string,
+	content: string,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
 	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags, 0o600);
 	try {
 		await handle.writeFile(content);
-		await handle.sync();
+		const outcome = await syncRegularFile(handle);
+		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 	} finally {
 		await handle.close();
 	}
@@ -333,7 +363,10 @@ async function renameChild(sourceParent: DirectoryRef, sourceName: string, desti
 	await assertDirectoryRef(destinationParent, "rename");
 }
 
-async function syncDirectoryTree(directory: DirectoryRef): Promise<void> {
+async function syncDirectoryTree(
+	directory: DirectoryRef,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
 	await assertDirectoryRef(directory, "directory sync");
 	const entries = await readdir(directory.operationPath, { withFileTypes: true });
 	for (const entry of entries) {
@@ -341,16 +374,17 @@ async function syncDirectoryTree(directory: DirectoryRef): Promise<void> {
 		if (entry.isDirectory()) {
 			const child = await openDirectoryChild(directory, entry.name);
 			try {
-				await syncDirectoryTree(child);
+				await syncDirectoryTree(child, tracker);
 			} finally {
 				await child.handle.close();
 			}
 		} else {
-			await syncRegularFileChild(directory, entry.name);
+			await syncRegularFileChild(directory, entry.name, tracker);
 		}
 	}
 	await assertDirectoryRef(directory, "directory sync");
-	await directory.handle.sync();
+	const outcome = await syncDirectory(directory.handle);
+	if (tracker) recordDirectorySyncOutcome(tracker, outcome);
 }
 
 export async function readOmxPluginCacheFileNoFollow(
@@ -550,6 +584,7 @@ async function claimPublicationLock(
 	cacheBaseRef: DirectoryRef,
 	cacheBase: string,
 	noFollowFlags: number,
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<FileHandle> {
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
@@ -561,10 +596,15 @@ async function claimPublicationLock(
 			);
 			try {
 				await lockHandle.writeFile(`${JSON.stringify({ pid: process.pid, createdAt: Date.now() })}\n`);
-				await lockHandle.sync();
+				const outcome = await syncRegularFile(lockHandle);
+				if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 			} catch (error) {
+				let lockIdentity: Stats | undefined;
+				try { lockIdentity = await lockHandle.stat(); } catch { /* preserve the primary failure */ }
 				try { await lockHandle.close(); } catch { /* preserve the primary failure */ }
-				try { await removeChild(cacheBaseRef, ".omx-publish.lock", { force: true }); } catch { /* preserve the primary failure */ }
+				if (lockIdentity) {
+					try { await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity); } catch { /* preserve the primary failure */ }
+				}
 				throw error;
 			}
 			return lockHandle;
@@ -898,18 +938,19 @@ async function stageCompletePluginSnapshot(
 	packagedMarketplace: PackagedOmxMarketplace,
 	version: string,
 	teamMode: SetupTeamMode | undefined,
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<DirectoryRef> {
 	await assertDirectoryRef(stagingParent, "snapshot staging");
 	await mkdirDirectoryChildExclusive(stagingParent, "snapshot");
 	const snapshot = await openDirectoryChild(stagingParent, "snapshot");
 	try {
-		await createExclusiveFileChild(snapshot, ".omx-incomplete", `${process.pid}\n`);
-		await copyPackagedTree(packagedMarketplace.pluginRoot, snapshot);
+		await createExclusiveFileChild(snapshot, ".omx-incomplete", `${process.pid}\n`, tracker);
+		await copyPackagedTree(packagedMarketplace.pluginRoot, snapshot, tracker);
 		await assertDirectoryRef(snapshot, "snapshot staging");
 		await applyTeamModeToPluginCache(snapshot, teamMode);
 		const hooksDir = await openDirectoryChild(snapshot, "hooks");
 		try {
-			await writePinnedHookLauncher(hooksDir, packagedMarketplace);
+			await writePinnedHookLauncher(hooksDir, packagedMarketplace, tracker);
 		} finally {
 			await hooksDir.handle.close();
 		}
@@ -1172,11 +1213,13 @@ async function pinnedHookLauncherMatchesPackaged(
 async function writePinnedHookLauncher(
 	hooksDir: DirectoryRef,
 	packagedMarketplace: PackagedOmxMarketplace,
+	tracker?: RegularFileDurabilityTracker,
 ): Promise<void> {
 	await writeRegularFileChild(
 		hooksDir,
 		OMX_PLUGIN_HOOK_LAUNCHER_FILE,
 		buildPinnedHookLauncherContent(packagedMarketplace),
+		tracker,
 	);
 }
 
@@ -1507,10 +1550,12 @@ async function materializePackagedOmxPluginCacheImpl(
 			cacheBaseRef = await openDirectoryRef(cacheBase);
 			ownsCacheBaseRef = true;
 		}
+		const durability: RegularFileDurabilityTracker = { degraded: false };
 		let lockHandle: FileHandle;
 		try {
-			lockHandle = await claimPublicationLock(cacheBaseRef, cacheBase, noFollowFlags);
+			lockHandle = await claimPublicationLock(cacheBaseRef, cacheBase, noFollowFlags, durability);
 		} catch (error) {
+			emitDegradedDurabilityWarning("plugin cache publication", durability);
 			if (ownsCacheBaseRef) await cacheBaseRef.handle.close();
 			return {
 				status: "stale-launcher",
@@ -1541,13 +1586,13 @@ async function materializePackagedOmxPluginCacheImpl(
 			tempName = tempDir.slice(cacheBaseRef.path.length + 1);
 			if (!tempName || tempName.includes("/")) throw new Error("temporary staging directory escaped the anchored cache namespace");
 			tempRef = await openDirectoryChild(cacheBaseRef, tempName);
-			snapshotRef = await stageCompletePluginSnapshot(tempRef, packagedMarketplace, version, options.teamMode);
-			await syncDirectoryTree(snapshotRef);
+			snapshotRef = await stageCompletePluginSnapshot(tempRef, packagedMarketplace, version, options.teamMode, durability);
+			await syncDirectoryTree(snapshotRef, durability);
 			await options.onCacheDirPrepared?.(cacheDir);
 			try {
-				await createExclusiveFileChild(snapshotRef, ".omx-complete", `${process.pid}\n`);
+				await createExclusiveFileChild(snapshotRef, ".omx-complete", `${process.pid}\n`, durability);
 				await removeChild(snapshotRef, ".omx-incomplete", { force: true });
-				await syncDirectoryTree(snapshotRef);
+				await syncDirectoryTree(snapshotRef, durability);
 				await renameChild(tempRef, "snapshot", cacheBaseRef, version);
 				await snapshotRef.handle.close();
 				snapshotRef = undefined;
@@ -1558,7 +1603,8 @@ async function materializePackagedOmxPluginCacheImpl(
 				if (!finalPathStats.isDirectory() || finalPathStats.isSymbolicLink() || finalPathStats.dev !== finalDescriptorStats.dev || finalPathStats.ino !== finalDescriptorStats.ino) {
 					throw new Error(`published cache directory changed before validation: ${cacheDir}`);
 				}
-				await cacheBaseRef.handle.sync();
+				const syncOutcome = await syncDirectory(cacheBaseRef.handle);
+				recordDirectorySyncOutcome(durability, syncOutcome);
 			} catch (error) {
 				if ((error as NodeJS.ErrnoException).code === "EEXIST") {
 					outcome = {
@@ -1591,13 +1637,15 @@ async function materializePackagedOmxPluginCacheImpl(
 			try {
 				if (!lockIdentity) throw new Error(`publication lock identity unavailable at ${cacheBase}`);
 				await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity);
-				await cacheBaseRef.handle.sync();
+				const syncOutcome = await syncDirectory(cacheBaseRef.handle);
+				recordDirectorySyncOutcome(durability, syncOutcome);
 			} catch (error) { cleanupError ??= error; }
 			if (ownsCacheBaseRef) {
 				try { await cacheBaseRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			}
 		}
 
+		emitDegradedDurabilityWarning("plugin cache publication", durability);
 		if (cleanupError) {
 			return {
 				status: "stale-launcher",

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,5 +1,6 @@
 import { constants as fsConstants, existsSync, type Stats } from "fs";
-import { cp, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, type FileHandle } from "fs/promises";
+import { randomUUID } from "crypto";
+import { lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, type FileHandle } from "fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
@@ -204,6 +205,64 @@ async function mkdirDirectoryChildExclusive(parent: DirectoryRef, name: string):
 	await assertDirectoryRef(parent, "exclusive mkdir");
 	await mkdir(operationPath);
 	await assertDirectoryRef(parent, "exclusive mkdir");
+}
+
+async function copyPackagedTree(sourcePath: string, destination: DirectoryRef): Promise<void> {
+	const sourceStats = await lstat(sourcePath);
+	if (!sourceStats.isDirectory() || sourceStats.isSymbolicLink()) {
+		throw new Error(`refusing to copy a non-directory packaged plugin root: ${sourcePath}`);
+	}
+	const entries = await readdir(sourcePath, { withFileTypes: true });
+	for (const entry of entries) {
+		const sourceChildPath = join(sourcePath, entry.name);
+		if (entry.isSymbolicLink()) {
+			throw new Error(`refusing to copy a symlinked packaged plugin entry: ${sourceChildPath}`);
+		}
+		if (entry.isDirectory()) {
+			await mkdirDirectoryChildExclusive(destination, entry.name);
+			const child = await openDirectoryChild(destination, entry.name);
+			try {
+				await copyPackagedTree(sourceChildPath, child);
+			} finally {
+				await child.handle.close();
+			}
+			continue;
+		}
+		if (!entry.isFile()) {
+			throw new Error(`refusing to copy a non-regular packaged plugin entry: ${sourceChildPath}`);
+		}
+		const sourceHandle = await open(sourceChildPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+		try {
+			const before = await sourceHandle.stat();
+			if (!before.isFile() || before.isSymbolicLink()) {
+				throw new Error(`packaged plugin entry changed while copying: ${sourceChildPath}`);
+			}
+			const content = await sourceHandle.readFile();
+			const after = await sourceHandle.stat();
+			if (
+				after.dev !== before.dev ||
+				after.ino !== before.ino ||
+				after.size !== before.size
+			) {
+				throw new Error(`packaged plugin entry changed while copying: ${sourceChildPath}`);
+			}
+			const destinationHandle = await openRegularFileChild(
+				destination,
+				entry.name,
+				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+				before.mode & 0o7777,
+			);
+			try {
+				await destinationHandle.writeFile(content);
+				await destinationHandle.chmod(before.mode & 0o7777);
+				await destinationHandle.sync();
+			} finally {
+				await destinationHandle.close();
+			}
+		} finally {
+			await sourceHandle.close();
+		}
+	}
 }
 
 async function openRegularFileChild(parent: DirectoryRef, name: string, flags: number, mode?: number): Promise<FileHandle> {
@@ -462,6 +521,31 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
+async function reclaimStalePublicationLock(
+	cacheBaseRef: DirectoryRef,
+	lockName: string,
+	lockStats: Stats,
+): Promise<void> {
+	const quarantineName = `${lockName}.reclaim-${process.pid}-${randomUUID()}`;
+	await renameChild(cacheBaseRef, lockName, cacheBaseRef, quarantineName);
+	const quarantinePath = childOperationPath(cacheBaseRef, quarantineName);
+	let quarantineStats: Stats;
+	try {
+		quarantineStats = await lstat(quarantinePath);
+	} catch (error) {
+		throw new Error(`stale publication lock disappeared during reclamation: ${(error as Error).message}`);
+	}
+	if (quarantineStats.dev !== lockStats.dev || quarantineStats.ino !== lockStats.ino) {
+		try {
+			await renameChild(cacheBaseRef, quarantineName, cacheBaseRef, lockName);
+		} catch {
+			// Preserve a replacement lock if another publisher claimed the name.
+		}
+		throw new Error("publication lock changed during stale-lock reclamation");
+	}
+	await removeChild(cacheBaseRef, quarantineName, { force: true });
+}
+
 async function claimPublicationLock(
 	cacheBaseRef: DirectoryRef,
 	cacheBase: string,
@@ -508,9 +592,15 @@ async function claimPublicationLock(
 			if (!stale) {
 				throw new Error(`another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`);
 			}
-			const unlinkBefore = await lstat(lockPath);
-			if (unlinkBefore.dev !== lockBefore.dev || unlinkBefore.ino !== lockBefore.ino) continue;
-			await removeChild(cacheBaseRef, ".omx-publish.lock", { force: true });
+			const reclaimBefore = await lstat(lockPath);
+			if (reclaimBefore.dev !== lockBefore.dev || reclaimBefore.ino !== lockBefore.ino) continue;
+			try {
+				await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", reclaimBefore);
+			} catch (reclaimError) {
+				if ((reclaimError as NodeJS.ErrnoException).code === "ENOENT") continue;
+				if ((reclaimError as Error).message === "publication lock changed during stale-lock reclamation") continue;
+				throw reclaimError;
+			}
 		}
 	}
 	throw new Error(`cannot recover stale OMX plugin cache publication lock at ${cacheBase}`);
@@ -813,7 +903,8 @@ async function stageCompletePluginSnapshot(
 	await mkdirDirectoryChildExclusive(stagingParent, "snapshot");
 	const snapshot = await openDirectoryChild(stagingParent, "snapshot");
 	try {
-		await cp(packagedMarketplace.pluginRoot, snapshot.path, { recursive: true });
+		await createExclusiveFileChild(snapshot, ".omx-incomplete", `${process.pid}\n`);
+		await copyPackagedTree(packagedMarketplace.pluginRoot, snapshot);
 		await assertDirectoryRef(snapshot, "snapshot staging");
 		await applyTeamModeToPluginCache(snapshot, teamMode);
 		const hooksDir = await openDirectoryChild(snapshot, "hooks");
@@ -822,7 +913,7 @@ async function stageCompletePluginSnapshot(
 		} finally {
 			await hooksDir.handle.close();
 		}
-		const manifest = await readRegularOmxPluginCacheManifest(snapshot.path, snapshot.path);
+		const manifest = await readRegularOmxPluginCacheManifest(snapshot.operationPath, snapshot.operationPath);
 		const skillsDir = await openDirectoryChild(snapshot, "skills");
 		await skillsDir.handle.close();
 		if (
@@ -1416,7 +1507,6 @@ async function materializePackagedOmxPluginCacheImpl(
 			cacheBaseRef = await openDirectoryRef(cacheBase);
 			ownsCacheBaseRef = true;
 		}
-		const lockPath = childOperationPath(cacheBaseRef, ".omx-publish.lock");
 		let lockHandle: FileHandle;
 		try {
 			lockHandle = await claimPublicationLock(cacheBaseRef, cacheBase, noFollowFlags);
@@ -1455,18 +1545,13 @@ async function materializePackagedOmxPluginCacheImpl(
 			await syncDirectoryTree(snapshotRef);
 			await options.onCacheDirPrepared?.(cacheDir);
 			try {
-				await mkdirDirectoryChildExclusive(cacheBaseRef, version);
+				await createExclusiveFileChild(snapshotRef, ".omx-complete", `${process.pid}\n`);
+				await removeChild(snapshotRef, ".omx-incomplete", { force: true });
+				await syncDirectoryTree(snapshotRef);
+				await renameChild(tempRef, "snapshot", cacheBaseRef, version);
+				await snapshotRef.handle.close();
+				snapshotRef = undefined;
 				finalRef = await openDirectoryChild(cacheBaseRef, version);
-				await createExclusiveFileChild(finalRef, ".omx-incomplete", `${process.pid}\n`);
-				const stagedEntries = await readdir(snapshotRef.operationPath, { withFileTypes: true });
-				for (const entry of stagedEntries) {
-					if (entry.isSymbolicLink()) throw new Error(`refusing to publish symlinked cache entry: ${entry.name}`);
-					await renameChild(snapshotRef, entry.name, finalRef, entry.name);
-				}
-				await syncDirectoryTree(finalRef);
-				await createExclusiveFileChild(finalRef, ".omx-complete", `${process.pid}\n`);
-				await removeChild(finalRef, ".omx-incomplete", { force: true });
-				await finalRef.handle.sync();
 				await assertDirectoryRef(finalRef, "publication validation");
 				const finalPathStats = await lstat(finalRef.path);
 				const finalDescriptorStats = await finalRef.handle.stat();
@@ -1505,9 +1590,7 @@ async function materializePackagedOmxPluginCacheImpl(
 			try { await lockHandle.close(); } catch (error) { cleanupError ??= error; }
 			try {
 				if (!lockIdentity) throw new Error(`publication lock identity unavailable at ${cacheBase}`);
-				const currentLockStats = await lstat(lockPath);
-				if (currentLockStats.dev !== lockIdentity.dev || currentLockStats.ino !== lockIdentity.ino) throw new Error(`publication lock changed before cleanup at ${cacheBase}`);
-				await removeChild(cacheBaseRef, ".omx-publish.lock", { force: true });
+				await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity);
 				await cacheBaseRef.handle.sync();
 			} catch (error) { cleanupError ??= error; }
 			if (ownsCacheBaseRef) {
@@ -1610,7 +1693,7 @@ export async function materializePackagedOmxPluginCache(
 					path: namespace.path,
 					operationPath: cacheBaseFdPath,
 				},
-				anchoredCacheDir: join(namespace.path, version),
+				anchoredCacheDir: join(namespace.fdPath, version),
 			},
 		);
 	} catch (error) {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -881,9 +881,19 @@ function isPublicationLockStale(record: PublicationLockRecord, now = Date.now())
 }
 
 async function refreshPublicationLockRecord(
+	lockPath: string,
 	lockHandle: FileHandle,
+	lockIdentity: Stats,
 	tracker?: RegularFileDurabilityTracker,
-): Promise<void> {
+	): Promise<boolean> {
+	let before: Stats;
+	try {
+		before = await lstat(lockPath);
+		const descriptorStats = await lockHandle.stat();
+		if (!sameFileIdentity(before, lockIdentity) || !sameFileIdentity(descriptorStats, lockIdentity)) return false;
+	} catch {
+		return false;
+	}
 	try {
 		const record = buildPublicationLockRecord();
 		const buf = Buffer.from(record, "utf-8");
@@ -897,15 +907,47 @@ async function refreshPublicationLockRecord(
 		// Heartbeat is best-effort; a slow filesystem or closed handle must not fail the
 		// already-claimed publication. The next interval will retry if the handle is still open.
 	}
+	try {
+		const after = await lstat(lockPath);
+		const descriptorStats = await lockHandle.stat();
+		return sameFileIdentity(after, lockIdentity) && sameFileIdentity(descriptorStats, lockIdentity);
+	} catch {
+		return false;
+	}
+}
+
+interface PublicationLockGuard {
+	timer: NodeJS.Timeout;
+	assertOwned: () => Promise<void>;
 }
 
 function startPublicationLockHeartbeat(
+	lockPath: string,
 	lockHandle: FileHandle,
+	lockIdentity: Stats,
 	tracker?: RegularFileDurabilityTracker,
-): NodeJS.Timeout {
-	return setInterval(() => {
-		void refreshPublicationLockRecord(lockHandle, tracker);
+	): PublicationLockGuard {
+	let lost = false;
+	const assertOwned = async (): Promise<void> => {
+		if (lost) throw new Error(`publication lock ownership lost at ${lockPath}`);
+		try {
+			const pathStats = await lstat(lockPath);
+			const descriptorStats = await lockHandle.stat();
+			if (!sameFileIdentity(pathStats, lockIdentity) || !sameFileIdentity(descriptorStats, lockIdentity)) {
+				lost = true;
+				throw new Error(`publication lock ownership lost at ${lockPath}`);
+			}
+		} catch (error) {
+			lost = true;
+			throw error;
+		}
+	};
+	const timer = setInterval(() => {
+		void refreshPublicationLockRecord(lockPath, lockHandle, lockIdentity, tracker).then((owned) => {
+			if (!owned) lost = true;
+		});
 	}, PUBLICATION_LOCK_HEARTBEAT_INTERVAL_MS);
+	return { timer, assertOwned };
 }
 
 export async function removeChildIfIdentity(
@@ -1859,7 +1901,7 @@ export async function retireUnpinnedManagedSnapshots(
 	let publicationLock: FileHandle | undefined;
 	let publicationLockIdentity: Stats | undefined;
 	const durability: RegularFileDurabilityTracker = { degraded: false };
-	let publicationLockHeartbeat: NodeJS.Timeout | undefined;
+	let publicationLockGuard: PublicationLockGuard | undefined;
 	const candidateRefs: DirectoryRef[] = [];
 	let cleanupError: unknown = null;
 	try {
@@ -1870,9 +1912,10 @@ export async function retireUnpinnedManagedSnapshots(
 		if (!publicationLockHeld) {
 			publicationLock = await claimPublicationLock(baseRef, cacheBase, noFollowFlags, durability);
 			publicationLockIdentity = await publicationLock.stat();
-			await refreshPublicationLockRecord(publicationLock, durability);
-			publicationLockHeartbeat = startPublicationLockHeartbeat(publicationLock, durability);
+			await refreshPublicationLockRecord(join(cacheBase, ".omx-publish.lock"), publicationLock, publicationLockIdentity!, durability);
+			publicationLockGuard = startPublicationLockHeartbeat(join(cacheBase, ".omx-publish.lock"), publicationLock, publicationLockIdentity!, durability);
 		}
+		await publicationLockGuard?.assertOwned();
 		const entries = await readdir(baseRef.operationPath, { withFileTypes: true });
 		const managed: Array<{ path: string; version: string; mtimeMs: number; ref: DirectoryRef; stats: Stats }> = [];
 		for (const entry of entries) {
@@ -1902,6 +1945,7 @@ export async function retireUnpinnedManagedSnapshots(
 		);
 		const retired: string[] = [];
 		for (const candidate of managed.slice(1)) {
+			await publicationLockGuard?.assertOwned();
 			await assertDirectoryRef(baseRef, "retirement");
 			const currentStats = await candidate.ref.handle.stat();
 			if (!currentStats.isDirectory() || currentStats.isSymbolicLink() || currentStats.dev !== candidate.stats.dev || currentStats.ino !== candidate.stats.ino) {
@@ -1918,7 +1962,7 @@ export async function retireUnpinnedManagedSnapshots(
 		}
 		return retired;
 	} finally {
-		if (publicationLockHeartbeat) clearInterval(publicationLockHeartbeat);
+		if (publicationLockGuard) clearInterval(publicationLockGuard.timer);
 		for (const candidateRef of candidateRefs.reverse()) {
 			try { await candidateRef.handle.close(); } catch (error) { cleanupError ??= error; }
 		}
@@ -2061,12 +2105,17 @@ async function materializePackagedOmxPluginCacheImpl(
 		}
 		const durability: RegularFileDurabilityTracker = { degraded: false };
 		let lockHandle: FileHandle;
-		let publicationLockHeartbeat: NodeJS.Timeout | undefined;
+		let lockIdentity: Stats;
+		let publicationLockGuard: PublicationLockGuard | undefined;
 		try {
 			lockHandle = await claimPublicationLock(cacheBaseRef, cacheBase, noFollowFlags, durability);
+			lockIdentity = await lockHandle.stat();
 			// Keep heartbeatAt fresh while the critical section is held so a slow live
 			// publisher is never reclaimed by a concurrent claimant after LEASE_MS.
-			publicationLockHeartbeat = startPublicationLockHeartbeat(lockHandle, durability);
+			if (!await refreshPublicationLockRecord(join(cacheBaseRef.path, ".omx-publish.lock"), lockHandle, lockIdentity, durability)) {
+				throw new Error(`publication lock ownership lost at ${join(cacheBaseRef.path, ".omx-publish.lock")}`);
+			}
+			publicationLockGuard = startPublicationLockHeartbeat(join(cacheBaseRef.path, ".omx-publish.lock"), lockHandle, lockIdentity, durability);
 		} catch (error) {
 			emitDegradedDurabilityWarning("plugin cache publication", durability);
 			if (ownsCacheBaseRef) await cacheBaseRef.handle.close();
@@ -2089,14 +2138,10 @@ async function materializePackagedOmxPluginCacheImpl(
 			retiredDirs: [],
 		};
 		let cleanupError: unknown = null;
-		let lockIdentity: Stats | undefined;
 		let finalRef: DirectoryRef | undefined;
 		let claimRef: DirectoryRef | undefined;
 		try {
-			lockIdentity = await lockHandle.stat();
-			// Refresh once under the held fd so the initial heartbeat is at most
-			// a few seconds old even on a fast publication path.
-			await refreshPublicationLockRecord(lockHandle, durability);
+			await publicationLockGuard.assertOwned();
 			const candidateTempName = `.omx-plugin-${version}-${process.pid}-${randomUUID()}`;
 			await mkdirDirectoryChildExclusive(cacheBaseRef, candidateTempName);
 			await assertDirectoryRef(cacheBaseRef, "temporary staging");
@@ -2106,6 +2151,7 @@ async function materializePackagedOmxPluginCacheImpl(
 			await syncDirectoryTree(snapshotRef, durability);
 			await options.onCacheDirPrepared?.(cacheDir);
 			try {
+				await publicationLockGuard.assertOwned();
 				// #3552 blockers 3+5 / review 3860267789: never rename onto
 				// `<version>` (rename silently replaces an empty destination and
 				// pre/post inode checks cannot make it atomic). The destination is
@@ -2151,6 +2197,7 @@ async function materializePackagedOmxPluginCacheImpl(
 					snapshotRef = undefined;
 					await createExclusiveFileChild(claimRef, OMX_PLUGIN_MANAGED_MARKER, `${process.pid}\n`, durability);
 					await pluginCacheMutationTestHooks?.beforeFinalClaimValidation?.(claimRef.path);
+					await publicationLockGuard.assertOwned();
 					await validateStagedPluginSnapshot(claimRef, packagedMarketplace, version, options.teamMode);
 					await pluginCacheMutationTestHooks?.beforeCompleteMarker?.(claimRef.path);
 					await validateStagedPluginSnapshot(claimRef, packagedMarketplace, version, options.teamMode);
@@ -2179,6 +2226,7 @@ async function materializePackagedOmxPluginCacheImpl(
 			}
 			if (outcome.status === "materialized") {
 				try {
+					await publicationLockGuard.assertOwned();
 					const preservedDirs: string[] = [];
 					outcome.retiredDirs = await retireUnpinnedManagedSnapshots(
 						codexHomeDir,
@@ -2209,7 +2257,7 @@ async function materializePackagedOmxPluginCacheImpl(
 			retiredDirs: [],
 		};
 	} finally {
-			if (publicationLockHeartbeat) clearInterval(publicationLockHeartbeat);
+			if (publicationLockGuard) clearInterval(publicationLockGuard.timer);
 			try { if (finalRef) await finalRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			if (claimRef && claimRef !== finalRef) {
 				try { await claimRef.handle.close(); } catch (error) { cleanupError ??= error; }

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -502,6 +502,8 @@ interface RemoveChildOptions {
 	force?: boolean;
 	preserveRecursive?: boolean;
 	expectedManagedVersion?: string;
+	preservedPaths?: string[];
+	beforeDestructiveRemove?: () => Promise<boolean>;
 }
 
 async function removeChild(parent: DirectoryRef, name: string, options: RemoveChildOptions = {}): Promise<boolean> {
@@ -541,6 +543,7 @@ async function removeChild(parent: DirectoryRef, name: string, options: RemoveCh
 		if (!final || !sameFileIdentity(before, final)) {
 			throw new Error(`identity-bound removal target changed before removal syscall: ${mutationPath}`);
 		}
+		if (options.beforeDestructiveRemove && !await options.beforeDestructiveRemove()) return false;
 	}
 	await rm(mutationPath, options);
 	if (before) {
@@ -746,13 +749,13 @@ async function readRegularFileTextNoFollow(path: string, options: { anchorDir?: 
 	return bytes?.toString("utf-8") ?? null;
 }
 
-async function computeImmutableClaimDigest(root: string): Promise<string> {
+export async function computeOmxPluginCacheClaimDigest(root: string): Promise<string> {
 	const hash = createHash("sha256");
-	const visit = async (directory: string): Promise<void> => {
+	const visit = async (directory: string, isRoot: boolean): Promise<void> => {
 		const entries = await readdir(directory, { withFileTypes: true });
 		entries.sort((left, right) => left.name.localeCompare(right.name));
 		for (const entry of entries) {
-			if (entry.name === ".omx-complete" || entry.name === ".omx-live-pin") continue;
+			if (isRoot && (entry.name === ".omx-complete" || entry.name === ".omx-live-pin")) continue;
 			const path = join(directory, entry.name);
 			const stats = await lstat(path);
 			if (stats.isSymbolicLink() || (!stats.isDirectory() && !stats.isFile()) || (stats.isFile() && stats.nlink !== 1)) {
@@ -760,7 +763,7 @@ async function computeImmutableClaimDigest(root: string): Promise<string> {
 			}
 			hash.update(`${entry.name}\0${stats.isDirectory() ? "d" : "f"}\0${stats.dev}\0${stats.ino}\0${stats.size}\0`);
 			if (stats.isDirectory()) {
-				await visit(path);
+				await visit(path, false);
 			} else {
 				const bytes = await readOmxPluginCacheFileNoFollow(path, { anchorDir: directory });
 				if (bytes === null) throw new Error(`claim entry cannot be read: ${path}`);
@@ -768,7 +771,7 @@ async function computeImmutableClaimDigest(root: string): Promise<string> {
 			}
 		}
 	};
-	await visit(root);
+	await visit(root, true);
 	return hash.digest("hex");
 }
 
@@ -778,14 +781,10 @@ async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complet
 	if (name !== ".omx-complete") return true;
 	try {
 		const record = JSON.parse(bytes.toString("utf-8")) as { claimDigest?: unknown };
-		if (typeof record.claimDigest !== "string") {
-			const managed = await readOmxPluginCacheFileNoFollow(join(cacheDir, OMX_PLUGIN_MANAGED_MARKER), { anchorDir: cacheDir });
-			return managed === null || managed.toString("utf-8").trim() === "fixture";
-		}
-		return record.claimDigest === await computeImmutableClaimDigest(cacheDir);
+		if (typeof record.claimDigest !== "string") return false;
+		return record.claimDigest === await computeOmxPluginCacheClaimDigest(cacheDir);
 	} catch {
-		const managed = await readOmxPluginCacheFileNoFollow(join(cacheDir, OMX_PLUGIN_MANAGED_MARKER), { anchorDir: cacheDir });
-		return managed === null || managed.toString("utf-8").trim() === "fixture";
+		return false;
 	}
 }
 
@@ -1038,6 +1037,7 @@ export async function removeChildIfIdentity(
 		throw new Error(`identity-bound removal target changed during reclamation; preserved quarantine ${quarantinePath}`);
 	}
 	if (options.expectedManagedVersion) {
+		const verifyQuarantineOwnership = async (): Promise<boolean> => {
 		const manifest = await readRegularOmxPluginCacheManifest(quarantinePath, quarantinePath);
 		const owned = manifest?.name === OMX_PLUGIN_NAME
 			&& manifest.version === options.expectedManagedVersion
@@ -1046,8 +1046,20 @@ export async function removeChildIfIdentity(
 			&& await hasRegularPublicationMarker(quarantinePath, OMX_PLUGIN_MANAGED_MARKER);
 		const livePin = await readOmxPluginCacheFileNoFollow(join(quarantinePath, ".omx-live-pin"), { anchorDir: quarantinePath }) !== null;
 		if (!owned || livePin) {
-			throw new Error(`managed cache ownership changed during reclamation; preserved quarantine ${quarantinePath}`);
+			return false;
 		}
+		return true;
+		};
+		await pluginCacheMutationTestHooks?.beforeRemove?.(quarantinePath, quarantineStats);
+		if (!await verifyQuarantineOwnership()) {
+			options.preservedPaths?.push(join(cacheBaseRef.path, quarantineName));
+			return false;
+		}
+		return removeChild(cacheBaseRef, quarantineName, {
+			...options,
+			preserveRecursive: true,
+			beforeDestructiveRemove: verifyQuarantineOwnership,
+		});
 	}
 	return removeChild(cacheBaseRef, quarantineName, {
 		...options,
@@ -1181,10 +1193,10 @@ async function claimPublicationLock(
 export async function omxPluginCacheExecutedAssetProvenanceReason(
 	cacheDir: string,
 ): Promise<string | null> {
-	if (!(await hasRegularPublicationMarker(cacheDir, ".omx-complete"))) {
+	if ((await readOmxPluginCacheFileNoFollow(join(cacheDir, ".omx-complete"), { anchorDir: cacheDir })) === null) {
 		return `cache snapshot publication marker is missing at ${cacheDir}`;
 	}
-	if (await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) {
+	if ((await readOmxPluginCacheFileNoFollow(join(cacheDir, ".omx-incomplete"), { anchorDir: cacheDir })) !== null) {
 		return `cache snapshot publication is incomplete at ${cacheDir}`;
 	}
 	const expectations: Array<{ path: string; kind: "file" | "directory"; label: string }> = [
@@ -1357,7 +1369,12 @@ export async function omxPluginCacheProvenanceReason(
 	if (!expectedSkillNames) return "packaged skill names are unavailable";
 	const skillsReason = await omxPluginCacheSkillsProvenanceReason(cacheDir, packagedMarketplace, expectedSkillNames);
 	if (skillsReason) return skillsReason;
-	return omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+	const assetReason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+	if (assetReason) return assetReason;
+	if (!(await hasRegularPublicationMarker(cacheDir, ".omx-complete"))) {
+		return `cache snapshot completion marker is malformed or does not match the immutable claim at ${cacheDir}`;
+	}
+	return null;
 }
 
 async function openManagedCacheNamespace(
@@ -1436,7 +1453,8 @@ async function inspectCacheRoot(cacheDir: string): Promise<"missing" | "director
 			if (!stats.isDirectory() || stats.isSymbolicLink()) {
 				return "untrusted";
 			}
-			if (!(await hasRegularPublicationMarker(cacheDir, ".omx-complete")) || await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) return "untrusted";
+			if (await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) return "untrusted";
+			if (!(await hasRegularPublicationMarker(cacheDir, ".omx-complete"))) return "directory";
 			const manifest = await readRegularOmxPluginCacheManifest(cacheDir);
 			if (!manifest) {
 				const manifestPath = join(cacheDir, ".codex-plugin", "plugin.json");
@@ -1956,6 +1974,7 @@ export async function retireUnpinnedManagedSnapshots(
 	anchoredCacheBaseRef?: DirectoryRef,
 	publicationLockHeld = false,
 	preservedDirs?: string[],
+	heldPublicationLockGuard?: PublicationLockGuard,
 ): Promise<string[]> {
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
@@ -1968,7 +1987,8 @@ export async function retireUnpinnedManagedSnapshots(
 	let publicationLock: FileHandle | undefined;
 	let publicationLockIdentity: Stats | undefined;
 	const durability: RegularFileDurabilityTracker = { degraded: false };
-	let publicationLockGuard: PublicationLockGuard | undefined;
+	let publicationLockGuard: PublicationLockGuard | undefined = heldPublicationLockGuard;
+	let ownsPublicationLockGuard = false;
 	const candidateRefs: DirectoryRef[] = [];
 	let cleanupError: unknown = null;
 	try {
@@ -1981,6 +2001,7 @@ export async function retireUnpinnedManagedSnapshots(
 			publicationLockIdentity = await publicationLock.stat();
 			await refreshPublicationLockRecord(join(cacheBase, ".omx-publish.lock"), publicationLock, publicationLockIdentity!, durability);
 			publicationLockGuard = startPublicationLockHeartbeat(join(cacheBase, ".omx-publish.lock"), publicationLock, publicationLockIdentity!, durability);
+			ownsPublicationLockGuard = true;
 		}
 		await publicationLockGuard?.assertOwned();
 		const entries = await readdir(baseRef.operationPath, { withFileTypes: true });
@@ -2021,7 +2042,7 @@ export async function retireUnpinnedManagedSnapshots(
 			if (await readOmxPluginCacheFileNoFollow(join(candidate.ref.operationPath, ".omx-live-pin"), { anchorDir: candidate.ref.operationPath }) !== null) {
 				continue;
 			}
-			if (await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true, expectedManagedVersion: candidate.version })) {
+			if (await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true, expectedManagedVersion: candidate.version, preservedPaths: preservedDirs })) {
 				retired.push(candidate.path);
 			} else {
 				preservedDirs?.push(candidate.path);
@@ -2029,7 +2050,7 @@ export async function retireUnpinnedManagedSnapshots(
 		}
 		return retired;
 	} finally {
-		if (publicationLockGuard) clearInterval(publicationLockGuard.timer);
+		if (ownsPublicationLockGuard && publicationLockGuard) clearInterval(publicationLockGuard.timer);
 		for (const candidateRef of candidateRefs.reverse()) {
 			try { await candidateRef.handle.close(); } catch (error) { cleanupError ??= error; }
 		}
@@ -2270,7 +2291,7 @@ async function materializePackagedOmxPluginCacheImpl(
 					await validateStagedPluginSnapshot(claimRef, packagedMarketplace, version, options.teamMode);
 					await syncDirectoryTree(claimRef, durability);
 					await publicationLockGuard.assertOwned();
-					const claimDigest = await computeImmutableClaimDigest(claimRef.path);
+					const claimDigest = await computeOmxPluginCacheClaimDigest(claimRef.path);
 					await createExclusiveFileChild(claimRef, ".omx-complete", `${JSON.stringify({ version, claimDigest })}\n`, durability);
 					const claimDirSyncOutcome = await syncDirectory(claimRef.handle);
 					recordDirectorySyncOutcome(durability, claimDirSyncOutcome);
@@ -2303,6 +2324,7 @@ async function materializePackagedOmxPluginCacheImpl(
 						cacheBaseRef,
 						true,
 						preservedDirs,
+						publicationLockGuard,
 					);
 					if (preservedDirs.length > 0) outcome.preservedDirs = preservedDirs;
 				} catch (error) {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1952,6 +1952,8 @@ async function materializePackagedOmxPluginCacheImpl(
 					snapshotRef = undefined;
 					await syncDirectoryTree(claimRef, durability);
 					await createExclusiveFileChild(claimRef, ".omx-complete", `${process.pid}\n`, durability);
+					const claimDirSyncOutcome = await syncDirectory(claimRef.handle);
+					recordDirectorySyncOutcome(durability, claimDirSyncOutcome);
 					await assertDirectoryRef(claimRef, "publication commit");
 					finalRef = claimRef;
 					const syncOutcome = await syncDirectory(cacheBaseRef.handle);

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -144,14 +144,18 @@ function directoryScanOperationPath(handle: FileHandle, path: string): string {
 
 function directoryOperationPath(handle: FileHandle, path: string): string | null {
 	// #3552 blockers 1+2: Linux mutates through a descriptor-relative
-	// /proc/self/fd path. Darwin has no usable fd path, so mutations fail
-	// closed (ENOTSUP) instead of degrading to visible paths. Windows opens
-	// the directory without traversing reparse points
-	// (O_NOFOLLOW|O_DIRECTORY), so the validated visible path is the safe
-	// mutation anchor there.
+	// /proc/self/fd path. Node exposes no *at() primitives on other
+	// platforms, so every mutation elsewhere goes through the visible path
+	// that this handle's open() already validated without following
+	// symlinks/reparse points, restricted to non-destructive shapes:
+	// exclusive mkdir / O_CREAT|O_EXCL|O_NOFOLLOW creates (never O_TRUNC on
+	// a foreign inode), fd-bound writes, quarantine+inode-gated rm, and
+	// rename only into this process's own verified claim, with
+	// assertDirectoryRef identity barriers immediately before and after
+	// every mutation so a replaced parent is detected before any result is
+	// trusted.
 	if (process.platform === "linux") return `/proc/self/fd/${handle.fd}`;
-	if (process.platform === "win32") return resolve(path);
-	return null;
+	return resolve(path);
 }
 
 function unsupportedDirectoryOperationError(): NodeJS.ErrnoException {
@@ -162,11 +166,14 @@ function unsupportedDirectoryOperationError(): NodeJS.ErrnoException {
 }
 
 function childMutationPath(parent: DirectoryRef, name: string): string {
-	if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+	// name is one or more "/"-joined simple components; callers validate the
+	// shape before reaching here, and every component must be a plain name.
+	const components = name.split("/");
+	if (components.some((component) => !component || component === "." || component === ".." || component.includes("\\"))) {
 		throw new Error(`invalid descriptor-relative child name: ${name}`);
 	}
 	if (!parent.mutationPath) throw unsupportedDirectoryOperationError();
-	return join(parent.mutationPath, name);
+	return join(parent.mutationPath, ...components);
 }
 
 function childOperationPath(parent: DirectoryRef, name: string): string {
@@ -350,24 +357,6 @@ async function syncRegularFileChild(
 	await assertDirectoryRef(parent, "file sync");
 }
 
-async function writeRegularFileChild(
-	parent: DirectoryRef,
-	name: string,
-	content: string,
-	tracker?: RegularFileDurabilityTracker,
-): Promise<void> {
-	const noFollowFlags = fsConstants.O_NOFOLLOW;
-	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
-	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | noFollowFlags, 0o600);
-	try {
-		await handle.writeFile(content);
-		const outcome = await syncRegularFile(handle);
-		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
-	} finally {
-		await handle.close();
-	}
-	await assertDirectoryRef(parent, "file write");
-}
 
 async function createExclusiveFileChild(
 	parent: DirectoryRef,
@@ -391,12 +380,40 @@ async function createExclusiveFileChild(
 async function removeChild(parent: DirectoryRef, name: string, options: { recursive?: boolean; force?: boolean } = {}): Promise<void> {
 	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "remove");
+	// #3552 blocker 2: gate the destructive rm on the current inode so a
+	// name swapped between the barrier and the syscall cannot redirect the
+	// deletion at a replacement target; the post-barrier re-assert detects
+	// a replaced parent before the result is trusted.
+	let before: Stats | undefined;
+	try {
+		before = await lstat(mutationPath);
+	} catch (error) {
+		if (!options.force || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
 	await rm(mutationPath, options);
+	if (before) {
+		try {
+			await lstat(mutationPath);
+			throw new Error(`removed cache entry reappeared during removal: ${mutationPath}`);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
 	await assertDirectoryRef(parent, "remove");
 }
 
 async function renameChild(sourceParent: DirectoryRef, sourceName: string, destinationParent: DirectoryRef, destinationName: string): Promise<void> {
-	const sourcePath = childMutationPath(sourceParent, sourceName);
+	// sourceName may be a single component or a "/"-joined relative path of
+	// simple components (publication moves staged snapshot entries), so
+	// validate each component instead of rejecting separators outright.
+	const sourceComponents = sourceName.split("/");
+	if (sourceComponents.some((component) => !component || component === "." || component === ".." || component.includes("\\"))) {
+		throw new Error(`invalid descriptor-relative child name: ${sourceName}`);
+	}
+	if (destinationName.includes("/") || destinationName.includes("\\") || !destinationName || destinationName === "." || destinationName === "..") {
+		throw new Error(`invalid descriptor-relative child name: ${destinationName}`);
+	}
+	const sourcePath = childMutationPath(sourceParent, sourceComponents.join("/"));
 	const destinationPath = childMutationPath(destinationParent, destinationName);
 	await assertDirectoryRef(sourceParent, "rename");
 	await assertDirectoryRef(destinationParent, "rename");
@@ -406,26 +423,37 @@ async function renameChild(sourceParent: DirectoryRef, sourceName: string, desti
 }
 
 /**
- * #3552 blocker 3: POSIX rename() silently replaces an empty same-version
- * directory, and Node exposes no renameat2(RENAME_NOREPLACE). Publication
- * therefore claims the destination with an atomic exclusive mkdir first:
- * EEXIST means another actor already claimed or published `<version>` (empty
- * or not) and the publication fails closed; success means this process owns
- * the empty claim, and the subsequent rename can only ever replace that
- * verified claim (inode re-checked immediately before the rename). The
- * caller re-verifies the published inode afterwards.
+ * #3552 blocker 3 / review 3860267789: POSIX rename() silently replaces an
+ * empty same-version directory and Node exposes no renameat2(RENAME_NOREPLACE),
+ * so pre/post inode checks around a rename can never be atomic no-replace.
+ * Publication therefore never renames onto `<version>`: the destination is
+ * claimed with an atomic exclusive mkdir (the one portable no-replace
+ * primitive). EEXIST — whether the destination is empty, foreign, incomplete,
+ * or a completed snapshot — always fails closed without touching it. The
+ * claim is self-described with an O_EXCL `.omx-incomplete` marker, the staged
+ * snapshot entries are renamed into the empty claim (destination names cannot
+ * pre-exist), and `.omx-complete` is committed last. Every trust path requires
+ * `.omx-complete` and rejects `.omx-incomplete`, so no intermediate state is
+ * trusted, and no pre-existing directory is ever replaced or removed.
+ *
+ * A claim abandoned by a crashed publisher keeps `.omx-incomplete` and no
+ * `.omx-complete`; the next publication fails closed on it (stale-launcher
+ * with the removal recovery hint) rather than deleting foreign content.
  */
 async function claimPublicationDestination(
 	destinationParent: DirectoryRef,
 	destinationName: string,
-): Promise<Stats> {
+	tracker?: RegularFileDurabilityTracker,
+): Promise<DirectoryRef> {
 	await mkdirDirectoryChildExclusive(destinationParent, destinationName);
 	const claimRef = await openDirectoryChild(destinationParent, destinationName);
 	try {
 		await assertDirectoryRef(claimRef, "publication claim");
-		return await claimRef.handle.stat();
-	} finally {
+		await createExclusiveFileChild(claimRef, ".omx-incomplete", `${process.pid}\n`, tracker);
+		return claimRef;
+	} catch (error) {
 		await claimRef.handle.close();
+		throw error;
 	}
 }
 
@@ -1405,7 +1433,11 @@ async function writePinnedHookLauncher(
 	packagedMarketplace: PackagedOmxMarketplace,
 	tracker?: RegularFileDurabilityTracker,
 ): Promise<void> {
-	await writeRegularFileChild(
+	// #3552 review 3859434238: the launcher is generated into a freshly
+	// created staging snapshot, so it must be created exclusively; a
+	// concurrent hard link at the staged path would otherwise let O_TRUNC
+	// clobber a foreign inode before any provenance check.
+	await createExclusiveFileChild(
 		hooksDir,
 		OMX_PLUGIN_HOOK_LAUNCHER_FILE,
 		buildPinnedHookLauncherContent(packagedMarketplace),
@@ -1801,53 +1833,54 @@ async function materializePackagedOmxPluginCacheImpl(
 			await syncDirectoryTree(snapshotRef, durability);
 			await options.onCacheDirPrepared?.(cacheDir);
 			try {
-				// #3552 blockers 3+5: commit the complete marker while the snapshot
-				// is still only reachable under the staging parent (discovery never
-				// descends into `.omx-plugin-*` staging trees), then claim the
-				// destination with an atomic exclusive mkdir so a concurrently
-				// created `<version>` directory (empty or not) can never be
-				// silently replaced by the final rename.
-				await createExclusiveFileChild(snapshotRef, ".omx-complete", `${process.pid}\n`, durability);
-				await removeChild(snapshotRef, ".omx-incomplete", { force: true });
-				await syncDirectoryTree(snapshotRef, durability);
-				let published = true;
+				// #3552 blockers 3+5 / review 3860267789: never rename onto
+				// `<version>` (rename silently replaces an empty destination and
+				// pre/post inode checks cannot make it atomic). The destination is
+				// claimed with an atomic exclusive mkdir self-described by
+				// `.omx-incomplete`; the staged snapshot entries are then renamed
+				// into that empty claim (destination names cannot pre-exist), and
+				// `.omx-complete` is committed last inside the claim. Every trust
+				// path requires `.omx-complete`, so no intermediate state is
+				// trusted, and no pre-existing directory is ever replaced.
+				let claimRef: DirectoryRef | undefined;
 				try {
-					await claimPublicationDestination(cacheBaseRef, version);
+					claimRef = await claimPublicationDestination(cacheBaseRef, version, durability);
 				} catch (error) {
 					if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-						published = false;
+						outcome = {
+							status: "stale-launcher",
+							cacheDir,
+							version,
+							reason: `same-version OMX plugin cache already exists at ${cacheDir}; refusing to replace or remove an existing directory; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
+							launcherTarget: undefined,
+							retiredDirs: [],
+						};
 					} else {
 						throw error;
 					}
 				}
-				if (!published) {
-					outcome = {
-						status: "stale-launcher",
-						cacheDir,
-						version,
-						reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
-						launcherTarget: undefined,
-						retiredDirs: [],
-					};
-				} else {
-					const snapshotStats = await snapshotRef.handle.stat();
-					await renameChild(tempRef, "snapshot", cacheBaseRef, version);
+				if (claimRef) {
+					// Drop the snapshot's staging marker, then the claim's own
+					// placeholder, so every entry moved below lands in an empty
+					// claim and the final marker is the only trust switch.
+					await removeChild(snapshotRef, ".omx-incomplete", { force: true });
+					await removeChild(claimRef, ".omx-incomplete", { force: true });
+					await assertDirectoryRef(claimRef, "publication claim");
+					const claimEntries = await readdir(claimRef.scanOperationPath, { withFileTypes: true });
+					if (claimEntries.length > 0) {
+						throw new Error(`publication claim is not empty at ${join(cacheBaseRef.path, version)}`);
+					}
+					const stagedEntries = await readdir(snapshotRef.scanOperationPath, { withFileTypes: true });
+					for (const entry of stagedEntries) {
+						if (entry.name === ".omx-incomplete") continue;
+						await renameChild(tempRef, `snapshot/${entry.name}`, claimRef, entry.name);
+					}
 					await snapshotRef.handle.close();
 					snapshotRef = undefined;
-					finalRef = await openDirectoryChild(cacheBaseRef, version);
-					await assertDirectoryRef(finalRef, "publication validation");
-					const finalPathStats = await lstat(finalRef.path);
-					const finalDescriptorStats = await finalRef.handle.stat();
-					if (
-						!finalPathStats.isDirectory() ||
-						finalPathStats.isSymbolicLink() ||
-						finalPathStats.dev !== finalDescriptorStats.dev ||
-						finalPathStats.ino !== finalDescriptorStats.ino ||
-						finalDescriptorStats.dev !== snapshotStats.dev ||
-						finalDescriptorStats.ino !== snapshotStats.ino
-					) {
-						throw new Error(`published cache directory changed before validation: ${cacheDir}`);
-					}
+					await syncDirectoryTree(claimRef, durability);
+					await createExclusiveFileChild(claimRef, ".omx-complete", `${process.pid}\n`, durability);
+					await assertDirectoryRef(claimRef, "publication commit");
+					finalRef = claimRef;
 					const syncOutcome = await syncDirectory(cacheBaseRef.handle);
 					recordDirectorySyncOutcome(durability, syncOutcome);
 				}

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,7 +1,6 @@
-import { existsSync } from "fs";
-import { cp, lstat, mkdir, mkdtemp, readdir, readFile, realpath, rename, rm, writeFile } from "fs/promises";
+import { constants as fsConstants, existsSync, type Stats } from "fs";
+import { cp, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, writeFile } from "fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "path";
-import { tmpdir } from "node:os";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
 
@@ -96,6 +95,110 @@ async function readPluginManifest(
 	}
 }
 
+function directoryFdPath(fd: number): string | null {
+	if (process.platform === "linux") return `/proc/self/fd/${fd}`;
+	if (process.platform === "darwin") return `/dev/fd/${fd}`;
+	return null;
+}
+
+async function syncRegularFile(path: string): Promise<void> {
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
+	const handle = await open(path, fsConstants.O_RDONLY | noFollowFlags);
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+async function syncDirectory(path: string): Promise<void> {
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	const directoryFlags = fsConstants.O_DIRECTORY;
+	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+		throw new Error("directory durability flags are unavailable");
+	}
+	const handle = await open(path, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+	try {
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+}
+
+export async function readOmxPluginCacheFileNoFollow(
+	path: string,
+	options: { requireSingleLink?: boolean; anchorDir?: string } = {},
+): Promise<Buffer | null> {
+	let handle;
+	let anchorHandle;
+	try {
+		const requireSingleLink = options.requireSingleLink ?? true;
+		const noFollowFlags = fsConstants.O_NOFOLLOW;
+		if (typeof noFollowFlags !== "number") return null;
+		let readPath = path;
+		let anchorBefore: Stats | null = null;
+		let anchoredRootParent = false;
+		if (options.anchorDir) {
+			const directoryFlags = fsConstants.O_DIRECTORY;
+			if (typeof directoryFlags !== "number") return null;
+			anchorHandle = await open(options.anchorDir, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+			anchorBefore = await anchorHandle.stat();
+			if (!anchorBefore.isDirectory()) return null;
+			if (typeof anchorBefore.dev !== "number" || typeof anchorBefore.ino !== "number") return null;
+			const fdPath = directoryFdPath(anchorHandle.fd);
+			if (!fdPath) return null;
+			const relativePath = relative(resolve(options.anchorDir), resolve(path));
+			if (!relativePath || relativePath.startsWith("..")) return null;
+			anchoredRootParent = !relativePath.includes(sep);
+			readPath = join(fdPath, relativePath);
+		}
+		const parentBefore = anchoredRootParent ? anchorBefore! : await lstat(resolve(readPath, ".."));
+		if (!parentBefore.isDirectory() || parentBefore.isSymbolicLink()) return null;
+		if (typeof parentBefore.dev !== "number" || typeof parentBefore.ino !== "number") return null;
+		const before = await lstat(readPath);
+		if (!before.isFile() || before.isSymbolicLink()) return null;
+		if (requireSingleLink && before.nlink !== 1) return null;
+		if (typeof before.dev !== "number" || typeof before.ino !== "number") return null;
+		handle = await open(readPath, fsConstants.O_RDONLY | noFollowFlags);
+		const descriptorStats = await handle.stat();
+		if (!descriptorStats.isFile()) return null;
+		if (requireSingleLink && descriptorStats.nlink !== 1) return null;
+		if (descriptorStats.dev !== before.dev || descriptorStats.ino !== before.ino) return null;
+		const bytes = await handle.readFile();
+		const after = await lstat(readPath);
+		const parentAfter = anchoredRootParent
+			? anchorHandle
+				? await anchorHandle.stat()
+				: null
+			: await lstat(resolve(readPath, ".."));
+		const anchorAfter = anchorHandle ? await anchorHandle.stat() : null;
+		if (!parentAfter) return null;
+		if (!after.isFile() || after.isSymbolicLink()) return null;
+		if (requireSingleLink && after.nlink !== 1) return null;
+		if (typeof after.dev !== "number" || typeof after.ino !== "number") return null;
+		if (after.dev !== before.dev || after.ino !== before.ino) return null;
+		if (!parentAfter.isDirectory() || parentAfter.isSymbolicLink()) return null;
+		if (typeof parentAfter.dev !== "number" || typeof parentAfter.ino !== "number" || parentAfter.dev !== parentBefore.dev || parentAfter.ino !== parentBefore.ino) return null;
+		if (anchorBefore && (!anchorAfter || typeof anchorAfter.dev !== "number" || typeof anchorAfter.ino !== "number" || !anchorAfter.isDirectory() || anchorAfter.dev !== anchorBefore.dev || anchorAfter.ino !== anchorBefore.ino)) return null;
+		return bytes;
+	} catch {
+		return null;
+	} finally {
+		if (handle) await handle.close();
+		if (anchorHandle) await anchorHandle.close();
+	}
+}
+
+async function readRegularFileTextNoFollow(path: string, options: { anchorDir?: string } = {}): Promise<string | null> {
+	const bytes = await readOmxPluginCacheFileNoFollow(path, options);
+	return bytes?.toString("utf-8") ?? null;
+}
+
+async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complete" | ".omx-incomplete"): Promise<boolean> {
+	return (await readOmxPluginCacheFileNoFollow(join(cacheDir, name), { anchorDir: cacheDir })) !== null;
+}
+
 async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
 	try {
 		const entries = await readdir(dir, { withFileTypes: true });
@@ -125,6 +228,7 @@ async function listRegularChildDirectoryNames(dir: string): Promise<string[] | n
 
 async function readRegularOmxPluginCacheManifest(
 	cacheDir: string,
+	anchorDir = cacheDir,
 ): Promise<PluginManifest | null> {
 	const manifestDir = join(cacheDir, ".codex-plugin");
 	const manifestPath = join(manifestDir, "plugin.json");
@@ -133,7 +237,8 @@ async function readRegularOmxPluginCacheManifest(
 		if (!manifestDirStats.isDirectory() || manifestDirStats.isSymbolicLink()) return null;
 		const manifestStats = await lstat(manifestPath);
 		if (!manifestStats.isFile() || manifestStats.isSymbolicLink()) return null;
-		return await readPluginManifest(manifestPath);
+		const bytes = await readOmxPluginCacheFileNoFollow(manifestPath, { anchorDir });
+		return bytes ? JSON.parse(bytes.toString("utf-8")) as PluginManifest : null;
 	} catch {
 		return null;
 	}
@@ -187,6 +292,12 @@ function isMissingPathError(error: unknown): boolean {
 export async function omxPluginCacheExecutedAssetProvenanceReason(
 	cacheDir: string,
 ): Promise<string | null> {
+	if (!(await hasRegularPublicationMarker(cacheDir, ".omx-complete"))) {
+		return `cache snapshot publication marker is missing at ${cacheDir}`;
+	}
+	if (await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) {
+		return `cache snapshot publication is incomplete at ${cacheDir}`;
+	}
 	const expectations: Array<{ path: string; kind: "file" | "directory"; label: string }> = [
 		{ path: cacheDir, kind: "directory", label: "cache root" },
 		{ path: join(cacheDir, "hooks"), kind: "directory", label: "hooks directory" },
@@ -203,7 +314,7 @@ export async function omxPluginCacheExecutedAssetProvenanceReason(
 		}
 		const shapeOk = kind === "directory"
 			? stats.isDirectory() && !stats.isSymbolicLink()
-			: stats.isFile() && !stats.isSymbolicLink();
+			: stats.isFile() && !stats.isSymbolicLink() && stats.nlink === 1;
 		if (!shapeOk) {
 			return `${label} at ${path} is a symlink or not a ${kind === "directory" ? "directory" : "regular file"}`;
 		}
@@ -232,10 +343,16 @@ async function omxPluginCacheManifestProvenanceReason(
 	} catch {
 		return `plugin manifest is missing at ${manifestPath}`;
 	}
-	if (!manifestStats.isFile() || manifestStats.isSymbolicLink()) {
+	if (!manifestStats.isFile() || manifestStats.isSymbolicLink() || manifestStats.nlink !== 1) {
 		return `plugin manifest at ${manifestPath} is a symlink or not a regular file`;
 	}
-	const manifest = await readPluginManifest(manifestPath);
+	const manifestBytes = await readOmxPluginCacheFileNoFollow(manifestPath, { anchorDir: cacheDir });
+	let manifest: PluginManifest | null = null;
+	try {
+		manifest = manifestBytes ? JSON.parse(manifestBytes.toString("utf-8")) as PluginManifest : null;
+	} catch {
+		manifest = null;
+	}
 	if (!manifest) return `plugin manifest at ${manifestPath} is unreadable or invalid JSON`;
 	if (manifest.name !== OMX_PLUGIN_NAME) {
 		return `plugin manifest name is not ${OMX_PLUGIN_NAME} at ${manifestPath}`;
@@ -273,6 +390,19 @@ async function omxPluginCacheSkillsProvenanceReason(
 	if (!skillsStats.isDirectory() || skillsStats.isSymbolicLink()) {
 		return `skills directory at ${skillsDir} is a symlink or not a directory`;
 	}
+	let skillEntries;
+	try {
+		skillEntries = await readdir(skillsDir, { withFileTypes: true });
+	} catch {
+		return `skills directory at ${skillsDir} is unreadable`;
+	}
+	const actualSkillNames = skillEntries.map((entry) => entry.name).sort();
+	if (skillEntries.some((entry) => entry.isSymbolicLink() || !entry.isDirectory())) {
+		return `skills directory at ${skillsDir} contains a symlink or non-directory entry`;
+	}
+	if (JSON.stringify(actualSkillNames) !== JSON.stringify([...expectedSkillNames].sort())) {
+		return `skills directory contents differ at ${skillsDir}`;
+	}
 	for (const skillName of expectedSkillNames) {
 		const skillDir = join(skillsDir, skillName);
 		let skillDirStats;
@@ -292,10 +422,10 @@ async function omxPluginCacheSkillsProvenanceReason(
 		} catch {
 			return `expected skill file is missing at ${cachedSkill}`;
 		}
-		if (!cachedSkillStats.isFile() || cachedSkillStats.isSymbolicLink()) {
+		if (!cachedSkillStats.isFile() || cachedSkillStats.isSymbolicLink() || cachedSkillStats.nlink !== 1) {
 			return `expected skill file at ${cachedSkill} is a symlink or not a regular file`;
 		}
-		if (!(await fileContentsEqual(cachedSkill, packagedSkill))) {
+		if (!(await fileContentsEqual(cachedSkill, packagedSkill, cacheDir))) {
 			return `expected skill file content differs at ${cachedSkill}`;
 		}
 	}
@@ -314,10 +444,10 @@ async function omxPluginCacheCompanionMetadataProvenanceReason(
 		} catch {
 			return `plugin manifest ${name} companion file is missing at ${cachedPath}`;
 		}
-		if (!stats.isFile() || stats.isSymbolicLink()) {
+		if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
 			return `plugin manifest ${name} companion file at ${cachedPath} is a symlink or not a regular file`;
 		}
-		if (!(await fileContentsEqual(cachedPath, join(packagedMarketplace.pluginRoot, relativePath)))) {
+		if (!(await fileContentsEqual(cachedPath, join(packagedMarketplace.pluginRoot, relativePath), cacheDir))) {
 			return `plugin manifest ${name} companion file content differs at ${cachedPath}`;
 		}
 	}
@@ -370,7 +500,11 @@ async function ensureManagedCacheNamespace(
 			}
 		} catch (error) {
 			if (!isMissingPathError(error)) throw error;
-			await mkdir(current);
+			try {
+				await mkdir(current);
+			} catch (mkdirError) {
+				if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
+			}
 			const stats = await lstat(current);
 			if (!stats.isDirectory() || stats.isSymbolicLink()) {
 				throw new Error(
@@ -387,7 +521,17 @@ async function inspectCacheRoot(cacheDir: string): Promise<"missing" | "director
 			if (!stats.isDirectory() || stats.isSymbolicLink()) {
 				return "untrusted";
 			}
-			const manifest = await readPluginManifest(join(cacheDir, ".codex-plugin", "plugin.json"));
+			if (!(await hasRegularPublicationMarker(cacheDir, ".omx-complete")) || await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) return "untrusted";
+			const manifest = await readRegularOmxPluginCacheManifest(cacheDir);
+			if (!manifest) {
+				const manifestPath = join(cacheDir, ".codex-plugin", "plugin.json");
+				try {
+					const manifestStats = await lstat(manifestPath);
+					if (manifestStats.isSymbolicLink()) return "directory";
+				} catch {
+					// Treat missing or unreadable manifests as foreign cache entries.
+				}
+			}
 			return manifest?.name === OMX_PLUGIN_NAME ? "directory" : "foreign";
 		} catch (error) {
 			if (isMissingPathError(error)) return "missing";
@@ -423,7 +567,15 @@ export async function discoverOmxPluginCacheDirs(
 	codexHomeDir: string,
 ): Promise<string[]> {
 	const cacheRoot = join(codexHomeDir, "plugins", "cache");
-	if (!existsSync(cacheRoot)) return [];
+	let cacheRootIdentity: { dev: number; ino: number };
+	try {
+		const cacheRootStats = await lstat(cacheRoot);
+		if (!cacheRootStats.isDirectory() || cacheRootStats.isSymbolicLink()) return [];
+		if (typeof cacheRootStats.dev !== "number" || typeof cacheRootStats.ino !== "number") return [];
+		cacheRootIdentity = { dev: cacheRootStats.dev, ino: cacheRootStats.ino };
+	} catch {
+		return [];
+	}
 
 	const queue: Array<{ path: string; depth: number }> = [
 		{ path: cacheRoot, depth: 0 },
@@ -434,10 +586,9 @@ export async function discoverOmxPluginCacheDirs(
 	while (queue.length > 0) {
 		const current = queue.shift();
 		if (!current) break;
-
-		const manifestPath = join(current.path, ".codex-plugin", "plugin.json");
-		if (existsSync(manifestPath)) {
-			const manifest = await readPluginManifest(manifestPath);
+		if (current.depth >= 2) {
+			if (await hasRegularPublicationMarker(current.path, ".omx-incomplete")) continue;
+			const manifest = await readRegularOmxPluginCacheManifest(current.path, cacheRoot);
 			if (manifest?.name === OMX_PLUGIN_NAME) {
 				matches.push(current.path);
 				continue;
@@ -463,6 +614,12 @@ export async function discoverOmxPluginCacheDirs(
 		}
 	}
 
+	try {
+		const finalRootStats = await lstat(cacheRoot);
+		if (!finalRootStats.isDirectory() || finalRootStats.isSymbolicLink() || finalRootStats.dev !== cacheRootIdentity.dev || finalRootStats.ino !== cacheRootIdentity.ino) return [];
+	} catch {
+		return [];
+	}
 	return matches.sort();
 }
 
@@ -484,13 +641,9 @@ export async function readOmxPluginCacheState(
 	// #3552: never read cache state through a symlinked or non-directory snapshot root —
 	// readFile-based manifest reads would follow an external target before provenance checks.
 	// A missing pinned launcher is reported by the dedicated launcher checks, not here.
-	if (
-		(await omxPluginCacheExecutedAssetProvenanceReason(cacheDir))?.startsWith(
-			"cache root",
-		)
-	) {
-		return null;
-	}
+	const executedAssetReason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+	if (executedAssetReason) return null;
+	if (await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) return null;
 	const manifest = await readRegularOmxPluginCacheManifest(cacheDir);
 	if (manifest?.name !== OMX_PLUGIN_NAME) return null;
 	if (expectedVersion !== undefined && manifest.version !== expectedVersion) return null;
@@ -503,16 +656,14 @@ export async function readOmxPluginCacheState(
 		hooksPointer: typeof manifest.hooks === "string" ? manifest.hooks : null,
 		mcpServersPointer: typeof manifest.mcpServers === "string" ? manifest.mcpServers : null,
 		appsPointer: typeof manifest.apps === "string" ? manifest.apps : null,
-		hookLauncherPinned: existsSync(
-			join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
-		),
+		hookLauncherPinned: true,
 	};
 }
 
 export async function hasExpectedOmxPluginCache(
 	codexHomeDir: string,
 	packagedMarketplace: PackagedOmxMarketplace,
-	options: { teamMode?: SetupTeamMode } = {},
+	options: { teamMode?: SetupTeamMode; cacheDirOverride?: string } = {},
 ): Promise<boolean> {
 	const [version, expectedSkillNames] = await Promise.all([
 		packagedOmxPluginVersion(packagedMarketplace),
@@ -520,16 +671,15 @@ export async function hasExpectedOmxPluginCache(
 	]);
 	if (!version || !expectedSkillNames) return false;
 	const state = await readOmxPluginCacheState(
-		join(omxPluginCacheBase(codexHomeDir), version),
+		options.cacheDirOverride ?? join(omxPluginCacheBase(codexHomeDir), version),
 		version,
 	);
+	if (!state) return false;
 	if (
-		state?.manifestVersion !== version ||
+		state.manifestVersion !== version ||
 		state.skillsPointer !== "./skills/" ||
 		state.hooksPointer !== "./hooks/hooks.json" ||
 		!state.hookLauncherPinned ||
-		!existsSync(join(state.cacheDir, "hooks", "hooks.json")) ||
-		!existsSync(join(state.cacheDir, "hooks", "codex-native-hook.mjs")) ||
 		JSON.stringify(state.skillNames) !== JSON.stringify(expectedSkillNames)
 	) {
 		return false;
@@ -541,16 +691,12 @@ export async function hasExpectedOmxPluginCache(
 	return pluginHookCacheMatchesPackaged(state.cacheDir, packagedMarketplace);
 }
 
-async function fileContentsEqual(leftPath: string, rightPath: string): Promise<boolean> {
-	try {
-		const [left, right] = await Promise.all([
-			readFile(leftPath),
-			readFile(rightPath),
-		]);
-		return left.equals(right);
-	} catch {
-		return false;
-	}
+async function fileContentsEqual(leftPath: string, rightPath: string, anchorDir?: string): Promise<boolean> {
+	const [left, right] = await Promise.all([
+		readOmxPluginCacheFileNoFollow(leftPath, anchorDir ? { anchorDir } : {}),
+		readOmxPluginCacheFileNoFollow(rightPath, { requireSingleLink: false }),
+	]);
+	return left !== null && right !== null && left.equals(right);
 }
 
 
@@ -574,9 +720,11 @@ export async function pluginHookCacheMatchesPackaged(
 	return await fileContentsEqual(
 		join(cacheDir, "hooks", "hooks.json"),
 		join(packagedMarketplace.pluginRoot, "hooks", "hooks.json"),
+		cacheDir,
 	) && await fileContentsEqual(
 		join(cacheDir, "hooks", "codex-native-hook.mjs"),
 		join(packagedMarketplace.pluginRoot, "hooks", "codex-native-hook.mjs"),
+		cacheDir,
 	) && await pinnedHookLauncherMatchesPackaged(
 		cacheDir,
 		packagedMarketplace,
@@ -600,14 +748,10 @@ async function pinnedHookLauncherMatchesPackaged(
 	cacheDir: string,
 	packagedMarketplace: PackagedOmxMarketplace,
 ): Promise<boolean> {
-	try {
-		return await readFile(
-			join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
-			"utf-8",
-		) === buildPinnedHookLauncherContent(packagedMarketplace);
-	} catch {
-		return false;
-	}
+	return await readRegularFileTextNoFollow(
+		join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
+		{ anchorDir: cacheDir },
+	) === buildPinnedHookLauncherContent(packagedMarketplace);
 }
 
 async function writePinnedHookLauncher(
@@ -659,20 +803,24 @@ async function canonicalRealpath(path: string): Promise<string | null> {
 
 export async function readPinnedLauncherRaw(cacheDir: string): Promise<{ raw: string | null; parsed: { command?: unknown; argsPrefix?: unknown } | null; error?: string }> {
 	const launcherPath = join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE);
-	try {
-		const raw = await readFile(launcherPath, "utf-8");
+	const raw = await readRegularFileTextNoFollow(launcherPath, { anchorDir: cacheDir });
+	if (raw === null) {
 		try {
-			const parsed = JSON.parse(raw) as { command?: unknown; argsPrefix?: unknown };
-			if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-				return { raw, parsed: null, error: `malformed pinned launcher JSON: expected object but got ${Array.isArray(parsed) ? "array" : String(parsed)}` };
-			}
-			return { raw, parsed, error: undefined };
+			await lstat(launcherPath);
+			return { raw: null, parsed: null, error: "cannot read pinned launcher" };
 		} catch (e) {
-			return { raw, parsed: null, error: `malformed pinned launcher JSON: ${(e as Error).message}` };
+			if (isMissingPathError(e)) return { raw: null, parsed: null, error: "missing pinned launcher" };
+			return { raw: null, parsed: null, error: `cannot read pinned launcher: ${(e as Error).message}` };
 		}
+	}
+	try {
+		const parsed = JSON.parse(raw) as { command?: unknown; argsPrefix?: unknown };
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return { raw, parsed: null, error: `malformed pinned launcher JSON: expected object but got ${Array.isArray(parsed) ? "array" : String(parsed)}` };
+		}
+		return { raw, parsed, error: undefined };
 	} catch (e) {
-		if (isMissingPathError(e)) return { raw: null, parsed: null, error: "missing pinned launcher" };
-		return { raw: null, parsed: null, error: `cannot read pinned launcher: ${(e as Error).message}` };
+		return { raw, parsed: null, error: `malformed pinned launcher JSON: ${(e as Error).message}` };
 	}
 }
 
@@ -680,13 +828,35 @@ export async function getPinnedLauncherIncompatibilityReason(
 	cacheDir: string,
 	packagedMarketplace: PackagedOmxMarketplace,
 ): Promise<{ reason: string; target?: string } | null> {
-	const launcherPath = join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE);
-	let raw: string;
+	const hooksDir = join(cacheDir, "hooks");
 	try {
-		raw = await readFile(launcherPath, "utf-8");
+		const hooksStats = await lstat(hooksDir);
+		if (!hooksStats.isDirectory() || hooksStats.isSymbolicLink()) {
+			return { reason: `hooks directory at ${hooksDir} is a symlink or not a directory; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+		}
+	} catch (e) {
+		if (isMissingPathError(e)) return { reason: `hooks directory missing at ${hooksDir}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+		return { reason: `cannot read hooks directory at ${hooksDir}: ${(e as Error).message}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	const launcherPath = join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE);
+	try {
+		const launcherStats = await lstat(launcherPath);
+		if (!launcherStats.isFile() || launcherStats.isSymbolicLink() || launcherStats.nlink !== 1) {
+			return { reason: `pinned launcher at ${launcherPath} is a symlink or not a regular file; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+		}
 	} catch (e) {
 		if (isMissingPathError(e)) return { reason: `pinned launcher missing at ${launcherPath}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
 		return { reason: `cannot read pinned launcher at ${launcherPath}: ${(e as Error).message}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+	}
+	const raw = await readRegularFileTextNoFollow(launcherPath, { anchorDir: cacheDir });
+	if (raw === null) {
+		try {
+			await lstat(launcherPath);
+			return { reason: `cannot read pinned launcher at ${launcherPath}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+		} catch (e) {
+			if (isMissingPathError(e)) return { reason: `pinned launcher missing at ${launcherPath}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+			return { reason: `cannot read pinned launcher at ${launcherPath}: ${(e as Error).message}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin` };
+		}
 	}
 	let parsed: unknown;
 	try {
@@ -745,23 +915,26 @@ export async function getPinnedLauncherIncompatibilityReason(
 async function retireUnpinnedManagedSnapshots(
 	codexHomeDir: string,
 	currentVersion: string,
+	anchoredCacheBasePath?: string,
 ): Promise<string[]> {
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
 	await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
+	const managedBase = anchoredCacheBasePath ?? cacheBase;
 	let entries;
 	try {
-		entries = await readdir(cacheBase, { withFileTypes: true });
+		entries = await readdir(managedBase, { withFileTypes: true });
 	} catch {
 		return [];
 	}
-	const managed: Array<{ path: string; version: string; mtimeMs: number }> = [];
+	const managed: Array<{ path: string; managedPath: string; version: string; mtimeMs: number }> = [];
 	for (const entry of entries) {
 		if (!entry.isDirectory() || entry.name === currentVersion) continue;
-		const path = join(cacheBase, entry.name);
-		const state = await readOmxPluginCacheState(path);
-		if (state?.manifestVersion !== entry.name) continue;
+		const path = join(managedBase, entry.name);
+		const manifest = await readRegularOmxPluginCacheManifest(path, path);
+		if (manifest?.name !== OMX_PLUGIN_NAME || manifest.version !== entry.name) continue;
+		if (!(await hasRegularPublicationMarker(path, ".omx-complete")) || await hasRegularPublicationMarker(path, ".omx-incomplete")) continue;
 		if (existsSync(join(path, ".omx-live-pin"))) continue;
-		managed.push({ path, version: entry.name, mtimeMs: (await lstat(path)).mtimeMs });
+		managed.push({ path: join(cacheBase, entry.name), managedPath: path, version: entry.name, mtimeMs: (await lstat(path)).mtimeMs });
 	}
 	managed.sort((left, right) =>
 		right.version.localeCompare(left.version, undefined, { numeric: true }) ||
@@ -769,34 +942,47 @@ async function retireUnpinnedManagedSnapshots(
 	);
 	const retired: string[] = [];
 	for (const candidate of managed.slice(1)) {
-		await rm(candidate.path, { recursive: true, force: true });
+		await rm(candidate.managedPath, { recursive: true, force: true });
 		retired.push(candidate.path);
 	}
 	return retired;
 }
 
-export async function materializePackagedOmxPluginCache(
+interface MaterializePackagedOmxPluginCacheOptions {
+	dryRun?: boolean;
+	teamMode?: SetupTeamMode;
+	onCacheDirPrepared?: (cacheDir: string) => void | Promise<void>;
+	anchoredCacheBasePath?: string;
+	anchoredCacheDir?: string;
+	cacheDirOverride?: string;
+}
+
+async function materializePackagedOmxPluginCacheImpl(
 	codexHomeDir: string,
 	packagedMarketplace: PackagedOmxMarketplace | null,
-	options: { dryRun?: boolean; teamMode?: SetupTeamMode; onCacheDirPrepared?: (cacheDir: string) => void | Promise<void> } = {},
+	options: MaterializePackagedOmxPluginCacheOptions = {},
 ): Promise<OmxPluginCacheMaterializeResult> {
 	if (!packagedMarketplace) return { status: "unavailable" };
 	const version = await packagedOmxPluginVersion(packagedMarketplace);
 	if (!version) return { status: "unavailable" };
 	const cacheDir = join(omxPluginCacheBase(codexHomeDir), version);
-	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace, options)) {
+	const inspectedCacheDir = options.anchoredCacheDir ?? cacheDir;
+	if (await hasExpectedOmxPluginCache(codexHomeDir, packagedMarketplace, {
+		...options,
+		cacheDirOverride: inspectedCacheDir,
+	})) {
 		return {
 			status: "unchanged",
 			cacheDir,
 			version,
 			retiredDirs: options.dryRun
 				? []
-				: await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+				: await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 		};
 	}
 	// Same-version directory exists but is not byte-identical: distinguish immutable-preserved vs dead/provenance-incompatible launcher.
 	// Preserve #3499 immutability: never rewrite an existing same-version directory in place.
-	const rootState = await inspectCacheRoot(cacheDir);
+	const rootState = await inspectCacheRoot(inspectedCacheDir);
 	if (rootState === "untrusted") {
 		return {
 			status: "stale-launcher",
@@ -804,11 +990,11 @@ export async function materializePackagedOmxPluginCache(
 			version,
 			reason: `OMX plugin cache root at ${cacheDir} is a symlink or non-directory entry; managed snapshots must be regular immutable directories; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
 			launcherTarget: undefined,
-			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 		};
 	}
 	if (rootState === "directory") {
-		const incompat = await getPinnedLauncherIncompatibilityReason(cacheDir, packagedMarketplace);
+		const incompat = await getPinnedLauncherIncompatibilityReason(inspectedCacheDir, packagedMarketplace);
 		if (incompat) {
 			return {
 				status: "stale-launcher",
@@ -816,11 +1002,11 @@ export async function materializePackagedOmxPluginCache(
 				version,
 				reason: incompat.reason,
 				launcherTarget: incompat.target,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 			};
 		}
 		const snapshotProvenanceReason = await omxPluginCacheProvenanceReason(
-			cacheDir,
+			inspectedCacheDir,
 			packagedMarketplace,
 			version,
 			options,
@@ -832,10 +1018,10 @@ export async function materializePackagedOmxPluginCache(
 				version,
 				reason: `${snapshotProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
 				launcherTarget: undefined,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 			};
 		}
-		const assetProvenanceReason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
+		const assetProvenanceReason = await omxPluginCacheExecutedAssetProvenanceReason(inspectedCacheDir);
 		if (assetProvenanceReason) {
 			return {
 				status: "stale-launcher",
@@ -843,14 +1029,14 @@ export async function materializePackagedOmxPluginCache(
 				version,
 				reason: `${assetProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
 				launcherTarget: undefined,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 			};
 		}
 		return {
 			status: "unchanged",
 			cacheDir,
 			version,
-			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 		};
 	}
 	if (rootState === "foreign") {
@@ -859,18 +1045,164 @@ export async function materializePackagedOmxPluginCache(
 	if (!options.dryRun) {
 		const cacheBase = omxPluginCacheBase(codexHomeDir);
 		await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
-		const tempDir = await mkdtemp(join(tmpdir(), `omx-plugin-${version}-`));
+		const noFollowFlags = fsConstants.O_NOFOLLOW;
+		const directoryFlags = fsConstants.O_DIRECTORY;
+		if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: "platform cannot provide no-follow directory anchoring for immutable cache publication",
+				launcherTarget: undefined,
+				retiredDirs: [],
+			};
+		}
+		let cacheBaseHandle;
+		let cacheBaseFdPath: string | null | undefined = options.anchoredCacheBasePath;
+		if (!cacheBaseFdPath) {
+			cacheBaseHandle = await open(cacheBase, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+			cacheBaseFdPath = directoryFdPath(cacheBaseHandle.fd);
+		}
+		if (!cacheBaseFdPath) {
+			if (cacheBaseHandle) await cacheBaseHandle.close();
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: "platform cannot expose an anchored cache directory descriptor for immutable publication",
+				launcherTarget: undefined,
+				retiredDirs: [],
+			};
+		}
+		const lockPath = join(cacheBaseFdPath, ".omx-publish.lock");
+		let lockHandle;
 		try {
+			lockHandle = await open(
+				lockPath,
+				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags,
+				0o600,
+			);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+				if (cacheBaseHandle) await cacheBaseHandle.close();
+				return {
+					status: "stale-launcher",
+					cacheDir,
+					version,
+					reason: `another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`,
+					launcherTarget: undefined,
+					retiredDirs: [],
+				};
+			}
+			if (cacheBaseHandle) await cacheBaseHandle.close();
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `cannot claim immutable OMX plugin cache publication at ${cacheBase}: ${(error as Error).message}`,
+				launcherTarget: undefined,
+				retiredDirs: [],
+			};
+		}
+		let tempDir: string | undefined;
+		let outcome: OmxPluginCacheMaterializeResult = {
+			status: "materialized",
+			cacheDir,
+			version,
+			retiredDirs: [],
+		};
+		let cleanupError: unknown = null;
+		try {
+			tempDir = await mkdtemp(join(cacheBaseFdPath, `.omx-plugin-${version}-`));
 			const snapshotDir = await stageCompletePluginSnapshot(
 				tempDir,
 				packagedMarketplace,
 				version,
 				options.teamMode,
 			);
-			await rename(snapshotDir, cacheDir);
+			const completeMarker = join(snapshotDir, ".omx-complete");
+			await writeFile(completeMarker, `${process.pid}\n`);
+			await syncRegularFile(completeMarker);
+			await syncDirectory(snapshotDir);
+			const finalPath = join(cacheBaseFdPath, version);
+			try {
+				await lstat(finalPath);
+				outcome = {
+					status: "stale-launcher",
+					cacheDir,
+					version,
+					reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
+					launcherTarget: undefined,
+					retiredDirs: [],
+				};
+			} catch (error) {
+				if (!isMissingPathError(error)) throw error;
+				await rename(snapshotDir, finalPath);
+				if (!options.anchoredCacheBasePath) await syncDirectory(cacheBase);
+			}
+		} catch (error) {
+			outcome = {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `immutable OMX plugin cache publication failed closed: ${(error as Error).message}`,
+				launcherTarget: undefined,
+				retiredDirs: [],
+			};
 		} finally {
-			await rm(tempDir, { recursive: true, force: true });
+			try {
+				if (tempDir) await rm(tempDir, { recursive: true, force: true });
+			} catch (error) {
+				cleanupError = error;
+			}
+			try {
+				await lockHandle.close();
+			} catch (error) {
+				cleanupError ??= error;
+			}
+			try {
+				await rm(lockPath, { force: true });
+				if (!options.anchoredCacheBasePath) await syncDirectory(cacheBase);
+			} catch (error) {
+				cleanupError ??= error;
+			}
+			if (cacheBaseHandle) {
+				try {
+					await cacheBaseHandle.close();
+				} catch (error) {
+					cleanupError ??= error;
+				}
+			}
 		}
+		if (cleanupError) {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `immutable OMX plugin cache publication cleanup failed closed: ${(cleanupError as Error).message}`,
+				launcherTarget: undefined,
+				retiredDirs: [],
+			};
+		}
+		if (outcome.status === "materialized" && !options.dryRun) {
+			try {
+				outcome.retiredDirs = await retireUnpinnedManagedSnapshots(
+					codexHomeDir,
+					version,
+					options.anchoredCacheBasePath,
+				);
+			} catch (error) {
+				return {
+					status: "stale-launcher",
+					cacheDir,
+					version,
+					reason: `immutable OMX plugin cache retirement failed closed: ${(error as Error).message}`,
+					launcherTarget: undefined,
+					retiredDirs: [],
+				};
+			}
+		}
+		return outcome;
 	}
 	return {
 		status: "materialized",
@@ -878,8 +1210,93 @@ export async function materializePackagedOmxPluginCache(
 		version,
 		retiredDirs: options.dryRun
 			? []
-			: await retireUnpinnedManagedSnapshots(codexHomeDir, version),
+			: await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
 	};
+}
+
+export async function materializePackagedOmxPluginCache(
+	codexHomeDir: string,
+	packagedMarketplace: PackagedOmxMarketplace | null,
+	options: MaterializePackagedOmxPluginCacheOptions = {},
+): Promise<OmxPluginCacheMaterializeResult> {
+	if (!packagedMarketplace) return { status: "unavailable" };
+	const version = await packagedOmxPluginVersion(packagedMarketplace);
+	if (!version) return { status: "unavailable" };
+	const cacheBase = omxPluginCacheBase(codexHomeDir);
+	const cacheDir = join(cacheBase, version);
+	await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	const directoryFlags = fsConstants.O_DIRECTORY;
+	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+		return {
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: "platform cannot provide no-follow directory anchoring for immutable cache validation/publication",
+			launcherTarget: undefined,
+			retiredDirs: [],
+		};
+	}
+	let cacheBaseHandle;
+	try {
+		cacheBaseHandle = await open(cacheBase, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		return {
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: `cannot anchor OMX plugin cache namespace at ${cacheBase}: ${code ?? "open failed"}; refusing to trust or publish cache contents`,
+			launcherTarget: undefined,
+			retiredDirs: [],
+		};
+	}
+	const cacheBaseFdPath = directoryFdPath(cacheBaseHandle.fd);
+	if (!cacheBaseFdPath) {
+		await cacheBaseHandle.close();
+		return {
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: "platform cannot expose an anchored cache directory descriptor for immutable cache validation/publication",
+			launcherTarget: undefined,
+			retiredDirs: [],
+		};
+	}
+	let result: OmxPluginCacheMaterializeResult;
+	try {
+		result = await materializePackagedOmxPluginCacheImpl(
+			codexHomeDir,
+			packagedMarketplace,
+			{
+				...options,
+				anchoredCacheBasePath: cacheBaseFdPath,
+				anchoredCacheDir: join(cacheBaseFdPath, version),
+			},
+		);
+	} catch (error) {
+		result = {
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: `anchored OMX plugin cache operation failed closed: ${(error as Error).message}`,
+			launcherTarget: undefined,
+			retiredDirs: [],
+		};
+	}
+	try {
+		await cacheBaseHandle.close();
+	} catch (error) {
+		return {
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: `anchored OMX plugin cache descriptor close failed closed: ${(error as Error).message}`,
+			launcherTarget: undefined,
+			retiredDirs: [],
+		};
+	}
+	return result;
 }
 
 function marketplaceTableHeaderPattern(): RegExp {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -42,6 +42,7 @@ interface PluginManifest {
 }
 
 const OMX_PLUGIN_HOOK_LAUNCHER_FILE = "omx-command.json";
+const OMX_PLUGIN_MANAGED_MARKER = ".omx-managed";
 const OMX_PLUGIN_CACHE_STAGING_PREFIX = ".omx-plugin-";
 const TEAM_MODE_PLUGIN_SKILL_NAMES = new Set(["team", "worker"]);
 
@@ -138,6 +139,31 @@ interface DirectoryRef {
 	mutationPath: string | null;
 }
 
+interface PluginCacheMutationTestHooks {
+	beforeRename?: (sourcePath: string, destinationPath: string) => void | Promise<void>;
+	beforeMkdirExclusive?: (parentPath: string, name: string) => void | Promise<void>;
+	beforeExclusiveCreate?: (parentPath: string, name: string) => void | Promise<void>;
+	afterStagedFileRead?: (path: string, stats: Stats, bytes: Buffer) => void | Promise<void>;
+	beforeFinalClaimValidation?: (claimPath: string) => void | Promise<void>;
+	beforeCompleteMarker?: (claimPath: string) => void | Promise<void>;
+	beforeStaleLockReclaim?: (lockPath: string, stats: Stats) => void | Promise<void>;
+	beforeRemove?: (path: string, stats: Stats) => void | Promise<void>;
+	beforeRemoveSyscall?: (path: string, stats: Stats) => void | Promise<void>;
+}
+
+let pluginCacheMutationTestHooks: PluginCacheMutationTestHooks | undefined;
+
+/** @internal Test seam for deterministic cache mutation interposition coverage. */
+export function setPluginCacheMutationHooksForTest(
+	hooks: PluginCacheMutationTestHooks | undefined,
+): () => void {
+	const previous = pluginCacheMutationTestHooks;
+	pluginCacheMutationTestHooks = hooks;
+	return () => {
+		pluginCacheMutationTestHooks = previous;
+	};
+}
+
 function directoryScanOperationPath(handle: FileHandle, path: string): string {
 	return directoryFdPath(handle.fd) ?? resolve(path);
 }
@@ -197,6 +223,12 @@ async function assertDirectoryRef(parent: DirectoryRef, operation: string): Prom
 	}
 }
 
+function sameFileIdentity(left: Stats, right: Stats): boolean {
+	return typeof left.dev === "number" && typeof left.ino === "number"
+		&& typeof right.dev === "number" && typeof right.ino === "number"
+		&& left.dev === right.dev && left.ino === right.ino;
+}
+
 async function openDirectoryRef(path: string): Promise<DirectoryRef> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
@@ -254,6 +286,7 @@ async function mkdirDirectoryChild(parent: DirectoryRef, name: string): Promise<
 async function mkdirDirectoryChildExclusive(parent: DirectoryRef, name: string): Promise<void> {
 	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "exclusive mkdir");
+	await pluginCacheMutationTestHooks?.beforeMkdirExclusive?.(parent.path, name);
 	await mkdir(mutationPath);
 	await assertDirectoryRef(parent, "exclusive mkdir");
 }
@@ -327,9 +360,84 @@ async function copyPackagedTree(
 	await assertDirectoryRef(source, "packaged source copy");
 }
 
+async function copyStagedTreeNoReplace(
+	source: DirectoryRef,
+	destination: DirectoryRef,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	await assertDirectoryRef(source, "staged source copy");
+	await assertDirectoryRef(destination, "staged destination copy");
+	const entries = await readdir(source.operationPath, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.name === ".omx-incomplete") continue;
+		if (entry.isSymbolicLink()) {
+			throw new Error(`refusing to copy a symlinked staged cache entry: ${join(source.path, entry.name)}`);
+		}
+		if (entry.isDirectory()) {
+			await mkdirDirectoryChildExclusive(destination, entry.name);
+			const sourceChild = await openDirectoryChild(source, entry.name);
+			const destinationChild = await openDirectoryChild(destination, entry.name);
+			try {
+				await copyStagedTreeNoReplace(sourceChild, destinationChild, tracker);
+			} finally {
+				await sourceChild.handle.close();
+				await destinationChild.handle.close();
+			}
+			continue;
+		}
+		if (!entry.isFile()) {
+			throw new Error(`refusing to copy a non-regular staged cache entry: ${join(source.path, entry.name)}`);
+		}
+		const sourceHandle = await openRegularFileChild(source, entry.name, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+		try {
+			const before = await sourceHandle.stat();
+			if (!before.isFile() || before.isSymbolicLink()) {
+				throw new Error(`staged cache entry changed while copying: ${join(source.path, entry.name)}`);
+			}
+			const content = await sourceHandle.readFile();
+			await pluginCacheMutationTestHooks?.afterStagedFileRead?.(join(source.path, entry.name), before, content);
+			const verifyHandle = await openRegularFileChild(source, entry.name, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+			try {
+				const verifyStats = await verifyHandle.stat();
+				const verifyContent = await verifyHandle.readFile();
+				if (
+					!sameFileIdentity(before, verifyStats)
+					|| verifyStats.size !== before.size
+					|| !content.equals(verifyContent)
+				) {
+					throw new Error(`staged cache entry changed while copying: ${join(source.path, entry.name)}`);
+				}
+			} finally {
+				await verifyHandle.close();
+			}
+			const destinationHandle = await openRegularFileChild(
+				destination,
+				entry.name,
+				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+				before.mode & 0o7777,
+			);
+			try {
+				await destinationHandle.writeFile(content);
+				await destinationHandle.chmod(before.mode & 0o7777);
+				const outcome = await syncRegularFile(destinationHandle);
+				if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
+			} finally {
+				await destinationHandle.close();
+			}
+		} finally {
+			await sourceHandle.close();
+		}
+	}
+	await assertDirectoryRef(source, "staged source copy");
+	await assertDirectoryRef(destination, "staged destination copy");
+}
+
 async function openRegularFileChild(parent: DirectoryRef, name: string, flags: number, mode?: number): Promise<FileHandle> {
 	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "file open");
+	if ((flags & fsConstants.O_EXCL) !== 0) {
+		await pluginCacheMutationTestHooks?.beforeExclusiveCreate?.(parent.path, name);
+	}
 	const handle = await open(mutationPath, flags, mode);
 	try {
 		await assertDirectoryRef(parent, "file open");
@@ -377,18 +485,49 @@ async function createExclusiveFileChild(
 	await assertDirectoryRef(parent, "exclusive file create");
 }
 
-async function removeChild(parent: DirectoryRef, name: string, options: { recursive?: boolean; force?: boolean } = {}): Promise<void> {
+interface RemoveChildOptions {
+	recursive?: boolean;
+	force?: boolean;
+	preserveRecursive?: boolean;
+}
+
+async function removeChild(parent: DirectoryRef, name: string, options: RemoveChildOptions = {}): Promise<boolean> {
 	const mutationPath = childMutationPath(parent, name);
 	await assertDirectoryRef(parent, "remove");
-	// #3552 blocker 2: gate the destructive rm on the current inode so a
-	// name swapped between the barrier and the syscall cannot redirect the
-	// deletion at a replacement target; the post-barrier re-assert detects
-	// a replaced parent before the result is trusted.
 	let before: Stats | undefined;
 	try {
 		before = await lstat(mutationPath);
 	} catch (error) {
 		if (!options.force || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	if (before) {
+		if (options.recursive && options.preserveRecursive && before.isDirectory()) {
+			return false;
+		}
+		// A final identity fence immediately before rm is the portable fallback
+		// for platforms without unlinkat(2). If an interposer changes the name
+		// after the quarantine lstat, preserve the replacement and report bounded
+		// cleanup instead of recursively deleting an unknown inode.
+		await pluginCacheMutationTestHooks?.beforeRemove?.(mutationPath, before);
+		const current = await lstat(mutationPath).catch((error) => {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw error;
+		});
+		if (!current || !sameFileIdentity(before, current)) {
+			throw new Error(`identity-bound removal target changed before deletion: ${mutationPath}`);
+		}
+		// Keep an explicit barrier immediately before the destructive syscall. The
+		// production path has no portable unlinkat(2) primitive; the final re-lstat
+		// after this barrier is the fail-closed fallback that preserves a raced
+		// replacement instead of trusting a stale pathname check.
+		await pluginCacheMutationTestHooks?.beforeRemoveSyscall?.(mutationPath, current);
+		const final = await lstat(mutationPath).catch((error) => {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+			throw error;
+		});
+		if (!final || !sameFileIdentity(before, final)) {
+			throw new Error(`identity-bound removal target changed before removal syscall: ${mutationPath}`);
+		}
 	}
 	await rm(mutationPath, options);
 	if (before) {
@@ -400,6 +539,7 @@ async function removeChild(parent: DirectoryRef, name: string, options: { recurs
 		}
 	}
 	await assertDirectoryRef(parent, "remove");
+	return true;
 }
 
 async function renameChild(sourceParent: DirectoryRef, sourceName: string, destinationParent: DirectoryRef, destinationName: string): Promise<void> {
@@ -417,6 +557,27 @@ async function renameChild(sourceParent: DirectoryRef, sourceName: string, desti
 	const destinationPath = childMutationPath(destinationParent, destinationName);
 	await assertDirectoryRef(sourceParent, "rename");
 	await assertDirectoryRef(destinationParent, "rename");
+	const destinationBefore = await lstat(destinationPath).catch((error) => {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
+	});
+	if (destinationBefore) {
+		throw Object.assign(
+			new Error(`rename destination already exists: ${destinationPath}`),
+			{ code: "EEXIST" },
+		);
+	}
+	await pluginCacheMutationTestHooks?.beforeRename?.(sourcePath, destinationPath);
+	const destinationAfter = await lstat(destinationPath).catch((error) => {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw error;
+	});
+	if (destinationAfter) {
+		throw Object.assign(
+			new Error(`rename destination appeared during no-replace check: ${destinationPath}`),
+			{ code: "EEXIST" },
+		);
+	}
 	await rename(sourcePath, destinationPath);
 	await assertDirectoryRef(sourceParent, "rename");
 	await assertDirectoryRef(destinationParent, "rename");
@@ -572,7 +733,7 @@ async function readRegularFileTextNoFollow(path: string, options: { anchorDir?: 
 	return bytes?.toString("utf-8") ?? null;
 }
 
-async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complete" | ".omx-incomplete"): Promise<boolean> {
+async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complete" | ".omx-incomplete" | ".omx-managed"): Promise<boolean> {
 	return (await readOmxPluginCacheFileNoFollow(join(cacheDir, name), { anchorDir: cacheDir })) !== null;
 }
 
@@ -682,7 +843,8 @@ function buildPublicationLockRecord(heartbeatAt: number = Date.now()): string {
 
 function parsePublicationLockRecord(bytes: Buffer): PublicationLockRecord | null {
 	try {
-		const parsed = JSON.parse(bytes.toString("utf-8")) as PublicationLockRecord;
+		const lines = bytes.toString("utf-8").split("\n").map((line) => line.trim()).filter(Boolean);
+		const parsed = JSON.parse(lines.at(-1) ?? "") as PublicationLockRecord;
 		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
 		return parsed;
 	} catch {
@@ -700,6 +862,18 @@ function publicationLockLeaseExpired(record: PublicationLockRecord, now = Date.n
 	return now - heartbeat > PUBLICATION_LOCK_LEASE_MS;
 }
 
+function publicationLockFileAgeExpired(stats: Stats, now = Date.now()): boolean {
+	return typeof stats.mtimeMs === "number" && Number.isFinite(stats.mtimeMs)
+		&& now - stats.mtimeMs > PUBLICATION_LOCK_LEASE_MS;
+}
+
+function publicationLockRecordStructurallyValid(record: PublicationLockRecord): boolean {
+	const hasPid = typeof record.pid === "number" && Number.isInteger(record.pid) && record.pid > 0;
+	const hasHeartbeat = typeof record.heartbeatAt === "number" && Number.isFinite(record.heartbeatAt);
+	const hasCreatedAt = typeof record.createdAt === "number" && Number.isFinite(record.createdAt);
+	return hasPid && (hasHeartbeat || hasCreatedAt);
+}
+
 function isPublicationLockStale(record: PublicationLockRecord, now = Date.now()): boolean {
 	if (typeof record.pid !== "number" || !Number.isInteger(record.pid) || record.pid <= 0) return false;
 	if (publicationLockLeaseExpired(record, now)) return true;
@@ -713,8 +887,10 @@ async function refreshPublicationLockRecord(
 	try {
 		const record = buildPublicationLockRecord();
 		const buf = Buffer.from(record, "utf-8");
-		await lockHandle.truncate(0);
-		await lockHandle.write(buf, 0, buf.length, 0);
+		// Heartbeats are append-only complete records. Readers consume the last
+		// complete line, so an in-progress write can never turn a previous valid
+		// owner record into a partially published lock state.
+		await lockHandle.write(buf);
 		const outcome = await syncRegularFile(lockHandle);
 		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
 	} catch {
@@ -736,8 +912,8 @@ export async function removeChildIfIdentity(
 	cacheBaseRef: DirectoryRef,
 	childName: string,
 	childStats: Stats,
-	options: { recursive?: boolean; force?: boolean },
-): Promise<void> {
+	options: RemoveChildOptions,
+): Promise<boolean> {
 	const quarantineName = `.${childName}.reclaim-${process.pid}-${randomUUID()}`;
 	await renameChild(cacheBaseRef, childName, cacheBaseRef, quarantineName);
 	const quarantinePath = childOperationPath(cacheBaseRef, quarantineName);
@@ -748,42 +924,33 @@ export async function removeChildIfIdentity(
 		throw new Error(`identity-bound removal target disappeared during reclamation: ${(error as Error).message}`);
 	}
 	if (quarantineStats.dev !== childStats.dev || quarantineStats.ino !== childStats.ino) {
-		// Quarantined the wrong inode (replacement after validation): restore it
-		// to its version path without clobbering a successor. For directories
-		// link(2) is EPERM, so rename the quarantine back only if the version
-		// name is still free; for regular files use link to avoid clobbering a
-		// successor that may have appeared.
-		const isDirQuarantine = quarantineStats.isDirectory();
+		// Quarantined the wrong inode (replacement after validation). There is no
+		// portable atomic no-replace directory restore: rename(quarantine, name)
+		// can overwrite a successor inserted after any lstat(name). Preserve the
+		// quarantined inode instead of risking overwrite or deletion. Regular
+		// files can be linked back with no-clobber semantics, but the quarantine
+		// link is intentionally retained so cleanup never follows a raced path.
 		try {
-			if (isDirQuarantine) {
-				const versionPath = join(cacheBaseRef.path, childName);
-				let versionExists = false;
-				try {
-					await lstat(versionPath);
-					versionExists = true;
-				} catch (e) {
-					if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
-				}
-				if (!versionExists) {
-					await renameChild(cacheBaseRef, quarantineName, cacheBaseRef, childName);
-				}
-			} else {
+			if (!quarantineStats.isDirectory()) {
 				await link(quarantinePath, childOperationPath(cacheBaseRef, childName));
-				await removeChild(cacheBaseRef, quarantineName, { force: true });
 			}
 		} catch {
 			// Preserve replacement without overwriting a successor that appeared
 			// between the quarantine and the restore attempt; quarantine remains.
 		}
-		throw new Error("identity-bound removal target changed during reclamation");
+		throw new Error(`identity-bound removal target changed during reclamation; preserved quarantine ${quarantinePath}`);
 	}
-	await removeChild(cacheBaseRef, quarantineName, options);
+	return removeChild(cacheBaseRef, quarantineName, {
+		...options,
+		preserveRecursive: options.preserveRecursive ?? options.recursive === true,
+	});
 }
 
 async function reclaimStalePublicationLock(
 	cacheBaseRef: DirectoryRef,
 	lockName: string,
 	lockStats: Stats,
+	checkLateHeartbeat = true,
 ): Promise<void> {
 	const quarantineName = `.${lockName}.reclaim-${process.pid}-${randomUUID()}`;
 	await renameChild(cacheBaseRef, lockName, cacheBaseRef, quarantineName);
@@ -797,11 +964,26 @@ async function reclaimStalePublicationLock(
 	if (quarantineStats.dev !== lockStats.dev || quarantineStats.ino !== lockStats.ino) {
 		try {
 			await link(quarantinePath, childOperationPath(cacheBaseRef, lockName));
-			await removeChild(cacheBaseRef, quarantineName, { force: true });
 		} catch {
 			// Preserve a replacement lock and its contents without overwriting it.
 		}
-		throw new Error("publication lock changed during stale-lock reclamation");
+		throw new Error(`publication lock changed during stale-lock reclamation; preserved quarantine ${quarantinePath}`);
+	}
+	if (checkLateHeartbeat) {
+		await pluginCacheMutationTestHooks?.beforeRemoveSyscall?.(quarantinePath, quarantineStats);
+		const quarantineBytes = await readFile(quarantinePath).catch(() => null);
+		const quarantineRecord = quarantineBytes === null ? null : parsePublicationLockRecord(quarantineBytes);
+		const quarantineStillStale = quarantineRecord !== null && publicationLockRecordStructurallyValid(quarantineRecord)
+			? isPublicationLockStale(quarantineRecord)
+			: publicationLockFileAgeExpired(quarantineStats);
+		if (!quarantineStillStale) {
+			try {
+				await link(quarantinePath, childOperationPath(cacheBaseRef, lockName));
+			} catch {
+				// Preserve a successor lock or a late-heartbeat owner without clobbering.
+			}
+			throw new Error(`publication lock heartbeat changed during stale-lock reclamation; preserved quarantine ${quarantinePath}`);
+		}
 	}
 	await removeChild(cacheBaseRef, quarantineName, { force: true });
 }
@@ -817,7 +999,7 @@ async function claimPublicationLock(
 			const lockHandle = await openRegularFileChild(
 				cacheBaseRef,
 				".omx-publish.lock",
-				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags,
+				fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags,
 				0o600,
 			);
 			try {
@@ -829,7 +1011,7 @@ async function claimPublicationLock(
 				try { lockIdentity = await lockHandle.stat(); } catch { /* preserve the primary failure */ }
 				try { await lockHandle.close(); } catch { /* preserve the primary failure */ }
 				if (lockIdentity) {
-					try { await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity); } catch { /* preserve the primary failure */ }
+					try { await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity, false); } catch { /* preserve the primary failure */ }
 				}
 				throw error;
 			}
@@ -849,18 +1031,26 @@ async function claimPublicationLock(
 			let stale = false;
 			if (lockBytes !== null) {
 				const record = parsePublicationLockRecord(lockBytes);
-				stale = record !== null && isPublicationLockStale(record);
+				stale = record !== null && publicationLockRecordStructurallyValid(record)
+					? isPublicationLockStale(record)
+					: publicationLockFileAgeExpired(lockBefore);
+			} else {
+				stale = publicationLockFileAgeExpired(lockBefore);
 			}
 			if (!stale) {
 				throw new Error(`another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`);
 			}
 			const reclaimBefore = await lstat(lockPath);
 			if (reclaimBefore.dev !== lockBefore.dev || reclaimBefore.ino !== lockBefore.ino) continue;
+			await pluginCacheMutationTestHooks?.beforeStaleLockReclaim?.(lockPath, reclaimBefore);
 			try {
 				await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", reclaimBefore);
 			} catch (reclaimError) {
 				if ((reclaimError as NodeJS.ErrnoException).code === "ENOENT") continue;
-				if ((reclaimError as Error).message === "publication lock changed during stale-lock reclamation") continue;
+				if (
+					(reclaimError as Error).message.startsWith("publication lock changed during stale-lock reclamation")
+					|| (reclaimError as Error).message.startsWith("publication lock heartbeat changed during stale-lock reclamation")
+				) continue;
 				throw reclaimError;
 			}
 		}
@@ -1525,6 +1715,7 @@ export interface OmxPluginCacheMaterializeResult {
 	cacheDir?: string;
 	version?: string;
 	retiredDirs?: string[];
+	preservedDirs?: string[];
 	reason?: string;
 	launcherTarget?: string;
 }
@@ -1655,6 +1846,7 @@ export async function retireUnpinnedManagedSnapshots(
 	currentVersion: string,
 	anchoredCacheBaseRef?: DirectoryRef,
 	publicationLockHeld = false,
+	preservedDirs?: string[],
 ): Promise<string[]> {
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
@@ -1700,6 +1892,7 @@ export async function retireUnpinnedManagedSnapshots(
 			const manifest = await readRegularOmxPluginCacheManifest(candidateRef.operationPath, candidateRef.operationPath);
 			if (manifest?.name !== OMX_PLUGIN_NAME || manifest.version !== entry.name) continue;
 			if (!(await hasRegularPublicationMarker(candidateRef.operationPath, ".omx-complete")) || await hasRegularPublicationMarker(candidateRef.operationPath, ".omx-incomplete")) continue;
+			if (!(await hasRegularPublicationMarker(candidateRef.operationPath, OMX_PLUGIN_MANAGED_MARKER))) continue;
 			if (await readOmxPluginCacheFileNoFollow(join(candidateRef.operationPath, ".omx-live-pin"), { anchorDir: candidateRef.operationPath }) !== null) continue;
 			managed.push({ path: join(cacheBase, entry.name), version: entry.name, mtimeMs: candidateStats.mtimeMs, ref: candidateRef, stats: candidateStats });
 		}
@@ -1714,8 +1907,14 @@ export async function retireUnpinnedManagedSnapshots(
 			if (!currentStats.isDirectory() || currentStats.isSymbolicLink() || currentStats.dev !== candidate.stats.dev || currentStats.ino !== candidate.stats.ino) {
 				throw new Error(`managed cache retirement target changed before removal: ${candidate.path}`);
 			}
-			await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true });
-			retired.push(candidate.path);
+			if (await readOmxPluginCacheFileNoFollow(join(candidate.ref.operationPath, ".omx-live-pin"), { anchorDir: candidate.ref.operationPath }) !== null) {
+				continue;
+			}
+			if (await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true })) {
+				retired.push(candidate.path);
+			} else {
+				preservedDirs?.push(candidate.path);
+			}
 		}
 		return retired;
 	} finally {
@@ -1734,7 +1933,7 @@ export async function retireUnpinnedManagedSnapshots(
 					cur.dev === publicationLockIdentity.dev &&
 					cur.ino === publicationLockIdentity.ino
 				) {
-					try { await reclaimStalePublicationLock(baseRef!, ".omx-publish.lock", publicationLockIdentity); } catch (error) { cleanupError ??= error; }
+					try { await reclaimStalePublicationLock(baseRef!, ".omx-publish.lock", publicationLockIdentity, false); } catch (error) { cleanupError ??= error; }
 				}
 			}
 		}
@@ -1892,6 +2091,7 @@ async function materializePackagedOmxPluginCacheImpl(
 		let cleanupError: unknown = null;
 		let lockIdentity: Stats | undefined;
 		let finalRef: DirectoryRef | undefined;
+		let claimRef: DirectoryRef | undefined;
 		try {
 			lockIdentity = await lockHandle.stat();
 			// Refresh once under the held fd so the initial heartbeat is at most
@@ -1915,7 +2115,6 @@ async function materializePackagedOmxPluginCacheImpl(
 				// `.omx-complete` is committed last inside the claim. Every trust
 				// path requires `.omx-complete`, so no intermediate state is
 				// trusted, and no pre-existing directory is ever replaced.
-				let claimRef: DirectoryRef | undefined;
 				try {
 					claimRef = await claimPublicationDestination(cacheBaseRef, version, durability);
 				} catch (error) {
@@ -1933,9 +2132,9 @@ async function materializePackagedOmxPluginCacheImpl(
 					}
 				}
 				if (claimRef) {
-					// Drop the snapshot's staging marker, then the claim's own
-					// placeholder, so every entry moved below lands in an empty
-					// claim and the final marker is the only trust switch.
+					// Drop the snapshot's staging marker and the claim's placeholder;
+					// the claim is then populated only through exclusive creates and
+					// the final marker is the trust switch.
 					await removeChild(snapshotRef, ".omx-incomplete", { force: true });
 					await removeChild(claimRef, ".omx-incomplete", { force: true });
 					await assertDirectoryRef(claimRef, "publication claim");
@@ -1943,13 +2142,18 @@ async function materializePackagedOmxPluginCacheImpl(
 					if (claimEntries.length > 0) {
 						throw new Error(`publication claim is not empty at ${join(cacheBaseRef.path, version)}`);
 					}
-					const stagedEntries = await readdir(snapshotRef.scanOperationPath, { withFileTypes: true });
-					for (const entry of stagedEntries) {
-						if (entry.name === ".omx-incomplete") continue;
-						await renameChild(tempRef, `snapshot/${entry.name}`, claimRef, entry.name);
-					}
+					// The portable no-replace primitive is exclusive create, not rename.
+					// Copy the private staged tree into the empty claim with exclusive
+					// mkdir/O_EXCL file creation so a destination inserted between any
+					// checks is rejected instead of overwritten.
+					await copyStagedTreeNoReplace(snapshotRef, claimRef, durability);
 					await snapshotRef.handle.close();
 					snapshotRef = undefined;
+					await createExclusiveFileChild(claimRef, OMX_PLUGIN_MANAGED_MARKER, `${process.pid}\n`, durability);
+					await pluginCacheMutationTestHooks?.beforeFinalClaimValidation?.(claimRef.path);
+					await validateStagedPluginSnapshot(claimRef, packagedMarketplace, version, options.teamMode);
+					await pluginCacheMutationTestHooks?.beforeCompleteMarker?.(claimRef.path);
+					await validateStagedPluginSnapshot(claimRef, packagedMarketplace, version, options.teamMode);
 					await syncDirectoryTree(claimRef, durability);
 					await createExclusiveFileChild(claimRef, ".omx-complete", `${process.pid}\n`, durability);
 					const claimDirSyncOutcome = await syncDirectory(claimRef.handle);
@@ -1975,12 +2179,15 @@ async function materializePackagedOmxPluginCacheImpl(
 			}
 			if (outcome.status === "materialized") {
 				try {
+					const preservedDirs: string[] = [];
 					outcome.retiredDirs = await retireUnpinnedManagedSnapshots(
 						codexHomeDir,
 						version,
 						cacheBaseRef,
 						true,
+						preservedDirs,
 					);
+					if (preservedDirs.length > 0) outcome.preservedDirs = preservedDirs;
 				} catch (error) {
 					outcome = {
 						status: "stale-launcher",
@@ -2004,6 +2211,9 @@ async function materializePackagedOmxPluginCacheImpl(
 	} finally {
 			if (publicationLockHeartbeat) clearInterval(publicationLockHeartbeat);
 			try { if (finalRef) await finalRef.handle.close(); } catch (error) { cleanupError ??= error; }
+			if (claimRef && claimRef !== finalRef) {
+				try { await claimRef.handle.close(); } catch (error) { cleanupError ??= error; }
+			}
 			try { if (snapshotRef) await snapshotRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			try { if (tempRef) await tempRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			try { if (tempName) await removeChild(cacheBaseRef, tempName, { recursive: true, force: true }); } catch (error) { cleanupError = error; }
@@ -2020,7 +2230,7 @@ async function materializePackagedOmxPluginCacheImpl(
 					cur.dev === lockIdentity.dev &&
 					cur.ino === lockIdentity.ino
 				) {
-					await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity);
+					await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity, false);
 				}
 				const syncOutcome = await syncDirectory(cacheBaseRef.handle);
 				recordDirectorySyncOutcome(durability, syncOutcome);

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants, existsSync, type Stats } from "fs";
-import { cp, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, writeFile, type FileHandle } from "fs/promises";
+import { cp, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, type FileHandle } from "fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
@@ -97,53 +97,201 @@ async function readPluginManifest(
 
 function directoryFdPath(fd: number): string | null {
 	if (process.platform === "linux") return `/proc/self/fd/${fd}`;
-	if (process.platform === "darwin") return `/dev/fd/${fd}`;
 	return null;
 }
 
 function isDirectoryDescriptorPath(path: string): boolean {
-	return /^\/(?:proc\/self\/fd|dev\/fd)\/\d+$/.test(path);
+	return /^\/proc\/self\/fd\/\d+$/.test(path);
 }
 
 function directoryOpenFlags(path: string, directoryFlags: number, noFollowFlags: number): number {
 	return fsConstants.O_RDONLY | directoryFlags | (isDirectoryDescriptorPath(path) ? 0 : noFollowFlags);
 }
 
-async function syncRegularFile(path: string): Promise<void> {
-	const noFollowFlags = fsConstants.O_NOFOLLOW;
-	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
-	const handle = await open(path, fsConstants.O_RDONLY | noFollowFlags);
-	try {
-		await handle.sync();
-	} finally {
-		await handle.close();
+interface DirectoryRef {
+	handle: FileHandle;
+	path: string;
+	operationPath: string;
+}
+
+function directoryOperationPath(handle: FileHandle, path: string): string | null {
+	return directoryFdPath(handle.fd) ?? resolve(path);
+}
+
+function childOperationPath(parent: DirectoryRef, name: string): string {
+	if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+		throw new Error(`invalid descriptor-relative child name: ${name}`);
+	}
+	return join(parent.operationPath, name);
+}
+
+async function assertDirectoryRef(parent: DirectoryRef, operation: string): Promise<void> {
+	const descriptorStats = await parent.handle.stat();
+	const visibleStats = await lstat(parent.path);
+	if (
+		!descriptorStats.isDirectory() ||
+		!visibleStats.isDirectory() ||
+		visibleStats.isSymbolicLink() ||
+		descriptorStats.dev !== visibleStats.dev ||
+		descriptorStats.ino !== visibleStats.ino
+	) {
+		throw new Error(`descriptor-bound ${operation} parent was replaced: ${parent.path}`);
 	}
 }
 
-async function syncDirectory(path: string): Promise<void> {
+async function openDirectoryRef(path: string): Promise<DirectoryRef> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
 	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
-		throw new Error("directory durability flags are unavailable");
+		throw new Error("directory anchoring flags are unavailable");
 	}
-	const handle = await open(path, directoryOpenFlags(path, directoryFlags, noFollowFlags));
+	const visiblePath = resolve(path);
+	const handle = await open(visiblePath, directoryOpenFlags(visiblePath, directoryFlags, noFollowFlags));
+	const operationPath = directoryOperationPath(handle, visiblePath);
+	if (!operationPath) {
+		await handle.close();
+		throw new Error("platform cannot expose a descriptor-relative directory operation path");
+	}
+	const ref = { handle, path: visiblePath, operationPath };
+	try {
+		await assertDirectoryRef(ref, "open");
+		return ref;
+	} catch (error) {
+		await handle.close();
+		throw error;
+	}
+}
+
+async function openDirectoryChild(parent: DirectoryRef, name: string): Promise<DirectoryRef> {
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	const directoryFlags = fsConstants.O_DIRECTORY;
+	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+		throw new Error("directory anchoring flags are unavailable");
+	}
+	const operationPath = childOperationPath(parent, name);
+	const visiblePath = join(parent.path, name);
+	await assertDirectoryRef(parent, "open");
+	const handle = await open(operationPath, directoryOpenFlags(operationPath, directoryFlags, noFollowFlags));
+	const childOperation = directoryOperationPath(handle, visiblePath);
+	if (!childOperation) {
+		await handle.close();
+		throw new Error("platform cannot expose a descriptor-relative directory operation path");
+	}
+	const child = { handle, path: visiblePath, operationPath: childOperation };
+	try {
+		await assertDirectoryRef(parent, "open");
+		await assertDirectoryRef(child, "open");
+		return child;
+	} catch (error) {
+		await handle.close();
+		throw error;
+	}
+}
+
+async function mkdirDirectoryChild(parent: DirectoryRef, name: string): Promise<void> {
+	const operationPath = childOperationPath(parent, name);
+	await assertDirectoryRef(parent, "mkdir");
+	try {
+		await mkdir(operationPath);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+	}
+	await assertDirectoryRef(parent, "mkdir");
+}
+
+async function mkdirDirectoryChildExclusive(parent: DirectoryRef, name: string): Promise<void> {
+	const operationPath = childOperationPath(parent, name);
+	await assertDirectoryRef(parent, "exclusive mkdir");
+	await mkdir(operationPath);
+	await assertDirectoryRef(parent, "exclusive mkdir");
+}
+
+async function openRegularFileChild(parent: DirectoryRef, name: string, flags: number, mode?: number): Promise<FileHandle> {
+	const operationPath = childOperationPath(parent, name);
+	await assertDirectoryRef(parent, "file open");
+	const handle = await open(operationPath, flags, mode);
+	try {
+		await assertDirectoryRef(parent, "file open");
+		return handle;
+	} catch (error) {
+		await handle.close();
+		throw error;
+	}
+}
+
+async function syncRegularFileChild(parent: DirectoryRef, name: string): Promise<void> {
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
+	const handle = await openRegularFileChild(parent, name, fsConstants.O_RDONLY | noFollowFlags);
 	try {
 		await handle.sync();
 	} finally {
 		await handle.close();
 	}
+	await assertDirectoryRef(parent, "file sync");
 }
 
-async function syncDirectoryTree(path: string, directoryHandle?: FileHandle): Promise<void> {
-	const entries = await readdir(path, { withFileTypes: true });
-	for (const entry of entries) {
-		const childPath = join(path, entry.name);
-		if (entry.isSymbolicLink()) throw new Error(`cannot sync symlinked cache entry: ${childPath}`);
-		if (entry.isDirectory()) await syncDirectoryTree(childPath);
-		else await syncRegularFile(childPath);
+async function writeRegularFileChild(parent: DirectoryRef, name: string, content: string): Promise<void> {
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
+	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | noFollowFlags, 0o600);
+	try {
+		await handle.writeFile(content);
+		await handle.sync();
+	} finally {
+		await handle.close();
 	}
-	if (directoryHandle) await directoryHandle.sync();
-	else await syncDirectory(path);
+	await assertDirectoryRef(parent, "file write");
+}
+
+async function createExclusiveFileChild(parent: DirectoryRef, name: string, content: string): Promise<void> {
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
+	const handle = await openRegularFileChild(parent, name, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags, 0o600);
+	try {
+		await handle.writeFile(content);
+		await handle.sync();
+	} finally {
+		await handle.close();
+	}
+	await assertDirectoryRef(parent, "exclusive file create");
+}
+
+async function removeChild(parent: DirectoryRef, name: string, options: { recursive?: boolean; force?: boolean } = {}): Promise<void> {
+	const operationPath = childOperationPath(parent, name);
+	await assertDirectoryRef(parent, "remove");
+	await rm(operationPath, options);
+	await assertDirectoryRef(parent, "remove");
+}
+
+async function renameChild(sourceParent: DirectoryRef, sourceName: string, destinationParent: DirectoryRef, destinationName: string): Promise<void> {
+	const sourcePath = childOperationPath(sourceParent, sourceName);
+	const destinationPath = childOperationPath(destinationParent, destinationName);
+	await assertDirectoryRef(sourceParent, "rename");
+	await assertDirectoryRef(destinationParent, "rename");
+	await rename(sourcePath, destinationPath);
+	await assertDirectoryRef(sourceParent, "rename");
+	await assertDirectoryRef(destinationParent, "rename");
+}
+
+async function syncDirectoryTree(directory: DirectoryRef): Promise<void> {
+	await assertDirectoryRef(directory, "directory sync");
+	const entries = await readdir(directory.operationPath, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.isSymbolicLink()) throw new Error(`cannot sync symlinked cache entry: ${join(directory.path, entry.name)}`);
+		if (entry.isDirectory()) {
+			const child = await openDirectoryChild(directory, entry.name);
+			try {
+				await syncDirectoryTree(child);
+			} finally {
+				await child.handle.close();
+			}
+		} else {
+			await syncRegularFileChild(directory, entry.name);
+		}
+	}
+	await assertDirectoryRef(directory, "directory sync");
+	await directory.handle.sync();
 }
 
 export async function readOmxPluginCacheFileNoFollow(
@@ -315,15 +463,15 @@ function isProcessAlive(pid: number): boolean {
 }
 
 async function claimPublicationLock(
-	cacheBaseFdPath: string,
+	cacheBaseRef: DirectoryRef,
 	cacheBase: string,
 	noFollowFlags: number,
 ): Promise<FileHandle> {
-	const lockPath = join(cacheBaseFdPath, ".omx-publish.lock");
 	for (let attempt = 0; attempt < 2; attempt += 1) {
 		try {
-			const lockHandle = await open(
-				lockPath,
+			const lockHandle = await openRegularFileChild(
+				cacheBaseRef,
+				".omx-publish.lock",
 				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags,
 				0o600,
 			);
@@ -332,13 +480,22 @@ async function claimPublicationLock(
 				await lockHandle.sync();
 			} catch (error) {
 				try { await lockHandle.close(); } catch { /* preserve the primary failure */ }
-				try { await rm(lockPath, { force: true }); } catch { /* preserve the primary failure */ }
+				try { await removeChild(cacheBaseRef, ".omx-publish.lock", { force: true }); } catch { /* preserve the primary failure */ }
 				throw error;
 			}
 			return lockHandle;
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt > 0) throw error;
-			const lockBytes = await readOmxPluginCacheFileNoFollow(lockPath, { anchorDir: cacheBaseFdPath });
+			const lockPath = join(cacheBaseRef.path, ".omx-publish.lock");
+			let lockBefore: Stats;
+			try { lockBefore = await lstat(lockPath); } catch { continue; }
+			if (!lockBefore.isFile() || lockBefore.isSymbolicLink() || typeof lockBefore.dev !== "number" || typeof lockBefore.ino !== "number") {
+				throw new Error(`another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`);
+			}
+			const lockBytes = await readOmxPluginCacheFileNoFollow(lockPath, { anchorDir: cacheBaseRef.path });
+			let lockAfter: Stats;
+			try { lockAfter = await lstat(lockPath); } catch { continue; }
+			if (lockAfter.dev !== lockBefore.dev || lockAfter.ino !== lockBefore.ino) continue;
 			let stale = false;
 			if (lockBytes !== null) {
 				try {
@@ -351,7 +508,9 @@ async function claimPublicationLock(
 			if (!stale) {
 				throw new Error(`another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`);
 			}
-			await rm(lockPath, { force: true });
+			const unlinkBefore = await lstat(lockPath);
+			if (unlinkBefore.dev !== lockBefore.dev || unlinkBefore.ino !== lockBefore.ino) continue;
+			await removeChild(cacheBaseRef, ".omx-publish.lock", { force: true });
 		}
 	}
 	throw new Error(`cannot recover stale OMX plugin cache publication lock at ${cacheBase}`);
@@ -554,7 +713,7 @@ async function openManagedCacheNamespace(
 	cacheBase: string,
 	codexHomeDir: string,
 	options: { create: boolean },
-): Promise<{ handle: FileHandle; fdPath: string; handles: FileHandle[] } | null> {
+): Promise<{ handle: FileHandle; fdPath: string; path: string; handles: FileHandle[] } | null> {
 	const managedNamespace = relative(resolve(codexHomeDir), resolve(cacheBase));
 	if (!managedNamespace || managedNamespace.startsWith("..") || isAbsolute(managedNamespace)) {
 		throw new Error(`Refusing to access an OMX plugin cache outside the Codex home: ${resolve(cacheBase)}`);
@@ -574,37 +733,13 @@ async function openManagedCacheNamespace(
 	}
 	const handles: FileHandle[] = [];
 	try {
-		const homeHandle = await open(homeRealpath, directoryOpenFlags(homeRealpath, directoryFlags, noFollowFlags));
-		handles.push(homeHandle);
-		let parentPath = process.platform === "darwin" ? homeRealpath : directoryFdPath(homeHandle.fd);
-		let actualParentPath = homeRealpath;
-		if (!parentPath) throw new Error("platform cannot expose a Codex home directory descriptor");
+		const homeRef = await openDirectoryRef(homeRealpath);
+		handles.push(homeRef.handle);
+		let parentRef = homeRef;
 		for (const component of managedNamespace.split(sep).filter(Boolean)) {
-			const childPath = join(parentPath, component);
-			const actualChildPath = join(actualParentPath, component);
-			const childOpenPath = process.platform === "darwin" ? actualChildPath : childPath;
-			const openChild = async (): Promise<FileHandle> => {
-				if (process.platform === "darwin") {
-					const parentStats = await handles.at(-1)!.stat();
-					const visibleParentStats = await lstat(actualParentPath);
-					if (parentStats.dev !== visibleParentStats.dev || parentStats.ino !== visibleParentStats.ino || !visibleParentStats.isDirectory() || visibleParentStats.isSymbolicLink()) {
-						throw new Error(`Refusing to access OMX plugin cache through a replaced namespace parent: ${actualParentPath}`);
-					}
-				}
-				const openedChild = await open(childOpenPath, directoryOpenFlags(childOpenPath, directoryFlags, noFollowFlags));
-				if (process.platform === "darwin") {
-					const parentStats = await handles.at(-1)!.stat();
-					const visibleParentStats = await lstat(actualParentPath);
-					if (parentStats.dev !== visibleParentStats.dev || parentStats.ino !== visibleParentStats.ino || !visibleParentStats.isDirectory() || visibleParentStats.isSymbolicLink()) {
-						await openedChild.close();
-						throw new Error(`Refusing to access OMX plugin cache through a replaced namespace parent: ${actualParentPath}`);
-					}
-				}
-				return openedChild;
-			};
-			let childHandle: FileHandle;
+			let childRef: DirectoryRef;
 			try {
-				childHandle = await openChild();
+				childRef = await openDirectoryChild(parentRef, component);
 			} catch (error) {
 				if (!isMissingPathError(error) || !options.create) {
 					if (isMissingPathError(error) && !options.create) {
@@ -613,36 +748,29 @@ async function openManagedCacheNamespace(
 					}
 					const code = (error as NodeJS.ErrnoException).code;
 					if (code === "ELOOP" || code === "ENOTDIR") {
-						throw new Error(`Refusing to access OMX plugin cache through a symbolic link or non-directory namespace component: ${childPath}`);
+						throw new Error(`Refusing to access OMX plugin cache through a symbolic link or non-directory namespace component: ${join(parentRef.path, component)}`);
 					}
 					throw error;
 				}
 				try {
-					const parentStats = await handles.at(-1)!.stat();
-					const visibleParentStats = await lstat(actualParentPath);
-					if (parentStats.dev !== visibleParentStats.dev || parentStats.ino !== visibleParentStats.ino || !visibleParentStats.isDirectory() || visibleParentStats.isSymbolicLink()) {
-						throw new Error(`Refusing to create OMX plugin cache through a replaced namespace parent: ${actualParentPath}`);
-					}
-					await mkdir(actualChildPath);
+					await mkdirDirectoryChild(parentRef, component);
 				} catch (mkdirError) {
 					if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
 				}
 				try {
-					childHandle = await openChild();
+					childRef = await openDirectoryChild(parentRef, component);
 				} catch (retryError) {
 					const code = (retryError as NodeJS.ErrnoException).code;
 					if (code === "ELOOP" || code === "ENOTDIR") {
-						throw new Error(`Refusing to access OMX plugin cache through a symbolic link or non-directory namespace component: ${childPath}`);
+						throw new Error(`Refusing to access OMX plugin cache through a symbolic link or non-directory namespace component: ${join(parentRef.path, component)}`);
 					}
 					throw retryError;
 				}
 			}
-			handles.push(childHandle);
-			parentPath = process.platform === "darwin" ? actualChildPath : directoryFdPath(childHandle.fd);
-			actualParentPath = actualChildPath;
-			if (!parentPath) throw new Error("platform cannot expose an OMX plugin cache directory descriptor");
+			handles.push(childRef.handle);
+			parentRef = childRef;
 		}
-		return { handle: handles.at(-1)!, fdPath: parentPath, handles };
+		return { handle: parentRef.handle, fdPath: parentRef.operationPath, path: parentRef.path, handles };
 	} catch (error) {
 		for (const handle of handles.reverse()) {
 			try { await handle.close(); } catch { /* preserve the primary failure */ }
@@ -676,27 +804,40 @@ async function inspectCacheRoot(cacheDir: string): Promise<"missing" | "director
 }
 
 async function stageCompletePluginSnapshot(
-	stagingParent: string,
+	stagingParent: DirectoryRef,
 	packagedMarketplace: PackagedOmxMarketplace,
 	version: string,
 	teamMode: SetupTeamMode | undefined,
-): Promise<string> {
-	const snapshotDir = join(stagingParent, "snapshot");
-	await cp(packagedMarketplace.pluginRoot, snapshotDir, { recursive: true });
-	await applyTeamModeToPluginCache(snapshotDir, teamMode);
-	await writePinnedHookLauncher(snapshotDir, packagedMarketplace);
-	const manifest = await readPluginManifest(join(snapshotDir, ".codex-plugin", "plugin.json"));
-	if (
-		manifest?.name !== OMX_PLUGIN_NAME ||
-		manifest.version !== version ||
-		manifest.skills !== "./skills/" ||
-		manifest.hooks !== "./hooks/hooks.json" ||
-		!(await pathIsDirectory(join(snapshotDir, "hooks"))) ||
-		!(await pathIsDirectory(join(snapshotDir, "skills")))
-	) {
-		throw new Error(`Packaged OMX plugin snapshot is incomplete or has invalid provenance: ${snapshotDir}`);
+): Promise<DirectoryRef> {
+	await assertDirectoryRef(stagingParent, "snapshot staging");
+	await mkdirDirectoryChildExclusive(stagingParent, "snapshot");
+	const snapshot = await openDirectoryChild(stagingParent, "snapshot");
+	try {
+		await cp(packagedMarketplace.pluginRoot, snapshot.path, { recursive: true });
+		await assertDirectoryRef(snapshot, "snapshot staging");
+		await applyTeamModeToPluginCache(snapshot, teamMode);
+		const hooksDir = await openDirectoryChild(snapshot, "hooks");
+		try {
+			await writePinnedHookLauncher(hooksDir, packagedMarketplace);
+		} finally {
+			await hooksDir.handle.close();
+		}
+		const manifest = await readRegularOmxPluginCacheManifest(snapshot.path, snapshot.path);
+		const skillsDir = await openDirectoryChild(snapshot, "skills");
+		await skillsDir.handle.close();
+		if (
+			manifest?.name !== OMX_PLUGIN_NAME ||
+			manifest.version !== version ||
+			manifest.skills !== "./skills/" ||
+			manifest.hooks !== "./hooks/hooks.json"
+		) {
+			throw new Error(`Packaged OMX plugin snapshot is incomplete or has invalid provenance: ${snapshot.path}`);
+		}
+		return snapshot;
+	} catch (error) {
+		await snapshot.handle.close();
+		throw error;
 	}
-	return snapshotDir;
 }
 
 export async function discoverOmxPluginCacheDirs(
@@ -938,30 +1079,34 @@ async function pinnedHookLauncherMatchesPackaged(
 }
 
 async function writePinnedHookLauncher(
-	cacheDir: string,
+	hooksDir: DirectoryRef,
 	packagedMarketplace: PackagedOmxMarketplace,
 ): Promise<void> {
-	await writeFile(
-		join(cacheDir, "hooks", OMX_PLUGIN_HOOK_LAUNCHER_FILE),
+	await writeRegularFileChild(
+		hooksDir,
+		OMX_PLUGIN_HOOK_LAUNCHER_FILE,
 		buildPinnedHookLauncherContent(packagedMarketplace),
 	);
 }
 
-async function pathIsDirectory(path: string): Promise<boolean> {
-	try {
-		return (await lstat(path)).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
 async function applyTeamModeToPluginCache(
-	cacheDir: string,
+	cacheDir: DirectoryRef,
 	teamMode: SetupTeamMode | undefined,
 ): Promise<void> {
 	if (teamModeEnabled(teamMode)) return;
-	for (const skillName of TEAM_MODE_PLUGIN_SKILL_NAMES) {
-		await rm(join(cacheDir, "skills", skillName), { recursive: true, force: true });
+	let skillsDir: DirectoryRef;
+	try {
+		skillsDir = await openDirectoryChild(cacheDir, "skills");
+	} catch (error) {
+		if (isMissingPathError(error)) return;
+		throw error;
+	}
+	try {
+		for (const skillName of TEAM_MODE_PLUGIN_SKILL_NAMES) {
+			await removeChild(skillsDir, skillName, { recursive: true, force: true });
+		}
+	} finally {
+		await skillsDir.handle.close();
 	}
 }
 
@@ -1098,45 +1243,43 @@ export async function getPinnedLauncherIncompatibilityReason(
 async function retireUnpinnedManagedSnapshots(
 	codexHomeDir: string,
 	currentVersion: string,
-	anchoredCacheBasePath?: string,
+	anchoredCacheBaseRef?: DirectoryRef,
 ): Promise<string[]> {
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
-	const managedBase = anchoredCacheBasePath ?? cacheBase;
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
 	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
 		throw new Error("platform cannot provide no-follow directory anchoring for cache retirement");
 	}
-	let baseHandle: FileHandle | undefined;
-	const candidateHandles: FileHandle[] = [];
+	let baseRef = anchoredCacheBaseRef;
+	let ownsBaseRef = false;
+	const candidateRefs: DirectoryRef[] = [];
 	try {
-		baseHandle = await open(managedBase, directoryOpenFlags(managedBase, directoryFlags, noFollowFlags));
-		const baseFdPath = directoryFdPath(baseHandle.fd);
-		if (!baseFdPath) throw new Error("platform cannot expose an anchored cache directory descriptor for cache retirement");
-		const entries = await readdir(baseFdPath, { withFileTypes: true });
-		const managed: Array<{ path: string; managedPath: string; version: string; mtimeMs: number; handle: FileHandle; stats: Stats }> = [];
+		if (!baseRef) {
+			baseRef = await openDirectoryRef(cacheBase);
+			ownsBaseRef = true;
+		}
+		const entries = await readdir(baseRef.operationPath, { withFileTypes: true });
+		const managed: Array<{ path: string; version: string; mtimeMs: number; ref: DirectoryRef; stats: Stats }> = [];
 		for (const entry of entries) {
 			if (!entry.isDirectory() || entry.name === currentVersion) continue;
-			const path = join(baseFdPath, entry.name);
-			let candidateHandle: FileHandle;
+			let candidateRef: DirectoryRef;
 			try {
-				candidateHandle = await open(path, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+				candidateRef = await openDirectoryChild(baseRef, entry.name);
 			} catch {
 				continue;
 			}
-			const candidateStats = await candidateHandle.stat();
+			const candidateStats = await candidateRef.handle.stat();
 			if (!candidateStats.isDirectory() || candidateStats.isSymbolicLink()) {
-				await candidateHandle.close();
+				await candidateRef.handle.close();
 				continue;
 			}
-			candidateHandles.push(candidateHandle);
-			const candidateFdPath = directoryFdPath(candidateHandle.fd);
-			if (!candidateFdPath) continue;
-			const manifest = await readRegularOmxPluginCacheManifest(candidateFdPath, candidateFdPath);
+			candidateRefs.push(candidateRef);
+			const manifest = await readRegularOmxPluginCacheManifest(candidateRef.path, candidateRef.path);
 			if (manifest?.name !== OMX_PLUGIN_NAME || manifest.version !== entry.name) continue;
-			if (!(await hasRegularPublicationMarker(candidateFdPath, ".omx-complete")) || await hasRegularPublicationMarker(candidateFdPath, ".omx-incomplete")) continue;
-			if (await readOmxPluginCacheFileNoFollow(join(candidateFdPath, ".omx-live-pin"), { anchorDir: candidateFdPath }) !== null) continue;
-			managed.push({ path: join(cacheBase, entry.name), managedPath: path, version: entry.name, mtimeMs: candidateStats.mtimeMs, handle: candidateHandle, stats: candidateStats });
+			if (!(await hasRegularPublicationMarker(candidateRef.path, ".omx-complete")) || await hasRegularPublicationMarker(candidateRef.path, ".omx-incomplete")) continue;
+			if (await readOmxPluginCacheFileNoFollow(join(candidateRef.path, ".omx-live-pin"), { anchorDir: candidateRef.path }) !== null) continue;
+			managed.push({ path: join(cacheBase, entry.name), version: entry.name, mtimeMs: candidateStats.mtimeMs, ref: candidateRef, stats: candidateStats });
 		}
 		managed.sort((left, right) =>
 			right.version.localeCompare(left.version, undefined, { numeric: true }) ||
@@ -1144,17 +1287,18 @@ async function retireUnpinnedManagedSnapshots(
 		);
 		const retired: string[] = [];
 		for (const candidate of managed.slice(1)) {
-			const currentStats = await lstat(candidate.managedPath);
+			await assertDirectoryRef(baseRef, "retirement");
+			const currentStats = await lstat(candidate.ref.path);
 			if (!currentStats.isDirectory() || currentStats.isSymbolicLink() || currentStats.dev !== candidate.stats.dev || currentStats.ino !== candidate.stats.ino) {
 				throw new Error(`managed cache retirement target changed before removal: ${candidate.path}`);
 			}
-			await rm(candidate.managedPath, { recursive: true, force: true });
+			await removeChild(baseRef, candidate.version, { recursive: true, force: true });
 			retired.push(candidate.path);
 		}
 		return retired;
 	} finally {
-		for (const candidateHandle of candidateHandles.reverse()) await candidateHandle.close();
-		if (baseHandle) await baseHandle.close();
+		for (const candidateRef of candidateRefs.reverse()) await candidateRef.handle.close();
+		if (ownsBaseRef && baseRef) await baseRef.handle.close();
 	}
 }
 
@@ -1162,7 +1306,7 @@ interface MaterializePackagedOmxPluginCacheOptions {
 	dryRun?: boolean;
 	teamMode?: SetupTeamMode;
 	onCacheDirPrepared?: (cacheDir: string) => void | Promise<void>;
-	anchoredCacheBasePath?: string;
+	anchoredCacheBaseRef?: DirectoryRef;
 	anchoredCacheDir?: string;
 	cacheDirOverride?: string;
 }
@@ -1187,7 +1331,7 @@ async function materializePackagedOmxPluginCacheImpl(
 			version,
 			retiredDirs: options.dryRun
 				? []
-				: await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+				: await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 		};
 	}
 	// Same-version directory exists but is not byte-identical: distinguish immutable-preserved vs dead/provenance-incompatible launcher.
@@ -1200,7 +1344,7 @@ async function materializePackagedOmxPluginCacheImpl(
 			version,
 			reason: `OMX plugin cache root at ${cacheDir} is a symlink or non-directory entry; managed snapshots must be regular immutable directories; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
 			launcherTarget: undefined,
-			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 		};
 	}
 	if (rootState === "directory") {
@@ -1212,7 +1356,7 @@ async function materializePackagedOmxPluginCacheImpl(
 				version,
 				reason: incompat.reason,
 				launcherTarget: incompat.target,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 			};
 		}
 		const snapshotProvenanceReason = await omxPluginCacheProvenanceReason(
@@ -1228,7 +1372,7 @@ async function materializePackagedOmxPluginCacheImpl(
 				version,
 				reason: `${snapshotProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
 				launcherTarget: undefined,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 			};
 		}
 		const assetProvenanceReason = await omxPluginCacheExecutedAssetProvenanceReason(inspectedCacheDir);
@@ -1239,14 +1383,14 @@ async function materializePackagedOmxPluginCacheImpl(
 				version,
 				reason: `${assetProvenanceReason}; run ${PLUGIN_LAUNCHER_RECOVERY_HINT} then rerun omx setup --plugin`,
 				launcherTarget: undefined,
-				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+				retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 			};
 		}
 		return {
 			status: "unchanged",
 			cacheDir,
 			version,
-			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+			retiredDirs: options.dryRun ? [] : await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 		};
 	}
 	if (rootState === "foreign") {
@@ -1266,29 +1410,18 @@ async function materializePackagedOmxPluginCacheImpl(
 				retiredDirs: [],
 			};
 		}
-		let cacheBaseHandle;
-		let cacheBaseFdPath: string | null | undefined = options.anchoredCacheBasePath;
-		if (!cacheBaseFdPath) {
-			cacheBaseHandle = await open(cacheBase, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
-			cacheBaseFdPath = directoryFdPath(cacheBaseHandle.fd);
+		let cacheBaseRef = options.anchoredCacheBaseRef;
+		let ownsCacheBaseRef = false;
+		if (!cacheBaseRef) {
+			cacheBaseRef = await openDirectoryRef(cacheBase);
+			ownsCacheBaseRef = true;
 		}
-		if (!cacheBaseFdPath) {
-			if (cacheBaseHandle) await cacheBaseHandle.close();
-			return {
-				status: "stale-launcher",
-				cacheDir,
-				version,
-				reason: "platform cannot expose an anchored cache directory descriptor for immutable publication",
-				launcherTarget: undefined,
-				retiredDirs: [],
-			};
-		}
-		const lockPath = join(cacheBaseFdPath, ".omx-publish.lock");
+		const lockPath = childOperationPath(cacheBaseRef, ".omx-publish.lock");
 		let lockHandle: FileHandle;
 		try {
-			lockHandle = await claimPublicationLock(cacheBaseFdPath, cacheBase, noFollowFlags);
+			lockHandle = await claimPublicationLock(cacheBaseRef, cacheBase, noFollowFlags);
 		} catch (error) {
-			if (cacheBaseHandle) await cacheBaseHandle.close();
+			if (ownsCacheBaseRef) await cacheBaseRef.handle.close();
 			return {
 				status: "stale-launcher",
 				cacheDir,
@@ -1298,7 +1431,9 @@ async function materializePackagedOmxPluginCacheImpl(
 				retiredDirs: [],
 			};
 		}
-		let tempDir: string | undefined;
+		let tempName: string | undefined;
+		let tempRef: DirectoryRef | undefined;
+		let snapshotRef: DirectoryRef | undefined;
 		let outcome: OmxPluginCacheMaterializeResult = {
 			status: "materialized",
 			cacheDir,
@@ -1307,51 +1442,47 @@ async function materializePackagedOmxPluginCacheImpl(
 		};
 		let cleanupError: unknown = null;
 		let lockIdentity: Stats | undefined;
-		let finalHandle: FileHandle | undefined;
+		let finalRef: DirectoryRef | undefined;
 		try {
 			lockIdentity = await lockHandle.stat();
-			tempDir = await mkdtemp(join(cacheBaseFdPath, `.omx-plugin-${version}-`));
-			const snapshotDir = await stageCompletePluginSnapshot(
-				tempDir,
-				packagedMarketplace,
-				version,
-				options.teamMode,
-			);
-			await syncDirectoryTree(snapshotDir);
-			const finalPath = join(cacheBaseFdPath, version);
+			await assertDirectoryRef(cacheBaseRef, "temporary staging");
+			const tempDir = await mkdtemp(join(cacheBaseRef.path, `.omx-plugin-${version}-`));
+			await assertDirectoryRef(cacheBaseRef, "temporary staging");
+			tempName = tempDir.slice(cacheBaseRef.path.length + 1);
+			if (!tempName || tempName.includes("/")) throw new Error("temporary staging directory escaped the anchored cache namespace");
+			tempRef = await openDirectoryChild(cacheBaseRef, tempName);
+			snapshotRef = await stageCompletePluginSnapshot(tempRef, packagedMarketplace, version, options.teamMode);
+			await syncDirectoryTree(snapshotRef);
 			await options.onCacheDirPrepared?.(cacheDir);
 			try {
-				await mkdir(finalPath);
-				finalHandle = await open(finalPath, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
-				const finalFdPath = directoryFdPath(finalHandle.fd);
-				if (!finalFdPath) throw new Error("platform cannot expose an anchored publication directory descriptor");
-				await writeFile(join(finalFdPath, ".omx-incomplete"), `${process.pid}\n`);
-				await syncRegularFile(join(finalFdPath, ".omx-incomplete"));
-				const stagedEntries = await readdir(snapshotDir, { withFileTypes: true });
+				await mkdirDirectoryChildExclusive(cacheBaseRef, version);
+				finalRef = await openDirectoryChild(cacheBaseRef, version);
+				await createExclusiveFileChild(finalRef, ".omx-incomplete", `${process.pid}\n`);
+				const stagedEntries = await readdir(snapshotRef.operationPath, { withFileTypes: true });
 				for (const entry of stagedEntries) {
 					if (entry.isSymbolicLink()) throw new Error(`refusing to publish symlinked cache entry: ${entry.name}`);
-					await rename(join(snapshotDir, entry.name), join(finalFdPath, entry.name));
+					await renameChild(snapshotRef, entry.name, finalRef, entry.name);
 				}
-				await syncDirectoryTree(finalFdPath, finalHandle);
-				await writeFile(join(finalFdPath, ".omx-complete"), `${process.pid}\n`);
-				await syncRegularFile(join(finalFdPath, ".omx-complete"));
-				await rm(join(finalFdPath, ".omx-incomplete"), { force: true });
-				await syncDirectory(finalFdPath);
-				const finalPathStats = await lstat(finalPath);
-				const finalDescriptorStats = await finalHandle.stat();
+				await syncDirectoryTree(finalRef);
+				await createExclusiveFileChild(finalRef, ".omx-complete", `${process.pid}\n`);
+				await removeChild(finalRef, ".omx-incomplete", { force: true });
+				await finalRef.handle.sync();
+				await assertDirectoryRef(finalRef, "publication validation");
+				const finalPathStats = await lstat(finalRef.path);
+				const finalDescriptorStats = await finalRef.handle.stat();
 				if (!finalPathStats.isDirectory() || finalPathStats.isSymbolicLink() || finalPathStats.dev !== finalDescriptorStats.dev || finalPathStats.ino !== finalDescriptorStats.ino) {
 					throw new Error(`published cache directory changed before validation: ${cacheDir}`);
 				}
-				if (!options.anchoredCacheBasePath) await syncDirectory(cacheBase);
+				await cacheBaseRef.handle.sync();
 			} catch (error) {
 				if ((error as NodeJS.ErrnoException).code === "EEXIST") {
 					outcome = {
-						status: "stale-launcher",
-						cacheDir,
-						version,
-						reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
-						launcherTarget: undefined,
-						retiredDirs: [],
+					status: "stale-launcher",
+					cacheDir,
+					version,
+					reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
+					launcherTarget: undefined,
+					retiredDirs: [],
 					};
 				} else {
 					throw error;
@@ -1359,48 +1490,31 @@ async function materializePackagedOmxPluginCacheImpl(
 			}
 		} catch (error) {
 			outcome = {
-				status: "stale-launcher",
-				cacheDir,
-				version,
-				reason: `immutable OMX plugin cache publication failed closed: ${(error as Error).message}`,
-				launcherTarget: undefined,
-				retiredDirs: [],
-			};
+			status: "stale-launcher",
+			cacheDir,
+			version,
+			reason: `immutable OMX plugin cache publication failed closed: ${(error as Error).message}`,
+			launcherTarget: undefined,
+			retiredDirs: [],
+		};
 		} finally {
-			try {
-				if (finalHandle) await finalHandle.close();
-			} catch (error) {
-				cleanupError ??= error;
-			}
-			try {
-				if (tempDir) await rm(tempDir, { recursive: true, force: true });
-			} catch (error) {
-				cleanupError = error;
-			}
-			try {
-				await lockHandle.close();
-			} catch (error) {
-				cleanupError ??= error;
-			}
+			try { if (finalRef) await finalRef.handle.close(); } catch (error) { cleanupError ??= error; }
+			try { if (snapshotRef) await snapshotRef.handle.close(); } catch (error) { cleanupError ??= error; }
+			try { if (tempRef) await tempRef.handle.close(); } catch (error) { cleanupError ??= error; }
+			try { if (tempName) await removeChild(cacheBaseRef, tempName, { recursive: true, force: true }); } catch (error) { cleanupError = error; }
+			try { await lockHandle.close(); } catch (error) { cleanupError ??= error; }
 			try {
 				if (!lockIdentity) throw new Error(`publication lock identity unavailable at ${cacheBase}`);
 				const currentLockStats = await lstat(lockPath);
-				if (currentLockStats.dev !== lockIdentity.dev || currentLockStats.ino !== lockIdentity.ino) {
-					throw new Error(`publication lock changed before cleanup at ${cacheBase}`);
-				}
-				await rm(lockPath, { force: true });
-				if (!options.anchoredCacheBasePath) await syncDirectory(cacheBase);
-			} catch (error) {
-				cleanupError ??= error;
-			}
-			if (cacheBaseHandle) {
-				try {
-					await cacheBaseHandle.close();
-				} catch (error) {
-					cleanupError ??= error;
-				}
+				if (currentLockStats.dev !== lockIdentity.dev || currentLockStats.ino !== lockIdentity.ino) throw new Error(`publication lock changed before cleanup at ${cacheBase}`);
+				await removeChild(cacheBaseRef, ".omx-publish.lock", { force: true });
+				await cacheBaseRef.handle.sync();
+			} catch (error) { cleanupError ??= error; }
+			if (ownsCacheBaseRef) {
+				try { await cacheBaseRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			}
 		}
+
 		if (cleanupError) {
 			return {
 				status: "stale-launcher",
@@ -1416,7 +1530,7 @@ async function materializePackagedOmxPluginCacheImpl(
 				outcome.retiredDirs = await retireUnpinnedManagedSnapshots(
 					codexHomeDir,
 					version,
-					options.anchoredCacheBasePath,
+					options.anchoredCacheBaseRef,
 				);
 			} catch (error) {
 				return {
@@ -1437,7 +1551,7 @@ async function materializePackagedOmxPluginCacheImpl(
 		version,
 		retiredDirs: options.dryRun
 			? []
-			: await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBasePath),
+			: await retireUnpinnedManagedSnapshots(codexHomeDir, version, options.anchoredCacheBaseRef),
 	};
 }
 
@@ -1463,7 +1577,7 @@ export async function materializePackagedOmxPluginCache(
 			retiredDirs: [],
 		};
 	}
-	let namespace: { handle: FileHandle; fdPath: string; handles: FileHandle[] } | null;
+	let namespace: { handle: FileHandle; fdPath: string; path: string; handles: FileHandle[] } | null;
 	try {
 		namespace = await openManagedCacheNamespace(cacheBase, codexHomeDir, { create: !options.dryRun });
 	} catch (error) {
@@ -1491,8 +1605,12 @@ export async function materializePackagedOmxPluginCache(
 			packagedMarketplace,
 			{
 				...options,
-				anchoredCacheBasePath: cacheBaseFdPath,
-				anchoredCacheDir: join(cacheBaseFdPath, version),
+				anchoredCacheBaseRef: {
+					handle: namespace.handle,
+					path: namespace.path,
+					operationPath: cacheBaseFdPath,
+				},
+				anchoredCacheDir: join(namespace.path, version),
 			},
 		);
 	} catch (error) {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants, existsSync, type Stats } from "fs";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { link, lstat, mkdir, open, readdir, readFile, realpath, rename, rm, type FileHandle } from "fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
@@ -489,6 +489,7 @@ interface RemoveChildOptions {
 	recursive?: boolean;
 	force?: boolean;
 	preserveRecursive?: boolean;
+	expectedManagedVersion?: string;
 }
 
 async function removeChild(parent: DirectoryRef, name: string, options: RemoveChildOptions = {}): Promise<boolean> {
@@ -733,8 +734,43 @@ async function readRegularFileTextNoFollow(path: string, options: { anchorDir?: 
 	return bytes?.toString("utf-8") ?? null;
 }
 
+async function computeImmutableClaimDigest(root: string): Promise<string> {
+	const hash = createHash("sha256");
+	const visit = async (directory: string): Promise<void> => {
+		const entries = await readdir(directory, { withFileTypes: true });
+		entries.sort((left, right) => left.name.localeCompare(right.name));
+		for (const entry of entries) {
+			if (entry.name === ".omx-complete") continue;
+			const path = join(directory, entry.name);
+			const stats = await lstat(path);
+			if (stats.isSymbolicLink() || (!stats.isDirectory() && !stats.isFile()) || (stats.isFile() && stats.nlink !== 1)) {
+				throw new Error(`claim entry is not a singly-linked regular file or directory: ${path}`);
+			}
+			hash.update(`${entry.name}\0${stats.isDirectory() ? "d" : "f"}\0${stats.dev}\0${stats.ino}\0${stats.size}\0`);
+			if (stats.isDirectory()) {
+				await visit(path);
+			} else {
+				const bytes = await readOmxPluginCacheFileNoFollow(path, { anchorDir: directory });
+				if (bytes === null) throw new Error(`claim entry cannot be read: ${path}`);
+				hash.update(bytes);
+			}
+		}
+	};
+	await visit(root);
+	return hash.digest("hex");
+}
+
 async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complete" | ".omx-incomplete" | ".omx-managed"): Promise<boolean> {
-	return (await readOmxPluginCacheFileNoFollow(join(cacheDir, name), { anchorDir: cacheDir })) !== null;
+	const bytes = await readOmxPluginCacheFileNoFollow(join(cacheDir, name), { anchorDir: cacheDir });
+	if (bytes === null) return false;
+	if (name !== ".omx-complete") return true;
+	try {
+		const record = JSON.parse(bytes.toString("utf-8")) as { claimDigest?: unknown };
+		if (typeof record.claimDigest !== "string") return true;
+		return record.claimDigest === await computeImmutableClaimDigest(cacheDir);
+	} catch {
+		return true;
+	}
 }
 
 async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
@@ -829,6 +865,7 @@ interface PublicationLockRecord {
 }
 
 const PUBLICATION_LOCK_LEASE_MS = 120_000;
+const PUBLICATION_LOCK_MAX_FUTURE_SKEW_MS = 300_000;
 const PUBLICATION_LOCK_PROCESS_TOKEN = randomUUID();
 const PUBLICATION_LOCK_HEARTBEAT_INTERVAL_MS = 30_000;
 
@@ -867,11 +904,13 @@ function publicationLockFileAgeExpired(stats: Stats, now = Date.now()): boolean 
 		&& now - stats.mtimeMs > PUBLICATION_LOCK_LEASE_MS;
 }
 
-function publicationLockRecordStructurallyValid(record: PublicationLockRecord): boolean {
+function publicationLockRecordStructurallyValid(record: PublicationLockRecord, now = Date.now()): boolean {
 	const hasPid = typeof record.pid === "number" && Number.isInteger(record.pid) && record.pid > 0;
 	const hasHeartbeat = typeof record.heartbeatAt === "number" && Number.isFinite(record.heartbeatAt);
 	const hasCreatedAt = typeof record.createdAt === "number" && Number.isFinite(record.createdAt);
-	return hasPid && (hasHeartbeat || hasCreatedAt);
+	const heartbeatPlausible = !hasHeartbeat || (record.heartbeatAt as number) <= now + PUBLICATION_LOCK_MAX_FUTURE_SKEW_MS;
+	const createdPlausible = !hasCreatedAt || (record.createdAt as number) <= now + PUBLICATION_LOCK_MAX_FUTURE_SKEW_MS;
+	return hasPid && (hasHeartbeat || hasCreatedAt) && heartbeatPlausible && createdPlausible;
 }
 
 function isPublicationLockStale(record: PublicationLockRecord, now = Date.now()): boolean {
@@ -981,6 +1020,18 @@ export async function removeChildIfIdentity(
 			// between the quarantine and the restore attempt; quarantine remains.
 		}
 		throw new Error(`identity-bound removal target changed during reclamation; preserved quarantine ${quarantinePath}`);
+	}
+	if (options.expectedManagedVersion) {
+		const manifest = await readRegularOmxPluginCacheManifest(quarantinePath, quarantinePath);
+		const owned = manifest?.name === OMX_PLUGIN_NAME
+			&& manifest.version === options.expectedManagedVersion
+			&& await hasRegularPublicationMarker(quarantinePath, ".omx-complete")
+			&& !(await hasRegularPublicationMarker(quarantinePath, ".omx-incomplete"))
+			&& await hasRegularPublicationMarker(quarantinePath, OMX_PLUGIN_MANAGED_MARKER);
+		const livePin = await readOmxPluginCacheFileNoFollow(join(quarantinePath, ".omx-live-pin"), { anchorDir: quarantinePath }) !== null;
+		if (!owned || livePin) {
+			throw new Error(`managed cache ownership changed during reclamation; preserved quarantine ${quarantinePath}`);
+		}
 	}
 	return removeChild(cacheBaseRef, quarantineName, {
 		...options,
@@ -1954,7 +2005,7 @@ export async function retireUnpinnedManagedSnapshots(
 			if (await readOmxPluginCacheFileNoFollow(join(candidate.ref.operationPath, ".omx-live-pin"), { anchorDir: candidate.ref.operationPath }) !== null) {
 				continue;
 			}
-			if (await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true })) {
+			if (await removeChildIfIdentity(baseRef, candidate.version, currentStats, { recursive: true, force: true, expectedManagedVersion: candidate.version })) {
 				retired.push(candidate.path);
 			} else {
 				preservedDirs?.push(candidate.path);
@@ -2202,7 +2253,9 @@ async function materializePackagedOmxPluginCacheImpl(
 					await pluginCacheMutationTestHooks?.beforeCompleteMarker?.(claimRef.path);
 					await validateStagedPluginSnapshot(claimRef, packagedMarketplace, version, options.teamMode);
 					await syncDirectoryTree(claimRef, durability);
-					await createExclusiveFileChild(claimRef, ".omx-complete", `${process.pid}\n`, durability);
+					await publicationLockGuard.assertOwned();
+					const claimDigest = await computeImmutableClaimDigest(claimRef.path);
+					await createExclusiveFileChild(claimRef, ".omx-complete", `${JSON.stringify({ version, claimDigest })}\n`, durability);
 					const claimDirSyncOutcome = await syncDirectory(claimRef.handle);
 					recordDirectorySyncOutcome(durability, claimDirSyncOutcome);
 					await assertDirectoryRef(claimRef, "publication commit");

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1057,8 +1057,12 @@ export async function removeChildIfIdentity(
 		}
 		return removeChild(cacheBaseRef, quarantineName, {
 			...options,
-			preserveRecursive: true,
-			beforeDestructiveRemove: verifyQuarantineOwnership,
+			preserveRecursive: false,
+			beforeDestructiveRemove: async () => {
+				const owned = await verifyQuarantineOwnership();
+				if (!owned) options.preservedPaths?.push(join(cacheBaseRef.path, quarantineName));
+				return owned;
+			},
 		});
 	}
 	return removeChild(cacheBaseRef, quarantineName, {

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -732,7 +732,7 @@ function startPublicationLockHeartbeat(
 	}, PUBLICATION_LOCK_HEARTBEAT_INTERVAL_MS);
 }
 
-async function removeChildIfIdentity(
+export async function removeChildIfIdentity(
 	cacheBaseRef: DirectoryRef,
 	childName: string,
 	childStats: Stats,
@@ -748,6 +748,33 @@ async function removeChildIfIdentity(
 		throw new Error(`identity-bound removal target disappeared during reclamation: ${(error as Error).message}`);
 	}
 	if (quarantineStats.dev !== childStats.dev || quarantineStats.ino !== childStats.ino) {
+		// Quarantined the wrong inode (replacement after validation): restore it
+		// to its version path without clobbering a successor. For directories
+		// link(2) is EPERM, so rename the quarantine back only if the version
+		// name is still free; for regular files use link to avoid clobbering a
+		// successor that may have appeared.
+		const isDirQuarantine = quarantineStats.isDirectory();
+		try {
+			if (isDirQuarantine) {
+				const versionPath = join(cacheBaseRef.path, childName);
+				let versionExists = false;
+				try {
+					await lstat(versionPath);
+					versionExists = true;
+				} catch (e) {
+					if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+				}
+				if (!versionExists) {
+					await renameChild(cacheBaseRef, quarantineName, cacheBaseRef, childName);
+				}
+			} else {
+				await link(quarantinePath, childOperationPath(cacheBaseRef, childName));
+				await removeChild(cacheBaseRef, quarantineName, { force: true });
+			}
+		} catch {
+			// Preserve replacement without overwriting a successor that appeared
+			// between the quarantine and the restore attempt; quarantine remains.
+		}
 		throw new Error("identity-bound removal target changed during reclamation");
 	}
 	await removeChild(cacheBaseRef, quarantineName, options);
@@ -1623,7 +1650,7 @@ export async function getPinnedLauncherIncompatibilityReason(
 	return null;
 }
 
-async function retireUnpinnedManagedSnapshots(
+export async function retireUnpinnedManagedSnapshots(
 	codexHomeDir: string,
 	currentVersion: string,
 	anchoredCacheBaseRef?: DirectoryRef,
@@ -1640,6 +1667,7 @@ async function retireUnpinnedManagedSnapshots(
 	let publicationLock: FileHandle | undefined;
 	let publicationLockIdentity: Stats | undefined;
 	const durability: RegularFileDurabilityTracker = { degraded: false };
+	let publicationLockHeartbeat: NodeJS.Timeout | undefined;
 	const candidateRefs: DirectoryRef[] = [];
 	let cleanupError: unknown = null;
 	try {
@@ -1650,6 +1678,8 @@ async function retireUnpinnedManagedSnapshots(
 		if (!publicationLockHeld) {
 			publicationLock = await claimPublicationLock(baseRef, cacheBase, noFollowFlags, durability);
 			publicationLockIdentity = await publicationLock.stat();
+			await refreshPublicationLockRecord(publicationLock, durability);
+			publicationLockHeartbeat = startPublicationLockHeartbeat(publicationLock, durability);
 		}
 		const entries = await readdir(baseRef.operationPath, { withFileTypes: true });
 		const managed: Array<{ path: string; version: string; mtimeMs: number; ref: DirectoryRef; stats: Stats }> = [];
@@ -1689,13 +1719,23 @@ async function retireUnpinnedManagedSnapshots(
 		}
 		return retired;
 	} finally {
+		if (publicationLockHeartbeat) clearInterval(publicationLockHeartbeat);
 		for (const candidateRef of candidateRefs.reverse()) {
 			try { await candidateRef.handle.close(); } catch (error) { cleanupError ??= error; }
 		}
 		if (publicationLock) {
 			try { await publicationLock.close(); } catch (error) { cleanupError ??= error; }
 			if (publicationLockIdentity) {
-				try { await reclaimStalePublicationLock(baseRef!, ".omx-publish.lock", publicationLockIdentity); } catch (error) { cleanupError ??= error; }
+				const cur = await lstat(join(baseRef!.path, ".omx-publish.lock")).catch(() => null);
+				if (
+					cur &&
+					cur.isFile() &&
+					!cur.isSymbolicLink() &&
+					cur.dev === publicationLockIdentity.dev &&
+					cur.ino === publicationLockIdentity.ino
+				) {
+					try { await reclaimStalePublicationLock(baseRef!, ".omx-publish.lock", publicationLockIdentity); } catch (error) { cleanupError ??= error; }
+				}
 			}
 		}
 		emitDegradedDurabilityWarning("plugin cache publication", durability);

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -669,6 +669,7 @@ interface PublicationLockRecord {
 
 const PUBLICATION_LOCK_LEASE_MS = 120_000;
 const PUBLICATION_LOCK_PROCESS_TOKEN = randomUUID();
+const PUBLICATION_LOCK_HEARTBEAT_INTERVAL_MS = 30_000;
 
 function buildPublicationLockRecord(heartbeatAt: number = Date.now()): string {
 	return `${JSON.stringify({
@@ -703,6 +704,32 @@ function isPublicationLockStale(record: PublicationLockRecord, now = Date.now())
 	if (typeof record.pid !== "number" || !Number.isInteger(record.pid) || record.pid <= 0) return false;
 	if (publicationLockLeaseExpired(record, now)) return true;
 	return !isProcessAlive(record.pid);
+}
+
+async function refreshPublicationLockRecord(
+	lockHandle: FileHandle,
+	tracker?: RegularFileDurabilityTracker,
+): Promise<void> {
+	try {
+		const record = buildPublicationLockRecord();
+		const buf = Buffer.from(record, "utf-8");
+		await lockHandle.truncate(0);
+		await lockHandle.write(buf, 0, buf.length, 0);
+		const outcome = await syncRegularFile(lockHandle);
+		if (tracker) recordRegularFileSyncOutcome(tracker, outcome);
+	} catch {
+		// Heartbeat is best-effort; a slow filesystem or closed handle must not fail the
+		// already-claimed publication. The next interval will retry if the handle is still open.
+	}
+}
+
+function startPublicationLockHeartbeat(
+	lockHandle: FileHandle,
+	tracker?: RegularFileDurabilityTracker,
+): NodeJS.Timeout {
+	return setInterval(() => {
+		void refreshPublicationLockRecord(lockHandle, tracker);
+	}, PUBLICATION_LOCK_HEARTBEAT_INTERVAL_MS);
 }
 
 async function removeChildIfIdentity(
@@ -1795,8 +1822,12 @@ async function materializePackagedOmxPluginCacheImpl(
 		}
 		const durability: RegularFileDurabilityTracker = { degraded: false };
 		let lockHandle: FileHandle;
+		let publicationLockHeartbeat: NodeJS.Timeout | undefined;
 		try {
 			lockHandle = await claimPublicationLock(cacheBaseRef, cacheBase, noFollowFlags, durability);
+			// Keep heartbeatAt fresh while the critical section is held so a slow live
+			// publisher is never reclaimed by a concurrent claimant after LEASE_MS.
+			publicationLockHeartbeat = startPublicationLockHeartbeat(lockHandle, durability);
 		} catch (error) {
 			emitDegradedDurabilityWarning("plugin cache publication", durability);
 			if (ownsCacheBaseRef) await cacheBaseRef.handle.close();
@@ -1823,7 +1854,9 @@ async function materializePackagedOmxPluginCacheImpl(
 		let finalRef: DirectoryRef | undefined;
 		try {
 			lockIdentity = await lockHandle.stat();
-			await assertDirectoryRef(cacheBaseRef, "temporary staging");
+			// Refresh once under the held fd so the initial heartbeat is at most
+			// a few seconds old even on a fast publication path.
+			await refreshPublicationLockRecord(lockHandle, durability);
 			const candidateTempName = `.omx-plugin-${version}-${process.pid}-${randomUUID()}`;
 			await mkdirDirectoryChildExclusive(cacheBaseRef, candidateTempName);
 			await assertDirectoryRef(cacheBaseRef, "temporary staging");
@@ -1926,7 +1959,8 @@ async function materializePackagedOmxPluginCacheImpl(
 			launcherTarget: undefined,
 			retiredDirs: [],
 		};
-		} finally {
+	} finally {
+			if (publicationLockHeartbeat) clearInterval(publicationLockHeartbeat);
 			try { if (finalRef) await finalRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			try { if (snapshotRef) await snapshotRef.handle.close(); } catch (error) { cleanupError ??= error; }
 			try { if (tempRef) await tempRef.handle.close(); } catch (error) { cleanupError ??= error; }
@@ -1934,7 +1968,18 @@ async function materializePackagedOmxPluginCacheImpl(
 			try { await lockHandle.close(); } catch (error) { cleanupError ??= error; }
 			try {
 				if (!lockIdentity) throw new Error(`publication lock identity unavailable at ${cacheBase}`);
-				await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity);
+				// Own-lock release must not quarantine a successor: only remove
+				// if the file on disk still has the dev/ino we created.
+				const cur = await lstat(join(cacheBaseRef.path, ".omx-publish.lock")).catch(() => null);
+				if (
+					cur &&
+					cur.isFile() &&
+					!cur.isSymbolicLink() &&
+					cur.dev === lockIdentity.dev &&
+					cur.ino === lockIdentity.ino
+				) {
+					await reclaimStalePublicationLock(cacheBaseRef, ".omx-publish.lock", lockIdentity);
+				}
 				const syncOutcome = await syncDirectory(cacheBaseRef.handle);
 				recordDirectorySyncOutcome(durability, syncOutcome);
 			} catch (error) { cleanupError ??= error; }

--- a/src/cli/plugin-marketplace.ts
+++ b/src/cli/plugin-marketplace.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants, existsSync, type Stats } from "fs";
-import { cp, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, writeFile } from "fs/promises";
+import { cp, lstat, mkdir, mkdtemp, open, readdir, readFile, realpath, rename, rm, writeFile, type FileHandle } from "fs/promises";
 import { isAbsolute, join, relative, resolve, sep } from "path";
 import { OMX_FIRST_PARTY_MCP_SERVER_NAMES } from "../config/omx-first-party-mcp.js";
 import { teamModeEnabled, type SetupTeamMode } from "../config/team-mode.js";
@@ -101,6 +101,14 @@ function directoryFdPath(fd: number): string | null {
 	return null;
 }
 
+function isDirectoryDescriptorPath(path: string): boolean {
+	return /^\/(?:proc\/self\/fd|dev\/fd)\/\d+$/.test(path);
+}
+
+function directoryOpenFlags(path: string, directoryFlags: number, noFollowFlags: number): number {
+	return fsConstants.O_RDONLY | directoryFlags | (isDirectoryDescriptorPath(path) ? 0 : noFollowFlags);
+}
+
 async function syncRegularFile(path: string): Promise<void> {
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	if (typeof noFollowFlags !== "number") throw new Error("O_NOFOLLOW is unavailable");
@@ -118,7 +126,7 @@ async function syncDirectory(path: string): Promise<void> {
 	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
 		throw new Error("directory durability flags are unavailable");
 	}
-	const handle = await open(path, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+	const handle = await open(path, directoryOpenFlags(path, directoryFlags, noFollowFlags));
 	try {
 		await handle.sync();
 	} finally {
@@ -126,34 +134,63 @@ async function syncDirectory(path: string): Promise<void> {
 	}
 }
 
+async function syncDirectoryTree(path: string, directoryHandle?: FileHandle): Promise<void> {
+	const entries = await readdir(path, { withFileTypes: true });
+	for (const entry of entries) {
+		const childPath = join(path, entry.name);
+		if (entry.isSymbolicLink()) throw new Error(`cannot sync symlinked cache entry: ${childPath}`);
+		if (entry.isDirectory()) await syncDirectoryTree(childPath);
+		else await syncRegularFile(childPath);
+	}
+	if (directoryHandle) await directoryHandle.sync();
+	else await syncDirectory(path);
+}
+
 export async function readOmxPluginCacheFileNoFollow(
 	path: string,
 	options: { requireSingleLink?: boolean; anchorDir?: string } = {},
 ): Promise<Buffer | null> {
-	let handle;
-	let anchorHandle;
+	let handle: FileHandle | undefined;
+	let anchorHandle: FileHandle | undefined;
+	const intermediateDirectories: Array<{ handle: FileHandle; path: string; stats: Stats }> = [];
 	try {
 		const requireSingleLink = options.requireSingleLink ?? true;
 		const noFollowFlags = fsConstants.O_NOFOLLOW;
 		if (typeof noFollowFlags !== "number") return null;
 		let readPath = path;
 		let anchorBefore: Stats | null = null;
-		let anchoredRootParent = false;
 		if (options.anchorDir) {
 			const directoryFlags = fsConstants.O_DIRECTORY;
 			if (typeof directoryFlags !== "number") return null;
-			anchorHandle = await open(options.anchorDir, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+			anchorHandle = await open(options.anchorDir, directoryOpenFlags(options.anchorDir, directoryFlags, noFollowFlags));
 			anchorBefore = await anchorHandle.stat();
 			if (!anchorBefore.isDirectory()) return null;
 			if (typeof anchorBefore.dev !== "number" || typeof anchorBefore.ino !== "number") return null;
-			const fdPath = directoryFdPath(anchorHandle.fd);
+			const fdPath = process.platform === "darwin"
+				? resolve(options.anchorDir)
+				: directoryFdPath(anchorHandle.fd);
 			if (!fdPath) return null;
 			const relativePath = relative(resolve(options.anchorDir), resolve(path));
 			if (!relativePath || relativePath.startsWith("..")) return null;
-			anchoredRootParent = !relativePath.includes(sep);
-			readPath = join(fdPath, relativePath);
+			const components = relativePath.split(sep);
+			if (components.some((component) => !component || component === "." || component === "..")) return null;
+			let parentPath = fdPath;
+			for (const component of components.slice(0, -1)) {
+				const childPath = join(parentPath, component);
+				const childHandle = await open(childPath, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+				const childStats = await childHandle.stat();
+				if (!childStats.isDirectory() || childStats.isSymbolicLink()) {
+					await childHandle.close();
+					return null;
+				}
+				intermediateDirectories.push({ handle: childHandle, path: childPath, stats: childStats });
+				parentPath = process.platform === "darwin" ? childPath : directoryFdPath(childHandle.fd) ?? "";
+				if (!parentPath) return null;
+			}
+			readPath = join(parentPath, components.at(-1)!);
 		}
-		const parentBefore = anchoredRootParent ? anchorBefore! : await lstat(resolve(readPath, ".."));
+		const parentDescriptor = intermediateDirectories.at(-1)?.handle ?? anchorHandle;
+		const parentBefore = parentDescriptor ? await parentDescriptor.stat() : await lstat(resolve(readPath, ".."));
 		if (!parentBefore.isDirectory() || parentBefore.isSymbolicLink()) return null;
 		if (typeof parentBefore.dev !== "number" || typeof parentBefore.ino !== "number") return null;
 		const before = await lstat(readPath);
@@ -167,12 +204,7 @@ export async function readOmxPluginCacheFileNoFollow(
 		if (descriptorStats.dev !== before.dev || descriptorStats.ino !== before.ino) return null;
 		const bytes = await handle.readFile();
 		const after = await lstat(readPath);
-		const parentAfter = anchoredRootParent
-			? anchorHandle
-				? await anchorHandle.stat()
-				: null
-			: await lstat(resolve(readPath, ".."));
-		const anchorAfter = anchorHandle ? await anchorHandle.stat() : null;
+		const parentAfter = parentDescriptor ? await parentDescriptor.stat() : await lstat(resolve(readPath, ".."));
 		if (!parentAfter) return null;
 		if (!after.isFile() || after.isSymbolicLink()) return null;
 		if (requireSingleLink && after.nlink !== 1) return null;
@@ -180,12 +212,22 @@ export async function readOmxPluginCacheFileNoFollow(
 		if (after.dev !== before.dev || after.ino !== before.ino) return null;
 		if (!parentAfter.isDirectory() || parentAfter.isSymbolicLink()) return null;
 		if (typeof parentAfter.dev !== "number" || typeof parentAfter.ino !== "number" || parentAfter.dev !== parentBefore.dev || parentAfter.ino !== parentBefore.ino) return null;
-		if (anchorBefore && (!anchorAfter || typeof anchorAfter.dev !== "number" || typeof anchorAfter.ino !== "number" || !anchorAfter.isDirectory() || anchorAfter.dev !== anchorBefore.dev || anchorAfter.ino !== anchorBefore.ino)) return null;
+		for (const directory of intermediateDirectories) {
+			const currentStats = await lstat(directory.path);
+			if (!currentStats.isDirectory() || currentStats.isSymbolicLink() || typeof currentStats.dev !== "number" || typeof currentStats.ino !== "number" || currentStats.dev !== directory.stats.dev || currentStats.ino !== directory.stats.ino) return null;
+		}
+		if (options.anchorDir && anchorBefore) {
+			const anchorAfter = isDirectoryDescriptorPath(options.anchorDir)
+				? await anchorHandle!.stat()
+				: await lstat(options.anchorDir);
+			if (!anchorAfter.isDirectory() || (!isDirectoryDescriptorPath(options.anchorDir) && anchorAfter.isSymbolicLink()) || typeof anchorAfter.dev !== "number" || typeof anchorAfter.ino !== "number" || anchorAfter.dev !== anchorBefore.dev || anchorAfter.ino !== anchorBefore.ino) return null;
+		}
 		return bytes;
 	} catch {
 		return null;
 	} finally {
 		if (handle) await handle.close();
+		for (const directory of intermediateDirectories.reverse()) await directory.handle.close();
 		if (anchorHandle) await anchorHandle.close();
 	}
 }
@@ -202,21 +244,6 @@ async function hasRegularPublicationMarker(cacheDir: string, name: ".omx-complet
 async function listChildDirectoryNames(dir: string): Promise<string[] | null> {
 	try {
 		const entries = await readdir(dir, { withFileTypes: true });
-		return entries
-			.filter((entry) => entry.isDirectory())
-			.map((entry) => entry.name)
-			.sort();
-	} catch {
-		return null;
-	}
-}
-
-async function listRegularChildDirectoryNames(dir: string): Promise<string[] | null> {
-	try {
-		const stats = await lstat(dir);
-		if (!stats.isDirectory() || stats.isSymbolicLink()) return null;
-		const entries = await readdir(dir, { withFileTypes: true });
-		if (entries.some((entry) => entry.isSymbolicLink())) return null;
 		return entries
 			.filter((entry) => entry.isDirectory())
 			.map((entry) => entry.name)
@@ -276,6 +303,58 @@ export function omxPluginCacheBase(codexHomeDir: string): string {
 
 function isMissingPathError(error: unknown): boolean {
 	return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ESRCH";
+	}
+}
+
+async function claimPublicationLock(
+	cacheBaseFdPath: string,
+	cacheBase: string,
+	noFollowFlags: number,
+): Promise<FileHandle> {
+	const lockPath = join(cacheBaseFdPath, ".omx-publish.lock");
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		try {
+			const lockHandle = await open(
+				lockPath,
+				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags,
+				0o600,
+			);
+			try {
+				await lockHandle.writeFile(`${JSON.stringify({ pid: process.pid, createdAt: Date.now() })}\n`);
+				await lockHandle.sync();
+			} catch (error) {
+				try { await lockHandle.close(); } catch { /* preserve the primary failure */ }
+				try { await rm(lockPath, { force: true }); } catch { /* preserve the primary failure */ }
+				throw error;
+			}
+			return lockHandle;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt > 0) throw error;
+			const lockBytes = await readOmxPluginCacheFileNoFollow(lockPath, { anchorDir: cacheBaseFdPath });
+			let stale = false;
+			if (lockBytes !== null) {
+				try {
+					const record = JSON.parse(lockBytes.toString("utf-8")) as { pid?: unknown };
+					stale = typeof record.pid === "number" && Number.isInteger(record.pid) && record.pid > 0 && !isProcessAlive(record.pid);
+				} catch {
+					stale = false;
+				}
+			}
+			if (!stale) {
+				throw new Error(`another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`);
+			}
+			await rm(lockPath, { force: true });
+		}
+	}
+	throw new Error(`cannot recover stale OMX plugin cache publication lock at ${cacheBase}`);
 }
 
 /**
@@ -471,47 +550,104 @@ export async function omxPluginCacheProvenanceReason(
 	return omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
 }
 
-/**
- * Only the namespace OMX owns below the Codex home is required to be free of symlinks; a symlinked
- * `plugins/` (or any component under the home) can redirect writes and is refused. Everything above
- * the home belongs to the platform or the user — macOS resolves TMPDIR through `/var -> /private/var`,
- * and symlinked home directories are ordinary — so those components are canonicalized, not rejected.
- */
-async function ensureManagedCacheNamespace(
+async function openManagedCacheNamespace(
 	cacheBase: string,
 	codexHomeDir: string,
-): Promise<void> {
+	options: { create: boolean },
+): Promise<{ handle: FileHandle; fdPath: string; handles: FileHandle[] } | null> {
 	const managedNamespace = relative(resolve(codexHomeDir), resolve(cacheBase));
 	if (!managedNamespace || managedNamespace.startsWith("..") || isAbsolute(managedNamespace)) {
-		throw new Error(
-			`Refusing to mutate an OMX plugin cache outside the Codex home: ${resolve(cacheBase)}`,
-		);
+		throw new Error(`Refusing to access an OMX plugin cache outside the Codex home: ${resolve(cacheBase)}`);
 	}
-	await mkdir(codexHomeDir, { recursive: true });
-	let current = await realpath(codexHomeDir);
-	for (const component of managedNamespace.split(sep).filter(Boolean)) {
-		current = join(current, component);
-		try {
-			const stats = await lstat(current);
-			if (!stats.isDirectory() || stats.isSymbolicLink()) {
-				throw new Error(
-					`Refusing to mutate OMX plugin cache through a non-directory namespace component: ${current}`,
-				);
-			}
-		} catch (error) {
-			if (!isMissingPathError(error)) throw error;
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	const directoryFlags = fsConstants.O_DIRECTORY;
+	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+		throw new Error("platform cannot provide no-follow directory anchoring for the OMX plugin cache namespace");
+	}
+	if (options.create) await mkdir(codexHomeDir, { recursive: true });
+	let homeRealpath: string;
+	try {
+		homeRealpath = await realpath(codexHomeDir);
+	} catch (error) {
+		if (isMissingPathError(error) && !options.create) return null;
+		throw error;
+	}
+	const handles: FileHandle[] = [];
+	try {
+		const homeHandle = await open(homeRealpath, directoryOpenFlags(homeRealpath, directoryFlags, noFollowFlags));
+		handles.push(homeHandle);
+		let parentPath = process.platform === "darwin" ? homeRealpath : directoryFdPath(homeHandle.fd);
+		let actualParentPath = homeRealpath;
+		if (!parentPath) throw new Error("platform cannot expose a Codex home directory descriptor");
+		for (const component of managedNamespace.split(sep).filter(Boolean)) {
+			const childPath = join(parentPath, component);
+			const actualChildPath = join(actualParentPath, component);
+			const childOpenPath = process.platform === "darwin" ? actualChildPath : childPath;
+			const openChild = async (): Promise<FileHandle> => {
+				if (process.platform === "darwin") {
+					const parentStats = await handles.at(-1)!.stat();
+					const visibleParentStats = await lstat(actualParentPath);
+					if (parentStats.dev !== visibleParentStats.dev || parentStats.ino !== visibleParentStats.ino || !visibleParentStats.isDirectory() || visibleParentStats.isSymbolicLink()) {
+						throw new Error(`Refusing to access OMX plugin cache through a replaced namespace parent: ${actualParentPath}`);
+					}
+				}
+				const openedChild = await open(childOpenPath, directoryOpenFlags(childOpenPath, directoryFlags, noFollowFlags));
+				if (process.platform === "darwin") {
+					const parentStats = await handles.at(-1)!.stat();
+					const visibleParentStats = await lstat(actualParentPath);
+					if (parentStats.dev !== visibleParentStats.dev || parentStats.ino !== visibleParentStats.ino || !visibleParentStats.isDirectory() || visibleParentStats.isSymbolicLink()) {
+						await openedChild.close();
+						throw new Error(`Refusing to access OMX plugin cache through a replaced namespace parent: ${actualParentPath}`);
+					}
+				}
+				return openedChild;
+			};
+			let childHandle: FileHandle;
 			try {
-				await mkdir(current);
-			} catch (mkdirError) {
-				if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
+				childHandle = await openChild();
+			} catch (error) {
+				if (!isMissingPathError(error) || !options.create) {
+					if (isMissingPathError(error) && !options.create) {
+						for (const handle of handles.reverse()) await handle.close();
+						return null;
+					}
+					const code = (error as NodeJS.ErrnoException).code;
+					if (code === "ELOOP" || code === "ENOTDIR") {
+						throw new Error(`Refusing to access OMX plugin cache through a symbolic link or non-directory namespace component: ${childPath}`);
+					}
+					throw error;
+				}
+				try {
+					const parentStats = await handles.at(-1)!.stat();
+					const visibleParentStats = await lstat(actualParentPath);
+					if (parentStats.dev !== visibleParentStats.dev || parentStats.ino !== visibleParentStats.ino || !visibleParentStats.isDirectory() || visibleParentStats.isSymbolicLink()) {
+						throw new Error(`Refusing to create OMX plugin cache through a replaced namespace parent: ${actualParentPath}`);
+					}
+					await mkdir(actualChildPath);
+				} catch (mkdirError) {
+					if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
+				}
+				try {
+					childHandle = await openChild();
+				} catch (retryError) {
+					const code = (retryError as NodeJS.ErrnoException).code;
+					if (code === "ELOOP" || code === "ENOTDIR") {
+						throw new Error(`Refusing to access OMX plugin cache through a symbolic link or non-directory namespace component: ${childPath}`);
+					}
+					throw retryError;
+				}
 			}
-			const stats = await lstat(current);
-			if (!stats.isDirectory() || stats.isSymbolicLink()) {
-				throw new Error(
-					`Refusing to mutate OMX plugin cache through a non-directory namespace component: ${current}`,
-				);
-			}
+			handles.push(childHandle);
+			parentPath = process.platform === "darwin" ? actualChildPath : directoryFdPath(childHandle.fd);
+			actualParentPath = actualChildPath;
+			if (!parentPath) throw new Error("platform cannot expose an OMX plugin cache directory descriptor");
 		}
+		return { handle: handles.at(-1)!, fdPath: parentPath, handles };
+	} catch (error) {
+		for (const handle of handles.reverse()) {
+			try { await handle.close(); } catch { /* preserve the primary failure */ }
+		}
+		throw error;
 	}
 }
 
@@ -590,6 +726,7 @@ export async function discoverOmxPluginCacheDirs(
 			if (await hasRegularPublicationMarker(current.path, ".omx-incomplete")) continue;
 			const manifest = await readRegularOmxPluginCacheManifest(current.path, cacheRoot);
 			if (manifest?.name === OMX_PLUGIN_NAME) {
+				if (!(await hasRegularPublicationMarker(current.path, ".omx-complete"))) continue;
 				matches.push(current.path);
 				continue;
 			}
@@ -634,6 +771,36 @@ export interface OmxPluginCacheState {
 	hookLauncherPinned: boolean;
 }
 
+async function readRegularCacheSkillNames(cacheDir: string): Promise<string[] | null> {
+	const skillsDir = join(cacheDir, "skills");
+	try {
+		const skillsStats = await lstat(skillsDir);
+		if (!skillsStats.isDirectory() || skillsStats.isSymbolicLink()) return null;
+		const entries = await readdir(skillsDir, { withFileTypes: true });
+		if (entries.some((entry) => entry.isSymbolicLink() || !entry.isDirectory())) return null;
+		for (const entry of entries) {
+			const skillFile = join(skillsDir, entry.name, "SKILL.md");
+			const skillStats = await lstat(skillFile);
+			if (!skillStats.isFile() || skillStats.isSymbolicLink() || skillStats.nlink !== 1) return null;
+			if (await readOmxPluginCacheFileNoFollow(skillFile, { anchorDir: cacheDir }) === null) return null;
+		}
+		return entries.map((entry) => entry.name).sort();
+	} catch {
+		return null;
+	}
+}
+
+async function cacheCompanionIsReadable(cacheDir: string, relativePath: ".mcp.json" | ".app.json"): Promise<boolean> {
+	const bytes = await readOmxPluginCacheFileNoFollow(join(cacheDir, relativePath), { anchorDir: cacheDir });
+	if (bytes === null) return false;
+	try {
+		JSON.parse(bytes.toString("utf-8"));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export async function readOmxPluginCacheState(
 	cacheDir: string,
 	expectedVersion?: string,
@@ -644,15 +811,31 @@ export async function readOmxPluginCacheState(
 	const executedAssetReason = await omxPluginCacheExecutedAssetProvenanceReason(cacheDir);
 	if (executedAssetReason) return null;
 	if (await hasRegularPublicationMarker(cacheDir, ".omx-incomplete")) return null;
+	if (await omxPluginCacheManifestProvenanceReason(cacheDir, expectedVersion)) return null;
 	const manifest = await readRegularOmxPluginCacheManifest(cacheDir);
 	if (manifest?.name !== OMX_PLUGIN_NAME) return null;
 	if (expectedVersion !== undefined && manifest.version !== expectedVersion) return null;
+	const skillNames = await readRegularCacheSkillNames(cacheDir);
+	if (!skillNames) return null;
+	if (!(await cacheCompanionIsReadable(cacheDir, ".mcp.json")) || !(await cacheCompanionIsReadable(cacheDir, ".app.json"))) return null;
+	const launcher = await readPinnedLauncherRaw(cacheDir);
+	if (
+		launcher.error ||
+		!launcher.parsed ||
+		typeof launcher.parsed.command !== "string" ||
+		launcher.parsed.command.trim() === "" ||
+		!Array.isArray(launcher.parsed.argsPrefix) ||
+		launcher.parsed.argsPrefix.length !== 1 ||
+		typeof launcher.parsed.argsPrefix[0] !== "string" ||
+		launcher.parsed.argsPrefix[0].trim() === "" ||
+		Object.keys(launcher.parsed).some((key) => key !== "command" && key !== "argsPrefix")
+	) return null;
 	return {
 		cacheDir,
 		manifestVersion:
 			typeof manifest.version === "string" ? manifest.version : null,
 		skillsPointer: typeof manifest.skills === "string" ? manifest.skills : null,
-		skillNames: await listRegularChildDirectoryNames(join(cacheDir, "skills")),
+		skillNames,
 		hooksPointer: typeof manifest.hooks === "string" ? manifest.hooks : null,
 		mcpServersPointer: typeof manifest.mcpServers === "string" ? manifest.mcpServers : null,
 		appsPointer: typeof manifest.apps === "string" ? manifest.apps : null,
@@ -918,34 +1101,61 @@ async function retireUnpinnedManagedSnapshots(
 	anchoredCacheBasePath?: string,
 ): Promise<string[]> {
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
-	await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
 	const managedBase = anchoredCacheBasePath ?? cacheBase;
-	let entries;
+	const noFollowFlags = fsConstants.O_NOFOLLOW;
+	const directoryFlags = fsConstants.O_DIRECTORY;
+	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
+		throw new Error("platform cannot provide no-follow directory anchoring for cache retirement");
+	}
+	let baseHandle: FileHandle | undefined;
+	const candidateHandles: FileHandle[] = [];
 	try {
-		entries = await readdir(managedBase, { withFileTypes: true });
-	} catch {
-		return [];
+		baseHandle = await open(managedBase, directoryOpenFlags(managedBase, directoryFlags, noFollowFlags));
+		const baseFdPath = directoryFdPath(baseHandle.fd);
+		if (!baseFdPath) throw new Error("platform cannot expose an anchored cache directory descriptor for cache retirement");
+		const entries = await readdir(baseFdPath, { withFileTypes: true });
+		const managed: Array<{ path: string; managedPath: string; version: string; mtimeMs: number; handle: FileHandle; stats: Stats }> = [];
+		for (const entry of entries) {
+			if (!entry.isDirectory() || entry.name === currentVersion) continue;
+			const path = join(baseFdPath, entry.name);
+			let candidateHandle: FileHandle;
+			try {
+				candidateHandle = await open(path, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+			} catch {
+				continue;
+			}
+			const candidateStats = await candidateHandle.stat();
+			if (!candidateStats.isDirectory() || candidateStats.isSymbolicLink()) {
+				await candidateHandle.close();
+				continue;
+			}
+			candidateHandles.push(candidateHandle);
+			const candidateFdPath = directoryFdPath(candidateHandle.fd);
+			if (!candidateFdPath) continue;
+			const manifest = await readRegularOmxPluginCacheManifest(candidateFdPath, candidateFdPath);
+			if (manifest?.name !== OMX_PLUGIN_NAME || manifest.version !== entry.name) continue;
+			if (!(await hasRegularPublicationMarker(candidateFdPath, ".omx-complete")) || await hasRegularPublicationMarker(candidateFdPath, ".omx-incomplete")) continue;
+			if (await readOmxPluginCacheFileNoFollow(join(candidateFdPath, ".omx-live-pin"), { anchorDir: candidateFdPath }) !== null) continue;
+			managed.push({ path: join(cacheBase, entry.name), managedPath: path, version: entry.name, mtimeMs: candidateStats.mtimeMs, handle: candidateHandle, stats: candidateStats });
+		}
+		managed.sort((left, right) =>
+			right.version.localeCompare(left.version, undefined, { numeric: true }) ||
+			right.mtimeMs - left.mtimeMs,
+		);
+		const retired: string[] = [];
+		for (const candidate of managed.slice(1)) {
+			const currentStats = await lstat(candidate.managedPath);
+			if (!currentStats.isDirectory() || currentStats.isSymbolicLink() || currentStats.dev !== candidate.stats.dev || currentStats.ino !== candidate.stats.ino) {
+				throw new Error(`managed cache retirement target changed before removal: ${candidate.path}`);
+			}
+			await rm(candidate.managedPath, { recursive: true, force: true });
+			retired.push(candidate.path);
+		}
+		return retired;
+	} finally {
+		for (const candidateHandle of candidateHandles.reverse()) await candidateHandle.close();
+		if (baseHandle) await baseHandle.close();
 	}
-	const managed: Array<{ path: string; managedPath: string; version: string; mtimeMs: number }> = [];
-	for (const entry of entries) {
-		if (!entry.isDirectory() || entry.name === currentVersion) continue;
-		const path = join(managedBase, entry.name);
-		const manifest = await readRegularOmxPluginCacheManifest(path, path);
-		if (manifest?.name !== OMX_PLUGIN_NAME || manifest.version !== entry.name) continue;
-		if (!(await hasRegularPublicationMarker(path, ".omx-complete")) || await hasRegularPublicationMarker(path, ".omx-incomplete")) continue;
-		if (existsSync(join(path, ".omx-live-pin"))) continue;
-		managed.push({ path: join(cacheBase, entry.name), managedPath: path, version: entry.name, mtimeMs: (await lstat(path)).mtimeMs });
-	}
-	managed.sort((left, right) =>
-		right.version.localeCompare(left.version, undefined, { numeric: true }) ||
-		right.mtimeMs - left.mtimeMs,
-	);
-	const retired: string[] = [];
-	for (const candidate of managed.slice(1)) {
-		await rm(candidate.managedPath, { recursive: true, force: true });
-		retired.push(candidate.path);
-	}
-	return retired;
 }
 
 interface MaterializePackagedOmxPluginCacheOptions {
@@ -1044,7 +1254,6 @@ async function materializePackagedOmxPluginCacheImpl(
 	}
 	if (!options.dryRun) {
 		const cacheBase = omxPluginCacheBase(codexHomeDir);
-		await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
 		const noFollowFlags = fsConstants.O_NOFOLLOW;
 		const directoryFlags = fsConstants.O_DIRECTORY;
 		if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
@@ -1075,25 +1284,10 @@ async function materializePackagedOmxPluginCacheImpl(
 			};
 		}
 		const lockPath = join(cacheBaseFdPath, ".omx-publish.lock");
-		let lockHandle;
+		let lockHandle: FileHandle;
 		try {
-			lockHandle = await open(
-				lockPath,
-				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlags,
-				0o600,
-			);
+			lockHandle = await claimPublicationLock(cacheBaseFdPath, cacheBase, noFollowFlags);
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-				if (cacheBaseHandle) await cacheBaseHandle.close();
-				return {
-					status: "stale-launcher",
-					cacheDir,
-					version,
-					reason: `another OMX plugin cache publication is active at ${cacheBase}; refusing concurrent publication`,
-					launcherTarget: undefined,
-					retiredDirs: [],
-				};
-			}
 			if (cacheBaseHandle) await cacheBaseHandle.close();
 			return {
 				status: "stale-launcher",
@@ -1112,7 +1306,10 @@ async function materializePackagedOmxPluginCacheImpl(
 			retiredDirs: [],
 		};
 		let cleanupError: unknown = null;
+		let lockIdentity: Stats | undefined;
+		let finalHandle: FileHandle | undefined;
 		try {
+			lockIdentity = await lockHandle.stat();
 			tempDir = await mkdtemp(join(cacheBaseFdPath, `.omx-plugin-${version}-`));
 			const snapshotDir = await stageCompletePluginSnapshot(
 				tempDir,
@@ -1120,25 +1317,45 @@ async function materializePackagedOmxPluginCacheImpl(
 				version,
 				options.teamMode,
 			);
-			const completeMarker = join(snapshotDir, ".omx-complete");
-			await writeFile(completeMarker, `${process.pid}\n`);
-			await syncRegularFile(completeMarker);
-			await syncDirectory(snapshotDir);
+			await syncDirectoryTree(snapshotDir);
 			const finalPath = join(cacheBaseFdPath, version);
+			await options.onCacheDirPrepared?.(cacheDir);
 			try {
-				await lstat(finalPath);
-				outcome = {
-					status: "stale-launcher",
-					cacheDir,
-					version,
-					reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
-					launcherTarget: undefined,
-					retiredDirs: [],
-				};
-			} catch (error) {
-				if (!isMissingPathError(error)) throw error;
-				await rename(snapshotDir, finalPath);
+				await mkdir(finalPath);
+				finalHandle = await open(finalPath, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+				const finalFdPath = directoryFdPath(finalHandle.fd);
+				if (!finalFdPath) throw new Error("platform cannot expose an anchored publication directory descriptor");
+				await writeFile(join(finalFdPath, ".omx-incomplete"), `${process.pid}\n`);
+				await syncRegularFile(join(finalFdPath, ".omx-incomplete"));
+				const stagedEntries = await readdir(snapshotDir, { withFileTypes: true });
+				for (const entry of stagedEntries) {
+					if (entry.isSymbolicLink()) throw new Error(`refusing to publish symlinked cache entry: ${entry.name}`);
+					await rename(join(snapshotDir, entry.name), join(finalFdPath, entry.name));
+				}
+				await syncDirectoryTree(finalFdPath, finalHandle);
+				await writeFile(join(finalFdPath, ".omx-complete"), `${process.pid}\n`);
+				await syncRegularFile(join(finalFdPath, ".omx-complete"));
+				await rm(join(finalFdPath, ".omx-incomplete"), { force: true });
+				await syncDirectory(finalFdPath);
+				const finalPathStats = await lstat(finalPath);
+				const finalDescriptorStats = await finalHandle.stat();
+				if (!finalPathStats.isDirectory() || finalPathStats.isSymbolicLink() || finalPathStats.dev !== finalDescriptorStats.dev || finalPathStats.ino !== finalDescriptorStats.ino) {
+					throw new Error(`published cache directory changed before validation: ${cacheDir}`);
+				}
 				if (!options.anchoredCacheBasePath) await syncDirectory(cacheBase);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+					outcome = {
+						status: "stale-launcher",
+						cacheDir,
+						version,
+						reason: `same-version OMX plugin cache appeared concurrently at ${cacheDir}; refusing to replace an immutable cache`,
+						launcherTarget: undefined,
+						retiredDirs: [],
+					};
+				} else {
+					throw error;
+				}
 			}
 		} catch (error) {
 			outcome = {
@@ -1151,6 +1368,11 @@ async function materializePackagedOmxPluginCacheImpl(
 			};
 		} finally {
 			try {
+				if (finalHandle) await finalHandle.close();
+			} catch (error) {
+				cleanupError ??= error;
+			}
+			try {
 				if (tempDir) await rm(tempDir, { recursive: true, force: true });
 			} catch (error) {
 				cleanupError = error;
@@ -1161,6 +1383,11 @@ async function materializePackagedOmxPluginCacheImpl(
 				cleanupError ??= error;
 			}
 			try {
+				if (!lockIdentity) throw new Error(`publication lock identity unavailable at ${cacheBase}`);
+				const currentLockStats = await lstat(lockPath);
+				if (currentLockStats.dev !== lockIdentity.dev || currentLockStats.ino !== lockIdentity.ino) {
+					throw new Error(`publication lock changed before cleanup at ${cacheBase}`);
+				}
 				await rm(lockPath, { force: true });
 				if (!options.anchoredCacheBasePath) await syncDirectory(cacheBase);
 			} catch (error) {
@@ -1224,7 +1451,6 @@ export async function materializePackagedOmxPluginCache(
 	if (!version) return { status: "unavailable" };
 	const cacheBase = omxPluginCacheBase(codexHomeDir);
 	const cacheDir = join(cacheBase, version);
-	await ensureManagedCacheNamespace(cacheBase, codexHomeDir);
 	const noFollowFlags = fsConstants.O_NOFOLLOW;
 	const directoryFlags = fsConstants.O_DIRECTORY;
 	if (typeof noFollowFlags !== "number" || typeof directoryFlags !== "number") {
@@ -1237,32 +1463,27 @@ export async function materializePackagedOmxPluginCache(
 			retiredDirs: [],
 		};
 	}
-	let cacheBaseHandle;
+	let namespace: { handle: FileHandle; fdPath: string; handles: FileHandle[] } | null;
 	try {
-		cacheBaseHandle = await open(cacheBase, fsConstants.O_RDONLY | directoryFlags | noFollowFlags);
+		namespace = await openManagedCacheNamespace(cacheBase, codexHomeDir, { create: !options.dryRun });
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
-		return {
-			status: "stale-launcher",
-			cacheDir,
-			version,
-			reason: `cannot anchor OMX plugin cache namespace at ${cacheBase}: ${code ?? "open failed"}; refusing to trust or publish cache contents`,
-			launcherTarget: undefined,
-			retiredDirs: [],
-		};
+		if (code === "EINVAL" || code === "ENOTSUP" || code === "EOPNOTSUPP") {
+			return {
+				status: "stale-launcher",
+				cacheDir,
+				version,
+				reason: `cannot anchor OMX plugin cache namespace at ${cacheBase}: ${code}; refusing to trust or publish cache contents`,
+				launcherTarget: undefined,
+				retiredDirs: [],
+			};
+		}
+		throw error;
 	}
-	const cacheBaseFdPath = directoryFdPath(cacheBaseHandle.fd);
-	if (!cacheBaseFdPath) {
-		await cacheBaseHandle.close();
-		return {
-			status: "stale-launcher",
-			cacheDir,
-			version,
-			reason: "platform cannot expose an anchored cache directory descriptor for immutable cache validation/publication",
-			launcherTarget: undefined,
-			retiredDirs: [],
-		};
+	if (!namespace) {
+		return { status: "materialized", cacheDir, version, retiredDirs: [] };
 	}
+	const cacheBaseFdPath = namespace.fdPath;
 	let result: OmxPluginCacheMaterializeResult;
 	try {
 		result = await materializePackagedOmxPluginCacheImpl(
@@ -1284,14 +1505,20 @@ export async function materializePackagedOmxPluginCache(
 			retiredDirs: [],
 		};
 	}
-	try {
-		await cacheBaseHandle.close();
-	} catch (error) {
+	let closeError: unknown = null;
+	for (const handle of namespace.handles.reverse()) {
+		try {
+			await handle.close();
+		} catch (error) {
+			closeError ??= error;
+		}
+	}
+	if (closeError) {
 		return {
 			status: "stale-launcher",
 			cacheDir,
 			version,
-			reason: `anchored OMX plugin cache descriptor close failed closed: ${(error as Error).message}`,
+			reason: `anchored OMX plugin cache descriptor close failed closed: ${(closeError as Error).message}`,
 			launcherTarget: undefined,
 			retiredDirs: [],
 		};

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -126,6 +126,26 @@ test("durability warning names combined regular-file and directory degradation",
 	]);
 });
 
+test("plugin cache publication treats Windows EPERM fsync as degraded success", () => {
+	const tracker: RegularFileDurabilityTracker = { degraded: false };
+	recordRegularFileSyncOutcome(tracker, "unsupported-windows-eperm");
+	recordDirectorySyncOutcome(tracker, "unsupported-windows-eperm");
+	const originalWrite = process.stderr.write;
+	const warnings: string[] = [];
+	process.stderr.write = ((value: string) => {
+		warnings.push(value);
+		return true;
+	}) as typeof process.stderr.write;
+	try {
+		emitDegradedDurabilityWarning("plugin cache publication", tracker);
+	} finally {
+		process.stderr.write = originalWrite;
+	}
+	assert.deepEqual(warnings, [
+		"[omx] warning: Windows EPERM regular-file and directory fsync unsupported in plugin cache publication; operation succeeded with degraded durability.\n",
+	]);
+});
+
 test("a throwing stderr sink cannot fail an already successful transaction", () => {
 	const originalWrite = process.stderr.write;
 	const tracker: RegularFileDurabilityTracker = { degraded: false };

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -8,7 +8,8 @@ export type DurabilityWarningSubsystem =
 	| "session pointer end"
 	| "native-hook setup"
 	| "native-hook uninstall"
-	| "native-hook claim-journal recovery";
+	| "native-hook claim-journal recovery"
+	| "plugin cache publication";
 
 export interface RegularFileDurabilityTracker {
 	degraded: boolean;


### PR DESCRIPTION
Closes #3552

Fixes the fresh exact-head #3568 blockers after #3575:

- Doctor now gives the succeeding `codex plugin remove oh-my-codex@oh-my-codex-local --json` then `omx setup --plugin` remediation path for invalid immutable cache provenance while retaining pointer-specific diagnostics.
- Cache provenance reads are descriptor-bound with `O_NOFOLLOW`, regular-file checks, and before/after identity validation to close lstat/read TOCTOU swaps.
- Added repeated companion symlink-swap regressions for `.mcp.json` and `.app.json`, preserving external sentinels.

Verification: 18 focused provenance tests, 106 full plugin/setup/doctor tests, lint, tsc --noEmit, check:no-unused, and build.