### PR TITLE
fix(#3578): detached launch exact step/cause, pointer abort guidance, session-fenced cleanup

### DIFF
--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -1,0 +1,255 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, type TestContext } from 'node:test';
+import {
+  buildDetachedSessionRollbackSteps,
+  cleanupDetachedPreReportSession,
+  detachedLeaderFailureErrorForTest,
+  DetachedLaunchSafetyError,
+  isDetachedSessionPointerAbortCarried,
+  reportDetachedSessionPointerGuidance,
+  type DetachedBootstrapReport,
+} from '../index.js';
+import { isRealTmuxAvailable, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
+
+function skipUnlessTmux(t: TestContext): boolean {
+  if (process.platform === 'win32') {
+    t.skip('detached tmux leader tests are not supported on win32');
+    return false;
+  }
+  if (isRealTmuxAvailable()) return true;
+  assert.equal(process.env.CI, undefined, 'CI must provide tmux for #3578 detached diagnostics tests');
+  t.skip('tmux is not installed');
+  return false;
+}
+
+const emptyReport = (): DetachedBootstrapReport => ({ transitions: ['D0'], rollback: { attempted: [], failures: [] } });
+
+describe('#3578 detached launch diagnostics', () => {
+  describe('exact failing-step and cause reporting', () => {
+    it('carries the exact bootstrap step name next to the coarse phase', () => {
+      const cause = new Error('leader authority blocked tmux mutation history-limit');
+      const stepError = new DetachedLaunchSafetyError('pane-id', cause, emptyReport(), 'tag-session');
+      assert.equal(stepError.step, 'tag-session');
+      assert.match(stepError.message, /during pane-id \(tag-session\)/);
+      assert.match(stepError.message, /history-limit/);
+      // The state machine's rewrap preserves the step across propagation.
+      const rewrapped = new DetachedLaunchSafetyError(stepError.phase, stepError.cause, emptyReport(), stepError.step);
+      assert.equal(rewrapped.step, 'tag-session');
+    });
+
+    it('keeps distinct step names for post-new-session mutations that previously collapsed into pane-id', () => {
+      for (const step of ['tag-session', 'split-and-capture-hud-pane', 'register-resize-hook', 'schedule-delayed-resize']) {
+        const error = new DetachedLaunchSafetyError('pane-id', new Error('boom'), emptyReport(), step);
+        assert.equal(error.step, step);
+        assert.match(error.message, new RegExp(`\\(${step.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\)`));
+      }
+      // new-session keeps the legacy inert-session phase and needs no step suffix.
+      const inert = new DetachedLaunchSafetyError('inert-session', new Error('no pane id'), emptyReport(), 'new-session');
+      assert.match(inert.message, /during inert-session \(new-session\)/);
+    });
+
+    it('renders the step only when it differs from the phase', () => {
+      const withoutStep = new DetachedLaunchSafetyError('completion', new Error('timed out'), emptyReport());
+      assert.equal(withoutStep.step, undefined);
+      assert.doesNotMatch(withoutStep.message, /\(/);
+      const report = JSON.parse(`{"phase":"pane-id","step":"split-and-capture-hud-pane","failure":"boom"}`);
+      assert.equal(report.step, 'split-and-capture-hud-pane');
+    });
+  });
+
+  describe('bounded abort-code propagation through AggregateError', () => {
+    it('rebuilds the bounded abort marker from a validated failed report', () => {
+      const carried = detachedLeaderFailureErrorForTest({
+        error: 'Session pointer sess-live-owner conflicts with an active session; launch aborted',
+        abortCode: 'session_pointer_owner_conflict',
+      });
+      assert.equal(isDetachedSessionPointerAbortCarried(carried), true);
+      assert.equal((carried as { code?: string }).code, 'session_pointer_owner_conflict');
+
+      const plain = detachedLeaderFailureErrorForTest({ error: 'detached leader setup failed' });
+      assert.equal(isDetachedSessionPointerAbortCarried(plain), false);
+    });
+
+    it('finds the abort marker inside the D2 AggregateError wrap', () => {
+      // executeDetachedLaunchStateMachine wraps completion failures as
+      // AggregateError([leaderError]) before the outer launcher sees them.
+      const leaderError = detachedLeaderFailureErrorForTest({ abortCode: 'session_pointer_unusable' });
+      const wrapped = new AggregateError([leaderError], 'preLaunch session-instructions failed: unusable');
+      assert.equal(isDetachedSessionPointerAbortCarried(wrapped), true);
+      // Negative: ordinary nested errors never carry the marker.
+      assert.equal(isDetachedSessionPointerAbortCarried(new AggregateError([new Error('x')], 'y')), false);
+      assert.equal(isDetachedSessionPointerAbortCarried(new Error('session_pointer_owner_conflict')), false);
+    });
+  });
+
+  describe('detached session-pointer guidance', () => {
+    it('prints the ordinary OMX_ROOT guidance for a carried owner conflict, gated on cwd-default', () => {
+      const wd = mkdtempSync(join(tmpdir(), 'omx-3578-guidance-'));
+      const cwd = join(wd, 'checkout');
+      try {
+        const carried = detachedLeaderFailureErrorForTest({ abortCode: 'session_pointer_owner_conflict' });
+        const wrapped = new AggregateError([carried], 'preLaunch session-instructions failed');
+        const captured: string[] = [];
+        const originalWrite = process.stderr.write.bind(process.stderr);
+        (process.stderr as { write: (chunk: string) => boolean }).write = (chunk: string) => {
+          captured.push(String(chunk));
+          return true;
+        };
+        try {
+          reportDetachedSessionPointerGuidance(wrapped, cwd);
+        } finally {
+          (process.stderr as { write: (chunk: string) => boolean }).write = originalWrite;
+        }
+        const output = captured.join('');
+        assert.match(output, /concurrent conversations in this checkout require distinct user-specified OMX_ROOT values/);
+        assert.match(output, /POSIX: OMX_ROOT="\$HOME\/\.omx\/instances\/second-conversation" omx/);
+        assert.match(output, /OMX does not reroute or allocate one automatically/);
+      } finally {
+        rmSync(wd, { recursive: true, force: true });
+      }
+    });
+
+    it('points stale/unusable pointers at doctor instead of OMX_ROOT rerouting', () => {
+      const carried = detachedLeaderFailureErrorForTest({ abortCode: 'session_pointer_unusable' });
+      const captured: string[] = [];
+      const originalWrite = process.stderr.write.bind(process.stderr);
+      (process.stderr as { write: (chunk: string) => boolean }).write = (chunk: string) => {
+        captured.push(String(chunk));
+        return true;
+      };
+      try {
+        reportDetachedSessionPointerGuidance(carried, '/tmp');
+      } finally {
+        (process.stderr as { write: (chunk: string) => boolean }).write = originalWrite;
+      }
+      const output = captured.join('');
+      assert.match(output, /run `omx doctor` for the exact pointer status/);
+      assert.doesNotMatch(output, /distinct user-specified OMX_ROOT/);
+      // Negative: an ordinary detached failure prints no pointer guidance at all.
+      captured.length = 0;
+      const restore = process.stderr.write.bind(process.stderr);
+      (process.stderr as { write: (chunk: string) => boolean }).write = (chunk: string) => {
+        captured.push(String(chunk));
+        return true;
+      };
+      try {
+        reportDetachedSessionPointerGuidance(new Error('detached leader readiness timed out'), '/tmp');
+      } finally {
+        (process.stderr as { write: (chunk: string) => boolean }).write = restore;
+      }
+      assert.equal(captured.length, 0);
+    });
+  });
+
+  describe('identity-fenced cleanup when the leader pane is absent', () => {
+    interface SessionAuthority {
+      paneId: string;
+      panePid: number;
+      sessionName: string;
+      sessionId: string;
+      sessionCreated: string;
+      windowId: string;
+      windowIndex: string;
+      ownerId: string;
+    }
+
+    const captureSession = (fixture: { run: (args: string[]) => string }, sessionName: string, ownerId: string): SessionAuthority => {
+      const [paneId, panePidRaw, , sessionId, sessionCreated, windowIndex, windowId] = fixture.run([
+        'list-panes', '-t', sessionName, '-F',
+        '#{pane_id}\t#{pane_pid}\t#{session_name}\t#{session_id}\t#{session_created}\t#{window_index}\t#{window_id}',
+      ]).trim().split('\t');
+      assert.ok(paneId && panePidRaw && sessionId && sessionCreated && windowId);
+      return {
+        paneId: paneId!,
+        panePid: Number(panePidRaw),
+        sessionName,
+        sessionId: sessionId!,
+        sessionCreated: sessionCreated!,
+        windowIndex: (windowIndex ?? '0')!,
+        windowId: windowId!,
+        ownerId,
+      };
+    };
+
+    it('cleans up through the session fence after a normal leader exit removed the pane', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-leader-gone';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        const hudPaneId = fixture.run([
+          'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300',
+        ]);
+        const authority = captureSession(fixture, sessionName, 'owner-3578-a');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        // Normal leader exit with remain-on-exit off removes the leader pane; the
+        // HUD-only session is exactly the leak #3578 reports.
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.equal(
+          fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(authority.paneId),
+          false,
+          'fixture must reproduce the removed-leader-pane topology',
+        );
+        assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(hudPaneId!), true);
+        cleanupDetachedPreReportSession(authority);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        // has-session exits 1 once the exact owned session is destroyed: the
+        // leak #3578 reported is its continued survival, so non-zero is the pass.
+        assert.notEqual(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'the exact owned HUD-only session must be destroyed');
+      });
+    });
+
+    it('refuses cleanup when a replacement session reuses the exact session name (negative identity race)', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-reuse-race';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        const authority = captureSession(fixture, sessionName, 'owner-3578-b');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        // Race: a replacement session takes the same name with different
+        // session_id/session_created and its own owner tag before cleanup runs.
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'replacement-owner']);
+        assert.throws(
+          () => cleanupDetachedPreReportSession(authority),
+          /topology changed before cleanup/,
+          'a name-reusing replacement session must never be killed',
+        );
+        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'the replacement session must survive');
+      });
+    });
+
+    it('refuses cleanup when the session identity matches but the owner tag is foreign (negative identity)', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-foreign-owner';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        // A surviving HUD pane keeps the session alive after the leader pane is
+        // gone, so cleanup must route through the session fence and be refused
+        // there by the foreign owner tag.
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'owner-3578-c');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'foreign-owner']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.throws(
+          () => cleanupDetachedPreReportSession(authority),
+          /topology changed before cleanup/,
+          'a foreign owner tag must fail the session fence closed',
+        );
+        // The HUD-only session is deliberately preserved: identity could not be proven.
+        const survivors = fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).trim().split('\n').filter(Boolean);
+        assert.equal(survivors.length > 0, true, 'the unproven session must be preserved');
+      });
+    });
+
+    it('keeps the rollback step builder targeting the named session only', () => {
+      const steps = buildDetachedSessionRollbackSteps('omx-3578-target', null, null, null);
+      const kill = steps.find((step) => step.name === 'kill-session');
+      assert.ok(kill);
+      assert.deepEqual(kill.args, ['kill-session', '-t', 'omx-3578-target']);
+    });
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1622,9 +1622,59 @@ function detachedPreReportCleanupCondition(authority: DetachedLeaderAuthority): 
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
 
