### PR TITLE
fix(#3578): fail-closed cleanup when exact session lookup fails

### DIFF
--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -354,7 +354,7 @@ describe('#3578 detached launch diagnostics', () => {
         assert.throws(
           () => cleanupDetachedPreReportSessionForTest(authority, () => {
             // This callback is the deterministic interposition point between
-            // detachedPreReportLeaderPaneAbsent and the destructive sink.
+            // detachedPreReportLeaderPaneState and the destructive sink.
             fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'foreign-race-owner']);
           }),
           /topology changed before cleanup/,
@@ -371,13 +371,11 @@ describe('#3578 detached launch diagnostics', () => {
       if (!skipUnlessTmux(t)) return;
       await withTempTmuxSession(async (fixture) => {
         const sessionName = 'omx-3578-ready-handoff-race';
-        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
         fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
         const authority = captureSession(fixture, sessionName, 'ready-handoff-owner');
         fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
-        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
-        await new Promise((resolve) => setTimeout(resolve, 5_500));
-        assert.equal(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']), '1');
+        assert.equal(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']), '0');
         const foreignSessionName = `${sessionName}-foreign`;
         fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
         let lateReadyReport: {
@@ -397,29 +395,29 @@ describe('#3578 detached launch diagnostics', () => {
           leaderPaneId: authority.paneId,
           leaderPanePid: authority.panePid,
         };
-        assert.throws(
-          () => cleanupDetachedPreReportSessionForTest(
-            authority,
-            () => {
-              // Deterministic completion-timeout/rollback barrier: the valid
-              // ready report is published only after topology probing and
-              // before the destructive session sink.
-              lateReadyReport = {
-                version: 1,
-                kind: 'ready',
-                nonce: expected.nonce,
-                sessionId: expected.sessionId,
-                sessionName: expected.sessionName,
-                paneId: authority.paneId,
-                leaderPid: authority.panePid,
-              };
-            },
-            false,
-            () => isDetachedReadyReportAuthorized(lateReadyReport, expected),
-          ),
-          /became ready or terminal before pre-report cleanup/,
-          'late authenticated readiness must suppress rollback cleanup',
+        cleanupDetachedPreReportSessionForTest(
+          authority,
+          () => {},
+          false,
+          () => {
+            // Completion has already read false. A valid ready report lands
+            // after that read but before the destructive sink is queued.
+            assert.equal(lateReadyReport, undefined);
+            return false;
+          },
+          () => {
+            lateReadyReport = {
+              version: 1,
+              kind: 'ready',
+              nonce: expected.nonce,
+              sessionId: expected.sessionId,
+              sessionName: expected.sessionName,
+              paneId: authority.paneId,
+              leaderPid: authority.panePid,
+            };
+          },
         );
+        assert.equal(isDetachedReadyReportAuthorized(lateReadyReport, expected), true, 'the late report must be authenticated');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'ready session must survive');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive');
       });

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -222,6 +222,22 @@ describe('#3578 detached launch diagnostics', () => {
       });
     });
 
+    it('rechecks the tag-attempt marker inside the destructive predicate', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-owner-phase-interposition';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'owner-phase-interposition');
+        cleanupDetachedLeaderSessionAfterFailureForTest(authority, authority.ownerId, () => {
+          // Simulate tag-session completing after any earlier observation but
+          // before the single queued destructive predicate evaluates.
+          fixture.run(['set-option', '-t', sessionName, '@omx_detached_owner_tag_attempted', '1']);
+        });
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'same-command marker recheck must preserve');
+      });
+    });
+
     interface SessionAuthority {
       paneId: string;
       panePid: number;

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -395,33 +395,28 @@ describe('#3578 detached launch diagnostics', () => {
           leaderPaneId: authority.paneId,
           leaderPanePid: authority.panePid,
         };
-        assert.throws(
-          () => cleanupDetachedPreReportSessionForTest(
-            authority,
-            () => {},
-            false,
-            () => {
-              // Completion has already read false. A valid ready report lands
-              // after that read but before the destructive session retry.
-              if (lateReadyReport) return isDetachedReadyReportAuthorized(lateReadyReport, expected);
-              return false;
-            },
-            () => {
-              lateReadyReport = {
-                version: 1,
-                kind: 'ready',
-                nonce: expected.nonce,
-                sessionId: expected.sessionId,
-                sessionName: expected.sessionName,
-                paneId: authority.paneId,
-                leaderPid: authority.panePid,
-              };
-            },
-            true,
-          ),
-          /became ready or terminal before pre-report cleanup/,
-          'late authenticated readiness must suppress cleanup retry',
+        const cleanupStartedAt = Date.now();
+        cleanupDetachedPreReportSessionForTest(
+          authority,
+          () => {},
+          false,
+          () => false,
+          () => {
+            // Completion has already read false. A valid ready report lands
+            // after that read; the live-pane branch must preserve immediately
+            // without entering the failed-report retry wait.
+            lateReadyReport = {
+              version: 1,
+              kind: 'ready',
+              nonce: expected.nonce,
+              sessionId: expected.sessionId,
+              sessionName: expected.sessionName,
+              paneId: authority.paneId,
+              leaderPid: authority.panePid,
+            };
+          },
         );
+        assert.ok(Date.now() - cleanupStartedAt < 1_000, 'ordinary timeout must not wait for failed-report retry');
         assert.equal(isDetachedReadyReportAuthorized(lateReadyReport, expected), true, 'the late report must be authenticated');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'ready session must survive');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive');
@@ -452,6 +447,7 @@ describe('#3578 detached launch diagnostics', () => {
           () => false,
           undefined,
           true,
+          () => failedReport !== undefined,
         );
         assert.deepEqual(failedReport, { kind: 'failed', sessionId: authority.sessionId, sessionName });
         const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -15,7 +15,6 @@ import {
   isDetachedSessionPointerAbortCarried,
   reportDetachedSessionPointerGuidance,
   resolveDetachedLeaderPaneForTest,
-  scheduleDetachedPreReportCleanupRetryForTest,
   type DetachedBootstrapReport,
 } from '../index.js';
 import { isRealTmuxAvailable, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
@@ -207,6 +206,19 @@ describe('#3578 detached launch diagnostics', () => {
         const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
         assert.equal(sessions.includes(sessionName), false, 'failed leader must clean its exact owned session');
         assert.equal(sessions.includes(foreignSessionName), true, 'failed leader cleanup must not touch unrelated sessions');
+      });
+    });
+
+    it('rejects empty ownership after the tag phase was attempted', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-owner-phase-fence';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'owner-phase-fence');
+        fixture.run(['set-option', '-t', sessionName, '@omx_detached_owner_tag_attempted', '1']);
+        cleanupDetachedLeaderSessionAfterFailureForTest(authority, authority.ownerId);
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'empty owner after tag attempt must preserve');
       });
     });
 
@@ -486,7 +498,7 @@ describe('#3578 detached launch diagnostics', () => {
       });
     });
 
