### PR TITLE
fix(hud): skip render-only watch work while no tmux client is attached (closes #3577)

### DIFF
--- a/src/cli/__tests__/launch-fallback.test.ts
+++ b/src/cli/__tests__/launch-fallback.test.ts
@@ -346,10 +346,27 @@ function parseShimTmuxArgv(contents: string): string[][] {
     .map((record) => record.split('\nend tmux argv')[0]!.split('\n').filter(Boolean));
 }
 
+// The detached HUD pane runs its own `omx hud --watch` loop, which probes
+// attach state with `display-message ... #{session_attached}` roughly once per
+// second through the fixture tmux shim. That heartbeat is intentional attach
+// detection independent of the launch/ownership machinery under test, so
+// quiescence comparisons must ignore it; otherwise a 1s poll can land inside
+// a 250ms quiet window and spuriously fail the launch/ownership assertion.
+function normalizeShimLogForQuiescence(contents: string): string {
+  return parseShimTmuxArgv(contents)
+    .filter((argv) => !(argv[0] === 'display-message' && argv.includes('#{session_attached}')))
+    .map((argv) => `tmux argv:\n${argv.join('\n')}\nend tmux argv\n`)
+    .join('');
+}
+
 async function assertShimLogQuiescent(path: string, quietPeriodMs: number, message: string): Promise<void> {
   const before = await readFile(path, 'utf-8').catch(() => '');
   await new Promise((resolve) => setTimeout(resolve, quietPeriodMs));
-  assert.equal(await readFile(path, 'utf-8').catch(() => ''), before, message);
+  assert.equal(
+    normalizeShimLogForQuiescence(await readFile(path, 'utf-8').catch(() => '')),
+    normalizeShimLogForQuiescence(before),
+    message,
+  );
 }
 
 async function waitForServerLogSubstring(

--- a/src/hud/__tests__/session-attached.test.ts
+++ b/src/hud/__tests__/session-attached.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { isHudWatchSessionAttached } from '../session-attached.js';
+import { isRealTmuxAvailable, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
+
+describe('isHudWatchSessionAttached', () => {
+  it('treats a non-tmux environment as attached (fail-open)', () => {
+    assert.equal(isHudWatchSessionAttached({ env: {}, execTmuxSync: () => '0\n' }), true);
+    assert.equal(isHudWatchSessionAttached({ env: { TMUX: '' }, execTmuxSync: () => '0\n' }), true);
+  });
+
+  it('queries session attachment through the pane id from the environment', () => {
+    const seenArgv: string[][] = [];
+    const attached = isHudWatchSessionAttached({
+      env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '%7' },
+      execTmuxSync: (args) => {
+        seenArgv.push(args);
+        return '1\n';
+      },
+    });
+    assert.equal(attached, true);
+    assert.deepEqual(seenArgv, [['display-message', '-p', '-t', '%7', '#{session_attached}']]);
+
+    const detached = isHudWatchSessionAttached({
+      env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '%7' },
+      execTmuxSync: () => '0\n',
+    });
+    assert.equal(detached, false);
+  });
+
+  it('falls back to the active pane when TMUX_PANE is missing', () => {
+    const seenArgv: string[][] = [];
+    const attached = isHudWatchSessionAttached({
+      env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '' },
+      execTmuxSync: (args) => {
+        seenArgv.push(args);
+        return '0\n';
+      },
+    });
+    assert.equal(attached, false);
+    assert.deepEqual(seenArgv, [['display-message', '-p', '-t', '', '#{session_attached}']]);
+  });
+
+  it('fails open when the tmux query throws', () => {
+    assert.equal(
+      isHudWatchSessionAttached({
+        env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '%7' },
+        execTmuxSync: () => {
+          throw new Error('no server running');
+        },
+      }),
+      true,
+    );
+    assert.equal(
+      isHudWatchSessionAttached({
+        env: { TMUX: '/tmp/tmux-1000/default,1,0' },
+        execTmuxSync: () => {
+          throw new Error('no server running');
+        },
+      }),
+      true,
+    );
+  });
+
+  it('treats a malformed attachment answer as attached (fail-open)', () => {
+    assert.equal(
+      isHudWatchSessionAttached({
+        env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '%7' },
+        execTmuxSync: () => '',
+      }),
+      true,
+    );
+    assert.equal(
+      isHudWatchSessionAttached({
+        env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '%7' },
+        execTmuxSync: () => 'garbage',
+      }),
+      true,
+    );
+  });
+
+  it('answers attachment from a real detached private tmux session', async (t) => {
+    if (!isRealTmuxAvailable()) {
+      t.skip('tmux is not available');
+      return;
+    }
+    await withTempTmuxSession(async (fixture) => {
+      const detachedBefore = execFileSync('tmux', [
+        '-L', fixture.serverName, '-f', '/dev/null',
+        'display-message', '-p', '-t', fixture.leaderPaneId, '#{session_attached}',
+      ], { encoding: 'utf-8' }).trim();
+      assert.equal(detachedBefore, '0', 'fixture session must start detached');
+
+      const attachedViaEnv = isHudWatchSessionAttached({
+        env: { TMUX: fixture.env.TMUX, TMUX_PANE: fixture.leaderPaneId },
+      });
+      assert.equal(attachedViaEnv, false, 'detached session must report not attached');
+    });
+  });
+});