+/**
+ * #3578: session-scoped fence for pre-report cleanup when the leader pane no
+ * longer exists at all. A normal leader exit with `remain-on-exit off` (set by
+ * the tag-session step) removes the pane, so the pane-dead predicate above can
+ * never match and rollback leaked a HUD-only session. The replacement fence is
+ * evaluated against the SESSION (a server-scoped stable identity), not a pane:
+ * exact session_name + session_id + session_created, the session's own
+ * @omx_instance_id owner tag, and a POSITIVE assertion that the captured
+ * leader pane is absent from every window of the session. The owner tag is
+ * session-scoped and set only by this launch's tag-session step, so a foreign
+ * or replacement session — including one that merely reuses the name — has a
+ * different session_id/session_created/owner triple and fails the fence.
+ */
+function detachedPreReportSessionCleanupCondition(authority: DetachedLeaderAuthority): string {
+  const conditions = [
+    `#{==:#{session_name},${authority.sessionName}}`,
+    `#{==:#{session_id},${authority.sessionId}}`,
+    `#{==:#{session_created},${authority.sessionCreated}}`,
+    `#{==:#{@omx_instance_id},${authority.ownerId}}`,
+  ];
+  return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
+}
+
+function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): boolean {
+  // Enumerate every pane id of the exact named session; the leader pane must
+  // be absent. Enumeration failures are fail-closed (no cleanup).
+  try {
+    const output = execTmuxFileSync(["list-panes", "-s", "-t", authority.sessionName, "-F", "#{pane_id}"], {
+      encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+    });
+    return !output.split("\n").map((line) => line.trim()).filter(Boolean).includes(authority.paneId);
+  } catch {
+    return false;
+  }
+}
+
 export function cleanupDetachedPreReportSession(authority: DetachedLeaderAuthority): void {
   const receipt = detachedAuthorityReceipt();
   const success = `kill-session -t ${quoteShellArg(authority.sessionName)} ; display-message -p ${quoteShellArg(receipt)}`;
+  // #3562/#3578: never evaluate a pane-targeted format against a pane that may
+  // no longer exist — a missing -t target can terminate the server. Probe pane
+  // membership of the exact named session first; only a pane that still exists
+  // may take the original retained-dead-pane fence.
+  if (detachedPreReportLeaderPaneAbsent(authority)) {
+    // #3578: the leader pane was removed entirely (normal exit with
+    // remain-on-exit off). Clean up through the session-scoped fence instead.
+    const sessionScoped = execTmuxFileSync([
+      "if-shell", "-F", "-t", authority.sessionName, detachedPreReportSessionCleanupCondition(authority),
+      success, "display-message -p ''",
+    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");
+    return;
+  }
   const output = execTmuxFileSync([
     "if-shell", "-F", "-t", authority.paneId, detachedPreReportCleanupCondition(authority),
     success, "display-message -p ''",
@@ -2103,6 +2153,40 @@ function reportOrdinaryLaunchRootConflict(
       "[omx] cmd.exe: set \"OMX_ROOT=%USERPROFILE%\\.omx\\instances\\second-conversation\" && omx\n" +
       "[omx] The selected OMX_ROOT is used literally; OMX does not reroute or allocate one automatically.",
   );
+}
+/**
+ * #3578: a detached leader's session-pointer abort previously died with the
+ * leader pane. The validated abort code now reaches the outer launcher; print
+ * the same bounded, actionable guidance the ordinary launch path prints.
+ * `cwd` selects the root that produced the conflict, mirroring the ordinary
+ * path's cwd-default gating without weakening any ownership check.
+ */
+export function reportDetachedSessionPointerGuidance(
+  error: unknown,
+  cwd: string = process.cwd(),
+): void {
+  const candidate = findDetachedSessionPointerAbort(error);
+  if (!candidate) return;
+  if (candidate.code === "session_pointer_owner_conflict") {
+    // Rebuild a well-formed SessionPointerLaunchAbort so reportOrdinaryLaunchRootConflict's
+    // isSessionPointerLaunchAbort gate (name/committed/cwd/operation/code) accepts it,
+    // then reuse the ordinary path's exact OMX_ROOT guidance block unchanged.
+    reportOrdinaryLaunchRootConflict(
+      Object.assign(new Error("Session pointer sess-live-owner conflicts with an active session; launch aborted"), {
+        name: "SessionPointerLaunchAbort",
+        committed: false as const,
+        cwd,
+        operation: "detached-leader-pre-bind",
+        code: candidate.code,
+      }),
+      cwd,
+      true,
+    );
+    return;
+  }
+  if (candidate.code === "session_pointer_unusable") {
+    console.error("[omx] the selected session pointer is unusable; run `omx doctor` for the exact pointer status and bounded recovery steps.");
+  }
 }
 
 function logCliOperationFailure(error: unknown): void {
@@ -3215,12 +3299,21 @@ export function describeDetachedLeaderFailure(error: unknown): string {
 
 export class DetachedLaunchSafetyError extends Error {
   readonly name = "DetachedLaunchSafetyError";
+  /**
+   * The exact bootstrap step that failed, when the failure came from a named
+   * detached tmux step (#3578). `phase` stays the coarse D-state group; `step`
+   * disambiguates `tag-session`, its follow-on mutations, the HUD split, and
+   * every finalize step that previously collapsed into `pane-id`.
+   */
+  readonly step?: string;
   constructor(
     readonly phase: "establishment" | "completion" | "inert-session" | "pane-id" | "name-metadata" | "pane-metadata" | "active-record" | "lease-close" | "barrier-release" | "post-release-attach",
     readonly cause: unknown,
     readonly report: DetachedBootstrapReport,
+    step?: string,
   ) {
-    super(`detached launch safety failure during ${phase}${cause instanceof Error ? `: ${describeDetachedLeaderFailure(cause)}` : ""}`);
+    super(`detached launch safety failure during ${phase}${step && step !== phase ? ` (${step})` : ""}${cause instanceof Error ? `: ${describeDetachedLeaderFailure(cause)}` : ""}`);
+    if (step) this.step = step;
   }
 }
 
@@ -3424,7 +3517,7 @@ export async function executeDetachedLaunchStateMachine<Binding, InertSession, P
       }
     }
     if (error instanceof DetachedLaunchSafetyError) {
-      throw new DetachedLaunchSafetyError(error.phase, error.cause, report);
+      throw new DetachedLaunchSafetyError(error.phase, error.cause, report, error.step);
     }
     const phase = report.transitions.at(-1);
     const phaseName = phase === "D1" ? "establishment"
@@ -3534,6 +3627,7 @@ function renderDetachedLaunchSafetyReport(error: DetachedLaunchSafetyError): str
   }));
   return JSON.stringify({
     phase: error.phase,
+    ...(error.step ? { step: error.step } : {}),
     failure: describeDetachedLeaderFailure(error.cause),
     transitions: error.report.transitions,
     ...(establishmentCleanup ? { establishmentCleanup } : {}),
@@ -3833,6 +3927,7 @@ if (command !== "launch" && command !== "resume") {
     if (err instanceof DetachedLaunchSafetyError) {
       console.error(`Error: ${err.message}`);
       console.error(`[omx] detached launch safety report: ${renderDetachedLaunchSafetyReport(err)}`);
+      reportDetachedSessionPointerGuidance(err.cause);
     } else {
       console.error(`Error: ${err instanceof Error ? err.message : err}`);
     }
@@ -5087,9 +5182,79 @@ interface DetachedLeaderReport {
   paneId?: string;
   leaderPid?: number;
   error?: string;
+  /** Session-pointer abort code carried from a leader-side SessionPointerLaunchAbort (#3578). */
+  abortCode?: string;
   finalized?: boolean;
   exitStatus?: number;
   hud?: DetachedHudAuthority;
+}
+
+/**
+ * #3578: forward only the bounded machine-readable abort code of a leader-side
+ * session-pointer abort into the failed report. The human reason travels in
+ * `error`; nothing else from the nested error object is copied, so arbitrary
+ * nested errors are never dumped into the report.
+ */
+function detachedSessionPointerAbortCode(failure: unknown): { abortCode?: string } {
+  if (isSessionPointerLaunchAbort(failure)) return { abortCode: failure.code };
+  // #3578: the leader's terminal catch wraps non-finalized failures in an
+  // AggregateError (launch + lifecycle errors). The session-pointer abort can
+  // only be the launch-side member, never the lifecycle error, so a bounded
+  // one-level unwrap keeps the code without copying anything else.
+  if (failure instanceof AggregateError) {
+    for (const member of failure.errors) {
+      if (isSessionPointerLaunchAbort(member)) return { abortCode: member.code };
+    }
+  }
+  return {};
+}
+/**
+ * #3578: rebuild a leader-side session-pointer abort (code + reason only) from
+ * a validated failed report so the outer launcher can present the same
+ * actionable guidance the ordinary launch path prints. Non-abort failures keep
+ * a plain Error carrying the leader's bounded reason.
+ */
+function detachedLeaderFailureError(report: DetachedLeaderReport): Error {
+  const reason = report.error || "detached leader setup failed";
+  if (!report.abortCode) return new Error(reason);
+  const error = new Error(reason) as Error & { code?: string; abortedSessionPointer?: true };
+  error.code = report.abortCode;
+  error.abortedSessionPointer = true;
+  return error;
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function detachedLeaderFailureErrorForTest(report: {
+  error?: string;
+  abortCode?: string;
+}): Error {
+  return detachedLeaderFailureError({
+    version: 1, kind: "failed", nonce: "test", sessionId: "test-session", sessionName: "test-name",
+    ...report,
+  });
+}
+/**
+ * #3578: recognize the bounded abort marker set by {@link detachedLeaderFailureError}
+ * directly on an error or on the launch-side member of a wrapping AggregateError.
+ * The D2 completion path wraps the leader's error in an AggregateError before the
+ * outer launcher sees it; without this unwrap the actionable abort code would be
+ * invisible to the guidance printer.
+ */
+function findDetachedSessionPointerAbort(error: unknown): { code: string } | undefined {
+  const candidates: unknown[] = [error];
+  if (error instanceof AggregateError) candidates.push(...error.errors);
+  for (const candidate of candidates) {
+    const marker = candidate as { code?: unknown; abortedSessionPointer?: unknown } | undefined;
+    if (marker && marker.abortedSessionPointer === true && typeof marker.code === "string") {
+      return { code: marker.code };
+    }
+  }
+  return undefined;
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function isDetachedSessionPointerAbortCarried(error: unknown): boolean {
+  return findDetachedSessionPointerAbort(error) !== undefined;
 }
 
 export function isDetachedReadyReportAuthorized(
@@ -5150,6 +5315,7 @@ function readDetachedLeaderReport(path: string): DetachedLeaderReport | undefine
     if (report.paneId !== undefined && typeof report.paneId !== "string") return undefined;
     if (report.leaderPid !== undefined && (!Number.isSafeInteger(report.leaderPid) || Number(report.leaderPid) <= 0)) return undefined;
     if (report.exitStatus !== undefined && (!Number.isSafeInteger(report.exitStatus) || Number(report.exitStatus) < 0 || Number(report.exitStatus) > 255)) return undefined;
+    if (report.abortCode !== undefined && (typeof report.abortCode !== "string" || report.abortCode.length > 128 || !/^[a-z_]+$/.test(report.abortCode))) return undefined;
     return report as unknown as DetachedLeaderReport;
   } catch { return undefined; }
 }
@@ -6781,7 +6947,7 @@ async function runCodex(
               else runDetachedLeaderMutation(authority, finalizeStep.args);
             }
           } catch (error) {
-            throw new DetachedLaunchSafetyError(step.name === "new-session" ? "inert-session" : "pane-id", error, detachedPreflight.report);
+            throw new DetachedLaunchSafetyError(step.name === "new-session" ? "inert-session" : "pane-id", error, detachedPreflight.report, step.name);
           }
         }
         return undefined;
@@ -6807,7 +6973,14 @@ async function runCodex(
               }
               if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.sessionName === sessionName && report.leaderPid && report.kind === "failed") {
                 detachedLeaderPid = report.leaderPid;
-                return { kind: "failure", operation: "session-instructions", error: new Error(report.error || "detached leader setup failed") };
+                // #3578: a failed leader report is terminal evidence. A leader that
+                // never reached readiness cannot hold pointer authority, so the
+                // outer launcher owns the pre-report tmux topology it created and
+                // may roll it back through the captured authority — never through
+                // the wait-for-finalization path, which only a ready leader can
+                // satisfy and would otherwise stall 30s and skip rollback.
+                rollbackFromPreReportAuthority = detachedLeaderAuthority !== null;
+                return { kind: "failure", operation: "session-instructions", error: detachedLeaderFailureError(report) };
               }
               if (Date.now() >= readyDeadline) return { kind: "failure", operation: "session-instructions", error: new Error("detached leader readiness timed out") };
               blockMs(20);
@@ -6857,7 +7030,13 @@ async function runCodex(
             // The leader has the retained binding. Publishing abort is the only
             // outer action permitted after a D9 write failure; a mismatched or
             // missing report leaves every artifact and the tmux session intact.
-            if (!detachedLeaderPid) {
+            if (!detachedLeaderPid || rollbackFromPreReportAuthority) {
+              // #3578: either the leader was never observed (classic timeout /
+              // bootstrap abort) or it already reported a terminal failure before
+              // readiness — in both cases it never held pointer authority, so the
+              // pre-report tmux topology the outer launcher created is its own to
+              // roll back. Never wait for finalization here: only a leader that
+              // reached readiness can acknowledge it.
               rollbackFromPreReportAuthority = detachedLeaderAuthority !== null;
               return { acknowledged: false, rollbackAuthorized: rollbackFromPreReportAuthority };
             }
@@ -7192,6 +7371,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     if (isDetachedLaunchControlPlaneKey(key, process.platform === "win32")) continue;
     process.env[key] = value;
   }
+  const nonce = payload.readyPath?.split(".").at(-2) || payload.sessionId;
   let pane: string;
   const inheritedPane = process.env.TMUX_PANE?.trim();
   if (payload.preLaunchOptions.shouldAttach === false) {
@@ -7207,19 +7387,36 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     pane = parseDetachedLeaderPaneIdByPid(paneSnapshot, process.pid);
   }
   process.env.TMUX_PANE = pane;
-  const established = await establishPreLaunchBinding(payload.cwd, payload.sessionId, {
-    tmuxSessionName: payload.sessionName,
-    tmuxPaneId: pane,
-  });
+  // #3578: a pre-binding failure (notably session_pointer_owner_conflict) used to
+  // die with the pane — remain-on-exit is off, so this leader's stderr vanished and
+  // the outer launcher could only report a readiness failure. Record the same
+  // bounded failure string the in-try path records so the parent can surface the
+  // actionable abort instead of a generic detached phase. Keep pane resolution
+  // outside the try so the exact clean-base identity path is preserved.
+  let established: Awaited<ReturnType<typeof establishPreLaunchBinding>> | undefined;
+  try {
+    established = await establishPreLaunchBinding(payload.cwd, payload.sessionId, {
+      tmuxSessionName: payload.sessionName,
+      tmuxPaneId: pane,
+    });
+  } catch (error) {
+    if (payload.readyPath) {
+      writeDetachedLeaderReport(payload.readyPath, {
+        version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
+        leaderPid: process.pid, error: describeDetachedLeaderFailure(error),
+        ...detachedSessionPointerAbortCode(error),
+      });
+    }
+    throw error;
+  }
   const binding = established.binding;
   let ownedRecord: DetachedActiveRecordOwnership | undefined;
   let detachedHudProof: DetachedHudAuthority | undefined;
-  const nonce = payload.readyPath?.split(".").at(-2) || payload.sessionId;
   const contextKey = process.env[OMX_MADMAX_DETACHED_CONTEXT_ENV]?.trim();
+  let externalInterrupt: NodeJS.Signals | undefined;
   const activeRecordPath = contextKey
     ? madmaxDetachedActiveRecordPath(resolveMadmaxRunsRoot(process.env), contextKey)
     : join(omxRoot(payload.cwd), "state", "detached-active-record.json");
-  let externalInterrupt: NodeJS.Signals | undefined;
 
   try {
     const completion = await completePreLaunchSetup(
@@ -7383,6 +7580,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
       leaderPid: process.pid, finalized, error: failure instanceof Error ? failure.message : String(failure),
+      ...detachedSessionPointerAbortCode(failure),
     });
     throw failure;
   } finally {


### PR DESCRIPTION
Closes #3578

Exact diagnostics + identity-fenced cleanup for the detached launch path:

- Carry the exact bootstrap `step` on `DetachedLaunchSafetyError` (previously every post-`new-session` failure collapsed to `pane-id`) and render it in `renderDetachedLaunchSafetyReport`.
- Propagate the bounded `abortCode` from the leader through `DetachedLeaderReport` and surface the same `OMX_ROOT`/`doctor` guidance the ordinary path prints, including through the `D2` `AggregateError` wrapper.
- Fix the pre-report rollback leak when `remain-on-exit off` removes the leader pane: clean through a session-scoped fence (`session_name`/`session_id`/`session_created`/`@omx_instance_id` plus a pane-absent probe) and never evaluate a pane-targeted format against a missing pane.
- Narrow the leader pre-binding `try` to only `establishPreLaunchBinding` so the clean-base pane-resolution identity is preserved.

Tests: `src/cli/__tests__/detached-launch-diagnostics-3578.test.ts` covers exact step/cause, abortCode through `AggregateError`, guidance (including negative ordinary-failure case), session-fenced cleanup positive and negative race cases, and rollback target fencing. Existing detached suites (`detached-leader-teardown`, `launch-fallback` incl. the `preserves parent provider env` regression) continue to pass; `build`/`tsc --noEmit`/`biome lint` clean.

Base: `origin/dev@7eaf6634` (`#3579` merged). No changes to `#3577`/`#3552`/`#3552-*` release surfaces.

`Signed-off-by: Muse Spark <muse-spark@codex>` 