-    it('keeps timeout rollback nonblocking and asynchronously cleans a later authenticated failure', async (t) => {
+    it('keeps timeout rollback nonblocking and lets the leader clean a later authenticated failure', async (t) => {
       if (!skipUnlessTmux(t)) return;
       await withTempTmuxSession(async (fixture) => {
         const sessionName = 'omx-3578-late-failure-async';
@@ -512,7 +524,6 @@ describe('#3578 detached launch diagnostics', () => {
           paneId: string;
           leaderPid: number;
         } | undefined;
-        let cleaned = false;
         const timeoutStartedAt = Date.now();
         cleanupDetachedPreReportSessionForTest(authority, () => {}, false, () => false);
         assert.ok(Date.now() - timeoutStartedAt < 1_000, 'plain timeout must return without synchronous retry wait');
@@ -527,20 +538,14 @@ describe('#3578 detached launch diagnostics', () => {
             paneId: authority.paneId,
             leaderPid: authority.panePid,
           };
+          cleanupDetachedLeaderSessionAfterFailureForTest(authority, authority.ownerId);
         }, 100);
-        scheduleDetachedPreReportCleanupRetryForTest(
-          authority,
-          () => false,
-          () => isDetachedFailedReportAuthorizedForTest(failedReport, expected, 'linux'),
-          () => { cleaned = true; },
-          5_000,
-        );
-        for (let attempt = 0; attempt < 300 && !cleaned; attempt += 1) {
+        for (let attempt = 0; attempt < 100 && fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName); attempt += 1) {
           await new Promise((resolve) => setTimeout(resolve, 20));
         }
-        assert.equal(cleaned, true, 'late authenticated failure must trigger asynchronous cleanup after exit');
+        assert.equal(isDetachedFailedReportAuthorizedForTest(failedReport, expected, 'linux'), true, 'late failure must be authenticated');
         const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
-        assert.equal(sessions.includes(sessionName), false, 'the exact late-failed session must be cleaned');
+        assert.equal(sessions.includes(sessionName), false, 'the leader-owned late-failed session must be cleaned');
         assert.equal(sessions.includes(foreignSessionName), true, 'the unrelated session must survive');
       });
     });

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -395,31 +395,68 @@ describe('#3578 detached launch diagnostics', () => {
           leaderPaneId: authority.paneId,
           leaderPanePid: authority.panePid,
         };
-        cleanupDetachedPreReportSessionForTest(
-          authority,
-          () => {},
-          false,
-          () => {
-            // Completion has already read false. A valid ready report lands
-            // after that read but before the destructive sink is queued.
-            assert.equal(lateReadyReport, undefined);
-            return false;
-          },
-          () => {
-            lateReadyReport = {
-              version: 1,
-              kind: 'ready',
-              nonce: expected.nonce,
-              sessionId: expected.sessionId,
-              sessionName: expected.sessionName,
-              paneId: authority.paneId,
-              leaderPid: authority.panePid,
-            };
-          },
+        assert.throws(
+          () => cleanupDetachedPreReportSessionForTest(
+            authority,
+            () => {},
+            false,
+            () => {
+              // Completion has already read false. A valid ready report lands
+              // after that read but before the destructive session retry.
+              if (lateReadyReport) return isDetachedReadyReportAuthorized(lateReadyReport, expected);
+              return false;
+            },
+            () => {
+              lateReadyReport = {
+                version: 1,
+                kind: 'ready',
+                nonce: expected.nonce,
+                sessionId: expected.sessionId,
+                sessionName: expected.sessionName,
+                paneId: authority.paneId,
+                leaderPid: authority.panePid,
+              };
+            },
+            true,
+          ),
+          /became ready or terminal before pre-report cleanup/,
+          'late authenticated readiness must suppress cleanup retry',
         );
         assert.equal(isDetachedReadyReportAuthorized(lateReadyReport, expected), true, 'the late report must be authenticated');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'ready session must survive');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive');
+      });
+    });
+
+    it('retries cleanup after an authenticated failed report while the leader is still live', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-failed-live-retry';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'failed-live-owner');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        assert.equal(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']), '0');
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        let failedReport: { kind: 'failed'; sessionId: string; sessionName: string } | undefined;
+        cleanupDetachedPreReportSessionForTest(
+          authority,
+          () => {
+            // The authenticated failed report is observable before the leader
+            // exits. Cleanup must retain responsibility instead of returning
+            // success and deleting the marker.
+            failedReport = { kind: 'failed', sessionId: authority.sessionId, sessionName };
+          },
+          false,
+          () => false,
+          undefined,
+          true,
+        );
+        assert.deepEqual(failedReport, { kind: 'failed', sessionId: authority.sessionId, sessionName });
+        const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
+        assert.equal(sessions.includes(sessionName), false, 'the exact failed session must be cleaned after leader exit');
+        assert.equal(sessions.includes(foreignSessionName), true, 'the unrelated session must survive retry');
       });
     });
 

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -7,6 +7,7 @@ import {
   buildDetachedSessionRollbackSteps,
   cleanupDetachedPreReportSession,
   cleanupDetachedPreReportSessionForTest,
+  cleanupDetachedLeaderSessionAfterFailureForTest,
   detachedLeaderFailureErrorForTest,
   DetachedLaunchSafetyError,
   isDetachedFailedReportAuthorizedForTest,
@@ -192,6 +193,23 @@ describe('#3578 detached launch diagnostics', () => {
   });
 
   describe('identity-fenced cleanup when the leader pane is absent', () => {
+    it('lets a failed leader clean its exact owned session after the parent exits', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-leader-owned-failure-cleanup';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'leader-failure-owner');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        cleanupDetachedLeaderSessionAfterFailureForTest(authority, authority.ownerId);
+        const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
+        assert.equal(sessions.includes(sessionName), false, 'failed leader must clean its exact owned session');
+        assert.equal(sessions.includes(foreignSessionName), true, 'failed leader cleanup must not touch unrelated sessions');
+      });
+    });
+
     interface SessionAuthority {
       paneId: string;
       panePid: number;

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupDetachedPreReportSessionForTest,
   detachedLeaderFailureErrorForTest,
   DetachedLaunchSafetyError,
+  isDetachedFailedReportAuthorizedForTest,
   isDetachedReadyReportAuthorized,
   isDetachedSessionPointerAbortCarried,
   reportDetachedSessionPointerGuidance,
@@ -434,22 +435,48 @@ describe('#3578 detached launch diagnostics', () => {
         assert.equal(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']), '0');
         const foreignSessionName = `${sessionName}-foreign`;
         fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
-        let failedReport: { kind: 'failed'; sessionId: string; sessionName: string } | undefined;
+        let failedReport: {
+          version: 1;
+          kind: 'failed';
+          nonce: string;
+          sessionId: string;
+          sessionName: string;
+          paneId: string;
+          leaderPid: number;
+        } | undefined;
+        const failedExpected = {
+          nonce: 'failed-live-nonce',
+          sessionId: authority.sessionId,
+          sessionName,
+          leaderPaneId: authority.paneId,
+          leaderPanePid: authority.panePid,
+        };
         cleanupDetachedPreReportSessionForTest(
           authority,
           () => {
             // The authenticated failed report is observable before the leader
             // exits. Cleanup must retain responsibility instead of returning
             // success and deleting the marker.
-            failedReport = { kind: 'failed', sessionId: authority.sessionId, sessionName };
+            failedReport = {
+              version: 1,
+              kind: 'failed',
+              nonce: failedExpected.nonce,
+              sessionId: failedExpected.sessionId,
+              sessionName: failedExpected.sessionName,
+              paneId: authority.paneId,
+              // Native Windows reports the spawned Node PID, not the
+              // PowerShell-owned tmux pane PID.
+              leaderPid: authority.panePid + 1,
+            };
           },
           false,
           () => false,
           undefined,
           true,
-          () => failedReport !== undefined,
+          () => isDetachedFailedReportAuthorizedForTest(failedReport, failedExpected, 'win32'),
         );
-        assert.deepEqual(failedReport, { kind: 'failed', sessionId: authority.sessionId, sessionName });
+        assert.equal(isDetachedFailedReportAuthorizedForTest(failedReport, failedExpected, 'win32'), true);
+        assert.equal(isDetachedFailedReportAuthorizedForTest(failedReport, failedExpected, 'linux'), false);
         const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
         assert.equal(sessions.includes(sessionName), false, 'the exact failed session must be cleaned after leader exit');
         assert.equal(sessions.includes(foreignSessionName), true, 'the unrelated session must survive retry');

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -13,6 +13,8 @@ import {
   isDetachedReadyReportAuthorized,
   isDetachedSessionPointerAbortCarried,
   reportDetachedSessionPointerGuidance,
+  resolveDetachedLeaderPaneForTest,
+  scheduleDetachedPreReportCleanupRetryForTest,
   type DetachedBootstrapReport,
 } from '../index.js';
 import { isRealTmuxAvailable, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
@@ -31,6 +33,48 @@ function skipUnlessTmux(t: TestContext): boolean {
 const emptyReport = (): DetachedBootstrapReport => ({ transitions: ['D0'], rollback: { attempted: [], failures: [] } });
 
 describe('#3578 detached launch diagnostics', () => {
+  describe('Windows detached leader identity', () => {
+    it('accepts an inherited pane when the tmux session id differs from the OMX session id', () => {
+      assert.equal(resolveDetachedLeaderPaneForTest({
+        sessionName: 'omx-session',
+        inheritedPane: '%42',
+        platform: 'win32',
+        leaderPid: 901,
+        requireInheritedPane: false,
+        identityOutput: 'omx-session\t$7\t%42',
+        paneSnapshot: '%42\t0\t901',
+      }), '%42');
+      assert.throws(() => resolveDetachedLeaderPaneForTest({
+        sessionName: 'omx-session',
+        expectedTmuxSessionId: '$1',
+        inheritedPane: '%42',
+        platform: 'win32',
+        leaderPid: 901,
+        requireInheritedPane: false,
+        identityOutput: 'omx-session\t$7\t%42',
+        paneSnapshot: '%42\t0\t901',
+      }), /inherited pane identity is unavailable/);
+    });
+
+    it('authorizes Windows ready and failed reports by pane identity when process PIDs differ', () => {
+      const expected = {
+        nonce: 'windows-nonce',
+        sessionId: 'omx-session-id',
+        sessionName: 'omx-session',
+        shouldAttach: true,
+        leaderPaneId: '%42',
+        leaderPanePid: 901,
+      };
+      const ready = { version: 1 as const, kind: 'ready' as const, ...expected, paneId: '%42', leaderPid: 1201 };
+      const failed = { version: 1 as const, kind: 'failed' as const, ...expected, paneId: '%42', leaderPid: 1201 };
+      assert.equal(isDetachedReadyReportAuthorized(ready, expected, 'win32'), true);
+      assert.equal(isDetachedReadyReportAuthorized(ready, expected, 'linux'), false);
+      assert.equal(isDetachedFailedReportAuthorizedForTest(failed, expected, 'win32'), true);
+      assert.equal(isDetachedFailedReportAuthorizedForTest(failed, expected, 'linux'), false);
+      assert.equal(isDetachedFailedReportAuthorizedForTest({ ...failed, paneId: '%43' }, expected, 'win32'), false);
+    });
+  });
+
   describe('exact failing-step and cause reporting', () => {
     it('carries the exact bootstrap step name next to the coarse phase', () => {
       const cause = new Error('leader authority blocked tmux mutation history-limit');
@@ -421,6 +465,65 @@ describe('#3578 detached launch diagnostics', () => {
         assert.equal(isDetachedReadyReportAuthorized(lateReadyReport, expected), true, 'the late report must be authenticated');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'ready session must survive');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive');
+      });
+    });
+
+    it('keeps timeout rollback nonblocking and asynchronously cleans a later authenticated failure', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-late-failure-async';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 3']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'late-failure-owner');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        const expected = {
+          nonce: 'late-failure-nonce',
+          sessionId: authority.sessionId,
+          sessionName,
+          leaderPaneId: authority.paneId,
+          leaderPanePid: authority.panePid,
+        };
+        let failedReport: {
+          version: 1;
+          kind: 'failed';
+          nonce: string;
+          sessionId: string;
+          sessionName: string;
+          paneId: string;
+          leaderPid: number;
+        } | undefined;
+        let cleaned = false;
+        const timeoutStartedAt = Date.now();
+        cleanupDetachedPreReportSessionForTest(authority, () => {}, false, () => false);
+        assert.ok(Date.now() - timeoutStartedAt < 1_000, 'plain timeout must return without synchronous retry wait');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true);
+        setTimeout(() => {
+          failedReport = {
+            version: 1,
+            kind: 'failed',
+            nonce: expected.nonce,
+            sessionId: expected.sessionId,
+            sessionName,
+            paneId: authority.paneId,
+            leaderPid: authority.panePid,
+          };
+        }, 100);
+        scheduleDetachedPreReportCleanupRetryForTest(
+          authority,
+          () => false,
+          () => isDetachedFailedReportAuthorizedForTest(failedReport, expected, 'linux'),
+          () => { cleaned = true; },
+          5_000,
+        );
+        for (let attempt = 0; attempt < 300 && !cleaned; attempt += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        assert.equal(cleaned, true, 'late authenticated failure must trigger asynchronous cleanup after exit');
+        const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
+        assert.equal(sessions.includes(sessionName), false, 'the exact late-failed session must be cleaned');
+        assert.equal(sessions.includes(foreignSessionName), true, 'the unrelated session must survive');
       });
     });
 

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -9,6 +9,7 @@ import {
   cleanupDetachedPreReportSessionForTest,
   detachedLeaderFailureErrorForTest,
   DetachedLaunchSafetyError,
+  isDetachedReadyReportAuthorized,
   isDetachedSessionPointerAbortCarried,
   reportDetachedSessionPointerGuidance,
   type DetachedBootstrapReport,
@@ -225,7 +226,7 @@ describe('#3578 detached launch diagnostics', () => {
         );
         const foreignSessionName = `${sessionName}-foreign`;
         fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
-        cleanupDetachedPreReportSession(authority);
+        cleanupDetachedPreReportSession(authority, true);
         await new Promise((resolve) => setTimeout(resolve, 300));
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), false, 'the exact pre-tag session must be destroyed');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'the unrelated session must survive');
@@ -245,7 +246,7 @@ describe('#3578 detached launch diagnostics', () => {
         // session is still in the pre-tag owner-unset state.
         fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
         assert.throws(
-          () => cleanupDetachedPreReportSession(authority),
+          () => cleanupDetachedPreReportSession(authority, true),
           /topology changed before cleanup/,
           'a name-reusing replacement session must never be killed',
         );
@@ -273,6 +274,30 @@ describe('#3578 detached launch diagnostics', () => {
         // The HUD-only session is deliberately preserved: identity could not be proven.
         const survivors = fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).trim().split('\n').filter(Boolean);
         assert.equal(survivors.length > 0, true, 'the unproven session must be preserved');
+      });
+    });
+
+    it('refuses cleanup when a tagged session loses ownership before rollback (post-tag unset)', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-post-tag-unset';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'post-tag-owner');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        fixture.run(['set-option', '-u', '-t', sessionName, '@omx_instance_id']);
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        assert.throws(
+          () => cleanupDetachedPreReportSession(authority),
+          /topology changed before cleanup/,
+          'an owner tag removed after tag-session must not be treated as pre-tag state',
+        );
+        const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
+        assert.equal(sessions.includes(sessionName), true, 'the unowned exact session must survive');
+        assert.equal(sessions.includes(foreignSessionName), true, 'the unrelated session must survive');
       });
     });
 
@@ -339,6 +364,64 @@ describe('#3578 detached launch diagnostics', () => {
         assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(authority.paneId), true, 'leader pane must survive race');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'HUD session must survive race');
         assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive race');
+      });
+    });
+
+    it('preserves the session when authenticated readiness arrives at the destructive boundary', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-ready-handoff-race';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'ready-handoff-owner');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.equal(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']), '1');
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        let lateReadyReport: {
+          version: 1;
+          kind: 'ready';
+          nonce: string;
+          sessionId: string;
+          sessionName: string;
+          paneId: string;
+          leaderPid: number;
+        } | undefined;
+        const expected = {
+          nonce: 'ready-handoff-nonce',
+          sessionId: authority.sessionId,
+          sessionName,
+          shouldAttach: false,
+          leaderPaneId: authority.paneId,
+          leaderPanePid: authority.panePid,
+        };
+        assert.throws(
+          () => cleanupDetachedPreReportSessionForTest(
+            authority,
+            () => {
+              // Deterministic completion-timeout/rollback barrier: the valid
+              // ready report is published only after topology probing and
+              // before the destructive session sink.
+              lateReadyReport = {
+                version: 1,
+                kind: 'ready',
+                nonce: expected.nonce,
+                sessionId: expected.sessionId,
+                sessionName: expected.sessionName,
+                paneId: authority.paneId,
+                leaderPid: authority.panePid,
+              };
+            },
+            false,
+            () => isDetachedReadyReportAuthorized(lateReadyReport, expected),
+          ),
+          /became ready or terminal before pre-report cleanup/,
+          'late authenticated readiness must suppress rollback cleanup',
+        );
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'ready session must survive');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive');
       });
     });
 

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -423,6 +423,72 @@ describe('#3578 detached launch diagnostics', () => {
       });
     });
 
+    it('preserves a respawned leader when its pane is revived after the dead-pane probe', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-respawn-race';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'respawn-race-owner');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.equal(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']), '1');
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        let lateReadyReport: {
+          version: 1;
+          kind: 'ready';
+          nonce: string;
+          sessionId: string;
+          sessionName: string;
+          paneId: string;
+          leaderPid: number;
+        } | undefined;
+        const expected = {
+          nonce: 'respawn-race-nonce',
+          sessionId: authority.sessionId,
+          sessionName,
+          shouldAttach: false,
+          leaderPaneId: authority.paneId,
+          leaderPanePid: authority.panePid,
+        };
+        assert.throws(
+          () => cleanupDetachedPreReportSessionForTest(
+            authority,
+            () => {
+              // respawn-pane retains the captured pane id but changes its
+              // process identity only after the non-atomic dead-pane probe.
+              fixture.run(['respawn-pane', '-k', '-t', authority.paneId, 'sleep 300']);
+            },
+            false,
+            () => {
+              assert.equal(lateReadyReport, undefined);
+              return false;
+            },
+            () => {
+              const respawnedPid = Number(fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_pid}']));
+              lateReadyReport = {
+                version: 1,
+                kind: 'ready',
+                nonce: expected.nonce,
+                sessionId: expected.sessionId,
+                sessionName: expected.sessionName,
+                paneId: authority.paneId,
+                leaderPid: respawnedPid,
+              };
+            },
+          ),
+          /topology changed before cleanup/,
+          'a respawned pane with a changed PID must fail closed',
+        );
+        assert.equal(isDetachedReadyReportAuthorized(lateReadyReport, expected), true, 'the respawned ready report must still be pane-authenticated');
+        const sessions = fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n');
+        assert.equal(sessions.includes(sessionName), true, 'the respawned live session must survive');
+        assert.equal(sessions.includes(foreignSessionName), true, 'the unrelated session must survive');
+      });
+    });
+
     it('preserves a replacement session when the captured leader disappears and its name is reused after the probe', async (t) => {
       if (!skipUnlessTmux(t)) return;
       await withTempTmuxSession(async (fixture) => {

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -251,5 +251,51 @@ describe('#3578 detached launch diagnostics', () => {
       assert.ok(kill);
       assert.deepEqual(kill.args, ['kill-session', '-t', 'omx-3578-target']);
     });
+
+    it('preserves without mutation when the exact session disappears before cleanup (destroyed session)', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-destroyed';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'owner-destroyed');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        fixture.run(['kill-session', '-t', sessionName]);
+        assert.throws(
+          () => cleanupDetachedPreReportSession(authority),
+          /topology changed before cleanup/,
+          'destroyed exact session must fail closed without mutation',
+        );
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'replacement-after-destroy']);
+        assert.throws(
+          () => cleanupDetachedPreReportSession(authority),
+          /topology changed before cleanup/,
+          'replacement after destroyed session must never be killed',
+        );
+        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'replacement session must survive');
+      });
+    });
+
+    it('preserves without mutation when owner drifts after probe but before pane-targeted sink (race)', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-probe-sink-race';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        const hudPaneId = fixture.run([
+          'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300',
+        ]);
+        const authority = captureSession(fixture, sessionName, 'owner-race');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'foreign-race-owner']);
+        assert.throws(
+          () => cleanupDetachedPreReportSession(authority),
+          /topology changed before cleanup/,
+          'probe present but sink owner drift must fail closed without pane-targeted mutation',
+        );
+        assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(hudPaneId), true, 'HUD pane must survive race');
+        assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(authority.paneId), true, 'leader pane must survive race');
+        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'HUD session must survive race');
+      });
+    });
   });
 });

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -6,6 +6,7 @@ import { describe, it, type TestContext } from 'node:test';
 import {
   buildDetachedSessionRollbackSteps,
   cleanupDetachedPreReportSession,
+  cleanupDetachedPreReportSessionForTest,
   detachedLeaderFailureErrorForTest,
   DetachedLaunchSafetyError,
   isDetachedSessionPointerAbortCarried,
@@ -276,25 +277,73 @@ describe('#3578 detached launch diagnostics', () => {
       });
     });
 