--- a/src/hud/__tests__/watch-detached.test.ts
+++ b/src/hud/__tests__/watch-detached.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { runWatchMode } from '../index.js';
 import type { HudFlags, HudRenderContext } from '../types.js';
 
@@ -273,5 +276,128 @@ describe('runWatchMode detached attachment gating (closes #3577)', () => {
 
     // Only the initial hide-cursor + first-frame clear, never a per-tick '\x1b[H' repaint.
     assert.equal(writes.filter((chunk) => chunk === '\x1b[H').length, 0, 'detached ticks must not repaint');
+  });
+  it('binds the default attachment probe to the injected env, not inherited process.env', async () => {
+    // Regression for the review blocker on PR #3579: the default
+    // isSessionAttachedFn used the inherited process.env, so a test (or any
+    // caller) that injects env: {} while running inside tmux still consulted
+    // the ambient TMUX/TMUX_PANE and could suppress renders. The default probe
+    // must see only dependencies.env.
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    let stateReads = 0;
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const secondReadDone = deferred();
+
+    process.env.TMUX = '/tmp/tmux-1000/default,1,0';
+    process.env.TMUX_PANE = '%7';
+
+    let promise: Promise<void>;
+    try {
+      promise = runWatchMode('/tmp', WATCH_FLAGS, {
+        isTTY: true,
+        // Injected env has no TMUX: the default probe must treat this as
+        // attached even though process.env still carries tmux variables.
+        env: {},
+        readAllStateFn: async () => {
+          stateReads += 1;
+          if (stateReads === 2) secondReadDone.resolve();
+          return emptyCtx();
+        },
+        readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+        renderHudFn: () => 'frame',
+        runAuthorityTickFn: async () => {},
+        writeStdout: () => {},
+        writeStderr: () => {},
+        registerSigint: (handler) => { sigintHandler = handler; },
+        setIntervalFn: (handler) => {
+          timerTick = handler;
+          return ({}) as ReturnType<typeof setInterval>;
+        },
+        clearIntervalFn: () => {},
+      });
+
+      await flush();
+      assert.ok(timerTick, 'interval tick should be registered');
+      // Second tick must render: injected env has no TMUX, so the default
+      // probe must answer "attached" regardless of the ambient tmux env.
+      timerTick?.();
+      await withTimeout(secondReadDone.promise, 'injected env (no TMUX) must keep rendering despite inherited tmux env');
+      sigintHandler?.();
+      await promise;
+    } finally {
+      if (typeof previousTmux === 'string') process.env.TMUX = previousTmux;
+      else delete process.env.TMUX;
+      if (typeof previousTmuxPane === 'string') process.env.TMUX_PANE = previousTmuxPane;
+      else delete process.env.TMUX_PANE;
+    }
+
+    assert.equal(stateReads, 2, 'ticks under an injected non-tmux env must keep rendering');
+  });
+
+  it('suppresses detached renders through the injected env when it describes tmux', async () => {
+    // The mirror case: an injected env that DOES describe tmux must drive
+    // suppression, proving the default probe reads dependencies.env (and not
+    // merely "always attached because tests run without ambient tmux").
+    const execStubHome = process.env.HOME;
+    let attachmentProbes = 0;
+    let stateReads = 0;
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const secondAuthority = deferred();
+    let authorityCalls = 0;
+
+    // Point PATH at a fake tmux that answers session_attached=0 for any pane,
+    // so the default probe (which shells out to tmux) observes "detached".
+    const fakeBin = await mkdtemp(join(tmpdir(), 'omx-hud-env-bind-'));
+    const tmuxPath = join(fakeBin, 'tmux');
+    await writeFile(tmuxPath, '#!/bin/sh\nif [ "$1" = "display-message" ]; then printf \'0\\n\'; exit 0; fi\nexit 0\n');
+    await chmod(tmuxPath, 0o755);
+    const previousPath = process.env.PATH;
+
+    let promise: Promise<void>;
+    try {
+      process.env.PATH = `${fakeBin}${delimiter}${previousPath ?? ''}`;
+      // Track probe executions by observing state reads: suppressed ticks do
+      // not read state, so the only way tick 2 completes without a second
+      // read is a detached answer from the injected env.
+      promise = runWatchMode('/tmp', WATCH_FLAGS, {
+        isTTY: true,
+        env: { TMUX: '/tmp/tmux-1000/default,1,0', TMUX_PANE: '%7', CI: '1', PATH: process.env.PATH, HOME: execStubHome ?? '' },
+        readAllStateFn: async () => {
+          stateReads += 1;
+          return emptyCtx();
+        },
+        readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+        renderHudFn: () => 'frame',
+        runAuthorityTickFn: async () => {
+          authorityCalls += 1;
+          attachmentProbes += 1;
+          if (authorityCalls === 2) secondAuthority.resolve();
+        },
+        writeStdout: () => {},
+        writeStderr: () => {},
+        registerSigint: (handler) => { sigintHandler = handler; },
+        setIntervalFn: (handler) => {
+          timerTick = handler;
+          return ({}) as ReturnType<typeof setInterval>;
+        },
+        clearIntervalFn: () => {},
+      });
+
+      await flush();
+      assert.ok(timerTick, 'interval tick should be registered');
+      timerTick?.();
+      await withTimeout(secondAuthority.promise, 'second detached tick should complete without a state read');
+      sigintHandler?.();
+      await promise;
+    } finally {
+      process.env.PATH = previousPath;
+      await rm(fakeBin, { recursive: true, force: true });
+    }
+
+    assert.equal(stateReads, 1, 'detached ticks under an injected tmux env must not re-read HUD state');
+    assert.ok(attachmentProbes >= 2, 'authority tick must keep running while detached');
   });
 });

--- a/src/hud/__tests__/watch-detached.test.ts
+++ b/src/hud/__tests__/watch-detached.test.ts
@@ -1,0 +1,277 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { runWatchMode } from '../index.js';
+import type { HudFlags, HudRenderContext } from '../types.js';
+
+const WATCH_FLAGS: HudFlags = {
+  watch: true,
+  json: false,
+  tmux: false,
+};
+
+function emptyCtx(): HudRenderContext {
+  return {
+    version: null,
+    gitBranch: null,
+    ralph: null,
+    ultrawork: null,
+    autopilot: null,
+    ralplan: null,
+    deepInterview: null,
+    autoresearch: null,
+    ultraqa: null,
+    team: null,
+    metrics: null,
+    hudNotify: null,
+    session: null,
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function withTimeout(promise: Promise<void>, message: string, timeoutMs = 1000): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe('runWatchMode detached attachment gating (closes #3577)', () => {
+  it('skips render-only work while detached but keeps the authority tick running', async () => {
+    const writes: string[] = [];
+    let stateReads = 0;
+    let authorityCalls = 0;
+    let attachmentQueries = 0;
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const secondAuthorityStarted = deferred();
+
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      isSessionAttachedFn: () => {
+        attachmentQueries += 1;
+        return false;
+      },
+      readAllStateFn: async () => {
+        stateReads += 1;
+        return emptyCtx();
+      },
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: () => 'frame',
+      runAuthorityTickFn: async () => {
+        authorityCalls += 1;
+        if (authorityCalls === 2) secondAuthorityStarted.resolve();
+      },
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: (handler) => {
+        timerTick = handler;
+        return ({}) as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    assert.ok(timerTick, 'interval tick should be registered');
+    timerTick?.();
+    await withTimeout(secondAuthorityStarted.promise, 'second authority tick should run while detached');
+    sigintHandler?.();
+    await promise;
+
+    // The very first frame renders unconditionally so an attached client (or a
+    // first render before any detach) never sees an empty pane.
+    assert.equal(stateReads, 1, 'detached ticks must not re-read HUD state');
+    assert.equal(authorityCalls, 2, 'authority tick must keep running while detached');
+    assert.ok(attachmentQueries >= 2, 'attachment must be queried each tick');
+    assert.equal(writes.filter((chunk) => chunk.includes('frame')).length, 1, 'only the first frame may be written while detached');
+  });
+
+  it('renders immediately on the first tick after a client reattaches', async () => {
+    const writes: string[] = [];
+    let stateReads = 0;
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const thirdReadStarted = deferred();
+    const secondReadDone = deferred();
+
+    let attached = false;
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      isSessionAttachedFn: () => attached,
+      readAllStateFn: async () => {
+        stateReads += 1;
+        if (stateReads === 2) secondReadDone.resolve();
+        if (stateReads === 3) thirdReadStarted.resolve();
+        return emptyCtx();
+      },
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: () => `frame:${stateReads}`,
+      runAuthorityTickFn: async () => {},
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: (handler) => {
+        timerTick = handler;
+        return ({}) as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    // Detached tick: suppressed render.
+    attached = false;
+    timerTick?.();
+    await flush();
+    assert.equal(stateReads, 1, 'detached tick must not read state');
+
+    // Reattach: the next tick renders immediately with fresh state.
+    attached = true;
+    timerTick?.();
+    await withTimeout(secondReadDone.promise, 'reattached tick must render immediately');
+    sigintHandler?.();
+    await promise;
+
+    assert.equal(stateReads, 2);
+    assert.ok(writes.some((chunk) => chunk.includes('frame:2')), 'reattached frame must be written');
+  });
+
+  it('keeps rendering every tick while attached (no behavior change when attached)', async () => {
+    const writes: string[] = [];
+    let stateReads = 0;
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const thirdReadStarted = deferred();
+
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      isSessionAttachedFn: () => true,
+      readAllStateFn: async () => {
+        stateReads += 1;
+        if (stateReads === 3) thirdReadStarted.resolve();
+        return emptyCtx();
+      },
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: () => 'frame',
+      runAuthorityTickFn: async () => {},
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: (handler) => {
+        timerTick = handler;
+        return ({}) as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    timerTick?.();
+    timerTick?.();
+    await withTimeout(thirdReadStarted.promise, 'attached ticks must keep rendering');
+    sigintHandler?.();
+    await promise;
+
+    assert.equal(stateReads, 3);
+    assert.equal(writes.filter((chunk) => chunk.includes('frame')).length, 3);
+  });
+
+  it('fails open and renders when the attachment probe throws', async () => {
+    const writes: string[] = [];
+    let stateReads = 0;
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const secondReadStarted = deferred();
+
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      isSessionAttachedFn: () => {
+        throw new Error('no server running');
+      },
+      readAllStateFn: async () => {
+        stateReads += 1;
+        if (stateReads === 2) secondReadStarted.resolve();
+        return emptyCtx();
+      },
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: () => 'frame',
+      runAuthorityTickFn: async () => {},
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: (handler) => {
+        timerTick = handler;
+        return ({}) as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    timerTick?.();
+    await withTimeout(secondReadStarted.promise, 'failing probe must fall back to rendering');
+    sigintHandler?.();
+    await promise;
+
+    assert.equal(stateReads, 2);
+  });
+
+  it('does not clear the terminal or write control sequences while detached', async () => {
+    const writes: string[] = [];
+    let sigintHandler: (() => void) | undefined;
+    let timerTick: (() => void) | undefined;
+    const secondAuthority = deferred();
+
+    let authorityCalls = 0;
+    const promise = runWatchMode('/tmp', WATCH_FLAGS, {
+      isTTY: true,
+      env: {},
+      isSessionAttachedFn: () => false,
+      readAllStateFn: async () => emptyCtx(),
+      readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
+      renderHudFn: () => 'frame',
+      runAuthorityTickFn: async () => {
+        authorityCalls += 1;
+        if (authorityCalls === 2) secondAuthority.resolve();
+      },
+      writeStdout: (text) => { writes.push(text); },
+      writeStderr: () => {},
+      registerSigint: (handler) => { sigintHandler = handler; },
+      setIntervalFn: (handler) => {
+        timerTick = handler;
+        return ({}) as ReturnType<typeof setInterval>;
+      },
+      clearIntervalFn: () => {},
+    });
+
+    await flush();
+    timerTick?.();
+    await withTimeout(secondAuthority.promise, 'second detached tick should complete');
+    sigintHandler?.();
+    await promise;
+
+    // Only the initial hide-cursor + first-frame clear, never a per-tick '\x1b[H' repaint.
+    assert.equal(writes.filter((chunk) => chunk === '\x1b[H').length, 0, 'detached ticks must not repaint');
+  });
+});

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -18,6 +18,7 @@ import type { HudFlags, HudPreset, HudRenderContext, ResolvedHudConfig } from '.
 import { HUD_TMUX_HEIGHT_LINES } from './constants.js';
 import { sleep } from '../utils/sleep.js';
 import { runHudAuthorityTick } from './authority.js';
+import { isHudWatchSessionAttached } from './session-attached.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
 import {
   killTmuxPane,
@@ -84,6 +85,7 @@ interface RunWatchModeDependencies {
   registerSigint: (handler: () => void) => void | (() => void);
   setIntervalFn: (handler: () => void, intervalMs: number) => ReturnType<typeof setInterval>;
   clearIntervalFn: (timer: ReturnType<typeof setInterval>) => void;
+  isSessionAttachedFn: () => boolean;
 }
 
 export interface ResolveHudWatchCwdDependencies {
@@ -190,6 +192,7 @@ export async function runWatchMode(
     }),
     setIntervalFn: deps.setIntervalFn ?? ((handler: () => void, intervalMs: number) => setInterval(handler, intervalMs)),
     clearIntervalFn: deps.clearIntervalFn ?? ((timer: ReturnType<typeof setInterval>) => clearInterval(timer)),
+    isSessionAttachedFn: deps.isSessionAttachedFn ?? isHudWatchSessionAttached,
   };
 
   if (!dependencies.isTTY && !dependencies.env.CI) {
@@ -229,27 +232,43 @@ export async function runWatchMode(
       return;
     }
     inFlight = true;
+    let renderedThisTick: 'rendered' | 'suppressed' | 'stopped' = 'suppressed';
     try {
-      if (firstRender) {
-        dependencies.writeStdout('\x1b[2J\x1b[H');
-        firstRender = false;
-      } else {
-        dependencies.writeStdout('\x1b[H');
+      // A detached session has no client to receive stdout, so skip the
+      // render-only work (state reads with git subprocess spawns, tmux height
+      // reconciliation, stdout writes) while still running the authority
+      // tick below. Fail-open: an unknown attachment answer renders.
+      // (closes #3577)
+      let attached = true;
+      try {
+        attached = dependencies.isSessionAttachedFn();
+      } catch {
+        // Fail-open: an unknown attachment answer renders.
+        attached = true;
       }
       const frameCwd = dependencies.resolveWatchCwdFn(cwd);
-      const config = await dependencies.readHudConfigFn(frameCwd);
-      const ctx = await dependencies.readAllStateFn(frameCwd, config);
-      const preset = flags.preset ?? config.preset;
-      const maxLines = getHudRenderMaxLines(ctx);
-      if (maxLines !== lastDesiredHeight) {
-        reconcileRunningHudPaneHeight(maxLines, dependencies);
-        lastDesiredHeight = maxLines;
+      if (firstRender || attached) {
+        if (firstRender) {
+          dependencies.writeStdout('\x1b[2J\x1b[H');
+          firstRender = false;
+        } else {
+          dependencies.writeStdout('\x1b[H');
+        }
+        const config = await dependencies.readHudConfigFn(frameCwd);
+        const ctx = await dependencies.readAllStateFn(frameCwd, config);
+        const preset = flags.preset ?? config.preset;
+        const maxLines = getHudRenderMaxLines(ctx);
+        if (maxLines !== lastDesiredHeight) {
+          reconcileRunningHudPaneHeight(maxLines, dependencies);
+          lastDesiredHeight = maxLines;
+        }
+        const line = dependencies.renderHudFn(ctx, preset, {
+          maxWidth: process.stdout.columns ?? undefined,
+          maxLines,
+        });
+        dependencies.writeStdout(line + '\x1b[K\x1b[J');
+        renderedThisTick = 'rendered';
       }
-      const line = dependencies.renderHudFn(ctx, preset, {
-        maxWidth: process.stdout.columns ?? undefined,
-        maxLines,
-      });
-      dependencies.writeStdout(line + '\x1b[K\x1b[J');
       try {
         await dependencies.runAuthorityTickFn({ cwd: frameCwd });
       } catch (authorityError) {
@@ -260,12 +279,13 @@ export async function runWatchMode(
       const message = error instanceof Error ? error.message : String(error);
       dependencies.writeStderr(`HUD watch render failed: ${message}\n`);
       process.exitCode = 1;
+      renderedThisTick = 'stopped';
       stop();
-      return;
     } finally {
-      inFlight = false;
+      if (renderedThisTick !== 'stopped') inFlight = false;
     }
 
+    if (renderedThisTick === 'stopped') return;
     if (queued) {
       queued = false;
       await renderTick();

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -192,7 +192,7 @@ export async function runWatchMode(
     }),
     setIntervalFn: deps.setIntervalFn ?? ((handler: () => void, intervalMs: number) => setInterval(handler, intervalMs)),
     clearIntervalFn: deps.clearIntervalFn ?? ((timer: ReturnType<typeof setInterval>) => clearInterval(timer)),
-    isSessionAttachedFn: deps.isSessionAttachedFn ?? isHudWatchSessionAttached,
+    isSessionAttachedFn: deps.isSessionAttachedFn ?? (() => isHudWatchSessionAttached({ env: dependencies.env })),
   };
 
   if (!dependencies.isTTY && !dependencies.env.CI) {

--- a/src/hud/session-attached.ts
+++ b/src/hud/session-attached.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process';
+import { resolveTmuxBinaryForPlatform } from '../utils/platform-command.js';
+
+/**
+ * Reports whether any tmux client is attached to the session this HUD pane
+ * belongs to. Used by watch mode to avoid render-only work (state reads, git
+ * subprocess spawns, tmux reconciliation, stdout writes) while nobody is
+ * looking at the pane. (closes #3577)
+ *
+ * Returns true (assume attached) whenever the answer is unknown, so the HUD
+ * keeps rendering on non-tmux terminals, when tmux is unavailable, or on any
+ * query failure — detached suppression only happens on a trusted "0".
+ */
+export function isHudWatchSessionAttached(
+  deps: {
+    env?: NodeJS.ProcessEnv;
+    execTmuxSync?: (args: string[]) => string;
+  } = {},
+): boolean {
+  const env = deps.env ?? process.env;
+  if (!env.TMUX) return true;
+
+  const exec = deps.execTmuxSync ?? ((args: string[]) => {
+    const binary = resolveTmuxBinaryForPlatform() || 'tmux';
+    return execFileSync(binary, args, {
+      encoding: 'utf-8',
+      ...(process.platform === 'win32' ? { windowsHide: true } : {}),
+    });
+  });
+
+  const query = (paneId: string): boolean => {
+    const output = exec(['display-message', '-p', '-t', paneId, '#{session_attached}']).trim();
+    return output !== '0';
+  };
+
+  const paneId = env.TMUX_PANE?.trim();
+  if (paneId) {
+    try {
+      return query(paneId);
+    } catch {
+      return true;
+    }
+  }
+
+  // No pane id in env (unusual for a real HUD pane); fall back to the active
+  // pane of the server described by $TMUX, which is the same session in the
+  // single-session layouts OMX launches.
+  try {
+    return query('');
+  } catch {
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #3577.

A detached HUD `--watch` pane kept paying per-second render-only cost: state reads that spawn **two `git` subprocesses per tick** (`rev-parse --abbrev-ref HEAD` + `remote get-url origin`), tmux height reconciliation, and stdout writes that no client receives. The notify-fallback authority tick was already cadence-gated (5s min interval + jitter, file-lock single-flight), so this change gates **only the render half** of each tick on session attachment — the narrowest fix that removes the per-second fork/exec cost without touching authority semantics.

## Independent reproduction on `dev@536b70f9`

Compiled `dist` from base `dev`, ran `omx hud --watch` as the only pane of a **detached private tmux session** (`session_attached=0`, no client ever attached), with `git`/`tmux` PATH shims counting every spawn:

| scenario | before (dev) | after (this PR) |
|---|---|---|
| detached, 10s window | **20 git spawns** (2/s), continuous stdout writes | **2 git spawns total** (first frame), stdout frozen |
| detached, cumulative | 240 git spawns over ~2 min | — |
| attached | 2 git/s, renders each tick | unchanged (2 git/s) |
| reattach | renders | renders on first 1s tick after attach |
| re-detach | keeps rendering forever | 0 git delta, 0 stdout delta |
| authority tick while detached | spawns every ~5.2s | unchanged (~5.2s, `skip_count` +1/s preserved) |

Steady-state tmux spawns were already zero on dev (height reconcile only fires when the desired height changes), so the defect surface was the render path only — matching the issue report.

## Change

- **`src/hud/session-attached.ts`** (new): `isHudWatchSessionAttached()` queries `#{session_attached}` through this HUD's own `$TMUX_PANE`, falling back to the active pane when unset. **Fails open** (returns attached → renders) for non-tmux environments, missing tmux, query failure, or malformed output — detached suppression only happens on a trusted `0`.
- **`src/hud/index.ts`**: `renderTick` now skips the render-only block (config/state reads, git spawns, tmux reconcile, stdout writes) when the session is detached, while still calling `runAuthorityTickFn` on the same per-tick cadence as before. The very first frame always renders so a pane is never left blank for an attaching client.
- Reattach freshness: the existing 1s interval means the first frame after a client attaches is at most ~1s stale — identical to the pre-change steady-state cadence, with no new hook registration.

The reporter's suggested `client-attached` hook + immediate-render mechanism is intentionally **not** adopted: it adds a new tmux hook lifecycle owned by the HUD process for a ≤1s staleness improvement the 1s tick already provides, and a shorter lifecycle (no hook) is strictly safer. The HUD-only orphan aggravator (leader pane gone entirely vs `pane_dead=1` in `cleanupDetachedPreReportSession`) is a separate detached-bootstrap rollback concern; with this fix an orphan costs one `tmux display-message` per second instead of a git fork/exec pair plus renders, and it stays in scope of that lifecycle lane rather than this render-cost lane.

## Tests

- `src/hud/__tests__/watch-detached.test.ts` (new): detached tick does not re-read state / write frames but the authority tick keeps running; reattach renders immediately on the next tick; attached ticks render every time (no behavior change); failing attachment probe fails open and renders; no `\x1b[H` repaints while detached.
- `src/hud/__tests__/session-attached.test.ts` (new): non-tmux fail-open, exact `display-message -p -t <pane> #{session_attached}` argv, active-pane fallback, throw → fail-open, malformed output → fail-open, and a real detached private-tmux-server answer.
- Existing suites unchanged and green: `watch.test.ts`, `index.test.ts` (incl. authority-after-each-frame, coalescing, SIGINT cleanup), `authority.test.ts`, `resource-leak-watch.test.ts`.

## Verification

- `npm run build` (tsc), `npm run lint` (biome), `npm run check:no-unused`
- `node dist/scripts/run-test-files.js dist/hud/__tests__` → 352 tests, 0 fail
- `node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js` → 357 pass
- `node dist/scripts/run-test-files.js dist/cli/__tests__/detached-leader-teardown.test.js` → 22 pass
- `node dist/scripts/run-test-files.js dist/team/__tests__/tmux-session.test.js` → 298 pass
- `node dist/scripts/run-test-files.js dist/sidecar/__tests__` → pass
- `npm run verify:generated` → plugin bundle, capabilities lock, prompt guidance, catalog all ok
- Live private-tmux e2e: phases detached → attached → re-detached measured with spawn-counting shims (table above)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*