-    it('preserves without mutation when owner drifts after probe but before pane-targeted sink (race)', async (t) => {
+    it('preserves the exact session when ownership drifts after the topology probe and before cleanup (race)', async (t) => {
       if (!skipUnlessTmux(t)) return;
       await withTempTmuxSession(async (fixture) => {
         const sessionName = 'omx-3578-probe-sink-race';
-        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
         const hudPaneId = fixture.run([
           'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300',
         ]);
         const authority = captureSession(fixture, sessionName, 'owner-race');
         fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
-        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'foreign-race-owner']);
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.equal(
+          fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']),
+          '1',
+          'the captured leader pane must be retained dead so the old pane sink would be eligible',
+        );
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
         assert.throws(
-          () => cleanupDetachedPreReportSession(authority),
+          () => cleanupDetachedPreReportSessionForTest(authority, () => {
+            // This callback is the deterministic interposition point between
+            // detachedPreReportLeaderPaneAbsent and the destructive sink.
+            fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'foreign-race-owner']);
+          }),
           /topology changed before cleanup/,
-          'probe present but sink owner drift must fail closed without pane-targeted mutation',
+          'ownership drift in the exact probe-to-sink interval must fail closed',
         );
         assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(hudPaneId), true, 'HUD pane must survive race');
         assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(authority.paneId), true, 'leader pane must survive race');
         assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'HUD session must survive race');
+        assert.equal(fixture.runResult(['has-session', '-t', foreignSessionName]).status, 0, 'unrelated session must survive race');
+      });
+    });
+
+    it('preserves a replacement session when the captured leader disappears and its name is reused after the probe', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-disappear-reuse-race';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        fixture.run(['split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300']);
+        const authority = captureSession(fixture, sessionName, 'owner-disappear-reuse');
+        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.equal(
+          fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']),
+          '1',
+          'the captured leader pane must be dead before the interposed reuse',
+        );
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+
+        assert.throws(
+          () => cleanupDetachedPreReportSessionForTest(authority, () => {
+            // The exact leader pane/session disappears only after the
+            // non-atomic topology probe has completed. The name is immediately
+            // reused by a different session, which must not receive cleanup.
+            fixture.run(['kill-session', '-t', sessionName]);
+            fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
+            fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'replacement-owner']);
+          }),
+          /topology changed before cleanup/,
+          'a vanished and name-reused leader must fail closed',
+        );
+        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'replacement session must survive race');
+        assert.equal(fixture.runResult(['has-session', '-t', foreignSessionName]).status, 0, 'unrelated session must survive race');
       });
     });
   });

--- a/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
+++ b/src/cli/__tests__/detached-launch-diagnostics-3578.test.ts
@@ -198,7 +198,38 @@ describe('#3578 detached launch diagnostics', () => {
         await new Promise((resolve) => setTimeout(resolve, 300));
         // has-session exits 1 once the exact owned session is destroyed: the
         // leak #3578 reported is its continued survival, so non-zero is the pass.
-        assert.notEqual(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'the exact owned HUD-only session must be destroyed');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), false, 'the exact owned HUD-only session must be destroyed');
+      });
+    });
+
+    it('cleans a retained dead leader before the session owner tag is installed', async (t) => {
+      if (!skipUnlessTmux(t)) return;
+      await withTempTmuxSession(async (fixture) => {
+        const sessionName = 'omx-3578-pre-tag-retained';
+        fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
+        const hudPaneId = fixture.run([
+          'split-window', '-d', '-P', '-F', '#{pane_id}', '-t', sessionName, 'sleep 300',
+        ]);
+        const authority = captureSession(fixture, sessionName, 'pre-tag-owner');
+        fixture.run(['set-option', '-t', sessionName, 'remain-on-exit', 'on']);
+        await new Promise((resolve) => setTimeout(resolve, 5_500));
+        assert.equal(
+          fixture.run(['display-message', '-p', '-t', authority.paneId, '#{pane_dead}']),
+          '1',
+          'the retained dead leader must reproduce the pre-tag rollback topology',
+        );
+        assert.equal(
+          fixture.run(['display-message', '-p', '-t', sessionName, '#{@omx_instance_id}']).trim(),
+          '',
+          'the pre-tag fixture must not install an owner tag',
+        );
+        const foreignSessionName = `${sessionName}-foreign`;
+        fixture.run(['new-session', '-d', '-s', foreignSessionName, '-c', fixture.sessionName, 'sleep 300']);
+        cleanupDetachedPreReportSession(authority);
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), false, 'the exact pre-tag session must be destroyed');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'the unrelated session must survive');
+        assert.equal(fixture.run(['list-panes', '-s', '-t', foreignSessionName, '-F', '#{pane_id}']).includes(hudPaneId), false);
       });
     });
 
@@ -208,18 +239,17 @@ describe('#3578 detached launch diagnostics', () => {
         const sessionName = 'omx-3578-reuse-race';
         fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 5']);
         const authority = captureSession(fixture, sessionName, 'owner-3578-b');
-        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', authority.ownerId]);
         await new Promise((resolve) => setTimeout(resolve, 5_500));
         // Race: a replacement session takes the same name with different
-        // session_id/session_created and its own owner tag before cleanup runs.
+        // session_id/session_created before cleanup runs, while the original
+        // session is still in the pre-tag owner-unset state.
         fixture.run(['new-session', '-d', '-s', sessionName, '-c', fixture.sessionName, 'sleep 300']);
-        fixture.run(['set-option', '-t', sessionName, '@omx_instance_id', 'replacement-owner']);
         assert.throws(
           () => cleanupDetachedPreReportSession(authority),
           /topology changed before cleanup/,
           'a name-reusing replacement session must never be killed',
         );
-        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'the replacement session must survive');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'the replacement session must survive');
       });
     });
 
@@ -273,7 +303,7 @@ describe('#3578 detached launch diagnostics', () => {
           /topology changed before cleanup/,
           'replacement after destroyed session must never be killed',
         );
-        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'replacement session must survive');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'replacement session must survive');
       });
     });
 
@@ -307,8 +337,8 @@ describe('#3578 detached launch diagnostics', () => {
         );
         assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(hudPaneId), true, 'HUD pane must survive race');
         assert.equal(fixture.run(['list-panes', '-s', '-t', sessionName, '-F', '#{pane_id}']).split('\n').includes(authority.paneId), true, 'leader pane must survive race');
-        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'HUD session must survive race');
-        assert.equal(fixture.runResult(['has-session', '-t', foreignSessionName]).status, 0, 'unrelated session must survive race');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'HUD session must survive race');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive race');
       });
     });
 
@@ -342,8 +372,8 @@ describe('#3578 detached launch diagnostics', () => {
           /topology changed before cleanup/,
           'a vanished and name-reused leader must fail closed',
         );
-        assert.equal(fixture.runResult(['has-session', '-t', sessionName]).status, 0, 'replacement session must survive race');
-        assert.equal(fixture.runResult(['has-session', '-t', foreignSessionName]).status, 0, 'unrelated session must survive race');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(sessionName), true, 'replacement session must survive race');
+        assert.equal(fixture.run(['list-sessions', '-F', '#{session_name}']).split('\n').includes(foreignSessionName), true, 'unrelated session must survive race');
       });
     });
   });

--- a/src/cli/__tests__/detached-leader-teardown.test.ts
+++ b/src/cli/__tests__/detached-leader-teardown.test.ts
@@ -294,7 +294,7 @@ describe('detached leader HUD teardown', () => {
     );
   });
 
-  it('cleans an exact retained dead pane without an owner tag and rejects changed topology', async (t) => {
+  it('cleans an exact retained dead pane with its owner tag and rejects changed identity', async (t) => {
     if (!skipUnlessTmux(t)) return;
     await withTempTmuxSession(async (fixture) => {
       fixture.run(['set-option', '-g', 'remain-on-exit', 'on']);
@@ -307,18 +307,20 @@ describe('detached leader HUD teardown', () => {
       if (!sessionName || !sessionId || !sessionCreated || !windowId || !paneId || !Number.isSafeInteger(panePid)) {
         throw new Error('invalid retained-pane topology fixture');
       }
-      fixture.runResult(['unset-option', '-t', fixture.sessionName, '@omx_instance_id']);
+      fixture.run(['set-option', '-t', fixture.sessionName, '@omx_instance_id', 'missing-owner-tag']);
       process.kill(panePid, 'SIGTERM');
       await poll('retained dead pane', () => fixture.run(['display-message', '-p', '-t', paneId, '#{pane_dead}']) === '1' ? true : undefined);
       const authority = {
         paneId, panePid, sessionName, sessionId, sessionCreated, windowId,
         windowIndex: '0', ownerId: 'missing-owner-tag',
       };
+      fixture.run(['set-option', '-t', fixture.sessionName, '@omx_instance_id', 'foreign-owner']);
       assert.throws(
-        () => cleanupDetachedPreReportSession({ ...authority, windowId: '@999999' }),
+        () => cleanupDetachedPreReportSession(authority),
         /topology changed before cleanup/,
       );
       assert.equal(fixture.sessionExists(sessionName), true);
+      fixture.run(['set-option', '-t', fixture.sessionName, '@omx_instance_id', authority.ownerId]);
       cleanupDetachedPreReportSession(authority);
       await poll('pre-report session destruction', () => !fixture.sessionExists(sessionName) ? true : undefined);
     });

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -52,7 +52,7 @@ describe('detached tmux authority contract', () => {
     assert.match(cliIndex, /detachedHudAuthority = runDetachedLeaderSplit\(authority, step\.args\)/);
     assert.match(cliIndex, /if \(targetsHudPane\) runDetachedHudMutation\(authority, detachedHudAuthority, guardDetachedHudDeferredMutation\(authority, detachedHudAuthority, finalizeStep\.args\)\)/);
     assert.match(cliIndex, /publishDetachedReleaseMarker\(releaseMarkerPath, detachedLaunchNonce, sessionId, sessionName, detachedLeaderPid, detachedHudAuthority \?\? undefined\)/);
-    assert.match(cliIndex, /runDetachedLeaderMutation\(detachedLeaderAuthority, step\.args\)/);
+    assert.match(cliIndex, /runDetachedLeaderMutation\(leaderAuthority, step\.args\)/);
     assert.match(cliIndex, /function removeDetachedHudPaneIfAuthorized[\s\S]*?if-shell[\s\S]*?detachedHudAuthorityCondition\(authority, true, ownerId\)[\s\S]*?kill-pane/);
     assert.ok(cliIndex.includes('splitArgs[commandIndex] = `env OMX_DETACHED_HUD_OPERATION=${operationMarker} ${splitArgs[commandIndex]}`;'));
   });

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -84,6 +84,9 @@ describe('detached tmux authority contract', () => {
     assert.match(complete, /rollbackFromPreReportAuthority = detachedLeaderAuthority !== null/);
     assert.doesNotMatch(cliIndex, /scheduleDetachedPreReportCleanupRetry\(/);
     assert.match(cliIndex, /@omx_detached_owner_tag_attempted/);
+    const failureCleanup = cliIndex.slice(cliIndex.indexOf('function cleanupDetachedLeaderSessionWithAuthority'));
+    assert.doesNotMatch(failureCleanup, /show-options/);
+    assert.match(failureCleanup, /@omx_detached_owner_tag_attempted/);
     assert.match(cliIndex, /cleanupDetachedLeaderSessionAfterFailure\(pane, payload\)/);
   });
 

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -78,6 +78,12 @@ describe('detached tmux authority contract', () => {
     assert.match(cleanup, /result === "cleaned" \|\| !authenticatedFailedReportProbe\?\.\(\)/);
   });
 
+  it('authenticates failed reports before complete selects rollback and retains async timeout cleanup', () => {
+    const complete = cliIndex.slice(cliIndex.indexOf('complete: async () =>'));
+    assert.match(complete, /if \(!isDetachedFailedReportAuthorized\(report,/);
+    assert.match(cliIndex, /scheduleDetachedPreReportCleanupRetry\(/);
+  });
+
   it('executes a created-HUD recycling denial fixture rather than only declaring one', () => {
     const recyclingTest = launchFallbackSource.match(
       /it\('denies detached HUD finalization when the receipted pane id is recycled'[\s\S]*?\n  \}\);/,

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -83,6 +83,7 @@ describe('detached tmux authority contract', () => {
     assert.match(complete, /if \(!isDetachedFailedReportAuthorized\(report,/);
     assert.match(complete, /rollbackFromPreReportAuthority = detachedLeaderAuthority !== null/);
     assert.match(cliIndex, /scheduleDetachedPreReportCleanupRetry\(/);
+    assert.match(cliIndex, /cleanupDetachedLeaderSessionAfterFailure\(pane, payload\)/);
   });
 
   it('executes a created-HUD recycling denial fixture rather than only declaring one', () => {

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -75,14 +75,15 @@ describe('detached tmux authority contract', () => {
 
   it('does not extend ordinary timeout rollback with the failed-report retry wait', () => {
     const cleanup = cliIndex.slice(cliIndex.indexOf('function cleanupDetachedPreReportSessionWithRetry'));
-    assert.match(cleanup, /result === "cleaned" \|\| !authenticatedFailedReportProbe\?\.\(\)/);
+    assert.match(cleanup, /result === "cleaned" \|\| !retryAuthenticatedFailure \|\| !authenticatedFailedReportProbe\?\.\(\)/);
   });
 
-  it('authenticates failed reports before complete selects rollback and retains async timeout cleanup', () => {
+  it('authenticates failed reports before complete and delegates late cleanup to the leader', () => {
     const complete = cliIndex.slice(cliIndex.indexOf('complete: async () =>'));
     assert.match(complete, /if \(!isDetachedFailedReportAuthorized\(report,/);
     assert.match(complete, /rollbackFromPreReportAuthority = detachedLeaderAuthority !== null/);
-    assert.match(cliIndex, /scheduleDetachedPreReportCleanupRetry\(/);
+    assert.doesNotMatch(cliIndex, /scheduleDetachedPreReportCleanupRetry\(/);
+    assert.match(cliIndex, /@omx_detached_owner_tag_attempted/);
     assert.match(cliIndex, /cleanupDetachedLeaderSessionAfterFailure\(pane, payload\)/);
   });
 

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -73,6 +73,11 @@ describe('detached tmux authority contract', () => {
     assert.match(rollback, /isDetachedTerminalReportAuthorized\(report, expected\)/);
   });
 
+  it('does not extend ordinary timeout rollback with the failed-report retry wait', () => {
+    const cleanup = cliIndex.slice(cliIndex.indexOf('function cleanupDetachedPreReportSessionWithRetry'));
+    assert.match(cleanup, /result === "cleaned" \|\| !authenticatedFailedReportProbe\?\.\(\)/);
+  });
+
   it('executes a created-HUD recycling denial fixture rather than only declaring one', () => {
     const recyclingTest = launchFallbackSource.match(
       /it\('denies detached HUD finalization when the receipted pane id is recycled'[\s\S]*?\n  \}\);/,

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -81,6 +81,7 @@ describe('detached tmux authority contract', () => {
   it('authenticates failed reports before complete selects rollback and retains async timeout cleanup', () => {
     const complete = cliIndex.slice(cliIndex.indexOf('complete: async () =>'));
     assert.match(complete, /if \(!isDetachedFailedReportAuthorized\(report,/);
+    assert.match(complete, /rollbackFromPreReportAuthority = detachedLeaderAuthority !== null/);
     assert.match(cliIndex, /scheduleDetachedPreReportCleanupRetry\(/);
   });
 

--- a/src/cli/__tests__/windows-popup-loop-contract.test.ts
+++ b/src/cli/__tests__/windows-popup-loop-contract.test.ts
@@ -62,6 +62,17 @@ describe('detached tmux authority contract', () => {
     assert.doesNotMatch(cliIndex, /execTmuxFileSync\(finalizeStep\.args, \{ stdio: "ignore" \}\)/);
   });
 
+  it('keeps the detached report visible until the session cleanup decision is complete', () => {
+    const rollback = cliIndex.slice(cliIndex.indexOf('rollback: async (_ownedRecord'));
+    const cleanupDecision = rollback.indexOf('cleanupDetachedPreReportSession(');
+    const markerRemoval = rollback.lastIndexOf('await attempt("rollback", removeReleaseMarkers)');
+    assert.ok(cleanupDecision >= 0, 'rollback must perform the authenticated pre-report cleanup decision');
+    assert.ok(markerRemoval > cleanupDecision, 'release marker removal must follow the cleanup decision');
+    assert.match(rollback, /readDetachedLeaderReport\(releaseMarkerPath\)/);
+    assert.match(rollback, /isDetachedReadyReportAuthorized\(report, expected\)/);
+    assert.match(rollback, /isDetachedTerminalReportAuthorized\(report, expected\)/);
+  });
+
   it('executes a created-HUD recycling denial fixture rather than only declaring one', () => {
     const recyclingTest = launchFallbackSource.match(
       /it\('denies detached HUD finalization when the receipted pane id is recycled'[\s\S]*?\n  \}\);/,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8649,22 +8649,35 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
   const nonce = payload.readyPath?.split(".").at(-2) || payload.sessionId;
   let pane: string;
   const inheritedPane = process.env.TMUX_PANE?.trim();
-  pane = resolveDetachedLeaderPaneIdentity(
-    payload.sessionName,
-    undefined,
-    inheritedPane,
-    process.platform,
-    process.pid,
-    payload.preLaunchOptions.shouldAttach === false,
-    (paneId) => execTmuxFileSync(
-      ["display-message", "-p", "-t", paneId, "#{session_name}\t#{session_id}\t#{pane_id}"],
-      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
-    ).trim(),
-    () => execTmuxFileSync(
-      ["list-panes", "-t", payload.sessionName, "-F", "#{pane_id}\t#{pane_dead}\t#{pane_pid}"],
-      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
-    ),
-  );
+  if (process.platform !== "win32") {
+    if (payload.preLaunchOptions.shouldAttach === false) {
+      if (!inheritedPane || !/^%[0-9]+$/.test(inheritedPane)) throw new Error("detached Hermes leader has no tmux pane identity");
+      pane = inheritedPane;
+    } else {
+      const paneSnapshot = execTmuxFileSync(
+        ["list-panes", "-t", payload.sessionName, "-F", "#{pane_id}\t#{pane_dead}\t#{pane_pid}"],
+        { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+      );
+      pane = parseDetachedLeaderPaneIdByPid(paneSnapshot, process.pid);
+    }
+  } else {
+    pane = resolveDetachedLeaderPaneIdentity(
+      payload.sessionName,
+      undefined,
+      inheritedPane,
+      process.platform,
+      process.pid,
+      payload.preLaunchOptions.shouldAttach === false,
+      (paneId) => execTmuxFileSync(
+        ["display-message", "-p", "-t", paneId, "#{session_name}\t#{session_id}\t#{pane_id}"],
+        { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+      ).trim(),
+      () => execTmuxFileSync(
+        ["list-panes", "-t", payload.sessionName, "-F", "#{pane_id}\t#{pane_dead}\t#{pane_pid}"],
+        { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+      ),
+    );
+  }
   process.env.TMUX_PANE = pane;
   // #3578: a pre-binding failure (notably session_pointer_owner_conflict) used to
   // die with the pane — remain-on-exit is off, so this leader's stderr vanished and

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1231,6 +1231,8 @@ function isDiscardableHistoryCopyError(error: unknown): boolean {
 const HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS = 5_000;
 const HISTORY_PERSISTENCE_LOCK_STALE_MS = 30_000;
 const HISTORY_PERSISTENCE_LOCK_HEARTBEAT_MS = 5_000;
+const HISTORY_PERSISTENCE_LOCK_RENAME_RETRIES = 20;
+const HISTORY_PERSISTENCE_LOCK_RENAME_RETRY_DELAY_MS = 10;
 
 interface HistoryPersistenceLockOptions {
   timeoutMs?: number;
@@ -1320,11 +1322,19 @@ async function retireHistoryLock(
     if (owner?.token !== expectedToken) return;
   }
   const retiredPath = `${lockPath}.retired-${randomUUID()}`;
-  try {
-    await rename(lockPath, retiredPath);
-  } catch {
-    return;
+  let retired = false;
+  for (let attempt = 0; attempt < HISTORY_PERSISTENCE_LOCK_RENAME_RETRIES; attempt += 1) {
+    try {
+      await rename(lockPath, retiredPath);
+      retired = true;
+      break;
+    } catch {
+      if (attempt + 1 < HISTORY_PERSISTENCE_LOCK_RENAME_RETRIES) {
+        await new Promise((resolveWait) => setTimeout(resolveWait, HISTORY_PERSISTENCE_LOCK_RENAME_RETRY_DELAY_MS));
+      }
+    }
   }
+  if (!retired) return;
   await assertHistoryPathWithin(retiredPath, root);
   await rm(retiredPath, { recursive: true, force: true }).catch(() => undefined);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8178,7 +8178,14 @@ async function runCodex(
                 rollbackFromPreReportAuthority = detachedLeaderAuthority !== null;
                 return { kind: "failure", operation: "session-instructions", error: detachedLeaderFailureError(report) };
               }
-              if (Date.now() >= readyDeadline) return { kind: "failure", operation: "session-instructions", error: new Error("detached leader readiness timed out") };
+              if (Date.now() >= readyDeadline) {
+                // A timeout still owns the created pre-report topology. Keep
+                // the marker and authorize the asynchronous watcher so a
+                // failed report published just after this boundary can trigger
+                // cleanup after the leader exits without blocking completion.
+                rollbackFromPreReportAuthority = detachedLeaderAuthority !== null;
+                return { kind: "failure", operation: "session-instructions", error: new Error("detached leader readiness timed out") };
+              }
               blockMs(20);
             }
           },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2602,16 +2602,18 @@ function detachedPreReportSessionCleanupCondition(authority: DetachedLeaderAutho
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
 
-function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): boolean {
+function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): "absent" | "present" | "unknown" {
   // Enumerate every pane id of the exact named session; the leader pane must
-  // be absent. Enumeration failures are fail-closed (no cleanup).
+  // be absent for the session-scoped fence to apply. Enumeration failures
+  // (notably the exact session no longer exists) are fail-closed: unknown
+  // topology preserves without mutation and is surfaced as a topology change.
   try {
     const output = execTmuxFileSync(["list-panes", "-s", "-t", authority.sessionName, "-F", "#{pane_id}"], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     });
-    return !output.split("\n").map((line) => line.trim()).filter(Boolean).includes(authority.paneId);
+    return !output.split("\n").map((line) => line.trim()).filter(Boolean).includes(authority.paneId) ? "absent" : "present";
   } catch {
-    return false;
+    return "unknown";
   }
 }
 
@@ -2622,7 +2624,9 @@ export function cleanupDetachedPreReportSession(authority: DetachedLeaderAuthori
   // no longer exist — a missing -t target can terminate the server. Probe pane
   // membership of the exact named session first; only a pane that still exists
   // may take the original retained-dead-pane fence.
-  if (detachedPreReportLeaderPaneAbsent(authority)) {
+  const absence = detachedPreReportLeaderPaneAbsent(authority);
+  if (absence === "unknown") throw new Error("detached pre-report topology changed before cleanup");
+  if (absence === "absent") {
     // #3578: the leader pane was removed entirely (normal exit with
     // remain-on-exit off). Clean up through the session-scoped fence instead.
     const sessionScoped = execTmuxFileSync([
@@ -2632,10 +2636,15 @@ export function cleanupDetachedPreReportSession(authority: DetachedLeaderAuthori
     if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");
     return;
   }
-  const output = execTmuxFileSync([
-    "if-shell", "-F", "-t", authority.paneId, detachedPreReportCleanupCondition(authority),
-    success, "display-message -p ''",
-  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  let output: string;
+  try {
+    output = execTmuxFileSync([
+      "if-shell", "-F", "-t", authority.paneId, detachedPreReportCleanupCondition(authority),
+      success, "display-message -p ''",
+    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    throw new Error("detached pre-report topology changed before cleanup");
+  }
   if (output !== receipt) throw new Error("detached pre-report topology changed before cleanup");
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8588,14 +8588,13 @@ function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLea
   }
 }
 
-function cleanupDetachedLeaderSessionWithAuthority(authority: DetachedLeaderAuthority, ownerId: string): void {
+function cleanupDetachedLeaderSessionWithAuthority(
+  authority: DetachedLeaderAuthority,
+  ownerId: string,
+  beforeSink?: () => void,
+): void {
   try {
-    const tagAttempted = execTmuxFileSync(["show-options", "-qv", "-t", authority.sessionName, "@omx_detached_owner_tag_attempted"], {
-      encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
-    }).trim() === "1";
-    const owner = tagAttempted
-      ? `#{==:#{@omx_instance_id},${ownerId}}`
-      : `#{||:#{==:#{@omx_instance_id},${ownerId}},#{==:#{@omx_instance_id},}}`;
+    const owner = `#{||:#{==:#{@omx_instance_id},${ownerId}},#{&&:#{==:#{@omx_instance_id},},#{!=:#{@omx_detached_owner_tag_attempted},1}}}`;
     const condition = [
       `#{==:#{session_name},${authority.sessionName}}`,
       `#{==:#{session_id},${authority.sessionId}}`,
@@ -8604,6 +8603,7 @@ function cleanupDetachedLeaderSessionWithAuthority(authority: DetachedLeaderAuth
     ].reduce((combined, item) => `#{&&:${combined},${item}}`);
     const receipt = detachedAuthorityReceipt();
     const success = `kill-session -t ${quoteShellArg(authority.sessionName)} ; display-message -p ${quoteShellArg(receipt)}`;
+    beforeSink?.();
     const result = execTmuxFileSync([
       "if-shell", "-F", "-t", authority.sessionName, condition, success, "display-message -p ''",
     ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
@@ -8628,8 +8628,9 @@ function cleanupDetachedLeaderSessionAfterFailure(paneId: string, payload: Detac
 export function cleanupDetachedLeaderSessionAfterFailureForTest(
   authority: DetachedLeaderAuthority,
   ownerId: string,
+  beforeSink?: () => void,
 ): void {
-  cleanupDetachedLeaderSessionWithAuthority(authority, ownerId);
+  cleanupDetachedLeaderSessionWithAuthority(authority, ownerId, beforeSink);
 }
 
 function traceDetachedLeaderPhase(phase: string): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8077,7 +8077,11 @@ async function runCodex(
             };
             await attempt("parent-env", async () => { if (detachedParentEnvFilePath) await rm(detachedParentEnvFilePath, { force: true }); });
             await attempt("runtime-codex-home", () => cleanupRuntimeCodexHome(runtimeCodexHomeForCleanup, projectLocalCodexHomeForCleanup));
-            await attempt("rollback", () => { rmSync(releaseMarkerPath, { force: true }); rmSync(`${releaseMarkerPath}.release`, { force: true }); rmSync(`${releaseMarkerPath}.abort`, { force: true }); });
+            const removeReleaseMarkers = (): void => {
+              rmSync(releaseMarkerPath, { force: true });
+              rmSync(`${releaseMarkerPath}.release`, { force: true });
+              rmSync(`${releaseMarkerPath}.abort`, { force: true });
+            };
             if (createdSession) {
               if (isExactDetachedFinalization(finalization, {
                 nonce: detachedLaunchNonce,
@@ -8092,6 +8096,7 @@ async function runCodex(
                     }
                   });
                 }
+                await attempt("rollback", removeReleaseMarkers);
                 return;
               }
               for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
@@ -8122,6 +8127,7 @@ async function runCodex(
                 });
               }
             }
+            await attempt("rollback", removeReleaseMarkers);
           },
         },
       );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2497,6 +2497,53 @@ export function parseDetachedLeaderPaneIdByPid(snapshot: string, leaderPid: numb
   return matches[0]!;
 }
 
+function resolveDetachedLeaderPaneIdentity(
+  sessionName: string,
+  sessionId: string,
+  inheritedPane: string | undefined,
+  platform: NodeJS.Platform,
+  leaderPid: number,
+  requireInheritedPane: boolean,
+  probeInheritedPane: (paneId: string) => string,
+  listPanes: () => string,
+): string {
+  if (inheritedPane && /^%[0-9]+$/.test(inheritedPane)) {
+    try {
+      const [observedSessionName, observedSessionId, observedPaneId] = probeInheritedPane(inheritedPane).split("\t");
+      if (observedSessionName === sessionName && observedSessionId === sessionId && observedPaneId === inheritedPane) return inheritedPane;
+    } catch {
+      // Fall through to the platform-specific resolution policy below.
+    }
+  }
+  if (requireInheritedPane || platform === "win32") {
+    throw new Error("detached leader inherited pane identity is unavailable");
+  }
+  return parseDetachedLeaderPaneIdByPid(listPanes(), leaderPid);
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function resolveDetachedLeaderPaneForTest(options: {
+  sessionName: string;
+  sessionId: string;
+  inheritedPane?: string;
+  platform: NodeJS.Platform;
+  leaderPid: number;
+  requireInheritedPane: boolean;
+  identityOutput: string;
+  paneSnapshot: string;
+}): string {
+  return resolveDetachedLeaderPaneIdentity(
+    options.sessionName,
+    options.sessionId,
+    options.inheritedPane,
+    options.platform,
+    options.leaderPid,
+    options.requireInheritedPane,
+    () => options.identityOutput,
+    () => options.paneSnapshot,
+  );
+}
+
 function detachedLeaderAuthorityCondition(authority: DetachedLeaderAuthority, requireOwner = true): string {
   const conditions = [
     "#{==:#{pane_dead},0}",
@@ -8493,18 +8540,22 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
   const nonce = payload.readyPath?.split(".").at(-2) || payload.sessionId;
   let pane: string;
   const inheritedPane = process.env.TMUX_PANE?.trim();
-  if (payload.preLaunchOptions.shouldAttach === false) {
-    if (!inheritedPane || !/^%[0-9]+$/.test(inheritedPane)) {
-      throw new Error("detached Hermes leader has no tmux pane identity");
-    }
-    pane = inheritedPane;
-  } else {
-    const paneSnapshot = execTmuxFileSync(
+  pane = resolveDetachedLeaderPaneIdentity(
+    payload.sessionName,
+    payload.sessionId,
+    inheritedPane,
+    process.platform,
+    process.pid,
+    payload.preLaunchOptions.shouldAttach === false,
+    (paneId) => execTmuxFileSync(
+      ["display-message", "-p", "-t", paneId, "#{session_name}\t#{session_id}\t#{pane_id}"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim(),
+    () => execTmuxFileSync(
       ["list-panes", "-t", payload.sessionName, "-F", "#{pane_id}\t#{pane_dead}\t#{pane_pid}"],
       { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
-    );
-    pane = parseDetachedLeaderPaneIdByPid(paneSnapshot, process.pid);
-  }
+    ),
+  );
   process.env.TMUX_PANE = pane;
   // #3578: a pre-binding failure (notably session_pointer_owner_conflict) used to
   // die with the pane — remain-on-exit is off, so this leader's stderr vanished and

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2644,7 +2644,7 @@ function cleanupDetachedPreReportSessionInternal(
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
   afterAuthenticatedReadyOrTerminalProbe?: () => void,
-): void {
+): DetachedPreReportCleanupResult {
   const receipt = detachedAuthorityReceipt();
   const sessionTarget = authority.sessionName;
   const success = `kill-session -t ${quoteShellArg(sessionTarget)} ; display-message -p ${quoteShellArg(receipt)}`;
@@ -2662,21 +2662,43 @@ function cleanupDetachedPreReportSessionInternal(
   if (authenticatedReady) {
     throw new Error("detached leader became ready or terminal before pre-report cleanup");
   }
-  if (paneState === "live") return;
+  if (paneState === "live") return "preserved-live";
   const sessionScoped = execTmuxFileSync([
     "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority, allowUnownedPreTag, paneState === "dead"),
     success, "display-message -p ''",
   ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
   if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");
+  return "cleaned";
+}
+
+type DetachedPreReportCleanupResult = "cleaned" | "preserved-live";
+
+function cleanupDetachedPreReportSessionWithRetry(
+  authority: DetachedLeaderAuthority,
+  allowUnownedPreTag: boolean,
+  authenticatedReadyOrTerminalProbe?: () => boolean,
+): void {
+  let result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  if (result === "cleaned") return;
+  // A failed report may be published while the leader pane is still live. Do
+  // not treat that observation as successful cleanup: retain the marker and
+  // retry the identity-fenced decision after the leader exits. A later ready,
+  // terminal, respawn, or ownership change fails closed inside the retry.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    blockMs(20);
+    result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+    if (result === "cleaned") return;
+  }
+  throw new Error("detached leader remained live before pre-report cleanup retry");
 }
 
 export function cleanupDetachedPreReportSession(
   authority: DetachedLeaderAuthority,
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
-  afterAuthenticatedReadyOrTerminalProbe?: () => void,
 ): void {
-  cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, afterAuthenticatedReadyOrTerminalProbe);
+  cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
 }
 
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
@@ -2686,8 +2708,12 @@ export function cleanupDetachedPreReportSessionForTest(
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
   afterAuthenticatedReadyOrTerminalProbe?: () => void,
+  retryAfterLive = false,
 ): void {
-  cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, afterAuthenticatedReadyOrTerminalProbe);
+  const result = cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, afterAuthenticatedReadyOrTerminalProbe);
+  if (retryAfterLive && result === "preserved-live") {
+    cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  }
 }
 
 function runDetachedHudMutation(
@@ -8107,6 +8133,7 @@ async function runCodex(
               rmSync(`${releaseMarkerPath}.release`, { force: true });
               rmSync(`${releaseMarkerPath}.abort`, { force: true });
             };
+            let sessionCleanupCompleted = !rollbackFromPreReportAuthority;
             if (createdSession) {
               if (isExactDetachedFinalization(finalization, {
                 nonce: detachedLaunchNonce,
@@ -8146,13 +8173,14 @@ async function runCodex(
                           isDetachedTerminalReportAuthorized(report, expected);
                       },
                     );
+                    sessionCleanupCompleted = true;
                     return;
                   }
                   runDetachedLeaderMutation(leaderAuthority, step.args);
                 });
               }
             }
-            await attempt("rollback", removeReleaseMarkers);
+            if (sessionCleanupCompleted) await attempt("rollback", removeReleaseMarkers);
           },
         },
       );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2677,9 +2677,10 @@ function cleanupDetachedPreReportSessionWithRetry(
   authority: DetachedLeaderAuthority,
   allowUnownedPreTag: boolean,
   authenticatedReadyOrTerminalProbe?: () => boolean,
-): void {
+  authenticatedFailedReportProbe?: () => boolean,
+): DetachedPreReportCleanupResult {
   let result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
-  if (result === "cleaned") return;
+  if (result === "cleaned" || !authenticatedFailedReportProbe?.()) return result;
   // A failed report may be published while the leader pane is still live. Do
   // not treat that observation as successful cleanup: retain the marker and
   // retry the identity-fenced decision after the leader exits. A later ready,
@@ -2688,7 +2689,7 @@ function cleanupDetachedPreReportSessionWithRetry(
   while (Date.now() < deadline) {
     blockMs(20);
     result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
-    if (result === "cleaned") return;
+    if (result === "cleaned") return result;
   }
   throw new Error("detached leader remained live before pre-report cleanup retry");
 }
@@ -2697,8 +2698,9 @@ export function cleanupDetachedPreReportSession(
   authority: DetachedLeaderAuthority,
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
-): void {
-  cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  authenticatedFailedReportProbe?: () => boolean,
+): DetachedPreReportCleanupResult {
+  return cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, authenticatedFailedReportProbe);
 }
 
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
@@ -2709,10 +2711,11 @@ export function cleanupDetachedPreReportSessionForTest(
   authenticatedReadyOrTerminalProbe?: () => boolean,
   afterAuthenticatedReadyOrTerminalProbe?: () => void,
   retryAfterLive = false,
+  authenticatedFailedReportProbe?: () => boolean,
 ): void {
   const result = cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, afterAuthenticatedReadyOrTerminalProbe);
   if (retryAfterLive && result === "preserved-live") {
-    cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+    cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, authenticatedFailedReportProbe);
   }
 }
 
@@ -6326,6 +6329,21 @@ function isDetachedTerminalReportAuthorized(
   return isDetachedReadyReportAuthorized({ ...report, kind: "ready" }, expected);
 }
 
+function isDetachedFailedReportAuthorized(
+  report: DetachedLeaderReport | null | undefined,
+  expected: {
+    nonce: string;
+    sessionId: string;
+    sessionName: string;
+    leaderPanePid: number | null;
+  },
+): boolean {
+  return report?.kind === "failed" && report.nonce === expected.nonce
+    && report.sessionId === expected.sessionId && report.sessionName === expected.sessionName
+    && typeof report.leaderPid === "number" && report.leaderPid > 0
+    && (expected.leaderPanePid === null || report.leaderPid === expected.leaderPanePid);
+}
+
 function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
@@ -8156,7 +8174,7 @@ async function runCodex(
                   const leaderAuthority = detachedLeaderAuthority;
                   if (!leaderAuthority) throw new Error("detached leader authority missing before rollback");
                   if (rollbackFromPreReportAuthority && step.name === "kill-session") {
-                    cleanupDetachedPreReportSession(
+                    const cleanupResult = cleanupDetachedPreReportSession(
                       leaderAuthority,
                       !detachedLeaderOwnerTagInstalled,
                       () => {
@@ -8172,8 +8190,14 @@ async function runCodex(
                         return isDetachedReadyReportAuthorized(report, expected) ||
                           isDetachedTerminalReportAuthorized(report, expected);
                       },
+                      () => isDetachedFailedReportAuthorized(readDetachedLeaderReport(releaseMarkerPath), {
+                        nonce: detachedLaunchNonce,
+                        sessionId,
+                        sessionName,
+                        leaderPanePid: leaderAuthority.panePid,
+                      }),
                     );
-                    sessionCleanupCompleted = true;
+                    sessionCleanupCompleted = cleanupResult === "cleaned";
                     return;
                   }
                   runDetachedLeaderMutation(leaderAuthority, step.args);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2499,7 +2499,7 @@ export function parseDetachedLeaderPaneIdByPid(snapshot: string, leaderPid: numb
 
 function resolveDetachedLeaderPaneIdentity(
   sessionName: string,
-  sessionId: string,
+  expectedTmuxSessionId: string | undefined,
   inheritedPane: string | undefined,
   platform: NodeJS.Platform,
   leaderPid: number,
@@ -2510,7 +2510,8 @@ function resolveDetachedLeaderPaneIdentity(
   if (inheritedPane && /^%[0-9]+$/.test(inheritedPane)) {
     try {
       const [observedSessionName, observedSessionId, observedPaneId] = probeInheritedPane(inheritedPane).split("\t");
-      if (observedSessionName === sessionName && observedSessionId === sessionId && observedPaneId === inheritedPane) return inheritedPane;
+      if (observedSessionName === sessionName && observedPaneId === inheritedPane
+        && (expectedTmuxSessionId === undefined || observedSessionId === expectedTmuxSessionId)) return inheritedPane;
     } catch {
       // Fall through to the platform-specific resolution policy below.
     }
@@ -2524,7 +2525,7 @@ function resolveDetachedLeaderPaneIdentity(
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
 export function resolveDetachedLeaderPaneForTest(options: {
   sessionName: string;
-  sessionId: string;
+  expectedTmuxSessionId?: string;
   inheritedPane?: string;
   platform: NodeJS.Platform;
   leaderPid: number;
@@ -2534,7 +2535,7 @@ export function resolveDetachedLeaderPaneForTest(options: {
 }): string {
   return resolveDetachedLeaderPaneIdentity(
     options.sessionName,
-    options.sessionId,
+    options.expectedTmuxSessionId,
     options.inheritedPane,
     options.platform,
     options.leaderPid,
@@ -2739,6 +2740,55 @@ function cleanupDetachedPreReportSessionWithRetry(
     if (result === "cleaned") return result;
   }
   throw new Error("detached leader remained live before pre-report cleanup retry");
+}
+
+function scheduleDetachedPreReportCleanupRetry(
+  authority: DetachedLeaderAuthority,
+  allowUnownedPreTag: boolean,
+  authenticatedReadyOrTerminalProbe: () => boolean,
+  authenticatedFailedReportProbe: () => boolean,
+  onCleaned: () => void,
+  maxWaitMs = 30_000,
+): void {
+  const deadline = Date.now() + maxWaitMs;
+  const poll = (): void => {
+    if (Date.now() >= deadline) return;
+    try {
+      if (authenticatedReadyOrTerminalProbe()) return;
+      if (!authenticatedFailedReportProbe()) {
+        setTimeout(poll, 20);
+        return;
+      }
+      if (cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe) === "cleaned") {
+        onCleaned();
+        return;
+      }
+    } catch {
+      // Readiness, finalization, identity, and ownership changes all preserve
+      // the marker and stop this watcher rather than attempting cleanup.
+      return;
+    }
+    setTimeout(poll, 20);
+  };
+  setTimeout(poll, 20);
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function scheduleDetachedPreReportCleanupRetryForTest(
+  authority: DetachedLeaderAuthority,
+  authenticatedReadyOrTerminalProbe: () => boolean,
+  authenticatedFailedReportProbe: () => boolean,
+  onCleaned: () => void,
+  maxWaitMs = 30_000,
+): void {
+  scheduleDetachedPreReportCleanupRetry(
+    authority,
+    false,
+    authenticatedReadyOrTerminalProbe,
+    authenticatedFailedReportProbe,
+    onCleaned,
+    maxWaitMs,
+  );
 }
 
 export function cleanupDetachedPreReportSession(
@@ -6351,10 +6401,12 @@ export function isDetachedReadyReportAuthorized(
     leaderPaneId: string | null;
     leaderPanePid: number | null;
   },
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (report?.kind !== "ready" || report.nonce !== expected.nonce
     || report.sessionId !== expected.sessionId || report.sessionName !== expected.sessionName
     || typeof report.leaderPid !== "number" || report.leaderPid <= 0) return false;
+  if (platform === "win32") return report.paneId === expected.leaderPaneId;
   if (expected.shouldAttach && expected.leaderPanePid !== null) {
     return report.leaderPid === expected.leaderPanePid;
   }
@@ -6371,9 +6423,10 @@ function isDetachedTerminalReportAuthorized(
     leaderPaneId: string | null;
     leaderPanePid: number | null;
   },
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   if (report?.kind !== "terminal" || report.finalized !== true) return false;
-  return isDetachedReadyReportAuthorized({ ...report, kind: "ready" }, expected);
+  return isDetachedReadyReportAuthorized({ ...report, kind: "ready" }, expected, platform);
 }
 
 function isDetachedFailedReportAuthorized(
@@ -8106,6 +8159,15 @@ async function runCodex(
                 return { kind: "success" };
               }
               if (report?.nonce === detachedLaunchNonce && report.sessionId === sessionId && report.sessionName === sessionName && report.leaderPid && report.kind === "failed") {
+                if (!isDetachedFailedReportAuthorized(report, {
+                  nonce: detachedLaunchNonce,
+                  sessionId,
+                  sessionName,
+                  leaderPaneId: detachedLeaderPaneId,
+                  leaderPanePid: detachedLeaderAuthority?.panePid ?? null,
+                })) {
+                  throw new Error("detached failed report is not authorized");
+                }
                 detachedLeaderPid = report.leaderPid;
                 // #3578: a failed leader report is terminal evidence. A leader that
                 // never reached readiness cannot hold pointer authority, so the
@@ -8270,7 +8332,35 @@ async function runCodex(
                 });
               }
             }
-            if (sessionCleanupCompleted) await attempt("rollback", removeReleaseMarkers);
+            if (sessionCleanupCompleted) {
+              await attempt("rollback", removeReleaseMarkers);
+            } else if (rollbackFromPreReportAuthority && detachedLeaderAuthority) {
+              scheduleDetachedPreReportCleanupRetry(
+                detachedLeaderAuthority,
+                !detachedLeaderOwnerTagInstalled,
+                () => {
+                  const expected = {
+                    nonce: detachedLaunchNonce,
+                    sessionId,
+                    sessionName,
+                    shouldAttach: detachedPreflight.shouldAttach,
+                    leaderPaneId: detachedLeaderPaneId,
+                    leaderPanePid: detachedLeaderAuthority!.panePid,
+                  };
+                  const report = readDetachedLeaderReport(releaseMarkerPath);
+                  return isDetachedReadyReportAuthorized(report, expected) ||
+                    isDetachedTerminalReportAuthorized(report, expected);
+                },
+                () => isDetachedFailedReportAuthorized(readDetachedLeaderReport(releaseMarkerPath), {
+                  nonce: detachedLaunchNonce,
+                  sessionId,
+                  sessionName,
+                  leaderPaneId: detachedLeaderPaneId,
+                  leaderPanePid: detachedLeaderAuthority!.panePid,
+                }),
+                removeReleaseMarkers,
+              );
+            }
           },
         },
       );
@@ -8542,7 +8632,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
   const inheritedPane = process.env.TMUX_PANE?.trim();
   pane = resolveDetachedLeaderPaneIdentity(
     payload.sessionName,
-    payload.sessionId,
+    undefined,
     inheritedPane,
     process.platform,
     process.pid,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2580,14 +2580,20 @@ function runDetachedLeaderMutation(
  * pane-targeted destructive sink; a replacement session has a different
  * session_id/session_created and fails the session fence.
  */
-function detachedPreReportSessionCleanupCondition(authority: DetachedLeaderAuthority): string {
+function detachedPreReportSessionCleanupCondition(
+  authority: DetachedLeaderAuthority,
+  allowUnownedPreTag: boolean,
+): string {
   // The tag-session step is the first mutation after new-session. A bootstrap
   // failure can therefore leave a retained dead leader pane in a session whose
-  // exact identity is ours but whose owner option is still unset. Accept only
-  // that empty pre-tag state or our expected tag; a foreign tag remains a hard
-  // denial. Session id + creation time prevent a name-reused session from
-  // satisfying the pre-tag branch.
-  const owner = `#{||:#{==:#{@omx_instance_id},${authority.ownerId}},#{==:#{@omx_instance_id},}}`;
+  // exact identity is ours but whose owner option is still unset. When the
+  // caller has authenticated the pre-tag phase, accept only that empty state
+  // or our expected tag; otherwise require our expected tag. A foreign tag
+  // remains a hard denial. Session id + creation time prevent a name-reused
+  // session from satisfying the pre-tag branch.
+  const owner = allowUnownedPreTag
+    ? `#{||:#{==:#{@omx_instance_id},${authority.ownerId}},#{==:#{@omx_instance_id},}}`
+    : `#{==:#{@omx_instance_id},${authority.ownerId}}`;
   const conditions = [
     `#{==:#{session_name},${authority.sessionName}}`,
     `#{==:#{session_id},${authority.sessionId}}`,
@@ -2616,6 +2622,8 @@ function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): 
 function cleanupDetachedPreReportSessionInternal(
   authority: DetachedLeaderAuthority,
   afterTopologyProbe?: () => void,
+  allowUnownedPreTag = false,
+  authenticatedReadyOrTerminalProbe?: () => boolean,
 ): void {
   const receipt = detachedAuthorityReceipt();
   const sessionTarget = authority.sessionName;
@@ -2629,23 +2637,32 @@ function cleanupDetachedPreReportSessionInternal(
   const absence = detachedPreReportLeaderPaneAbsent(authority);
   if (absence === "unknown") throw new Error("detached pre-report topology changed before cleanup");
   afterTopologyProbe?.();
+  if (authenticatedReadyOrTerminalProbe?.()) {
+    throw new Error("detached leader became ready or terminal before pre-report cleanup");
+  }
   const sessionScoped = execTmuxFileSync([
-    "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority),
+    "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority, allowUnownedPreTag),
     success, "display-message -p ''",
   ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
   if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");
 }
 
-export function cleanupDetachedPreReportSession(authority: DetachedLeaderAuthority): void {
-  cleanupDetachedPreReportSessionInternal(authority);
+export function cleanupDetachedPreReportSession(
+  authority: DetachedLeaderAuthority,
+  allowUnownedPreTag = false,
+  authenticatedReadyOrTerminalProbe?: () => boolean,
+): void {
+  cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
 }
 
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
 export function cleanupDetachedPreReportSessionForTest(
   authority: DetachedLeaderAuthority,
   afterTopologyProbe: () => void,
+  allowUnownedPreTag = false,
+  authenticatedReadyOrTerminalProbe?: () => boolean,
 ): void {
-  cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe);
+  cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
 }
 
 function runDetachedHudMutation(
@@ -6243,6 +6260,21 @@ export function isDetachedReadyReportAuthorized(
   return report.paneId === expected.leaderPaneId;
 }
 
+function isDetachedTerminalReportAuthorized(
+  report: DetachedLeaderReport | null | undefined,
+  expected: {
+    nonce: string;
+    sessionId: string;
+    sessionName: string;
+    shouldAttach: boolean;
+    leaderPaneId: string | null;
+    leaderPanePid: number | null;
+  },
+): boolean {
+  if (report?.kind !== "terminal" || report.finalized !== true) return false;
+  return isDetachedReadyReportAuthorized({ ...report, kind: "ready" }, expected);
+}
+
 function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
@@ -7849,6 +7881,7 @@ async function runCodex(
 
     const launchDetachedSession = async (): Promise<{ postLaunchHandledExternally: boolean }> => {
       let createdSession = false;
+      let detachedLeaderOwnerTagInstalled = false;
       const bootstrapLeader = async (): Promise<void> => {
         if (!nativeWindows) detachedParentEnvFilePath = writeDetachedSessionParentEnvFile(cwd, sessionId, codexEnvWithNotify);
         const bootstrapSteps = buildDetachedSessionBootstrapSteps(
@@ -7880,6 +7913,7 @@ async function runCodex(
             if (!authority) throw new Error("detached leader authority missing before tmux mutation");
             if (step.name === "tag-session") {
               runDetachedLeaderMutation(authority, step.args, false);
+              detachedLeaderOwnerTagInstalled = true;
               // tmux can acknowledge the session tag before the first owner-format
               // evaluation sees it. Retrying this idempotent first owner-guarded
               // mutation once gives the server a command boundary without relaxing
@@ -8062,12 +8096,29 @@ async function runCodex(
               }
               for (const step of buildDetachedSessionRollbackSteps(sessionName, null, null, null)) {
                 await attempt(`session:${step.name}`, () => {
-                  if (!detachedLeaderAuthority) throw new Error("detached leader authority missing before rollback");
+                  const leaderAuthority = detachedLeaderAuthority;
+                  if (!leaderAuthority) throw new Error("detached leader authority missing before rollback");
                   if (rollbackFromPreReportAuthority && step.name === "kill-session") {
-                    cleanupDetachedPreReportSession(detachedLeaderAuthority);
+                    cleanupDetachedPreReportSession(
+                      leaderAuthority,
+                      !detachedLeaderOwnerTagInstalled,
+                      () => {
+                        const expected = {
+                          nonce: detachedLaunchNonce,
+                          sessionId,
+                          sessionName,
+                          shouldAttach: detachedPreflight.shouldAttach,
+                          leaderPaneId: detachedLeaderPaneId,
+                          leaderPanePid: leaderAuthority.panePid,
+                        };
+                        const report = readDetachedLeaderReport(releaseMarkerPath);
+                        return isDetachedReadyReportAuthorized(report, expected) ||
+                          isDetachedTerminalReportAuthorized(report, expected);
+                      },
+                    );
                     return;
                   }
-                  runDetachedLeaderMutation(detachedLeaderAuthority, step.args);
+                  runDetachedLeaderMutation(leaderAuthority, step.args);
                 });
               }
             }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2686,6 +2686,17 @@ function detachedPreReportLeaderPaneState(authority: DetachedLeaderAuthority): "
   }
 }
 
+function detachedSessionExists(sessionName: string): boolean {
+  try {
+    execTmuxFileSync(["has-session", "-t", sessionName], {
+      encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function cleanupDetachedPreReportSessionInternal(
   authority: DetachedLeaderAuthority,
   afterTopologyProbe?: () => void,
@@ -2727,7 +2738,16 @@ function cleanupDetachedPreReportSessionWithRetry(
   authenticatedReadyOrTerminalProbe?: () => boolean,
   authenticatedFailedReportProbe?: () => boolean,
 ): DetachedPreReportCleanupResult {
-  let result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  let result: DetachedPreReportCleanupResult;
+  try {
+    result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  } catch (error) {
+    // A failed leader may have already removed its own exact session before
+    // the parent reaches rollback. Only an authenticated failed report permits
+    // acknowledging that disappearance as completed cleanup.
+    if (authenticatedFailedReportProbe?.() && !detachedSessionExists(authority.sessionName)) return "cleaned";
+    throw error;
+  }
   if (result === "cleaned" || !authenticatedFailedReportProbe?.()) return result;
   // A failed report may be published while the leader pane is still live. Do
   // not treat that observation as successful cleanup: retain the marker and
@@ -2736,7 +2756,12 @@ function cleanupDetachedPreReportSessionWithRetry(
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     blockMs(20);
-    result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+    try {
+      result = cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+    } catch (error) {
+      if (authenticatedFailedReportProbe() && !detachedSessionExists(authority.sessionName)) return "cleaned";
+      throw error;
+    }
     if (result === "cleaned") return result;
   }
   throw new Error("detached leader remained live before pre-report cleanup retry");
@@ -8621,6 +8646,45 @@ function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLea
   }
 }
 
+function cleanupDetachedLeaderSessionWithAuthority(authority: DetachedLeaderAuthority, ownerId: string): void {
+  try {
+    const owner = `#{||:#{==:#{@omx_instance_id},${ownerId}},#{==:#{@omx_instance_id},}}`;
+    const condition = [
+      `#{==:#{session_name},${authority.sessionName}}`,
+      `#{==:#{session_id},${authority.sessionId}}`,
+      `#{==:#{session_created},${authority.sessionCreated}}`,
+      owner,
+    ].reduce((combined, item) => `#{&&:${combined},${item}}`);
+    const receipt = detachedAuthorityReceipt();
+    const success = `kill-session -t ${quoteShellArg(authority.sessionName)} ; display-message -p ${quoteShellArg(receipt)}`;
+    const result = execTmuxFileSync([
+      "if-shell", "-F", "-t", authority.sessionName, condition, success, "display-message -p ''",
+    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    if (result !== receipt) throw new Error("detached failed leader session authority changed before cleanup");
+  } catch {
+    // The parent retains the report and its own identity-fenced cleanup marker.
+    // A failed leader must never turn an uncertain session lookup into a kill.
+  }
+}
+
+function cleanupDetachedLeaderSessionAfterFailure(paneId: string, payload: DetachedLeaderPayload): void {
+  try {
+    const authority = captureDetachedLeaderAuthority(paneId, payload.sessionName, payload.sessionId);
+    cleanupDetachedLeaderSessionWithAuthority(authority, payload.sessionId);
+  } catch {
+    // The parent retains the report and its own identity-fenced cleanup marker.
+    // A failed leader must never turn an uncertain session lookup into a kill.
+  }
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function cleanupDetachedLeaderSessionAfterFailureForTest(
+  authority: DetachedLeaderAuthority,
+  ownerId: string,
+): void {
+  cleanupDetachedLeaderSessionWithAuthority(authority, ownerId);
+}
+
 function traceDetachedLeaderPhase(phase: string): void {
   if (process.env.OMX_TEST_DETACHED_TRACE !== "1") return;
   const line = `[omx-test-detached] ${phase}\n`;
@@ -8675,6 +8739,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
         ...detachedSessionPointerAbortCode(error),
       });
     }
+    cleanupDetachedLeaderSessionAfterFailure(pane, payload);
     throw error;
   }
   const binding = established.binding;
@@ -8685,6 +8750,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
   const activeRecordPath = contextKey
     ? madmaxDetachedActiveRecordPath(resolveMadmaxRunsRoot(process.env), contextKey)
     : join(omxRoot(payload.cwd), "state", "detached-active-record.json");
+  let readyReportWritten = false;
 
   try {
     const completion = await completePreLaunchSetup(
@@ -8718,6 +8784,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     });
     if (payload.readyPath) {
       writeDetachedLeaderReport(payload.readyPath, { version: 1, kind: "ready", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName, paneId: pane, leaderPid: process.pid });
+      readyReportWritten = true;
       const releasePath = `${payload.readyPath}.release`;
       const abortPath = `${payload.readyPath}.abort`;
       const releaseDeadline = Date.now() + 30_000;
@@ -8851,6 +8918,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
       leaderPid: process.pid, finalized, error: failure instanceof Error ? failure.message : String(failure),
       ...detachedSessionPointerAbortCode(failure),
     });
+    if (!readyReportWritten) cleanupDetachedLeaderSessionAfterFailure(pane, payload);
     throw failure;
   } finally {
     await closeLaunchSessionBindingOnce(binding);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2603,17 +2603,24 @@ function detachedPreReportSessionCleanupCondition(
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
 
-function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): "absent" | "present" | "unknown" {
-  // Enumerate every pane id of the exact named session; the leader pane must
-  // be absent for the session-scoped fence to apply. Enumeration failures
-  // (notably the exact session no longer exists) are fail-closed: unknown
-  // topology preserves without mutation and is surfaced as a topology change.
+function detachedPreReportLeaderPaneState(authority: DetachedLeaderAuthority): "absent" | "dead" | "live" | "unknown" {
+  // Enumerate the exact named session and classify the captured pane before any
+  // destructive command. A live captured leader is always preserved: a report
+  // can arrive after the final file read and before a separate tmux command,
+  // so timeout-based cleanup must never kill a pane that is still running.
+  // Enumeration failures (notably the exact session no longer exists) are
+  // fail-closed: unknown topology preserves without mutation.
   try {
     const sessionTarget = authority.sessionName;
-    const output = execTmuxFileSync(["list-panes", "-s", "-t", sessionTarget, "-F", "#{pane_id}"], {
+    const output = execTmuxFileSync(["list-panes", "-s", "-t", sessionTarget, "-F", "#{pane_id}\t#{pane_dead}"], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     });
-    return !output.split("\n").map((line) => line.trim()).filter(Boolean).includes(authority.paneId) ? "absent" : "present";
+    const row = output.split("\n").map((line) => line.trim()).filter(Boolean).find((line) => line.split("\t")[0] === authority.paneId);
+    if (!row) return "absent";
+    const paneDead = row.split("\t")[1];
+    if (paneDead === "1") return "dead";
+    if (paneDead === "0") return "live";
+    return "unknown";
   } catch {
     return "unknown";
   }
@@ -2624,6 +2631,7 @@ function cleanupDetachedPreReportSessionInternal(
   afterTopologyProbe?: () => void,
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
+  afterAuthenticatedReadyOrTerminalProbe?: () => void,
 ): void {
   const receipt = detachedAuthorityReceipt();
   const sessionTarget = authority.sessionName;
@@ -2634,12 +2642,15 @@ function cleanupDetachedPreReportSessionInternal(
   // The sink therefore targets only the session name and rechecks the complete
   // session identity plus the authenticated owner/pre-tag fence in the same
   // tmux command queue.
-  const absence = detachedPreReportLeaderPaneAbsent(authority);
-  if (absence === "unknown") throw new Error("detached pre-report topology changed before cleanup");
+  const paneState = detachedPreReportLeaderPaneState(authority);
+  if (paneState === "unknown") throw new Error("detached pre-report topology changed before cleanup");
   afterTopologyProbe?.();
-  if (authenticatedReadyOrTerminalProbe?.()) {
+  const authenticatedReady = authenticatedReadyOrTerminalProbe?.() === true;
+  afterAuthenticatedReadyOrTerminalProbe?.();
+  if (authenticatedReady) {
     throw new Error("detached leader became ready or terminal before pre-report cleanup");
   }
+  if (paneState === "live") return;
   const sessionScoped = execTmuxFileSync([
     "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority, allowUnownedPreTag),
     success, "display-message -p ''",
@@ -2651,8 +2662,9 @@ export function cleanupDetachedPreReportSession(
   authority: DetachedLeaderAuthority,
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
+  afterAuthenticatedReadyOrTerminalProbe?: () => void,
 ): void {
-  cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, afterAuthenticatedReadyOrTerminalProbe);
 }
 
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
@@ -2661,8 +2673,9 @@ export function cleanupDetachedPreReportSessionForTest(
   afterTopologyProbe: () => void,
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
+  afterAuthenticatedReadyOrTerminalProbe?: () => void,
 ): void {
-  cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe, allowUnownedPreTag, authenticatedReadyOrTerminalProbe);
+  cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, afterAuthenticatedReadyOrTerminalProbe);
 }
 
 function runDetachedHudMutation(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2567,18 +2567,6 @@ function runDetachedLeaderMutation(
   throw new Error(`detached leader authority blocked tmux mutation ${mutation}: ${describeDetachedLeaderAuthorityMismatch(authority)}`);
 }
 
-function detachedPreReportCleanupCondition(authority: DetachedLeaderAuthority): string {
-  const conditions = [
-    "#{==:#{pane_dead},1}",
-    `#{==:#{pane_id},${authority.paneId}}`,
-    `#{==:#{session_name},${authority.sessionName}}`,
-    `#{==:#{session_id},${authority.sessionId}}`,
-    `#{==:#{session_created},${authority.sessionCreated}}`,
-    `#{==:#{window_id},${authority.windowId}}`,
-  ];
-  return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
-}
-
 /**
  * #3578: session-scoped fence for pre-report cleanup when the leader pane no
  * longer exists at all. A normal leader exit with `remain-on-exit off` (set by
@@ -2617,35 +2605,37 @@ function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): 
   }
 }
 
-export function cleanupDetachedPreReportSession(authority: DetachedLeaderAuthority): void {
+function cleanupDetachedPreReportSessionInternal(
+  authority: DetachedLeaderAuthority,
+  afterTopologyProbe?: () => void,
+): void {
   const receipt = detachedAuthorityReceipt();
   const success = `kill-session -t ${quoteShellArg(authority.sessionName)} ; display-message -p ${quoteShellArg(receipt)}`;
-  // #3562/#3578: never evaluate a pane-targeted format against a pane that may
-  // no longer exist — a missing -t target can terminate the server. Probe pane
-  // membership of the exact named session first; only a pane that still exists
-  // may take the original retained-dead-pane fence.
+  // #3562/#3578: probe the exact session topology for diagnostics, but never
+  // feed the captured pane id into the destructive sink. The probe is
+  // non-atomic; a leader pane can disappear or be reused before the sink runs.
+  // The sink therefore targets only the session name and rechecks the complete
+  // session identity plus owner tag in the same tmux command queue.
   const absence = detachedPreReportLeaderPaneAbsent(authority);
   if (absence === "unknown") throw new Error("detached pre-report topology changed before cleanup");
-  if (absence === "absent") {
-    // #3578: the leader pane was removed entirely (normal exit with
-    // remain-on-exit off). Clean up through the session-scoped fence instead.
-    const sessionScoped = execTmuxFileSync([
-      "if-shell", "-F", "-t", authority.sessionName, detachedPreReportSessionCleanupCondition(authority),
-      success, "display-message -p ''",
-    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-    if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");
-    return;
-  }
-  let output: string;
-  try {
-    output = execTmuxFileSync([
-      "if-shell", "-F", "-t", authority.paneId, detachedPreReportCleanupCondition(authority),
-      success, "display-message -p ''",
-    ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-  } catch {
-    throw new Error("detached pre-report topology changed before cleanup");
-  }
-  if (output !== receipt) throw new Error("detached pre-report topology changed before cleanup");
+  afterTopologyProbe?.();
+  const sessionScoped = execTmuxFileSync([
+    "if-shell", "-F", "-t", authority.sessionName, detachedPreReportSessionCleanupCondition(authority),
+    success, "display-message -p ''",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");
+}
+
+export function cleanupDetachedPreReportSession(authority: DetachedLeaderAuthority): void {
+  cleanupDetachedPreReportSessionInternal(authority);
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function cleanupDetachedPreReportSessionForTest(
+  authority: DetachedLeaderAuthority,
+  afterTopologyProbe: () => void,
+): void {
+  cleanupDetachedPreReportSessionInternal(authority, afterTopologyProbe);
 }
 
 function runDetachedHudMutation(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2583,6 +2583,7 @@ function runDetachedLeaderMutation(
 function detachedPreReportSessionCleanupCondition(
   authority: DetachedLeaderAuthority,
   allowUnownedPreTag: boolean,
+  requireCapturedDeadPane: boolean,
 ): string {
   // The tag-session step is the first mutation after new-session. A bootstrap
   // failure can therefore leave a retained dead leader pane in a session whose
@@ -2600,6 +2601,17 @@ function detachedPreReportSessionCleanupCondition(
     `#{==:#{session_created},${authority.sessionCreated}}`,
     owner,
   ];
+  if (requireCapturedDeadPane) {
+    // The session target resolves the active pane without using a pane target.
+    // If the captured dead pane was respawned, its PID or liveness changes and
+    // this single queued tmux predicate refuses the destructive sink. If a
+    // different pane is active, preserving is the only safe result.
+    conditions.push(
+      `#{==:#{pane_id},${authority.paneId}}`,
+      `#{==:#{pane_pid},${authority.panePid}}`,
+      "#{==:#{pane_dead},1}",
+    );
+  }
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
 
@@ -2652,7 +2664,7 @@ function cleanupDetachedPreReportSessionInternal(
   }
   if (paneState === "live") return;
   const sessionScoped = execTmuxFileSync([
-    "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority, allowUnownedPreTag),
+    "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority, allowUnownedPreTag, paneState === "dead"),
     success, "display-message -p ''",
   ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
   if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2573,19 +2573,26 @@ function runDetachedLeaderMutation(
  * the tag-session step) removes the pane, so the pane-dead predicate above can
  * never match and rollback leaked a HUD-only session. The replacement fence is
  * evaluated against the SESSION (a server-scoped stable identity), not a pane:
- * exact session_name + session_id + session_created, the session's own
- * @omx_instance_id owner tag, and a POSITIVE assertion that the captured
- * leader pane is absent from every window of the session. The owner tag is
- * session-scoped and set only by this launch's tag-session step, so a foreign
- * or replacement session — including one that merely reuses the name — has a
- * different session_id/session_created/owner triple and fails the fence.
+ * exact session_name + session_id + session_created, plus either this launch's
+ * @omx_instance_id owner tag or the empty owner state that exists before the
+ * tag-session step succeeds. A foreign tag is never accepted. The leader-pane
+ * probe is retained as a fail-closed existence check, but is not reused as a
+ * pane-targeted destructive sink; a replacement session has a different
+ * session_id/session_created and fails the session fence.
  */
 function detachedPreReportSessionCleanupCondition(authority: DetachedLeaderAuthority): string {
+  // The tag-session step is the first mutation after new-session. A bootstrap
+  // failure can therefore leave a retained dead leader pane in a session whose
+  // exact identity is ours but whose owner option is still unset. Accept only
+  // that empty pre-tag state or our expected tag; a foreign tag remains a hard
+  // denial. Session id + creation time prevent a name-reused session from
+  // satisfying the pre-tag branch.
+  const owner = `#{||:#{==:#{@omx_instance_id},${authority.ownerId}},#{==:#{@omx_instance_id},}}`;
   const conditions = [
     `#{==:#{session_name},${authority.sessionName}}`,
     `#{==:#{session_id},${authority.sessionId}}`,
     `#{==:#{session_created},${authority.sessionCreated}}`,
-    `#{==:#{@omx_instance_id},${authority.ownerId}}`,
+    owner,
   ];
   return conditions.reduce((combined, condition) => `#{&&:${combined},${condition}}`);
 }
@@ -2596,7 +2603,8 @@ function detachedPreReportLeaderPaneAbsent(authority: DetachedLeaderAuthority): 
   // (notably the exact session no longer exists) are fail-closed: unknown
   // topology preserves without mutation and is surfaced as a topology change.
   try {
-    const output = execTmuxFileSync(["list-panes", "-s", "-t", authority.sessionName, "-F", "#{pane_id}"], {
+    const sessionTarget = authority.sessionName;
+    const output = execTmuxFileSync(["list-panes", "-s", "-t", sessionTarget, "-F", "#{pane_id}"], {
       encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
     });
     return !output.split("\n").map((line) => line.trim()).filter(Boolean).includes(authority.paneId) ? "absent" : "present";
@@ -2610,17 +2618,19 @@ function cleanupDetachedPreReportSessionInternal(
   afterTopologyProbe?: () => void,
 ): void {
   const receipt = detachedAuthorityReceipt();
-  const success = `kill-session -t ${quoteShellArg(authority.sessionName)} ; display-message -p ${quoteShellArg(receipt)}`;
+  const sessionTarget = authority.sessionName;
+  const success = `kill-session -t ${quoteShellArg(sessionTarget)} ; display-message -p ${quoteShellArg(receipt)}`;
   // #3562/#3578: probe the exact session topology for diagnostics, but never
   // feed the captured pane id into the destructive sink. The probe is
   // non-atomic; a leader pane can disappear or be reused before the sink runs.
   // The sink therefore targets only the session name and rechecks the complete
-  // session identity plus owner tag in the same tmux command queue.
+  // session identity plus the authenticated owner/pre-tag fence in the same
+  // tmux command queue.
   const absence = detachedPreReportLeaderPaneAbsent(authority);
   if (absence === "unknown") throw new Error("detached pre-report topology changed before cleanup");
   afterTopologyProbe?.();
   const sessionScoped = execTmuxFileSync([
-    "if-shell", "-F", "-t", authority.sessionName, detachedPreReportSessionCleanupCondition(authority),
+    "if-shell", "-F", "-t", sessionTarget, detachedPreReportSessionCleanupCondition(authority),
     success, "display-message -p ''",
   ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
   if (sessionScoped !== receipt) throw new Error("detached pre-report topology changed before cleanup");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2615,6 +2615,18 @@ function runDetachedLeaderMutation(
   throw new Error(`detached leader authority blocked tmux mutation ${mutation}: ${describeDetachedLeaderAuthorityMismatch(authority)}`);
 }
 
+function runDetachedLeaderTagMutation(authority: DetachedLeaderAuthority, ownerId: string): void {
+  const receipt = detachedAuthorityReceipt();
+  const phaseMarker = ["set-option", "-t", authority.sessionName, "@omx_detached_owner_tag_attempted", "1"].map(quoteShellArg).join(" ");
+  const ownerTag = ["set-option", "-t", authority.sessionName, OMX_INSTANCE_OPTION, ownerId].map(quoteShellArg).join(" ");
+  const success = `${phaseMarker} ; ${ownerTag} ; display-message -p ${quoteShellArg(receipt)}`;
+  const output = execTmuxFileSync([
+    "if-shell", "-F", "-t", authority.paneId, detachedLeaderAuthorityCondition(authority, false),
+    success, "display-message -p ''",
+  ], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  if (output !== receipt) throw new Error(`detached leader authority blocked tmux mutation tag-session: ${describeDetachedLeaderAuthorityMismatch(authority)}`);
+}
+
 /**
  * #3578: session-scoped fence for pre-report cleanup when the leader pane no
  * longer exists at all. A normal leader exit with `remain-on-exit off` (set by
@@ -2737,6 +2749,7 @@ function cleanupDetachedPreReportSessionWithRetry(
   allowUnownedPreTag: boolean,
   authenticatedReadyOrTerminalProbe?: () => boolean,
   authenticatedFailedReportProbe?: () => boolean,
+  retryAuthenticatedFailure = true,
 ): DetachedPreReportCleanupResult {
   let result: DetachedPreReportCleanupResult;
   try {
@@ -2748,7 +2761,7 @@ function cleanupDetachedPreReportSessionWithRetry(
     if (authenticatedFailedReportProbe?.() && !detachedSessionExists(authority.sessionName)) return "cleaned";
     throw error;
   }
-  if (result === "cleaned" || !authenticatedFailedReportProbe?.()) return result;
+  if (result === "cleaned" || !retryAuthenticatedFailure || !authenticatedFailedReportProbe?.()) return result;
   // A failed report may be published while the leader pane is still live. Do
   // not treat that observation as successful cleanup: retain the marker and
   // retry the identity-fenced decision after the leader exits. A later ready,
@@ -2767,62 +2780,14 @@ function cleanupDetachedPreReportSessionWithRetry(
   throw new Error("detached leader remained live before pre-report cleanup retry");
 }
 
-function scheduleDetachedPreReportCleanupRetry(
-  authority: DetachedLeaderAuthority,
-  allowUnownedPreTag: boolean,
-  authenticatedReadyOrTerminalProbe: () => boolean,
-  authenticatedFailedReportProbe: () => boolean,
-  onCleaned: () => void,
-  maxWaitMs = 30_000,
-): void {
-  const deadline = Date.now() + maxWaitMs;
-  const poll = (): void => {
-    if (Date.now() >= deadline) return;
-    try {
-      if (authenticatedReadyOrTerminalProbe()) return;
-      if (!authenticatedFailedReportProbe()) {
-        setTimeout(poll, 20);
-        return;
-      }
-      if (cleanupDetachedPreReportSessionInternal(authority, undefined, allowUnownedPreTag, authenticatedReadyOrTerminalProbe) === "cleaned") {
-        onCleaned();
-        return;
-      }
-    } catch {
-      // Readiness, finalization, identity, and ownership changes all preserve
-      // the marker and stop this watcher rather than attempting cleanup.
-      return;
-    }
-    setTimeout(poll, 20);
-  };
-  setTimeout(poll, 20);
-}
-
-/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
-export function scheduleDetachedPreReportCleanupRetryForTest(
-  authority: DetachedLeaderAuthority,
-  authenticatedReadyOrTerminalProbe: () => boolean,
-  authenticatedFailedReportProbe: () => boolean,
-  onCleaned: () => void,
-  maxWaitMs = 30_000,
-): void {
-  scheduleDetachedPreReportCleanupRetry(
-    authority,
-    false,
-    authenticatedReadyOrTerminalProbe,
-    authenticatedFailedReportProbe,
-    onCleaned,
-    maxWaitMs,
-  );
-}
-
 export function cleanupDetachedPreReportSession(
   authority: DetachedLeaderAuthority,
   allowUnownedPreTag = false,
   authenticatedReadyOrTerminalProbe?: () => boolean,
   authenticatedFailedReportProbe?: () => boolean,
+  retryAuthenticatedFailure = true,
 ): DetachedPreReportCleanupResult {
-  return cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, authenticatedFailedReportProbe);
+  return cleanupDetachedPreReportSessionWithRetry(authority, allowUnownedPreTag, authenticatedReadyOrTerminalProbe, authenticatedFailedReportProbe, retryAuthenticatedFailure);
 }
 
 /** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
@@ -8088,6 +8053,7 @@ async function runCodex(
     let detachedHudAuthority: DetachedHudAuthority | null = null;
     let detachedLeaderPid: number | null = null;
     let rollbackFromPreReportAuthority = false;
+    let rollbackFromAuthenticatedFailure = false;
 
     let attachStep: DetachedSessionTmuxStep | null = null;
 
@@ -8124,7 +8090,7 @@ async function runCodex(
             const authority = detachedLeaderAuthority;
             if (!authority) throw new Error("detached leader authority missing before tmux mutation");
             if (step.name === "tag-session") {
-              runDetachedLeaderMutation(authority, step.args, false);
+              runDetachedLeaderTagMutation(authority, sessionId);
               detachedLeaderOwnerTagInstalled = true;
               // tmux can acknowledge the session tag before the first owner-format
               // evaluation sees it. Retrying this idempotent first owner-guarded
@@ -8201,6 +8167,7 @@ async function runCodex(
                 // the wait-for-finalization path, which only a ready leader can
                 // satisfy and would otherwise stall 30s and skip rollback.
                 rollbackFromPreReportAuthority = detachedLeaderAuthority !== null;
+                rollbackFromAuthenticatedFailure = rollbackFromPreReportAuthority;
                 return { kind: "failure", operation: "session-instructions", error: detachedLeaderFailureError(report) };
               }
               if (Date.now() >= readyDeadline) {
@@ -8356,6 +8323,7 @@ async function runCodex(
                         leaderPaneId: detachedLeaderPaneId,
                         leaderPanePid: leaderAuthority.panePid,
                       }),
+                      rollbackFromAuthenticatedFailure,
                     );
                     sessionCleanupCompleted = cleanupResult === "cleaned";
                     return;
@@ -8366,32 +8334,6 @@ async function runCodex(
             }
             if (sessionCleanupCompleted) {
               await attempt("rollback", removeReleaseMarkers);
-            } else if (rollbackFromPreReportAuthority && detachedLeaderAuthority) {
-              scheduleDetachedPreReportCleanupRetry(
-                detachedLeaderAuthority,
-                !detachedLeaderOwnerTagInstalled,
-                () => {
-                  const expected = {
-                    nonce: detachedLaunchNonce,
-                    sessionId,
-                    sessionName,
-                    shouldAttach: detachedPreflight.shouldAttach,
-                    leaderPaneId: detachedLeaderPaneId,
-                    leaderPanePid: detachedLeaderAuthority!.panePid,
-                  };
-                  const report = readDetachedLeaderReport(releaseMarkerPath);
-                  return isDetachedReadyReportAuthorized(report, expected) ||
-                    isDetachedTerminalReportAuthorized(report, expected);
-                },
-                () => isDetachedFailedReportAuthorized(readDetachedLeaderReport(releaseMarkerPath), {
-                  nonce: detachedLaunchNonce,
-                  sessionId,
-                  sessionName,
-                  leaderPaneId: detachedLeaderPaneId,
-                  leaderPanePid: detachedLeaderAuthority!.panePid,
-                }),
-                removeReleaseMarkers,
-              );
             }
           },
         },
@@ -8648,7 +8590,12 @@ function teardownDetachedOwnedHudPane(leaderPaneId: string, payload: DetachedLea
 
 function cleanupDetachedLeaderSessionWithAuthority(authority: DetachedLeaderAuthority, ownerId: string): void {
   try {
-    const owner = `#{||:#{==:#{@omx_instance_id},${ownerId}},#{==:#{@omx_instance_id},}}`;
+    const tagAttempted = execTmuxFileSync(["show-options", "-qv", "-t", authority.sessionName, "@omx_detached_owner_tag_attempted"], {
+      encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+    }).trim() === "1";
+    const owner = tagAttempted
+      ? `#{==:#{@omx_instance_id},${ownerId}}`
+      : `#{||:#{==:#{@omx_instance_id},${ownerId}},#{==:#{@omx_instance_id},}}`;
     const condition = [
       `#{==:#{session_name},${authority.sessionName}}`,
       `#{==:#{session_id},${authority.sessionId}}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6335,13 +6335,31 @@ function isDetachedFailedReportAuthorized(
     nonce: string;
     sessionId: string;
     sessionName: string;
+    leaderPaneId: string | null;
     leaderPanePid: number | null;
   },
+  platform: NodeJS.Platform = process.platform,
 ): boolean {
   return report?.kind === "failed" && report.nonce === expected.nonce
     && report.sessionId === expected.sessionId && report.sessionName === expected.sessionName
+    && report.paneId === expected.leaderPaneId
     && typeof report.leaderPid === "number" && report.leaderPid > 0
-    && (expected.leaderPanePid === null || report.leaderPid === expected.leaderPanePid);
+    && (platform === "win32" || expected.leaderPanePid === null || report.leaderPid === expected.leaderPanePid);
+}
+
+/** Internal detached-launch seam. Exported solely for deterministic CLI tests. */
+export function isDetachedFailedReportAuthorizedForTest(
+  report: DetachedLeaderReport | null | undefined,
+  expected: {
+    nonce: string;
+    sessionId: string;
+    sessionName: string;
+    leaderPaneId: string | null;
+    leaderPanePid: number | null;
+  },
+  platform: NodeJS.Platform,
+): boolean {
+  return isDetachedFailedReportAuthorized(report, expected, platform);
 }
 
 function writeDetachedLeaderReport(path: string, report: DetachedLeaderReport): void {
@@ -8194,6 +8212,7 @@ async function runCodex(
                         nonce: detachedLaunchNonce,
                         sessionId,
                         sessionName,
+                        leaderPaneId: detachedLeaderPaneId,
                         leaderPanePid: leaderAuthority.panePid,
                       }),
                     );
@@ -8503,6 +8522,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     if (payload.readyPath) {
       writeDetachedLeaderReport(payload.readyPath, {
         version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
+        paneId: pane,
         leaderPid: process.pid, error: describeDetachedLeaderFailure(error),
         ...detachedSessionPointerAbortCode(error),
       });
@@ -8679,6 +8699,7 @@ async function runDetachedSessionLeader(payload: DetachedLeaderPayload): Promise
     }
     if (payload.readyPath) writeDetachedLeaderReport(payload.readyPath, {
       version: 1, kind: "failed", nonce, sessionId: payload.sessionId, sessionName: payload.sessionName,
+      paneId: pane,
       leaderPid: process.pid, finalized, error: failure instanceof Error ? failure.message : String(failure),
       ...detachedSessionPointerAbortCode(failure),
     });


### PR DESCRIPTION
Follow-up to #3580 (merged dev@87b43ff9 despite exact-head REQUEST_CHANGES 5423098005). Closes #3578.

**Blocker addressed:** `detachedPreReportLeaderPaneAbsent` previously mapped any `list-panes -s -t <exact session>` error (notably destroyed exact session) to `false` ("pane present"), so control fell through to the pane-targeted `if-shell -t <stale leader pane>` sink. That path could execute against a missing/recycled target and violated the no-cross-session-deletion fail-closed contract; the new safety comment explicitly says a missing pane target can terminate the server.

**Fix:** `detachedPreReportLeaderPaneAbsent` now returns tri-state `absent | present | unknown`. On `unknown` (exact-session lookup failure — session disappeared, tmux error) `cleanupDetachedPreReportSession` throws `topology changed before cleanup` without touching any pane. The remaining pane-targeted sink is `try`/`catch` fail-closed: if topology changes between probe and sink, it preserves. All mutations remain exact `session_name`/`session_id`/`session_created`/`@omx_instance_id` fenced.

**Tests:** `detached-launch-diagnostics-3578.test.ts` adds `preserves without mutation when the exact session disappears before cleanup (destroyed session)` (destroyed + reuse-after-destroy both fail closed) and `preserves without mutation when owner drifts after probe but before pane-targeted sink (race)` (probe sees present, owner drifts before sink, no stale pane mutated; HUD/leader pane/session survive). Focused suites 13/22/38 pass, `npm run build`/`tsc --noEmit`/`biome lint` clean.

Base: `origin/dev@87b43ff9 (#3580)`. No changes to #3577/#3552/main/releases. No reuse of #3580 green CI as authority — requires fresh exact-head review.

`Signed-off-by: Muse Spark <muse-spark@codex>`