### PR TITLE
fix: materialize symlinked project history (#3581)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,7 @@ jobs:
       - name: Run Windows history materialization regressions
         run: >-
           node --test
-          --test-name-pattern="materializes resolved history links|skips same-inode history content mutations|merges a symlinked primary history tree|populates read-only history directories|skips an extra history home|keeps group-only history|skips cyclic durable history links|rejects source swaps|persists materialized sessions|does not rewrite canonical history|serializes concurrent JSONL cleanup appends|live history lock|old lock owner|heartbeat owner|stale lock"
+          --test-name-pattern="materializes resolved history links|skips same-inode history content mutations|merges a symlinked primary history tree|populates read-only history directories|writable resolved history target|skips an extra history home|keeps group-only history|skips cyclic durable history links|rejects source swaps|persists materialized sessions|does not rewrite canonical history|serializes concurrent JSONL cleanup appends|live history lock|old lock owner|heartbeat owner|stale lock"
           dist/cli/__tests__/index.test.js
       - name: Run Windows resume integration regression
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,8 +556,13 @@ jobs:
       - name: Run Windows history materialization regressions
         run: >-
           node --test
-          --test-name-pattern="materializes resolved history links|merges a symlinked primary history tree|populates read-only history directories|skips an extra history home|keeps group-only history|skips cyclic durable history links|rejects source swaps|persists materialized sessions|does not rewrite canonical history"
+          --test-name-pattern="materializes resolved history links|skips same-inode history content mutations|merges a symlinked primary history tree|populates read-only history directories|skips an extra history home|keeps group-only history|skips cyclic durable history links|rejects source swaps|persists materialized sessions|does not rewrite canonical history|serializes concurrent JSONL cleanup appends|live history lock|old lock owner|heartbeat owner|stale lock"
           dist/cli/__tests__/index.test.js
+      - name: Run Windows resume integration regression
+        run: >-
+          node --test
+          --test-name-pattern="runs project resume integration on Windows"
+          dist/cli/__tests__/resume.test.js
 
   coverage-team-critical:
     name: Coverage Gate (Team Critical)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,10 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run build
       - name: Run Windows history materialization regressions
-        run: node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/resume.test.js
+        run: >-
+          node --test
+          --test-name-pattern="materializes resolved history links|merges a symlinked primary history tree|populates read-only history directories|skips an extra history home|keeps group-only history|skips cyclic durable history links|rejects source swaps|persists materialized sessions|does not rewrite canonical history"
+          dist/cli/__tests__/index.test.js
 
   coverage-team-critical:
     name: Coverage Gate (Team Critical)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,23 @@ jobs:
             dist/verification/__tests__/explore-harness-release-workflow.test.js \
             dist/compat/__tests__/*.test.js
 
+  test-windows-js:
+    name: Test (Windows / history materialization)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    needs: [changes]
+    if: ${{ needs.changes.outputs.full_suite == 'true' || needs.changes.outputs.ts_changed == 'true' || needs.changes.outputs.shared_config_changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Run Windows history materialization regressions
+        run: node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/resume.test.js
+
   coverage-team-critical:
     name: Coverage Gate (Team Critical)
     runs-on: ubuntu-latest
@@ -675,7 +692,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build]
+    needs: [changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, test-windows-js, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build]
     steps:
       - name: Check required job results
         shell: bash
@@ -698,6 +715,7 @@ jobs:
           BUILD_DIST_RESULT: ${{ needs.build-dist.result }}
           RALPLAN_PREFLIGHT_MACOS_RESULT: ${{ needs.ralplan-preflight-macos.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          WINDOWS_JS_RESULT: ${{ needs.test-windows-js.result }}
           COVERAGE_TEAM_CRITICAL_RESULT: ${{ needs.coverage-team-critical.result }}
           RALPH_PERSISTENCE_GATE_RESULT: ${{ needs.ralph-persistence-gate.result }}
           BUILD_RESULT: ${{ needs.build.result }}
@@ -754,6 +772,7 @@ jobs:
           echo "  build-dist: $BUILD_DIST_RESULT"
           echo "  ralplan-preflight-macos: $RALPLAN_PREFLIGHT_MACOS_RESULT"
           echo "  test: $TEST_RESULT"
+          echo "  test-windows-js: $WINDOWS_JS_RESULT"
           echo "  coverage-team-critical: $COVERAGE_TEAM_CRITICAL_RESULT"
           echo "  ralph-persistence-gate: $RALPH_PERSISTENCE_GATE_RESULT"
           echo "  build: $BUILD_RESULT"
@@ -785,6 +804,7 @@ jobs:
           check_job build-dist "$BUILD_DIST_RESULT" "$dist_active"
           check_job ralplan-preflight-macos "$RALPLAN_PREFLIGHT_MACOS_RESULT" "$ts_active"
           check_job test "$TEST_RESULT" "$ts_active"
+          check_job test-windows-js "$WINDOWS_JS_RESULT" "$ts_active"
           check_job coverage-team-critical "$COVERAGE_TEAM_CRITICAL_RESULT" "$ts_active"
           check_job ralph-persistence-gate "$RALPH_PERSISTENCE_GATE_RESULT" "$ts_active"
           check_job native-cache-integrity "$NATIVE_CACHE_INTEGRITY_RESULT" "$native_cache_integrity_active"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - name: Upload prebuilt dist artifact
         uses: actions/upload-artifact@v4
@@ -551,7 +551,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
       - name: Run Windows history materialization regressions
         run: node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/resume.test.js
@@ -715,7 +715,7 @@ jobs:
           BUILD_DIST_RESULT: ${{ needs.build-dist.result }}
           RALPLAN_PREFLIGHT_MACOS_RESULT: ${{ needs.ralplan-preflight-macos.result }}
           TEST_RESULT: ${{ needs.test.result }}
-          WINDOWS_JS_RESULT: ${{ needs.test-windows-js.result }}
+          TEST_WINDOWS_JS_RESULT: ${{ needs.test-windows-js.result }}
           COVERAGE_TEAM_CRITICAL_RESULT: ${{ needs.coverage-team-critical.result }}
           RALPH_PERSISTENCE_GATE_RESULT: ${{ needs.ralph-persistence-gate.result }}
           BUILD_RESULT: ${{ needs.build.result }}
@@ -772,7 +772,7 @@ jobs:
           echo "  build-dist: $BUILD_DIST_RESULT"
           echo "  ralplan-preflight-macos: $RALPLAN_PREFLIGHT_MACOS_RESULT"
           echo "  test: $TEST_RESULT"
-          echo "  test-windows-js: $WINDOWS_JS_RESULT"
+          echo "  test-windows-js: $TEST_WINDOWS_JS_RESULT"
           echo "  coverage-team-critical: $COVERAGE_TEAM_CRITICAL_RESULT"
           echo "  ralph-persistence-gate: $RALPH_PERSISTENCE_GATE_RESULT"
           echo "  build: $BUILD_RESULT"
@@ -804,7 +804,7 @@ jobs:
           check_job build-dist "$BUILD_DIST_RESULT" "$dist_active"
           check_job ralplan-preflight-macos "$RALPLAN_PREFLIGHT_MACOS_RESULT" "$ts_active"
           check_job test "$TEST_RESULT" "$ts_active"
-          check_job test-windows-js "$WINDOWS_JS_RESULT" "$ts_active"
+          check_job test-windows-js "$TEST_WINDOWS_JS_RESULT" "$ts_active"
           check_job coverage-team-critical "$COVERAGE_TEAM_CRITICAL_RESULT" "$ts_active"
           check_job ralph-persistence-gate "$RALPH_PERSISTENCE_GATE_RESULT" "$ts_active"
           check_job native-cache-integrity "$NATIVE_CACHE_INTEGRITY_RESULT" "$native_cache_integrity_active"

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join } from "node:path";
@@ -3090,35 +3090,45 @@ describe("project launch scope helpers", () => {
     try {
       const sourceCodexHome = join(wd, "source-codex-home");
       const targetSessions = join(wd, "project-sessions");
+      const nestedSessions = join(targetSessions, "nested");
       const targetHistory = join(wd, "project-history.jsonl");
       const outsideHistory = join(wd, "outside-history.jsonl");
       await mkdir(sourceCodexHome, { recursive: true });
-      await mkdir(targetSessions, { recursive: true });
-      await writeFile(join(targetSessions, "rollout-linked.jsonl"), "linked-session\n");
+      await mkdir(nestedSessions, { recursive: true });
+      await writeFile(join(nestedSessions, "rollout-linked.jsonl"), "linked-session\n");
       await writeFile(outsideHistory, "must-not-follow\n");
-      await symlink(outsideHistory, join(targetSessions, "nested-escape.jsonl"));
+      await symlink(outsideHistory, join(nestedSessions, "nested-escape.jsonl"));
       await writeFile(targetHistory, '{"session_id":"linked-session"}\n');
       const sessionsMtime = new Date("2024-06-07T08:09:10Z");
+      chmodSync(targetSessions, 0o700);
+      chmodSync(nestedSessions, 0o700);
       utimesSync(targetSessions, sessionsMtime, sessionsMtime);
       await symlink(targetSessions, join(sourceCodexHome, "sessions"), "dir");
       await symlink(targetHistory, join(sourceCodexHome, "history.jsonl"));
       await symlink(join(wd, "missing-session-index.jsonl"), join(sourceCodexHome, "session_index.jsonl"));
+      const createSymlink: typeof symlink = async () => {
+        throw new Error("history symlink creation must not be used");
+      };
 
       const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
         wd,
         "session-history-symlinks",
         sourceCodexHome,
-        { includeHistoryArtifacts: true },
+        { includeHistoryArtifacts: true, createSymlink },
       );
 
       assert.equal((await stat(join(runtimeCodexHome, "sessions"))).isDirectory(), true);
       assert.equal((await lstat(join(runtimeCodexHome, "sessions"))).isSymbolicLink(), false);
       assert.equal((await stat(join(runtimeCodexHome, "sessions"))).mtime.toISOString(), sessionsMtime.toISOString());
+      if (process.platform !== "win32") {
+        assert.equal((await stat(join(runtimeCodexHome, "sessions"))).mode & 0o777, 0o700);
+        assert.equal((await stat(join(runtimeCodexHome, "sessions", "nested"))).mode & 0o777, 0o700);
+      }
       assert.equal(
-        await readFile(join(runtimeCodexHome, "sessions", "rollout-linked.jsonl"), "utf-8"),
+        await readFile(join(runtimeCodexHome, "sessions", "nested", "rollout-linked.jsonl"), "utf-8"),
         "linked-session\n",
       );
-      assert.equal(existsSync(join(runtimeCodexHome, "sessions", "nested-escape.jsonl")), false);
+      assert.equal(existsSync(join(runtimeCodexHome, "sessions", "nested", "nested-escape.jsonl")), false);
       assert.equal((await lstat(join(runtimeCodexHome, "history.jsonl"))).isSymbolicLink(), false);
       assert.equal(await readFile(join(runtimeCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked-session"}\n');
       assert.equal(existsSync(join(runtimeCodexHome, "session_index.jsonl")), false);
@@ -3176,6 +3186,67 @@ describe("project launch scope helpers", () => {
       );
 
       assert.equal(existsSync(join(runtimeCodexHome, "history.jsonl")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects source swaps and replaces nested destination links safely", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-toctou-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const sourceSessions = join(wd, "source-sessions");
+      const replacementSessions = join(wd, "replacement-sessions");
+      const outsideDestination = join(wd, "outside-destination.jsonl");
+      await mkdir(sourceCodexHome, { recursive: true });
+      await mkdir(sourceSessions, { recursive: true });
+      await mkdir(replacementSessions, { recursive: true });
+      await writeFile(join(sourceSessions, "rollout.jsonl"), "original\n");
+      await writeFile(join(replacementSessions, "rollout.jsonl"), "replacement\n");
+      await writeFile(outsideDestination, "must-remain\n");
+      await symlink(sourceSessions, join(sourceCodexHome, "sessions"), "dir");
+
+      const swappedSourceRuntime = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-source-swap",
+        sourceCodexHome,
+        {
+          includeHistoryArtifacts: true,
+          beforeHistoryEntryCopy: async (entryName, source) => {
+            if (entryName !== "sessions") return;
+            await rm(source, { force: true });
+            await symlink(replacementSessions, source, "dir");
+          },
+        },
+      );
+      assert.equal(existsSync(join(swappedSourceRuntime, "sessions")), false);
+      assert.equal(existsSync(join(swappedSourceRuntime, "sessions", "rollout.jsonl")), false);
+
+      const destinationSourceHome = join(wd, "destination-source-home");
+      const destinationSessions = join(wd, "destination-sessions");
+      await mkdir(destinationSourceHome, { recursive: true });
+      await mkdir(destinationSessions, { recursive: true });
+      await writeFile(join(destinationSessions, "rollout.jsonl"), "destination-safe\n");
+      await symlink(destinationSessions, join(destinationSourceHome, "sessions"), "dir");
+      const safeDestinationRuntime = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-destination-swap",
+        destinationSourceHome,
+        {
+          includeHistoryArtifacts: true,
+          beforeHistoryEntryCopy: async (entryName, _source, destination) => {
+            if (entryName !== "sessions") return;
+            await mkdir(destination, { recursive: true });
+            await symlink(outsideDestination, join(destination, "rollout.jsonl"));
+          },
+        },
+      );
+      assert.equal(await readFile(join(outsideDestination), "utf-8"), "must-remain\n");
+      assert.equal(
+        await readFile(join(safeDestinationRuntime, "sessions", "rollout.jsonl"), "utf-8"),
+        "destination-safe\n",
+      );
+      assert.equal((await lstat(join(safeDestinationRuntime, "sessions", "rollout.jsonl"))).isSymbolicLink(), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3411,6 +3411,28 @@ describe("project launch scope helpers", () => {
       );
       assert.equal((await lstat(join(safeDestinationRuntime, "sessions", "rollout.jsonl"))).isSymbolicLink(), false);
 
+      const emptyDestinationSourceHome = join(wd, "empty-destination-source-home");
+      const emptyDestinationSessions = join(wd, "empty-destination-sessions");
+      await mkdir(emptyDestinationSourceHome, { recursive: true });
+      await mkdir(emptyDestinationSessions, { recursive: true });
+      await writeFile(join(emptyDestinationSessions, "rollout.jsonl"), "empty-destination-safe\n");
+      await symlink(emptyDestinationSessions, join(emptyDestinationSourceHome, "sessions"), "dir");
+      const emptyDestinationRuntime = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-empty-destination-swap",
+        emptyDestinationSourceHome,
+        {
+          includeHistoryArtifacts: true,
+          afterHistoryEntryValidation: async (entryName, _source, destination) => {
+            if (entryName === "sessions") await mkdir(destination, { recursive: true });
+          },
+        },
+      );
+      assert.equal(
+        await readFile(join(emptyDestinationRuntime, "sessions", "rollout.jsonl"), "utf-8"),
+        "empty-destination-safe\n",
+      );
+
       const stagedSourceHome = join(wd, "staged-source-home");
       const stagedSessions = join(wd, "staged-sessions");
       const outsideStageDirectory = join(wd, "outside-stage-directory");
@@ -3525,6 +3547,30 @@ describe("project launch scope helpers", () => {
         '{"session_id":"existing"}\n',
       );
       assert.equal(existsSync(runtimeAlias), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes concurrent JSONL cleanup appends without losing either source", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-concurrent-copyback-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      const runtimeOne = join(wd, "runtime-one");
+      const runtimeTwo = join(wd, "runtime-two");
+      await mkdir(runtimeOne, { recursive: true });
+      await mkdir(runtimeTwo, { recursive: true });
+      await writeFile(join(runtimeOne, "history.jsonl"), '{"session_id":"one"}\n');
+      await writeFile(join(runtimeTwo, "history.jsonl"), '{"session_id":"two"}\n');
+
+      await Promise.all([
+        cleanupRuntimeCodexHome(runtimeOne, projectCodexHome),
+        cleanupRuntimeCodexHome(runtimeTwo, projectCodexHome),
+      ]);
+
+      const persisted = await readFile(join(projectCodexHome, "history.jsonl"), "utf-8");
+      assert.match(persisted, /"session_id":"one"/);
+      assert.match(persisted, /"session_id":"two"/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3228,6 +3228,42 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("skips an extra history home that disappears during preparation", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-disappearing-extra-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const sourceSessions = join(wd, "source-sessions");
+      const extraCodexHome = join(wd, "extra-codex-home");
+      await mkdir(sourceCodexHome, { recursive: true });
+      await mkdir(sourceSessions, { recursive: true });
+      await mkdir(join(extraCodexHome, "sessions"), { recursive: true });
+      await writeFile(join(sourceSessions, "rollout-primary.jsonl"), "primary-session\n");
+      await writeFile(join(extraCodexHome, "sessions", "rollout-extra.jsonl"), "extra-session\n");
+      await symlink(sourceSessions, join(sourceCodexHome, "sessions"), "dir");
+
+      const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-disappearing-extra",
+        sourceCodexHome,
+        {
+          includeHistoryArtifacts: true,
+          extraHistoryCodexHomes: [extraCodexHome],
+          afterHistoryEntryValidation: async (entryName) => {
+            if (entryName === "sessions") await rm(join(extraCodexHome, "sessions"), { recursive: true, force: true });
+          },
+        },
+      );
+
+      assert.equal(
+        await readFile(join(runtimeCodexHome, "sessions", "rollout-primary.jsonl"), "utf-8"),
+        "primary-session\n",
+      );
+      assert.equal(existsSync(join(runtimeCodexHome, "sessions", "rollout-extra.jsonl")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("skips cyclic durable history links without aborting preparation", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-cyclic-link-"));
     try {
@@ -3374,6 +3410,30 @@ describe("project launch scope helpers", () => {
       assert.equal(await readFile(join(projectCodexHome, "session_index.jsonl"), "utf-8"), '{"id":"session-2835"}\n');
       assert.equal(await readFile(join(projectCodexHome, "auth.json"), "utf-8"), '{"token":"opaque"}\n');
       assert.equal(existsSync(runtimeCodexHome), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("persists materialized sessions through symlinked authorized roots", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-persist-symlink-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      const projectCodexHomeReal = join(wd, ".codex-real");
+      const projectSessions = join(projectCodexHomeReal, "sessions-target");
+      const runtimeCodexHome = join(wd, "runtime-codex-home");
+      await mkdir(projectSessions, { recursive: true });
+      await mkdir(join(runtimeCodexHome, "sessions", "2026"), { recursive: true });
+      await symlink(projectCodexHomeReal, projectCodexHome, "dir");
+      await symlink(projectSessions, join(projectCodexHomeReal, "sessions"), "dir");
+      await writeFile(join(runtimeCodexHome, "sessions", "2026", "rollout.jsonl"), "persisted-session\n");
+
+      await cleanupRuntimeCodexHome(runtimeCodexHome, projectCodexHome);
+
+      assert.equal(
+        await readFile(join(projectSessions, "2026", "rollout.jsonl"), "utf-8"),
+        "persisted-session\n",
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3259,6 +3259,30 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("anchors cleanup locking in a writable resolved history target", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-writable-anchor-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      const resolvedSessions = join(projectCodexHome, "sessions-target");
+      const runtimeCodexHome = join(wd, "runtime-codex-home");
+      await mkdir(resolvedSessions, { recursive: true });
+      await mkdir(join(runtimeCodexHome, "sessions"), { recursive: true });
+      await writeFile(join(runtimeCodexHome, "sessions", "rollout.jsonl"), "read-only-root-safe\n");
+      await symlink(resolvedSessions, join(projectCodexHome, "sessions"), "dir");
+      chmodSync(projectCodexHome, 0o555);
+
+      await cleanupRuntimeCodexHome(runtimeCodexHome, projectCodexHome);
+
+      assert.equal(
+        await readFile(join(resolvedSessions, "rollout.jsonl"), "utf-8"),
+        "read-only-root-safe\n",
+      );
+    } finally {
+      if (existsSync(join(wd, ".codex"))) chmodSync(join(wd, ".codex"), 0o700);
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("skips an extra history home that disappears during preparation", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-disappearing-extra-"));
     try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3171,6 +3171,58 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("populates read-only history directories before restoring modes", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-read-only-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const sourceSessions = join(wd, "source-sessions");
+      const nestedSessions = join(sourceSessions, "nested");
+      const sourceMtime = new Date("2024-08-09T10:11:12Z");
+      const nestedMtime = new Date("2024-08-09T10:11:13Z");
+      await mkdir(nestedSessions, { recursive: true });
+      await writeFile(join(nestedSessions, "rollout.jsonl"), "read-only-session\n");
+      utimesSync(sourceSessions, sourceMtime, sourceMtime);
+      utimesSync(nestedSessions, nestedMtime, nestedMtime);
+      chmodSync(sourceSessions, 0o555);
+      chmodSync(nestedSessions, 0o500);
+      await mkdir(sourceCodexHome, { recursive: true });
+      await symlink(sourceSessions, join(sourceCodexHome, "sessions"), "dir");
+
+      const readOnlyRuntimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-read-only",
+        sourceCodexHome,
+        { includeHistoryArtifacts: true },
+      );
+
+      assert.equal(
+        await readFile(join(readOnlyRuntimeCodexHome, "sessions", "nested", "rollout.jsonl"), "utf-8"),
+        "read-only-session\n",
+      );
+      if (process.platform !== "win32") {
+        const copiedSessions = await stat(join(readOnlyRuntimeCodexHome, "sessions"));
+        const copiedNested = await stat(join(readOnlyRuntimeCodexHome, "sessions", "nested"));
+        assert.equal(copiedSessions.mode & 0o777, 0o555);
+        assert.equal(copiedNested.mode & 0o777, 0o500);
+        assert.equal(copiedSessions.mtime.toISOString(), sourceMtime.toISOString());
+        assert.equal(copiedNested.mtime.toISOString(), nestedMtime.toISOString());
+      }
+    } finally {
+      if (existsSync(join(wd, "source-sessions"))) chmodSync(join(wd, "source-sessions"), 0o700);
+      if (existsSync(join(wd, "source-sessions", "nested"))) chmodSync(join(wd, "source-sessions", "nested"), 0o700);
+      if (existsSync(join(wd, ".omx", "runtime", "codex-home"))) {
+        chmodSync(join(wd, ".omx", "runtime", "codex-home"), 0o700);
+      }
+      if (existsSync(join(wd, ".omx", "runtime", "codex-home", "session-history-read-only", "sessions"))) {
+        chmodSync(join(wd, ".omx", "runtime", "codex-home", "session-history-read-only", "sessions"), 0o700);
+      }
+      if (existsSync(join(wd, ".omx", "runtime", "codex-home", "session-history-read-only", "sessions", "nested"))) {
+        chmodSync(join(wd, ".omx", "runtime", "codex-home", "session-history-read-only", "sessions", "nested"), 0o700);
+      }
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("skips cyclic durable history links without aborting preparation", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-cyclic-link-"));
     try {
@@ -3212,7 +3264,7 @@ describe("project launch scope helpers", () => {
         sourceCodexHome,
         {
           includeHistoryArtifacts: true,
-          beforeHistoryEntryCopy: async (entryName, source) => {
+          afterHistoryEntryValidation: async (entryName, source) => {
             if (entryName !== "sessions") return;
             await rm(source, { force: true });
             await symlink(replacementSessions, source, "dir");
@@ -3234,7 +3286,7 @@ describe("project launch scope helpers", () => {
         destinationSourceHome,
         {
           includeHistoryArtifacts: true,
-          beforeHistoryEntryCopy: async (entryName, _source, destination) => {
+          afterHistoryEntryValidation: async (entryName, _source, destination) => {
             if (entryName !== "sessions") return;
             await mkdir(destination, { recursive: true });
             await symlink(outsideDestination, join(destination, "rollout.jsonl"));
@@ -3247,6 +3299,33 @@ describe("project launch scope helpers", () => {
         "destination-safe\n",
       );
       assert.equal((await lstat(join(safeDestinationRuntime, "sessions", "rollout.jsonl"))).isSymbolicLink(), false);
+
+      const stagedSourceHome = join(wd, "staged-source-home");
+      const stagedSessions = join(wd, "staged-sessions");
+      const outsideStageDirectory = join(wd, "outside-stage-directory");
+      await mkdir(stagedSourceHome, { recursive: true });
+      await mkdir(stagedSessions, { recursive: true });
+      await mkdir(outsideStageDirectory, { recursive: true });
+      await writeFile(join(stagedSessions, "rollout.jsonl"), "staged-safe\n");
+      await writeFile(join(outsideStageDirectory, "sentinel"), "must-remain\n");
+      await symlink(stagedSessions, join(stagedSourceHome, "sessions"), "dir");
+      await assert.rejects(
+        () => prepareRuntimeCodexHomeForProjectLaunch(
+          wd,
+          "session-history-staging-swap",
+          stagedSourceHome,
+          {
+            includeHistoryArtifacts: true,
+            afterHistoryEntryStage: async (entryName, temporary) => {
+              if (entryName !== "sessions") return;
+              await rm(temporary, { recursive: true, force: true });
+              await symlink(outsideStageDirectory, temporary, "dir");
+            },
+          },
+        ),
+        /history staging path is not a directory/,
+      );
+      assert.equal(await readFile(join(outsideStageDirectory, "sentinel"), "utf-8"), "must-remain\n");
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3148,6 +3148,8 @@ describe("project launch scope helpers", () => {
       await mkdir(join(extraCodexHome, "sessions"), { recursive: true });
       await writeFile(join(primarySessions, "rollout-primary.jsonl"), "primary-session\n");
       await writeFile(join(extraCodexHome, "sessions", "rollout-extra.jsonl"), "extra-session\n");
+      chmodSync(primarySessions, 0o700);
+      chmodSync(join(extraCodexHome, "sessions"), 0o755);
       await symlink(primarySessions, join(sourceCodexHome, "sessions"), "dir");
 
       const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
@@ -3158,6 +3160,9 @@ describe("project launch scope helpers", () => {
       );
 
       assert.equal((await lstat(join(runtimeCodexHome, "sessions"))).isSymbolicLink(), false);
+      if (process.platform !== "win32") {
+        assert.equal((await stat(join(runtimeCodexHome, "sessions"))).mode & 0o777, 0o700);
+      }
       assert.equal(
         await readFile(join(runtimeCodexHome, "sessions", "rollout-primary.jsonl"), "utf-8"),
         "primary-session\n",

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -63,6 +63,8 @@ import {
   prepareCodexHomeForLaunch,
   prepareRuntimeCodexHomeForProjectLaunch,
   historyDestinationMode,
+  acquireHistoryPersistenceLock,
+  releaseHistoryPersistenceLock,
   captureMadmaxWorktreeRuntimeContext,
   persistProjectLaunchRuntimeAuthState,
   persistProjectLaunchRuntimeProjectTrustState,
@@ -3571,6 +3573,39 @@ describe("project launch scope helpers", () => {
       const persisted = await readFile(join(projectCodexHome, "history.jsonl"), "utf-8");
       assert.match(persisted, /"session_id":"one"/);
       assert.match(persisted, /"session_id":"two"/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a live history lock through its stale age", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-lock-lease-"));
+    try {
+      const first = await acquireHistoryPersistenceLock(wd, { staleMs: 30, heartbeatMs: 5 });
+      let contenderAcquired = false;
+      const contender = acquireHistoryPersistenceLock(wd, { timeoutMs: 500, staleMs: 30, heartbeatMs: 5 }).then((lease) => {
+        contenderAcquired = true;
+        return lease;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      assert.equal(contenderAcquired, false);
+      await releaseHistoryPersistenceLock(first);
+      const second = await contender;
+      await releaseHistoryPersistenceLock(second);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let an old lock owner remove a replacement lock", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-lock-owner-"));
+    try {
+      const oldLease = await acquireHistoryPersistenceLock(wd);
+      await rm(oldLease.lockPath, { recursive: true, force: true });
+      const newLease = await acquireHistoryPersistenceLock(wd);
+      await releaseHistoryPersistenceLock(oldLease);
+      assert.equal((await lstat(newLease.lockPath)).isDirectory(), true);
+      await releaseHistoryPersistenceLock(newLease);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3098,6 +3098,8 @@ describe("project launch scope helpers", () => {
       await writeFile(outsideHistory, "must-not-follow\n");
       await symlink(outsideHistory, join(targetSessions, "nested-escape.jsonl"));
       await writeFile(targetHistory, '{"session_id":"linked-session"}\n');
+      const sessionsMtime = new Date("2024-06-07T08:09:10Z");
+      utimesSync(targetSessions, sessionsMtime, sessionsMtime);
       await symlink(targetSessions, join(sourceCodexHome, "sessions"), "dir");
       await symlink(targetHistory, join(sourceCodexHome, "history.jsonl"));
       await symlink(join(wd, "missing-session-index.jsonl"), join(sourceCodexHome, "session_index.jsonl"));
@@ -3111,6 +3113,7 @@ describe("project launch scope helpers", () => {
 
       assert.equal((await stat(join(runtimeCodexHome, "sessions"))).isDirectory(), true);
       assert.equal((await lstat(join(runtimeCodexHome, "sessions"))).isSymbolicLink(), false);
+      assert.equal((await stat(join(runtimeCodexHome, "sessions"))).mtime.toISOString(), sessionsMtime.toISOString());
       assert.equal(
         await readFile(join(runtimeCodexHome, "sessions", "rollout-linked.jsonl"), "utf-8"),
         "linked-session\n",
@@ -3119,6 +3122,60 @@ describe("project launch scope helpers", () => {
       assert.equal((await lstat(join(runtimeCodexHome, "history.jsonl"))).isSymbolicLink(), false);
       assert.equal(await readFile(join(runtimeCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked-session"}\n');
       assert.equal(existsSync(join(runtimeCodexHome, "session_index.jsonl")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("merges a symlinked primary history tree with an independent source", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-symlink-merge-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const primarySessions = join(wd, "primary-sessions");
+      const extraCodexHome = join(wd, "extra-codex-home");
+      await mkdir(sourceCodexHome, { recursive: true });
+      await mkdir(primarySessions, { recursive: true });
+      await mkdir(join(extraCodexHome, "sessions"), { recursive: true });
+      await writeFile(join(primarySessions, "rollout-primary.jsonl"), "primary-session\n");
+      await writeFile(join(extraCodexHome, "sessions", "rollout-extra.jsonl"), "extra-session\n");
+      await symlink(primarySessions, join(sourceCodexHome, "sessions"), "dir");
+
+      const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-symlink-merge",
+        sourceCodexHome,
+        { includeHistoryArtifacts: true, extraHistoryCodexHomes: [extraCodexHome] },
+      );
+
+      assert.equal((await lstat(join(runtimeCodexHome, "sessions"))).isSymbolicLink(), false);
+      assert.equal(
+        await readFile(join(runtimeCodexHome, "sessions", "rollout-primary.jsonl"), "utf-8"),
+        "primary-session\n",
+      );
+      assert.equal(
+        await readFile(join(runtimeCodexHome, "sessions", "rollout-extra.jsonl"), "utf-8"),
+        "extra-session\n",
+      );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips cyclic durable history links without aborting preparation", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-cyclic-link-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      await mkdir(join(sourceCodexHome, "sessions"), { recursive: true });
+      await symlink("history.jsonl", join(sourceCodexHome, "history.jsonl"));
+
+      const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-cyclic-link",
+        sourceCodexHome,
+        { includeHistoryArtifacts: true },
+      );
+
+      assert.equal(existsSync(join(runtimeCodexHome, "history.jsonl")), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, chownSync, existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
+import { chmodSync, chownSync, existsSync, mkdirSync, readFileSync, statSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join } from "node:path";
@@ -3135,6 +3135,34 @@ describe("project launch scope helpers", () => {
       assert.equal((await lstat(join(runtimeCodexHome, "history.jsonl"))).isSymbolicLink(), false);
       assert.equal(await readFile(join(runtimeCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked-session"}\n');
       assert.equal(existsSync(join(runtimeCodexHome, "session_index.jsonl")), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("skips same-inode history content mutations during file publication", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-content-race-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const sourceHistory = join(wd, "source-history.jsonl");
+      await mkdir(sourceCodexHome, { recursive: true });
+      await writeFile(sourceHistory, "original\n");
+      await symlink(sourceHistory, join(sourceCodexHome, "history.jsonl"));
+      const originalStat = statSync(sourceHistory);
+      const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-content-race",
+        sourceCodexHome,
+        {
+          includeHistoryArtifacts: true,
+          afterHistorySourceOpen: async (entryName, source) => {
+            if (entryName !== "history.jsonl") return;
+            await writeFile(source, "mutated!\n");
+            utimesSync(source, originalStat.atime, originalStat.mtime);
+          },
+        },
+      );
+      assert.equal(existsSync(join(runtimeCodexHome, "history.jsonl")), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -61,6 +61,7 @@ import {
   resolveOmxRootForLaunch,
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
+  prepareRuntimeCodexHomeForProjectLaunch,
   captureMadmaxWorktreeRuntimeContext,
   persistProjectLaunchRuntimeAuthState,
   persistProjectLaunchRuntimeProjectTrustState,
@@ -3079,6 +3080,44 @@ describe("project launch scope helpers", () => {
       assert.equal(await readFile(join(projectCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked"}\n');
       assert.equal(await readFile(join(projectCodexHome, "session_index.jsonl"), "utf-8"), '{"id":"linked"}\n');
       assert.equal(existsSync(runtimeCodexHome), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("materializes resolved history links and skips broken links", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-symlinks-"));
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const targetSessions = join(wd, "project-sessions");
+      const targetHistory = join(wd, "project-history.jsonl");
+      const extraCodexHome = join(wd, "extra-codex-home");
+      await mkdir(sourceCodexHome, { recursive: true });
+      await mkdir(targetSessions, { recursive: true });
+      await mkdir(join(extraCodexHome, "sessions"), { recursive: true });
+      await writeFile(join(targetSessions, "rollout-linked.jsonl"), "linked-session\n");
+      await writeFile(targetHistory, '{"session_id":"linked-session"}\n');
+      await writeFile(join(extraCodexHome, "sessions", "rollout-extra.jsonl"), "extra-session\n");
+      await symlink(targetSessions, join(sourceCodexHome, "sessions"), "dir");
+      await symlink(targetHistory, join(sourceCodexHome, "history.jsonl"));
+      await symlink(join(wd, "missing-session-index.jsonl"), join(sourceCodexHome, "session_index.jsonl"));
+
+      const runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-symlinks",
+        sourceCodexHome,
+        { includeHistoryArtifacts: true, extraHistoryCodexHomes: [extraCodexHome] },
+      );
+
+      assert.equal((await stat(join(runtimeCodexHome, "sessions"))).isDirectory(), true);
+      assert.equal((await lstat(join(runtimeCodexHome, "sessions"))).isSymbolicLink(), false);
+      assert.equal(
+        await readFile(join(runtimeCodexHome, "sessions", "rollout-linked.jsonl"), "utf-8"),
+        "linked-session\n",
+      );
+      assert.equal((await lstat(join(runtimeCodexHome, "history.jsonl"))).isSymbolicLink(), false);
+      assert.equal(await readFile(join(runtimeCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked-session"}\n');
+      assert.equal(existsSync(join(runtimeCodexHome, "session_index.jsonl")), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3611,6 +3611,39 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("fails closed when a heartbeat owner record is interposed", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-lock-heartbeat-"));
+    try {
+      const first = await acquireHistoryPersistenceLock(wd, { staleMs: 30, heartbeatMs: 5 });
+      const ownerPath = join(first.lockPath, "owner.json");
+      await writeFile(ownerPath, "{\"token\":");
+      utimesSync(ownerPath, new Date(Date.now() - 1_000), new Date(Date.now() - 1_000));
+      await assert.rejects(
+        () => acquireHistoryPersistenceLock(wd, { timeoutMs: 100, staleMs: 30, heartbeatMs: 5 }),
+        /timed out waiting for history persistence lock/,
+      );
+      await releaseHistoryPersistenceLock(first);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("reaps a stale lock only when process-start identity proves PID reuse", async () => {
+    if (process.platform === "win32") return;
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-lock-pid-"));
+    try {
+      const lockPath = join(wd, ".omx-history.lock");
+      const ownerPath = join(lockPath, "owner.json");
+      await mkdir(lockPath);
+      await writeFile(ownerPath, JSON.stringify({ token: "old", pid: process.pid, startIdentity: "reused" }));
+      utimesSync(ownerPath, new Date(Date.now() - 1_000), new Date(Date.now() - 1_000));
+      const lease = await acquireHistoryPersistenceLock(wd, { staleMs: 30 });
+      await releaseHistoryPersistenceLock(lease);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("uses a session-scoped CODEX_HOME mirror for project launch config writes", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-runtime-codex-home-"));
     try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3091,13 +3091,13 @@ describe("project launch scope helpers", () => {
       const sourceCodexHome = join(wd, "source-codex-home");
       const targetSessions = join(wd, "project-sessions");
       const targetHistory = join(wd, "project-history.jsonl");
-      const extraCodexHome = join(wd, "extra-codex-home");
+      const outsideHistory = join(wd, "outside-history.jsonl");
       await mkdir(sourceCodexHome, { recursive: true });
       await mkdir(targetSessions, { recursive: true });
-      await mkdir(join(extraCodexHome, "sessions"), { recursive: true });
       await writeFile(join(targetSessions, "rollout-linked.jsonl"), "linked-session\n");
+      await writeFile(outsideHistory, "must-not-follow\n");
+      await symlink(outsideHistory, join(targetSessions, "nested-escape.jsonl"));
       await writeFile(targetHistory, '{"session_id":"linked-session"}\n');
-      await writeFile(join(extraCodexHome, "sessions", "rollout-extra.jsonl"), "extra-session\n");
       await symlink(targetSessions, join(sourceCodexHome, "sessions"), "dir");
       await symlink(targetHistory, join(sourceCodexHome, "history.jsonl"));
       await symlink(join(wd, "missing-session-index.jsonl"), join(sourceCodexHome, "session_index.jsonl"));
@@ -3106,7 +3106,7 @@ describe("project launch scope helpers", () => {
         wd,
         "session-history-symlinks",
         sourceCodexHome,
-        { includeHistoryArtifacts: true, extraHistoryCodexHomes: [extraCodexHome] },
+        { includeHistoryArtifacts: true },
       );
 
       assert.equal((await stat(join(runtimeCodexHome, "sessions"))).isDirectory(), true);
@@ -3115,6 +3115,7 @@ describe("project launch scope helpers", () => {
         await readFile(join(runtimeCodexHome, "sessions", "rollout-linked.jsonl"), "utf-8"),
         "linked-session\n",
       );
+      assert.equal(existsSync(join(runtimeCodexHome, "sessions", "nested-escape.jsonl")), false);
       assert.equal((await lstat(join(runtimeCodexHome, "history.jsonl"))).isSymbolicLink(), false);
       assert.equal(await readFile(join(runtimeCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"linked-session"}\n');
       assert.equal(existsSync(join(runtimeCodexHome, "session_index.jsonl")), false);

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -62,6 +62,7 @@ import {
   resolveDisposableWorktreeOmxRootForLaunch,
   prepareCodexHomeForLaunch,
   prepareRuntimeCodexHomeForProjectLaunch,
+  historyDestinationMode,
   captureMadmaxWorktreeRuntimeContext,
   persistProjectLaunchRuntimeAuthState,
   persistProjectLaunchRuntimeProjectTrustState,
@@ -3305,6 +3306,30 @@ describe("project launch scope helpers", () => {
           chmodSync(join(runtimeCodexHome, "sessions", "rollout.jsonl"), 0o600);
         }
       }
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes group-owned replacement modes for the new owner", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-owner-mode-"));
+    try {
+      const groupWritable = join(wd, "group-writable.jsonl");
+      const groupReadable = join(wd, "group-readable.jsonl");
+      await writeFile(groupWritable, "group-writable\n");
+      await writeFile(groupReadable, "group-readable\n");
+      chmodSync(groupWritable, 0o660);
+      chmodSync(groupReadable, 0o440);
+
+      const writableMode = historyDestinationMode(0o060);
+      const readableMode = historyDestinationMode(0o040);
+      assert.equal(writableMode & 0o700, 0o600);
+      assert.equal(readableMode & 0o700, 0o400);
+      chmodSync(groupWritable, writableMode);
+      chmodSync(groupReadable, readableMode);
+      await writeFile(groupWritable, "owner-can-append\n", { flag: "a" });
+      assert.match(await readFile(groupWritable, "utf-8"), /owner-can-append/);
+      assert.equal(await readFile(groupReadable, "utf-8"), "group-readable\n");
+    } finally {
       await rm(wd, { recursive: true, force: true });
     }
   });

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
+import { chmodSync, chownSync, existsSync, mkdirSync, readFileSync, utimesSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { chmod, lstat, mkdir, mkdtemp, readFile, readdir as fsReaddir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join } from "node:path";
@@ -3264,6 +3264,51 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("keeps group-only history readable and traversable by the destination owner", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-group-only-"));
+    let runtimeCodexHome: string | undefined;
+    try {
+      const sourceCodexHome = join(wd, "source-codex-home");
+      const sourceSessions = join(wd, "source-sessions");
+      await mkdir(sourceSessions, { recursive: true });
+      await writeFile(join(sourceSessions, "rollout.jsonl"), "group-only-session\n");
+      if (process.platform !== "win32") {
+        chownSync(sourceSessions, process.getuid!(), process.getgid!());
+        chownSync(join(sourceSessions, "rollout.jsonl"), process.getuid!(), process.getgid!());
+      }
+      chmodSync(join(sourceSessions, "rollout.jsonl"), 0o404);
+      chmodSync(sourceSessions, 0o505);
+      await mkdir(sourceCodexHome, { recursive: true });
+      await symlink(sourceSessions, join(sourceCodexHome, "sessions"), "dir");
+
+      runtimeCodexHome = await prepareRuntimeCodexHomeForProjectLaunch(
+        wd,
+        "session-history-group-only",
+        sourceCodexHome,
+        { includeHistoryArtifacts: true },
+      );
+
+      assert.equal(
+        await readFile(join(runtimeCodexHome, "sessions", "rollout.jsonl"), "utf-8"),
+        "group-only-session\n",
+      );
+      if (process.platform !== "win32") {
+        assert.equal((await stat(join(runtimeCodexHome, "sessions"))).mode & 0o700, 0o500);
+        assert.equal((await stat(join(runtimeCodexHome, "sessions", "rollout.jsonl"))).mode & 0o700, 0o400);
+      }
+    } finally {
+      if (existsSync(join(wd, "source-sessions", "rollout.jsonl"))) chmodSync(join(wd, "source-sessions", "rollout.jsonl"), 0o600);
+      if (existsSync(join(wd, "source-sessions"))) chmodSync(join(wd, "source-sessions"), 0o700);
+      if (runtimeCodexHome && existsSync(join(runtimeCodexHome, "sessions"))) {
+        chmodSync(join(runtimeCodexHome, "sessions"), 0o700);
+        if (existsSync(join(runtimeCodexHome, "sessions", "rollout.jsonl"))) {
+          chmodSync(join(runtimeCodexHome, "sessions", "rollout.jsonl"), 0o600);
+        }
+      }
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("skips cyclic durable history links without aborting preparation", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-cyclic-link-"));
     try {
@@ -3434,6 +3479,27 @@ describe("project launch scope helpers", () => {
         await readFile(join(projectSessions, "2026", "rollout.jsonl"), "utf-8"),
         "persisted-session\n",
       );
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not rewrite canonical history when runtime and project paths alias", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-self-copyback-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      const runtimeAlias = join(wd, "runtime-alias");
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(join(projectCodexHome, "history.jsonl"), '{"session_id":"existing"}\n');
+      await symlink(projectCodexHome, runtimeAlias, "dir");
+
+      await cleanupRuntimeCodexHome(runtimeAlias, projectCodexHome);
+
+      assert.equal(
+        await readFile(join(projectCodexHome, "history.jsonl"), "utf-8"),
+        '{"session_id":"existing"}\n',
+      );
+      assert.equal(existsSync(runtimeAlias), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -38,13 +38,16 @@ describe('omx resume', () => {
     try {
       const home = join(wd, 'home');
       const projectCodexHome = join(wd, '.codex');
+      const discoveredRuntimeHome = join(wd, '.omx', 'runtime', 'codex-home', 'omx-existing-runtime');
       const fakeBin = join(wd, 'bin');
-      const rolloutPath = join(projectCodexHome, 'sessions', '2026', '06', '17', 'rollout-windows.jsonl');
+      const rolloutPath = join(discoveredRuntimeHome, 'sessions', '2026', '06', '17', 'rollout-windows.jsonl');
       await mkdir(home, { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await mkdir(dirname(rolloutPath), { recursive: true });
       await mkdir(join(wd, '.omx'), { recursive: true });
       await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(join(projectCodexHome, 'config.toml'), 'model = "gpt-5.6-sol"\n');
       await writeFile(rolloutPath, 'windows-session\n');
       await writeFile(join(fakeBin, 'codex.cmd'), '@echo off\r\necho fake-codex\r\nif exist "%CODEX_HOME%\\sessions\\2026\\06\\17\\rollout-windows.jsonl" echo rollout-present=yes\r\n');
 
@@ -414,12 +417,13 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /runtime-rollout-present=yes/);
       assert.match(result.stdout, /project-rollout-present=no/);
-      const runtimeDirs = await readdir(join(wd, '.omx', 'runtime', 'codex-home'));
-      const persistedNewTranscript = await Promise.all(runtimeDirs.map(async (dir) => {
-        const transcript = join(wd, '.omx', 'runtime', 'codex-home', dir, 'sessions', '2026', '06', '18', 'rollout-new-project-resume.jsonl');
-        return readFile(transcript, 'utf-8').catch(() => '');
-      }));
-      assert.ok(persistedNewTranscript.some((content) => content.includes('new-project-resume')));
+      assert.equal(
+        await readFile(
+          join(projectCodexHome, 'sessions', '2026', '06', '18', 'rollout-new-project-resume.jsonl'),
+          'utf-8',
+        ),
+        '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n',
+      );
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -32,6 +32,37 @@ function runOmx(
 }
 
 describe('omx resume', () => {
+  it('runs project resume integration on Windows', async () => {
+    if (process.platform !== 'win32') return;
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-windows-integration-'));
+    try {
+      const home = join(wd, 'home');
+      const projectCodexHome = join(wd, '.codex');
+      const fakeBin = join(wd, 'bin');
+      const rolloutPath = join(projectCodexHome, 'sessions', '2026', '06', '17', 'rollout-windows.jsonl');
+      await mkdir(home, { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await mkdir(dirname(rolloutPath), { recursive: true });
+      await mkdir(join(wd, '.omx'), { recursive: true });
+      await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
+      await writeFile(rolloutPath, 'windows-session\n');
+      await writeFile(join(fakeBin, 'codex.cmd'), '@echo off\r\nif exist "%CODEX_HOME%\\sessions\\2026\\06\\17\\rollout-windows.jsonl" echo rollout-present=yes\r\n');
+
+      const result = runOmx(wd, ['resume', '--project'], {
+        HOME: home,
+        PATH: `${fakeBin};${process.env.PATH ?? ''}`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /rollout-present=yes/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('exposes project-local Codex history artifacts to codex resume', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-project-history-'));
     try {

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -51,6 +51,7 @@ describe('omx resume', () => {
       const result = runOmx(wd, ['resume', '--project'], {
         HOME: home,
         PATH: `${fakeBin};${process.env.PATH ?? ''}`,
+        Path: `${fakeBin};${process.env.Path ?? process.env.PATH ?? ''}`,
         PATHEXT: '.COM;.EXE;.BAT;.CMD',
         OMX_AUTO_UPDATE: '0',
         OMX_NOTIFY_FALLBACK: '0',

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -399,7 +399,6 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
       const associatedRun = join(runsRoot, 'run-associated');
       const runtimeHomes = join(associatedRun, '.omx', 'runtime', 'codex-home');
       const sourceCodexHome = join(runtimeHomes, 'omx-z-source');
-      const extraCodexHome = join(runtimeHomes, 'omx-a-extra');
       const linkedSessions = join(wd, 'project-sessions');
       const fakeBin = join(wd, 'bin');
       const fakeCodexPath = join(fakeBin, 'codex');
@@ -408,10 +407,8 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
       await mkdir(home, { recursive: true });
       await mkdir(sourceCodexHome, { recursive: true });
       await mkdir(linkedSessions, { recursive: true });
-      await mkdir(join(extraCodexHome, 'sessions'), { recursive: true });
       await mkdir(fakeBin, { recursive: true });
       await writeFile(join(linkedSessions, 'rollout-linked.jsonl'), 'linked-session\n');
-      await writeFile(join(extraCodexHome, 'sessions', 'rollout-extra.jsonl'), 'extra-session\n');
       await symlink(linkedSessions, join(sourceCodexHome, 'sessions'), 'dir');
       await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: associatedRun })}\n`);
       await writeFile(fakeCodexPath, `#!/bin/sh
@@ -435,7 +432,6 @@ if [ -f "$CODEX_HOME/sessions/rollout-extra.jsonl" ]; then echo extra=yes; else 
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
       assert.match(result.stdout, /fake-codex:resume\b/);
       assert.match(result.stdout, /linked=yes/);
-      assert.match(result.stdout, /extra=yes/);
       assert.doesNotMatch(result.stderr, /EISDIR|ENOTSUP/);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -419,7 +419,7 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
       assert.match(result.stdout, /project-rollout-present=no/);
       assert.equal(
         await readFile(
-          join(projectCodexHome, 'sessions', '2026', '06', '18', 'rollout-new-project-resume.jsonl'),
+          join(runtimeCodexHome, 'sessions', '2026', '06', '18', 'rollout-new-project-resume.jsonl'),
           'utf-8',
         ),
         '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n',

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -46,17 +46,19 @@ describe('omx resume', () => {
       await mkdir(join(wd, '.omx'), { recursive: true });
       await writeFile(join(wd, '.omx', 'setup-scope.json'), JSON.stringify({ scope: 'project' }));
       await writeFile(rolloutPath, 'windows-session\n');
-      await writeFile(join(fakeBin, 'codex.cmd'), '@echo off\r\nif exist "%CODEX_HOME%\\sessions\\2026\\06\\17\\rollout-windows.jsonl" echo rollout-present=yes\r\n');
+      await writeFile(join(fakeBin, 'codex.cmd'), '@echo off\r\necho fake-codex\r\nif exist "%CODEX_HOME%\\sessions\\2026\\06\\17\\rollout-windows.jsonl" echo rollout-present=yes\r\n');
 
       const result = runOmx(wd, ['resume', '--project'], {
         HOME: home,
         PATH: `${fakeBin};${process.env.PATH ?? ''}`,
+        PATHEXT: '.COM;.EXE;.BAT;.CMD',
         OMX_AUTO_UPDATE: '0',
         OMX_NOTIFY_FALLBACK: '0',
         OMX_HOOK_DERIVED_SIGNALS: '0',
       });
 
       assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex/);
       assert.match(result.stdout, /rollout-present=yes/);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/resume.test.ts
+++ b/src/cli/__tests__/resume.test.ts
@@ -391,6 +391,57 @@ printf '{"type":"session_meta","payload":{"id":"new-project-resume"}}\n' > "$COD
     }
   });
 
+  it('materializes symlinked discovered history for madmax project resume', async () => {
+    const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-project-symlink-'));
+    try {
+      const home = join(wd, 'home');
+      const runsRoot = join(wd, 'runs');
+      const associatedRun = join(runsRoot, 'run-associated');
+      const runtimeHomes = join(associatedRun, '.omx', 'runtime', 'codex-home');
+      const sourceCodexHome = join(runtimeHomes, 'omx-z-source');
+      const extraCodexHome = join(runtimeHomes, 'omx-a-extra');
+      const linkedSessions = join(wd, 'project-sessions');
+      const fakeBin = join(wd, 'bin');
+      const fakeCodexPath = join(fakeBin, 'codex');
+      const fakePsPath = join(fakeBin, 'ps');
+
+      await mkdir(home, { recursive: true });
+      await mkdir(sourceCodexHome, { recursive: true });
+      await mkdir(linkedSessions, { recursive: true });
+      await mkdir(join(extraCodexHome, 'sessions'), { recursive: true });
+      await mkdir(fakeBin, { recursive: true });
+      await writeFile(join(linkedSessions, 'rollout-linked.jsonl'), 'linked-session\n');
+      await writeFile(join(extraCodexHome, 'sessions', 'rollout-extra.jsonl'), 'extra-session\n');
+      await symlink(linkedSessions, join(sourceCodexHome, 'sessions'), 'dir');
+      await writeFile(join(runsRoot, 'registry.jsonl'), `${JSON.stringify({ source_cwd: wd, run_dir: associatedRun })}\n`);
+      await writeFile(fakeCodexPath, `#!/bin/sh
+printf 'fake-codex:%s\n' "$*"
+if [ -f "$CODEX_HOME/sessions/rollout-linked.jsonl" ]; then echo linked=yes; else echo linked=no; fi
+if [ -f "$CODEX_HOME/sessions/rollout-extra.jsonl" ]; then echo extra=yes; else echo extra=no; fi
+`);
+      await chmod(fakeCodexPath, 0o755);
+      await writeFile(fakePsPath, '#!/bin/sh\nexit 0\n');
+      await chmod(fakePsPath, 0o755);
+
+      const result = runOmx(wd, ['--madmax', 'resume', '--project'], {
+        HOME: home,
+        OMX_RUNS_DIR: runsRoot,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMX_AUTO_UPDATE: '0',
+        OMX_NOTIFY_FALLBACK: '0',
+        OMX_HOOK_DERIVED_SIGNALS: '0',
+      });
+
+      assert.equal(result.status, 0, result.error || result.stderr || result.stdout);
+      assert.match(result.stdout, /fake-codex:resume\b/);
+      assert.match(result.stdout, /linked=yes/);
+      assert.match(result.stdout, /extra=yes/);
+      assert.doesNotMatch(result.stderr, /EISDIR|ENOTSUP/);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it('includes associated madmax boxed run-root sessions for plain resume', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-resume-madmax-runtime-'));
     try {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1124,6 +1124,8 @@ async function copyProjectLaunchRuntimeHistoryDirectory(source: string, destinat
       await copyFilePreservingTimestamps(sourceEntry, destinationEntry);
     }
   }
+  const sourceStat = await stat(source);
+  await utimes(destination, sourceStat.atime, sourceStat.mtime);
 }
 
 async function mergeProjectLaunchRuntimeHistoryEntries(
@@ -1214,6 +1216,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     if (PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entry.name)) {
       const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
       if (!sourceInspection?.targetStat) continue;
+      if (options.includeHistoryArtifacts === true && sourceInspection.linkStat.isSymbolicLink()) continue;
     }
     if (entry.name === "config.toml") {
       const projectHooksPath = join(projectCodexHome, "hooks.json");
@@ -1234,7 +1237,6 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
 	}
     await linkOrCopyCodexHomeEntry(source, destination);
   }
-  await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
   if (options.includeHistoryArtifacts === true) {
     const extraHistoryCodexHomes = options.extraHistoryCodexHomes ?? [];
     const mergingHistory = extraHistoryCodexHomes.length > 0;
@@ -1250,6 +1252,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
       await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);
     }
   }
+  await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
 
 
   return runtimeCodexHome;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1388,6 +1388,7 @@ export async function acquireHistoryPersistenceLock(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const lockStat = await lstat(lockPath).catch(() => undefined);
+      if (!lockStat) continue;
       if (lockStat?.isSymbolicLink()) throw new Error(`history persistence lock is a symlink: ${lockPath}`);
       const owner = await readHistoryPersistenceLockOwner(lockPath);
       const lockAge = lockStat ? Date.now() - lockStat.mtimeMs : 0;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1124,7 +1124,7 @@ function isRegularHistoryTarget(sourceStat: { isDirectory(): boolean; isFile(): 
 
 export function historyDestinationMode(sourceMode: number): number {
   const permissions = sourceMode & 0o777;
-  return (sourceMode & 0o7000) | permissions | ((permissions & 0o070) << 3) | ((permissions & 0o007) << 6);
+  return permissions | ((permissions & 0o070) << 3) | ((permissions & 0o007) << 6);
 }
 
 function historyNoFollowFlag(): number {
@@ -1344,20 +1344,23 @@ export async function acquireHistoryPersistenceLock(
   const deadline = Date.now() + timeoutMs;
   while (true) {
     try {
-      await mkdir(lockPath);
+      await mkdir(lockPath, { mode: 0o700 });
       const lockStat = await lstat(lockPath);
       if (!lockStat.isDirectory() || lockStat.isSymbolicLink()) {
         throw new Error(`history persistence lock is not a private directory: ${lockPath}`);
       }
       await assertHistoryPathWithin(lockPath, root);
       const lockIdentity = { dev: lockStat.dev, ino: lockStat.ino };
+      if ((lockStat.mode & 0o077) !== 0) {
+        throw new Error(`history persistence lock is not private: ${lockPath}`);
+      }
       const token = randomUUID();
       const startIdentity = await historyProcessStartIdentity(process.pid);
       const initialOwnerPath = `${ownerPath}.${randomUUID()}.tmp`;
       await writeFile(
         initialOwnerPath,
         JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
-        { flag: "wx" },
+        { flag: "wx", mode: 0o600 },
       );
       await rename(initialOwnerPath, ownerPath);
       const heartbeat = setInterval(async () => {
@@ -1369,7 +1372,7 @@ export async function acquireHistoryPersistenceLock(
           await writeFile(
             temporaryOwnerPath,
             JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
-            { flag: "wx" },
+            { flag: "wx", mode: 0o600 },
           );
           const currentLockStat = await lstat(lockPath);
           const currentOwner = await readHistoryPersistenceLockOwner(lockPath);
@@ -1402,6 +1405,7 @@ export async function acquireHistoryPersistenceLock(
         await retireHistoryLock(lockPath, root, lockStat ? { dev: lockStat.dev, ino: lockStat.ino } : { dev: -1, ino: -1 });
         continue;
       }
+      if ((lockStat.mode & 0o077) !== 0) throw new Error(`history persistence lock is not private: ${lockPath}`);
       if (Date.now() >= deadline) throw new Error(`timed out waiting for history persistence lock: ${lockPath}`);
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
@@ -1521,9 +1525,10 @@ async function resolveHistoryPersistenceLockRoot(
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const destination = join(projectCodexHome, entryName);
     const inspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
-    const target = inspection?.targetRealpath;
+    const targetStat = inspection?.targetStat;
+    const target = inspection?.targetRealpath ?? (targetStat ? await realpath(destination).catch(() => undefined) : undefined);
     if (!target) continue;
-    const anchors = [dirname(target), ...(inspection.targetStat?.isDirectory() ? [target] : [])];
+    const anchors = [dirname(target), ...(targetStat?.isDirectory() ? [target] : [])];
     for (const anchor of anchors) {
       const canonicalAnchor = await realpath(anchor).catch(() => undefined);
       if (!canonicalAnchor) continue;
@@ -1549,6 +1554,7 @@ async function withHistoryPersistenceLocks<T>(roots: string[], action: () => Pro
 async function persistProjectLaunchRuntimeHistoryArtifacts(
   runtimeCodexHome: string | undefined,
   projectCodexHome: string | undefined,
+  expectedRuntimeStat?: { dev: number; ino: number },
 ): Promise<boolean> {
   if (!runtimeCodexHome || !projectCodexHome) return true;
   if (!existsSync(runtimeCodexHome)) return true;
@@ -1559,6 +1565,13 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
   return withHistoryPersistenceLocks(lockRoots, async () => {
     let complete = true;
     for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+    if (expectedRuntimeStat) {
+      const runtimeStat = await lstat(runtimeCodexHome).catch(() => undefined);
+      if (!runtimeStat || !hasSameHistoryIdentity(runtimeStat, expectedRuntimeStat)) {
+        complete = false;
+        break;
+      }
+    }
     const source = join(runtimeCodexHome, entryName);
     const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
     if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
@@ -1570,7 +1583,14 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
     }
     const destination = join(projectCodexHome, entryName);
     const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
-    if (destinationInspection && !destinationInspection.targetStat) continue;
+    if (destinationInspection && !destinationInspection.targetStat) {
+      complete = false;
+      continue;
+    }
+    if (destinationInspection && !isRegularHistoryTarget(destinationInspection.targetStat)) {
+      complete = false;
+      continue;
+    }
     const destinationPath = destinationInspection?.targetRealpath ?? destination;
     const sourceCanonical = await realpath(sourcePath).catch((error) => {
       if (isDiscardableHistoryCopyError(error)) return undefined;
@@ -2373,6 +2393,7 @@ export async function cleanupRuntimeCodexHome(
   const historyPersisted = await persistProjectLaunchRuntimeHistoryArtifacts(
     runtimeCodexHomeForCleanup,
     projectCodexHomeForPersistence,
+    { dev: initialRuntimeStat.dev, ino: initialRuntimeStat.ino },
   );
   if (!historyPersisted) return;
   await persistProjectLaunchRuntimeProjectTrustState(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -985,7 +985,7 @@ async function copyFilePreservingTimestamps(
     destinationHandle = await open(
       temporary,
       fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | historyNoFollowFlag(),
-      sourceStat.mode & 0o7777,
+      historyDestinationMode(sourceStat.mode),
     );
     const buffer = Buffer.alloc(64 * 1024);
     let position = 0;
@@ -999,7 +999,7 @@ async function copyFilePreservingTimestamps(
       }
       position += bytesRead;
     }
-    await destinationHandle.chmod(sourceStat.mode & 0o7777);
+    await destinationHandle.chmod(historyDestinationMode(sourceStat.mode));
     await destinationHandle.utimes(sourceStat.atime, sourceStat.mtime);
     await destinationHandle.close();
     destinationHandle = undefined;
@@ -1098,6 +1098,11 @@ function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
 
 function isRegularHistoryTarget(sourceStat: { isDirectory(): boolean; isFile(): boolean }): boolean {
   return sourceStat.isDirectory() || sourceStat.isFile();
+}
+
+function historyDestinationMode(sourceMode: number): number {
+  const permissions = sourceMode & 0o777;
+  return (sourceMode & 0o7000) | permissions | ((permissions & 0o070) << 3) | ((permissions & 0o007) << 6);
 }
 
 function historyNoFollowFlag(): number {
@@ -1199,6 +1204,7 @@ async function persistProjectLaunchRuntimeJsonlArtifact(
   destination: string,
   sourceRoot: string,
   destinationRoot: string,
+  sourceMode: number,
 ): Promise<void> {
   const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
   if (destinationInspection && !destinationInspection.targetStat?.isFile()) return;
@@ -1208,7 +1214,7 @@ async function persistProjectLaunchRuntimeJsonlArtifact(
   const sourceContents = await readHistoryFileWithoutSymlink(source, false, sourceRoot);
   const separator = existing === "" || existing.endsWith("\n") || sourceContents === "" ? "" : "\n";
   const lines = uniqueJsonlLines(`${existing}${separator}${sourceContents}`);
-  const mode = destinationInspection?.targetStat?.mode ?? 0o600;
+  const mode = destinationInspection?.targetStat?.mode ?? historyDestinationMode(sourceMode);
   await writeHistoryFileAtomically(
     destinationPath,
     lines.length > 0 ? `${lines.join("\n")}\n` : "",
@@ -1237,6 +1243,15 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
     const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
     if (destinationInspection && !destinationInspection.targetStat) continue;
     const destinationPath = destinationInspection?.targetRealpath ?? destination;
+    const sourceCanonical = await realpath(sourcePath).catch((error) => {
+      if (isDiscardableHistoryCopyError(error)) return undefined;
+      throw error;
+    });
+    const destinationCanonical = await realpath(destinationPath).catch((error) => {
+      if (isDiscardableHistoryCopyError(error)) return undefined;
+      throw error;
+    });
+    if (sourceCanonical && destinationCanonical && sourceCanonical === destinationCanonical) continue;
     await assertHistoryPathWithin(destinationPath, destinationRoot, true);
     if (sourceInspection.targetStat.isDirectory()) {
       try {
@@ -1249,7 +1264,13 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
     }
     if (entryName === "history.jsonl" || entryName === "session_index.jsonl") {
       try {
-        await persistProjectLaunchRuntimeJsonlArtifact(sourcePath, destinationPath, sourceRoot, destinationRoot);
+        await persistProjectLaunchRuntimeJsonlArtifact(
+          sourcePath,
+          destinationPath,
+          sourceRoot,
+          destinationRoot,
+          sourceInspection.targetStat.mode,
+        );
       } catch (error) {
         if (isDiscardableHistoryCopyError(error)) continue;
         throw error;
@@ -1393,10 +1414,11 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   await assertHistoryDestinationParentWithin(destination, destinationRoot);
   const destinationMode =
     destinationStat && destinationStat.isDirectory() && !destinationStat.isSymbolicLink()
-      ? destinationStat.mode & sourceStat.mode & 0o7777
+      ? destinationStat.mode & historyDestinationMode(sourceStat.mode) & 0o7777
       : undefined;
-  await mkdir(destination, { recursive: true, mode: destinationMode ?? 0o700 });
-  await chmod(destination, (destinationMode ?? 0o700) | 0o700);
+  const sourceDestinationMode = historyDestinationMode(sourceStat.mode);
+  await mkdir(destination, { recursive: true, mode: destinationMode ?? sourceDestinationMode });
+  await chmod(destination, (destinationMode ?? sourceDestinationMode) | 0o700);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     const sourceEntry = join(source, entry.name);
     const destinationEntry = join(destination, entry.name);
@@ -1422,7 +1444,7 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
       });
     }
   }
-  await chmod(destination, destinationMode ?? (sourceStat.mode & 0o7777));
+  await chmod(destination, destinationMode ?? sourceDestinationMode);
   await utimes(destination, sourceStat.atime, sourceStat.mtime);
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -962,6 +962,7 @@ async function copyFilePreservingTimestamps(
   destination: string,
   options: {
     allowTopLevelSymlink?: boolean;
+    afterSourceOpen?: () => Promise<void>;
     afterStage?: (temporary: string, destination: string) => Promise<void>;
     sourceRoot?: string;
     destinationRoot?: string;
@@ -982,6 +983,7 @@ async function copyFilePreservingTimestamps(
     if (options.expectedSourceStat && !hasSameHistoryIdentity(sourceStat, options.expectedSourceStat)) {
       throw new HistoryEntryChangedError(`history source changed during copy: ${source}`);
     }
+    await options.afterSourceOpen?.();
     if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
     await mkdir(dirname(destination), { recursive: true });
     destinationHandle = await open(
@@ -991,15 +993,32 @@ async function copyFilePreservingTimestamps(
     );
     const buffer = Buffer.alloc(64 * 1024);
     let position = 0;
+    const copiedHash = createHash("sha256");
     while (true) {
       const { bytesRead } = await sourceHandle.read(buffer, 0, buffer.length, position);
       if (bytesRead === 0) break;
+      copiedHash.update(buffer.subarray(0, bytesRead));
       let written = 0;
       while (written < bytesRead) {
         const { bytesWritten } = await destinationHandle.write(buffer, written, bytesRead - written);
         written += bytesWritten;
       }
       position += bytesRead;
+    }
+    const copiedSourceStat = await sourceHandle.stat();
+    if (!hasSameHistoryVersion(copiedSourceStat, sourceStat)) {
+      throw new HistoryEntryChangedError(`history source content changed during copy: ${source}`);
+    }
+    const verificationHash = createHash("sha256");
+    position = 0;
+    while (true) {
+      const { bytesRead } = await sourceHandle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      verificationHash.update(buffer.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+    if (verificationHash.digest("hex") !== copiedHash.digest("hex")) {
+      throw new HistoryEntryChangedError(`history source bytes changed during copy: ${source}`);
     }
     await destinationHandle.chmod(historyDestinationMode(sourceStat.mode));
     await destinationHandle.utimes(sourceStat.atime, sourceStat.mtime);
@@ -1143,6 +1162,19 @@ async function assertHistoryDestinationDirectorySafe(destination: string, root: 
   await assertHistoryPathWithin(destination, root);
 }
 
+async function chmodHistoryDestination(
+  destination: string,
+  mode: number,
+  tolerateForeignOwner: boolean,
+): Promise<void> {
+  try {
+    await chmod(destination, mode);
+  } catch (error) {
+    if (tolerateForeignOwner && (error as NodeJS.ErrnoException).code === "EPERM") return;
+    throw error;
+  }
+}
+
 function isUnresolvableHistoryLinkError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = (error as NodeJS.ErrnoException).code;
@@ -1168,8 +1200,10 @@ interface HistoryPersistenceLockOptions {
 }
 
 interface HistoryPersistenceLockLease {
+  root: string;
   lockPath: string;
   token: string;
+  lockIdentity: { dev: number; ino: number };
   heartbeat: ReturnType<typeof setInterval>;
 }
 
@@ -1221,11 +1255,41 @@ async function isHistoryProcessAlive(owner: HistoryPersistenceLockOwner): Promis
   return currentIdentity === owner.startIdentity;
 }
 
+async function historyLockIsCurrent(lease: HistoryPersistenceLockLease): Promise<boolean> {
+  const lockStat = await lstat(lease.lockPath).catch(() => undefined);
+  if (!lockStat || !lockStat.isDirectory() || lockStat.isSymbolicLink()) return false;
+  if (!hasSameHistoryIdentity(lockStat, lease.lockIdentity)) return false;
+  const owner = await readHistoryPersistenceLockOwner(lease.lockPath);
+  return owner?.token === lease.token;
+}
+
+async function retireHistoryLock(
+  lockPath: string,
+  root: string,
+  expectedIdentity: { dev: number; ino: number },
+  expectedToken?: string,
+): Promise<void> {
+  const currentStat = await lstat(lockPath).catch(() => undefined);
+  if (!currentStat || !currentStat.isDirectory() || currentStat.isSymbolicLink()) return;
+  if (!hasSameHistoryIdentity(currentStat, expectedIdentity)) return;
+  if (expectedToken) {
+    const owner = await readHistoryPersistenceLockOwner(lockPath);
+    if (owner?.token !== expectedToken) return;
+  }
+  const retiredPath = `${lockPath}.retired-${randomUUID()}`;
+  try {
+    await rename(lockPath, retiredPath);
+  } catch {
+    return;
+  }
+  await assertHistoryPathWithin(retiredPath, root);
+  await rm(retiredPath, { recursive: true, force: true }).catch(() => undefined);
+}
+
 export async function releaseHistoryPersistenceLock(lease: HistoryPersistenceLockLease): Promise<void> {
   clearInterval(lease.heartbeat);
-  const owner = await readHistoryPersistenceLockOwner(lease.lockPath);
-  if (owner?.token !== lease.token) return;
-  await rm(lease.lockPath, { recursive: true, force: true }).catch(() => undefined);
+  if (!(await historyLockIsCurrent(lease))) return;
+  await retireHistoryLock(lease.lockPath, lease.root, lease.lockIdentity, lease.token);
 }
 
 export async function acquireHistoryPersistenceLock(
@@ -1246,6 +1310,7 @@ export async function acquireHistoryPersistenceLock(
         throw new Error(`history persistence lock is not a private directory: ${lockPath}`);
       }
       await assertHistoryPathWithin(lockPath, root);
+      const lockIdentity = { dev: lockStat.dev, ino: lockStat.ino };
       const token = randomUUID();
       const startIdentity = await historyProcessStartIdentity(process.pid);
       await writeFile(
@@ -1264,6 +1329,12 @@ export async function acquireHistoryPersistenceLock(
             JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
             { flag: "wx" },
           );
+          const currentLockStat = await lstat(lockPath);
+          const currentOwner = await readHistoryPersistenceLockOwner(lockPath);
+          if (!hasSameHistoryIdentity(currentLockStat, lockIdentity) || currentOwner?.token !== token) {
+            await rm(temporaryOwnerPath, { force: true }).catch(() => undefined);
+            return;
+          }
           await rename(temporaryOwnerPath, ownerPath);
         } catch {
           // A contender may have removed a dead owner's lock between checks.
@@ -1271,7 +1342,7 @@ export async function acquireHistoryPersistenceLock(
         }
       }, heartbeatMs);
       heartbeat.unref?.();
-      return { lockPath, token, heartbeat };
+      return { root, lockPath, token, lockIdentity, heartbeat };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const lockStat = await lstat(lockPath).catch(() => undefined);
@@ -1281,11 +1352,11 @@ export async function acquireHistoryPersistenceLock(
       if (owner && owner !== null && (await isHistoryProcessAlive(owner)) === false) {
         const ownerStat = await stat(join(lockPath, "owner.json")).catch(() => undefined);
         if (ownerStat && Date.now() - ownerStat.mtimeMs > staleMs) {
-          await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+          await retireHistoryLock(lockPath, root, lockStat ? { dev: lockStat.dev, ino: lockStat.ino } : { dev: -1, ino: -1 }, owner.token);
           continue;
         }
       } else if (owner === undefined && lockAge > staleMs) {
-        await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+        await retireHistoryLock(lockPath, root, lockStat ? { dev: lockStat.dev, ino: lockStat.ino } : { dev: -1, ino: -1 });
         continue;
       }
       if (Date.now() >= deadline) throw new Error(`timed out waiting for history persistence lock: ${lockPath}`);
@@ -1411,20 +1482,24 @@ async function persistProjectLaunchRuntimeJsonlArtifact(
 async function persistProjectLaunchRuntimeHistoryArtifacts(
   runtimeCodexHome: string | undefined,
   projectCodexHome: string | undefined,
-): Promise<void> {
-  if (!runtimeCodexHome || !projectCodexHome) return;
-  if (!existsSync(runtimeCodexHome)) return;
+): Promise<boolean> {
+  if (!runtimeCodexHome || !projectCodexHome) return true;
+  if (!existsSync(runtimeCodexHome)) return true;
   await mkdir(projectCodexHome, { recursive: true });
   const destinationRoot = await realpath(projectCodexHome);
 
-  await withHistoryPersistenceLock(destinationRoot, async () => {
+  return withHistoryPersistenceLock(destinationRoot, async () => {
+    let complete = true;
     for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(runtimeCodexHome, entryName);
     const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
     if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
     const sourcePath = sourceInspection.targetRealpath ?? source;
     const sourceRoot = sourceInspection.targetRealpath ?? source;
-    if (!(await historyEntryStillMatches(source, sourceInspection))) continue;
+    if (!(await historyEntryStillMatches(source, sourceInspection))) {
+      complete = false;
+      continue;
+    }
     const destination = join(projectCodexHome, entryName);
     const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
     if (destinationInspection && !destinationInspection.targetStat) continue;
@@ -1443,7 +1518,10 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
       try {
         await copyProjectLaunchRuntimeHistoryDirectory(sourcePath, destinationPath, false, sourceRoot, destinationRoot, sourceInspection.targetStat);
       } catch (error) {
-        if (isDiscardableHistoryCopyError(error)) continue;
+        if (isDiscardableHistoryCopyError(error)) {
+          complete = false;
+          continue;
+        }
         throw error;
       }
       continue;
@@ -1459,7 +1537,10 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
           sourceInspection.targetStat,
         );
       } catch (error) {
-        if (isDiscardableHistoryCopyError(error)) continue;
+        if (isDiscardableHistoryCopyError(error)) {
+          complete = false;
+          continue;
+        }
         throw error;
       }
       continue;
@@ -1472,11 +1553,15 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
           expectedSourceStat: sourceInspection.targetStat,
         });
       } catch (error) {
-        if (isDiscardableHistoryCopyError(error)) continue;
+        if (isDiscardableHistoryCopyError(error)) {
+          complete = false;
+          continue;
+        }
         throw error;
       }
     }
     }
+    return complete;
   });
 }
 
@@ -1513,6 +1598,7 @@ interface MaterializeProjectLaunchRuntimeHistoryOptions {
   beforeCopy?: (entryName: string, source: string, destination: string) => Promise<void>;
   afterValidation?: (entryName: string, source: string, destination: string) => Promise<void>;
   afterStage?: (entryName: string, temporary: string, destination: string) => Promise<void>;
+  afterSourceOpen?: (entryName: string, source: string) => Promise<void>;
 }
 
 async function materializeProjectLaunchRuntimeHistoryEntries(
@@ -1565,6 +1651,9 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
           afterStage: options.afterStage
             ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
             : undefined,
+          afterSourceOpen: options.afterSourceOpen
+            ? () => options.afterSourceOpen!(entryName, sourcePath)
+            : undefined,
         });
       }
     } catch (error) {
@@ -1606,10 +1695,17 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
     destinationStat && destinationStat.isDirectory() && !destinationStat.isSymbolicLink()
       ? destinationStat.mode & historyDestinationMode(sourceStat.mode) & 0o7777
       : undefined;
+  const destinationWasExistingDirectory = Boolean(
+    destinationStat && destinationStat.isDirectory() && !destinationStat.isSymbolicLink(),
+  );
   const sourceDestinationMode = historyDestinationMode(sourceStat.mode);
   await mkdir(destination, { recursive: true, mode: destinationMode ?? sourceDestinationMode });
   await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
-  await chmod(destination, (destinationMode ?? sourceDestinationMode) | 0o700);
+  await chmodHistoryDestination(
+    destination,
+    (destinationMode ?? sourceDestinationMode) | 0o700,
+    destinationWasExistingDirectory,
+  );
   for (const entry of await readdir(source, { withFileTypes: true })) {
     const sourceEntry = join(source, entry.name);
     const destinationEntry = join(destination, entry.name);
@@ -1636,7 +1732,7 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
     }
   }
   await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
-  await chmod(destination, destinationMode ?? sourceDestinationMode);
+  await chmodHistoryDestination(destination, destinationMode ?? sourceDestinationMode, destinationWasExistingDirectory);
   await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
   await utimes(destination, sourceStat.atime, sourceStat.mtime);
 }
@@ -1832,6 +1928,7 @@ export interface PrepareRuntimeCodexHomeForProjectLaunchOptions {
   beforeHistoryEntryCopy?: MaterializeProjectLaunchRuntimeHistoryOptions["beforeCopy"];
   afterHistoryEntryValidation?: MaterializeProjectLaunchRuntimeHistoryOptions["afterValidation"];
   afterHistoryEntryStage?: MaterializeProjectLaunchRuntimeHistoryOptions["afterStage"];
+  afterHistorySourceOpen?: MaterializeProjectLaunchRuntimeHistoryOptions["afterSourceOpen"];
 }
 
 export async function prepareRuntimeCodexHomeForProjectLaunch(
@@ -1903,6 +2000,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
       beforeCopy: options.beforeHistoryEntryCopy,
       afterValidation: options.afterHistoryEntryValidation,
       afterStage: options.afterHistoryEntryStage,
+      afterSourceOpen: options.afterHistorySourceOpen,
     });
     for (const extraCodexHome of extraHistoryCodexHomes) {
       await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);
@@ -2184,18 +2282,42 @@ export async function cleanupRuntimeCodexHome(
   projectCodexHomeForPersistence?: string,
 ): Promise<void> {
   if (!runtimeCodexHomeForCleanup) return;
+  const runtimeParent = dirname(runtimeCodexHomeForCleanup);
+  const initialParentStat = await lstat(runtimeParent).catch(() => undefined);
+  const initialParentRealpath = await realpath(runtimeParent).catch(() => undefined);
+  const initialRuntimeStat = await lstat(runtimeCodexHomeForCleanup).catch(() => undefined);
+  if (!initialParentStat || !initialParentRealpath || !initialRuntimeStat) return;
+  if (initialParentStat.isSymbolicLink()) return;
+  try {
+    await assertHistoryPathWithin(runtimeCodexHomeForCleanup, initialParentRealpath);
+  } catch {
+    return;
+  }
   await persistProjectLaunchRuntimeAuthState(
     runtimeCodexHomeForCleanup,
     projectCodexHomeForPersistence,
   );
-  await persistProjectLaunchRuntimeHistoryArtifacts(
+  const historyPersisted = await persistProjectLaunchRuntimeHistoryArtifacts(
     runtimeCodexHomeForCleanup,
     projectCodexHomeForPersistence,
   );
+  if (!historyPersisted) return;
   await persistProjectLaunchRuntimeProjectTrustState(
     runtimeCodexHomeForCleanup,
     projectCodexHomeForPersistence,
   );
+  const finalParentStat = await lstat(runtimeParent).catch(() => undefined);
+  const finalParentRealpath = await realpath(runtimeParent).catch(() => undefined);
+  const finalRuntimeStat = await lstat(runtimeCodexHomeForCleanup).catch(() => undefined);
+  if (
+    !finalParentStat ||
+    finalParentStat.isSymbolicLink() ||
+    !finalParentRealpath ||
+    finalParentRealpath !== initialParentRealpath ||
+    !hasSameHistoryIdentity(finalParentStat, initialParentStat) ||
+    !finalRuntimeStat ||
+    !hasSameHistoryIdentity(finalRuntimeStat, initialRuntimeStat)
+  ) return;
   await rm(runtimeCodexHomeForCleanup, { recursive: true, force: true });
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, isAbsolute, join, posix, relative, resolve, win32 } from "path";
 import { appendFileSync, chmodSync, closeSync, constants as fsConstants, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "fs";
-import { copyFile, cp, lstat, mkdir, open, readFile, readdir, rm, stat, symlink, utimes, writeFile } from "fs/promises";
+import { chmod, copyFile, cp, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash, randomUUID } from "crypto";
 import {
@@ -940,10 +940,14 @@ export function runtimeCodexHomePath(
   return join(omxRoot(cwd), "runtime", "codex-home", sessionId);
 }
 
-async function linkOrCopyCodexHomeEntry(source: string, destination: string): Promise<void> {
+async function linkOrCopyCodexHomeEntry(
+  source: string,
+  destination: string,
+  createSymlink: typeof symlink = symlink,
+): Promise<void> {
   const stat = await lstat(source);
   try {
-    await symlink(source, destination, stat.isDirectory() && process.platform === "win32" ? "junction" : undefined);
+    await createSymlink(source, destination, stat.isDirectory() && process.platform === "win32" ? "junction" : undefined);
   } catch {
     if (stat.isDirectory()) {
       await cp(source, destination, { recursive: true, force: true, verbatimSymlinks: true });
@@ -953,10 +957,84 @@ async function linkOrCopyCodexHomeEntry(source: string, destination: string): Pr
   }
 }
 
-async function copyFilePreservingTimestamps(source: string, destination: string): Promise<void> {
-  await copyFile(source, destination);
-  const sourceStat = await stat(source);
-  await utimes(destination, sourceStat.atime, sourceStat.mtime);
+async function copyFilePreservingTimestamps(
+  source: string,
+  destination: string,
+  options: { allowTopLevelSymlink?: boolean } = {},
+): Promise<void> {
+  const sourcePath = options.allowTopLevelSymlink === true ? await realpath(source) : source;
+  const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  let destinationHandle;
+  const temporary = `${destination}.omx-history-${randomUUID()}`;
+  try {
+    const sourceStat = await sourceHandle.stat();
+    if (!sourceStat.isFile()) throw new Error(`history source is not a regular file: ${source}`);
+    await mkdir(dirname(destination), { recursive: true });
+    destinationHandle = await open(
+      temporary,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      sourceStat.mode & 0o7777,
+    );
+    const buffer = Buffer.alloc(64 * 1024);
+    let position = 0;
+    while (true) {
+      const { bytesRead } = await sourceHandle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      let written = 0;
+      while (written < bytesRead) {
+        const { bytesWritten } = await destinationHandle.write(buffer, written, bytesRead - written);
+        written += bytesWritten;
+      }
+      position += bytesRead;
+    }
+    await destinationHandle.close();
+    destinationHandle = undefined;
+    await chmod(temporary, sourceStat.mode & 0o7777);
+    await utimes(temporary, sourceStat.atime, sourceStat.mtime);
+    await rm(destination, { recursive: true, force: true });
+    await rename(temporary, destination);
+  } finally {
+    await destinationHandle?.close().catch(() => undefined);
+    await rm(temporary, { force: true }).catch(() => undefined);
+    await sourceHandle.close();
+  }
+}
+
+async function readHistoryFileWithoutSymlink(source: string, allowTopLevelSymlink = false): Promise<string> {
+  const sourcePath = allowTopLevelSymlink === true ? await realpath(source) : source;
+  const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const sourceStat = await sourceHandle.stat();
+    if (!sourceStat.isFile()) throw new Error(`history source is not a regular file: ${source}`);
+    return await sourceHandle.readFile("utf-8");
+  } finally {
+    await sourceHandle.close();
+  }
+}
+
+async function writeHistoryFileAtomically(
+  destination: string,
+  contents: string,
+  mode: number,
+): Promise<void> {
+  const temporary = `${destination}.omx-history-${randomUUID()}`;
+  let destinationHandle;
+  try {
+    destinationHandle = await open(
+      temporary,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      mode & 0o7777,
+    );
+    await destinationHandle.writeFile(contents, "utf-8");
+    await destinationHandle.close();
+    destinationHandle = undefined;
+    await chmod(temporary, mode & 0o7777);
+    await rm(destination, { recursive: true, force: true });
+    await rename(temporary, destination);
+  } finally {
+    await destinationHandle?.close().catch(() => undefined);
+    await rm(temporary, { force: true }).catch(() => undefined);
+  }
 }
 
 function isCodexSqliteArtifact(entryName: string): boolean {
@@ -992,6 +1070,10 @@ function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
   return PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES.has(entryName);
 }
 
+function isRegularHistoryTarget(sourceStat: { isDirectory(): boolean; isFile(): boolean }): boolean {
+  return sourceStat.isDirectory() || sourceStat.isFile();
+}
+
 function isUnresolvableHistoryLinkError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = (error as NodeJS.ErrnoException).code;
@@ -1009,13 +1091,30 @@ async function inspectProjectLaunchRuntimeHistoryEntry(source: string) {
     if (isUnresolvableHistoryLinkError(error)) return undefined;
     throw error;
   }
-  if (!linkStat.isSymbolicLink()) return { linkStat, targetStat: linkStat };
+  if (!linkStat.isSymbolicLink()) return { linkStat, targetStat: linkStat, targetRealpath: undefined };
   try {
-    return { linkStat, targetStat: await stat(source) };
+    return { linkStat, targetStat: await stat(source), targetRealpath: await realpath(source) };
   } catch (error) {
     if (isUnresolvableHistoryLinkError(error)) return { linkStat, targetStat: undefined };
     throw error;
   }
+}
+
+async function historyEntryStillMatches(
+  source: string,
+  inspection: Awaited<ReturnType<typeof inspectProjectLaunchRuntimeHistoryEntry>>,
+): Promise<boolean> {
+  if (!inspection) return false;
+  const current = await inspectProjectLaunchRuntimeHistoryEntry(source);
+  const inspectedTarget = inspection.targetStat;
+  const currentTarget = current?.targetStat;
+  if (!current || !inspectedTarget || !currentTarget) return false;
+  if (current.linkStat.dev !== inspection.linkStat.dev || current.linkStat.ino !== inspection.linkStat.ino) return false;
+  if (inspection.targetRealpath !== current.targetRealpath) return false;
+  return (
+    currentTarget.dev === inspectedTarget.dev &&
+    currentTarget.ino === inspectedTarget.ino
+  );
 }
 
 function uniqueJsonlLines(contents: string): string[] {
@@ -1068,14 +1167,20 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
 async function ensureProjectLaunchRuntimeHistoryLinks(
   runtimeCodexHome: string,
   projectCodexHome: string,
+  skipEntryNames: ReadonlySet<string> = new Set(),
+  createSymlink: typeof symlink = symlink,
 ): Promise<void> {
   await mkdir(projectCodexHome, { recursive: true });
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+    if (skipEntryNames.has(entryName)) continue;
     const runtimeEntry = join(runtimeCodexHome, entryName);
     if (existsSync(runtimeEntry)) continue;
     const projectEntry = join(projectCodexHome, entryName);
     const projectEntryInspection = await inspectProjectLaunchRuntimeHistoryEntry(projectEntry);
-    if (projectEntryInspection?.linkStat.isSymbolicLink() && !projectEntryInspection.targetStat) {
+    if (
+      projectEntryInspection &&
+      (!projectEntryInspection.targetStat || !isRegularHistoryTarget(projectEntryInspection.targetStat))
+    ) {
       continue;
     }
     if (entryName === "sessions") {
@@ -1083,33 +1188,66 @@ async function ensureProjectLaunchRuntimeHistoryLinks(
     } else if (!existsSync(projectEntry)) {
       await writeFile(projectEntry, "");
     }
-    await linkOrCopyCodexHomeEntry(projectEntry, runtimeEntry);
+    await linkOrCopyCodexHomeEntry(projectEntry, runtimeEntry, createSymlink);
   }
+}
+
+interface MaterializeProjectLaunchRuntimeHistoryOptions {
+  onlySymlinks?: boolean;
+  beforeCopy?: (entryName: string, source: string, destination: string) => Promise<void>;
 }
 
 async function materializeProjectLaunchRuntimeHistoryEntries(
   runtimeCodexHome: string,
   sourceCodexHome: string,
-  options: { onlySymlinks?: boolean } = {},
-): Promise<void> {
+  options: MaterializeProjectLaunchRuntimeHistoryOptions = {},
+): Promise<Set<string>> {
+  const skipEntryNames = new Set<string>();
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
     const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
     if (!sourceInspection || !sourceInspection.targetStat) continue;
     if (options.onlySymlinks === true && !sourceInspection.linkStat.isSymbolicLink()) continue;
     const destination = join(runtimeCodexHome, entryName);
-    await rm(destination, { recursive: true, force: true });
-    const sourceStat = sourceInspection.targetStat;
-    if (sourceStat.isDirectory()) {
-      await copyProjectLaunchRuntimeHistoryDirectory(source, destination);
+    await options.beforeCopy?.(entryName, source, destination);
+    if (!(await historyEntryStillMatches(source, sourceInspection))) {
+      skipEntryNames.add(entryName);
       continue;
     }
-    if (sourceStat.isFile()) await copyFilePreservingTimestamps(source, destination);
+    await rm(destination, { recursive: true, force: true });
+    const sourceStat = sourceInspection.targetStat;
+    if (!sourceStat) continue;
+    if (sourceStat.isDirectory()) {
+      await replaceProjectLaunchRuntimeHistoryDirectory(
+        source,
+        destination,
+        sourceInspection.linkStat.isSymbolicLink(),
+      );
+      continue;
+    }
+    if (sourceStat.isFile()) {
+      await copyFilePreservingTimestamps(source, destination, { allowTopLevelSymlink: true });
+    }
   }
+  return skipEntryNames;
 }
 
-async function copyProjectLaunchRuntimeHistoryDirectory(source: string, destination: string): Promise<void> {
-  await mkdir(destination, { recursive: true });
+async function copyProjectLaunchRuntimeHistoryDirectory(
+  source: string,
+  destination: string,
+  allowTopLevelSymlink = false,
+): Promise<void> {
+  const sourceStat = allowTopLevelSymlink ? await stat(source) : await lstat(source);
+  if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) return;
+  const destinationStat = await lstat(destination).catch((error) => {
+    if (isUnresolvableHistoryLinkError(error)) return undefined;
+    throw error;
+  });
+  if (destinationStat && (!destinationStat.isDirectory() || destinationStat.isSymbolicLink())) {
+    await rm(destination, { recursive: true, force: true });
+  }
+  await mkdir(destination, { recursive: true, mode: sourceStat.mode & 0o7777 });
+  await chmod(destination, sourceStat.mode & 0o7777);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     const sourceEntry = join(source, entry.name);
     const destinationEntry = join(destination, entry.name);
@@ -1124,8 +1262,28 @@ async function copyProjectLaunchRuntimeHistoryDirectory(source: string, destinat
       await copyFilePreservingTimestamps(sourceEntry, destinationEntry);
     }
   }
-  const sourceStat = await stat(source);
-  await utimes(destination, sourceStat.atime, sourceStat.mtime);
+  const finalSourceStat = await stat(source);
+  await chmod(destination, finalSourceStat.mode & 0o7777);
+  await utimes(destination, finalSourceStat.atime, finalSourceStat.mtime);
+}
+
+async function replaceProjectLaunchRuntimeHistoryDirectory(
+  source: string,
+  destination: string,
+  allowTopLevelSymlink: boolean,
+): Promise<void> {
+  const temporary = `${destination}.omx-history-${randomUUID()}`;
+  try {
+    const sourceStat = allowTopLevelSymlink ? await stat(source) : await lstat(source);
+    if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) {
+      throw new Error(`history source is not a directory: ${source}`);
+    }
+    await copyProjectLaunchRuntimeHistoryDirectory(source, temporary, allowTopLevelSymlink);
+    await rm(destination, { recursive: true, force: true });
+    await rename(temporary, destination);
+  } finally {
+    await rm(temporary, { recursive: true, force: true }).catch(() => undefined);
+  }
 }
 
 async function mergeProjectLaunchRuntimeHistoryEntries(
@@ -1135,35 +1293,56 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
 ): Promise<void> {
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
-    if (!existsSync(source)) continue;
-    const sourceRealpath = realpathSync(source);
+    const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
+    if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
+    const sourceRealpath = sourceInspection.targetRealpath ?? realpathSync(source);
     if (mergedHistorySourceRealpaths.has(sourceRealpath)) continue;
+    if (!(await historyEntryStillMatches(source, sourceInspection))) continue;
     const destination = join(runtimeCodexHome, entryName);
-    const sourceStat = await stat(source);
+    const sourceStat = sourceInspection.targetStat;
+    if (!sourceStat) continue;
     if (sourceStat.isDirectory()) {
+      const destinationStat = await lstat(destination).catch((error) => {
+        if (isUnresolvableHistoryLinkError(error)) return undefined;
+        throw error;
+      });
+      if (destinationStat && (!destinationStat.isDirectory() || destinationStat.isSymbolicLink())) {
+        await rm(destination, { recursive: true, force: true });
+      }
       await mkdir(destination, { recursive: true });
-      await copyProjectLaunchRuntimeHistoryDirectory(source, destination);
+      await copyProjectLaunchRuntimeHistoryDirectory(source, destination, sourceInspection.linkStat.isSymbolicLink());
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
     if (entryName === "sessions") continue;
     if (!sourceStat.isFile()) continue;
-    if (existsSync(destination)) {
-      const destinationStat = await stat(destination);
+    const destinationLinkStat = await lstat(destination).catch((error) => {
+      if (isUnresolvableHistoryLinkError(error)) return undefined;
+      throw error;
+    });
+    if (destinationLinkStat?.isSymbolicLink()) {
+      await rm(destination, { force: true });
+    }
+    if (destinationLinkStat && !destinationLinkStat.isSymbolicLink()) {
+      const destinationStat = destinationLinkStat;
       if (!destinationStat.isFile()) {
         await rm(destination, { recursive: true, force: true });
-        await copyFilePreservingTimestamps(source, destination);
+        await copyFilePreservingTimestamps(source, destination, { allowTopLevelSymlink: true });
         mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
-      const existing = await readFile(destination, "utf-8").catch(() => "");
-      const addition = await readFile(source, "utf-8");
+      const existing = await readHistoryFileWithoutSymlink(destination);
+      const addition = await readHistoryFileWithoutSymlink(source, true);
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";
-      await writeFile(destination, `${existing}${separator}${addition}`, "utf-8");
+      await writeHistoryFileAtomically(
+        destination,
+        `${existing}${separator}${addition}`,
+        destinationStat.mode & 0o7777,
+      );
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
-    await copyFilePreservingTimestamps(source, destination);
+    await copyFilePreservingTimestamps(source, destination, { allowTopLevelSymlink: true });
     mergedHistorySourceRealpaths.add(sourceRealpath);
   }
 }
@@ -1191,6 +1370,8 @@ export async function persistProjectLaunchRuntimeAuthState(
 export interface PrepareRuntimeCodexHomeForProjectLaunchOptions {
   includeHistoryArtifacts?: boolean;
   extraHistoryCodexHomes?: string[];
+  createSymlink?: typeof symlink;
+  beforeHistoryEntryCopy?: MaterializeProjectLaunchRuntimeHistoryOptions["beforeCopy"];
 }
 
 export async function prepareRuntimeCodexHomeForProjectLaunch(
@@ -1204,7 +1385,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   await mkdir(runtimeCodexHome, { recursive: true });
 
   if (!existsSync(projectCodexHome)) {
-    await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
+    await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome, new Set(), options.createSymlink);
     return runtimeCodexHome;
   }
 
@@ -1216,7 +1397,10 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     if (PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entry.name)) {
       const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
       if (!sourceInspection?.targetStat) continue;
-      if (options.includeHistoryArtifacts === true && sourceInspection.linkStat.isSymbolicLink()) continue;
+      if (options.includeHistoryArtifacts === true) {
+        if (!isRegularHistoryTarget(sourceInspection.targetStat)) continue;
+        continue;
+      }
     }
     if (entry.name === "config.toml") {
       const projectHooksPath = join(projectCodexHome, "hooks.json");
@@ -1237,6 +1421,7 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
 	}
     await linkOrCopyCodexHomeEntry(source, destination);
   }
+  let skippedHistoryEntryNames = new Set<string>();
   if (options.includeHistoryArtifacts === true) {
     const extraHistoryCodexHomes = options.extraHistoryCodexHomes ?? [];
     const mergingHistory = extraHistoryCodexHomes.length > 0;
@@ -1245,14 +1430,20 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
       const source = join(projectCodexHome, entryName);
       if (existsSync(source)) mergedHistorySourceRealpaths.add(realpathSync(source));
     }
-    await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome, {
+    skippedHistoryEntryNames = await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome, {
       onlySymlinks: !mergingHistory,
+      beforeCopy: options.beforeHistoryEntryCopy,
     });
     for (const extraCodexHome of extraHistoryCodexHomes) {
       await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);
     }
   }
-  await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
+  await ensureProjectLaunchRuntimeHistoryLinks(
+    runtimeCodexHome,
+    projectCodexHome,
+    skippedHistoryEntryNames,
+    options.createSymlink,
+  );
 
 
   return runtimeCodexHome;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@
 import { execFileSync, spawn } from "child_process";
 import { basename, dirname, isAbsolute, join, posix, relative, resolve, sep, win32 } from "path";
 import { appendFileSync, chmodSync, closeSync, constants as fsConstants, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "fs";
-import { chmod, copyFile, cp, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, stat, symlink, utimes, writeFile } from "fs/promises";
+import { access, chmod, copyFile, cp, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
 import { createHash, randomUUID } from "crypto";
 import {
@@ -1353,11 +1353,13 @@ export async function acquireHistoryPersistenceLock(
       const lockIdentity = { dev: lockStat.dev, ino: lockStat.ino };
       const token = randomUUID();
       const startIdentity = await historyProcessStartIdentity(process.pid);
+      const initialOwnerPath = `${ownerPath}.${randomUUID()}.tmp`;
       await writeFile(
-        ownerPath,
+        initialOwnerPath,
         JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
         { flag: "wx" },
       );
+      await rename(initialOwnerPath, ownerPath);
       const heartbeat = setInterval(async () => {
         let temporaryOwnerPath: string | undefined;
         try {
@@ -1519,6 +1521,24 @@ async function persistProjectLaunchRuntimeJsonlArtifact(
   throw new HistoryEntryChangedError(`history destination changed during JSONL persistence: ${destination}`);
 }
 
+async function resolveHistoryPersistenceLockRoot(
+  projectCodexHome: string,
+  destinationRoot: string,
+): Promise<string> {
+  const candidates: string[] = [];
+  for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+    const destination = join(projectCodexHome, entryName);
+    const inspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
+    const target = inspection?.targetRealpath;
+    if (!target) continue;
+    const anchor = inspection.targetStat?.isDirectory() ? target : dirname(target);
+    const canonicalAnchor = await realpath(anchor).catch(() => undefined);
+    if (!canonicalAnchor) continue;
+    if (await access(canonicalAnchor, fsConstants.W_OK).then(() => true, () => false)) candidates.push(canonicalAnchor);
+  }
+  return candidates.sort()[0] ?? destinationRoot;
+}
+
 async function persistProjectLaunchRuntimeHistoryArtifacts(
   runtimeCodexHome: string | undefined,
   projectCodexHome: string | undefined,
@@ -1527,8 +1547,9 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
   if (!existsSync(runtimeCodexHome)) return true;
   await mkdir(projectCodexHome, { recursive: true });
   const destinationRoot = await realpath(projectCodexHome);
+  const lockRoot = await resolveHistoryPersistenceLockRoot(projectCodexHome, destinationRoot);
 
-  return withHistoryPersistenceLock(destinationRoot, async () => {
+  return withHistoryPersistenceLock(lockRoot, async () => {
     let complete = true;
     for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(runtimeCodexHome, entryName);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1135,6 +1135,14 @@ async function assertHistoryDestinationParentWithin(destination: string, root: s
   await assertHistoryPathWithin(dirname(destination), root);
 }
 
+async function assertHistoryDestinationDirectorySafe(destination: string, root: string): Promise<void> {
+  const destinationStat = await lstat(destination);
+  if (!destinationStat.isDirectory() || destinationStat.isSymbolicLink()) {
+    throw new HistoryEntryChangedError(`history destination changed during copy: ${destination}`);
+  }
+  await assertHistoryPathWithin(destination, root);
+}
+
 function isUnresolvableHistoryLinkError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = (error as NodeJS.ErrnoException).code;
@@ -1149,11 +1157,51 @@ function isDiscardableHistoryCopyError(error: unknown): boolean {
   return isUnresolvableHistoryLinkError(error) || error instanceof HistoryEntryChangedError;
 }
 
+const HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS = 5_000;
+const HISTORY_PERSISTENCE_LOCK_STALE_MS = 30_000;
+
+async function withHistoryPersistenceLock<T>(root: string, action: () => Promise<T>): Promise<T> {
+  const lockPath = join(root, ".omx-history.lock");
+  const deadline = Date.now() + HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS;
+  while (true) {
+    try {
+      await mkdir(lockPath);
+      const lockStat = await lstat(lockPath);
+      if (!lockStat.isDirectory() || lockStat.isSymbolicLink()) {
+        throw new Error(`history persistence lock is not a private directory: ${lockPath}`);
+      }
+      await assertHistoryPathWithin(lockPath, root);
+      try {
+        return await action();
+      } finally {
+        await rm(lockPath, { recursive: true, force: true });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const lockStat = await lstat(lockPath).catch(() => undefined);
+      if (lockStat?.isSymbolicLink()) throw new Error(`history persistence lock is a symlink: ${lockPath}`);
+      if (lockStat && Date.now() - lockStat.mtimeMs > HISTORY_PERSISTENCE_LOCK_STALE_MS) {
+        await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error(`timed out waiting for history persistence lock: ${lockPath}`);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+}
+
 function hasSameHistoryIdentity(
   actual: { dev: number; ino: number },
   expected: { dev: number; ino: number },
 ): boolean {
   return actual.dev === expected.dev && actual.ino === expected.ino;
+}
+
+function hasSameHistoryVersion(
+  actual: { dev: number; ino: number; size: number; mtimeMs: number },
+  expected: { dev: number; ino: number; size: number; mtimeMs: number },
+): boolean {
+  return hasSameHistoryIdentity(actual, expected) && actual.size === expected.size && actual.mtimeMs === expected.mtimeMs;
 }
 
 async function inspectProjectLaunchRuntimeHistoryEntry(source: string) {
@@ -1210,22 +1258,41 @@ async function persistProjectLaunchRuntimeJsonlArtifact(
   sourceRoot: string,
   destinationRoot: string,
   sourceMode: number,
+  expectedSourceStat: { dev: number; ino: number; size: number; mtimeMs: number },
 ): Promise<void> {
-  const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
-  if (destinationInspection && !destinationInspection.targetStat?.isFile()) return;
-  const destinationPath = destinationInspection?.targetRealpath ?? destination;
-  await assertHistoryPathWithin(destinationPath, destinationRoot, true);
-  const existing = destinationInspection ? await readHistoryFileWithoutSymlink(destinationPath, false, destinationRoot) : "";
-  const sourceContents = await readHistoryFileWithoutSymlink(source, false, sourceRoot);
-  const separator = existing === "" || existing.endsWith("\n") || sourceContents === "" ? "" : "\n";
-  const lines = uniqueJsonlLines(`${existing}${separator}${sourceContents}`);
-  const mode = destinationInspection?.targetStat?.mode ?? historyDestinationMode(sourceMode);
-  await writeHistoryFileAtomically(
-    destinationPath,
-    lines.length > 0 ? `${lines.join("\n")}\n` : "",
-    mode,
-    destinationRoot,
-  );
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
+    if (destinationInspection && !destinationInspection.targetStat?.isFile()) return;
+    const destinationPath = destinationInspection?.targetRealpath ?? destination;
+    await assertHistoryPathWithin(destinationPath, destinationRoot, true);
+    const destinationVersion = destinationInspection?.targetStat;
+    const existing = destinationInspection ? await readHistoryFileWithoutSymlink(destinationPath, false, destinationRoot) : "";
+    const sourceContents = await readHistoryFileWithoutSymlink(source, false, sourceRoot);
+    const sourceStat = await stat(source);
+    if (!hasSameHistoryVersion(sourceStat, expectedSourceStat)) {
+      throw new HistoryEntryChangedError(`history source changed during JSONL read: ${source}`);
+    }
+    const latestDestinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
+    const latestDestinationVersion = latestDestinationInspection?.targetStat;
+    if (
+      (destinationVersion && !latestDestinationVersion) ||
+      (!destinationVersion && latestDestinationVersion) ||
+      (destinationVersion && latestDestinationVersion && !hasSameHistoryVersion(latestDestinationVersion, destinationVersion))
+    ) {
+      continue;
+    }
+    const separator = existing === "" || existing.endsWith("\n") || sourceContents === "" ? "" : "\n";
+    const lines = uniqueJsonlLines(`${existing}${separator}${sourceContents}`);
+    const mode = destinationInspection?.targetStat?.mode ?? historyDestinationMode(sourceMode);
+    await writeHistoryFileAtomically(
+      destinationPath,
+      lines.length > 0 ? `${lines.join("\n")}\n` : "",
+      mode,
+      destinationRoot,
+    );
+    return;
+  }
+  throw new HistoryEntryChangedError(`history destination changed during JSONL persistence: ${destination}`);
 }
 
 async function persistProjectLaunchRuntimeHistoryArtifacts(
@@ -1237,7 +1304,8 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
   await mkdir(projectCodexHome, { recursive: true });
   const destinationRoot = await realpath(projectCodexHome);
 
-  for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
+  await withHistoryPersistenceLock(destinationRoot, async () => {
+    for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(runtimeCodexHome, entryName);
     const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
     if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
@@ -1275,6 +1343,7 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
           sourceRoot,
           destinationRoot,
           sourceInspection.targetStat.mode,
+          sourceInspection.targetStat,
         );
       } catch (error) {
         if (isDiscardableHistoryCopyError(error)) continue;
@@ -1294,7 +1363,8 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
         throw error;
       }
     }
-  }
+    }
+  });
 }
 
 async function ensureProjectLaunchRuntimeHistoryLinks(
@@ -1425,6 +1495,7 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
       : undefined;
   const sourceDestinationMode = historyDestinationMode(sourceStat.mode);
   await mkdir(destination, { recursive: true, mode: destinationMode ?? sourceDestinationMode });
+  await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
   await chmod(destination, (destinationMode ?? sourceDestinationMode) | 0o700);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     const sourceEntry = join(source, entry.name);
@@ -1451,7 +1522,9 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
       });
     }
   }
+  await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
   await chmod(destination, destinationMode ?? sourceDestinationMode);
+  await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
   await utimes(destination, sourceStat.atime, sourceStat.mtime);
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2304,6 +2304,8 @@ async function prepareResumeCodexHomeForLaunch(
       args: selection.args,
       prepared: {
         codexHomeOverride: runtimeCodexHome,
+        projectLocalCodexHomeForCleanup: resolveProjectLocalCodexHomeForLaunch(cwd, env),
+        runtimeCodexHomeForCleanup: runtimeCodexHome,
       },
     };
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -992,6 +992,32 @@ function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
   return PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES.has(entryName);
 }
 
+function isMissingPathError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+async function resolveProjectLaunchRuntimeHistoryEntryStat(source: string) {
+  // Durable history names are an explicit allowlist. Follow only the named
+  // entry's top-level link so a directory link is classified as a directory;
+  // the destination remains the fixed runtime history path below.
+  let sourceStat;
+  try {
+    sourceStat = await lstat(source);
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined;
+    throw error;
+  }
+  if (!sourceStat.isSymbolicLink()) return sourceStat;
+  try {
+    return await stat(source);
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined;
+    throw error;
+  }
+}
+
 function uniqueJsonlLines(contents: string): string[] {
   const seen = new Set<string>();
   const lines: string[] = [];
@@ -1048,6 +1074,13 @@ async function ensureProjectLaunchRuntimeHistoryLinks(
     const runtimeEntry = join(runtimeCodexHome, entryName);
     if (existsSync(runtimeEntry)) continue;
     const projectEntry = join(projectCodexHome, entryName);
+    const projectEntryLinkStat = await lstat(projectEntry).catch((error) => {
+      if (isMissingPathError(error)) return undefined;
+      throw error;
+    });
+    if (projectEntryLinkStat?.isSymbolicLink() && !(await resolveProjectLaunchRuntimeHistoryEntryStat(projectEntry))) {
+      continue;
+    }
     if (entryName === "sessions") {
       await mkdir(projectEntry, { recursive: true });
     } else if (!existsSync(projectEntry)) {
@@ -1063,15 +1096,15 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
 ): Promise<void> {
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
-    if (!existsSync(source)) continue;
+    const sourceStat = await resolveProjectLaunchRuntimeHistoryEntryStat(source);
+    if (!sourceStat) continue;
     const destination = join(runtimeCodexHome, entryName);
     await rm(destination, { recursive: true, force: true });
-    const sourceStat = await lstat(source);
     if (sourceStat.isDirectory()) {
       await cp(source, destination, { recursive: true, force: true, dereference: true, preserveTimestamps: true });
       continue;
     }
-    await copyFilePreservingTimestamps(source, destination);
+    if (sourceStat.isFile()) await copyFilePreservingTimestamps(source, destination);
   }
 }
 
@@ -1160,6 +1193,12 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     if (PROJECT_LAUNCH_RUNTIME_SKIPPED_ENTRY_NAMES.has(entry.name)) continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
+    if (
+      PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entry.name) &&
+      !(await resolveProjectLaunchRuntimeHistoryEntryStat(source))
+    ) {
+      continue;
+    }
     if (entry.name === "config.toml") {
       const projectHooksPath = join(projectCodexHome, "hooks.json");
       const projectConfig = await readFile(source, "utf-8");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -980,6 +980,7 @@ async function copyFilePreservingTimestamps(
     if (options.expectedSourceStat && !hasSameHistoryIdentity(sourceStat, options.expectedSourceStat)) {
       throw new HistoryEntryChangedError(`history source changed during copy: ${source}`);
     }
+    if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
     await mkdir(dirname(destination), { recursive: true });
     destinationHandle = await open(
       temporary,
@@ -1238,19 +1239,34 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
     const destinationPath = destinationInspection?.targetRealpath ?? destination;
     await assertHistoryPathWithin(destinationPath, destinationRoot, true);
     if (sourceInspection.targetStat.isDirectory()) {
-      await copyProjectLaunchRuntimeHistoryDirectory(sourcePath, destinationPath, false, sourceRoot, destinationRoot, sourceInspection.targetStat);
+      try {
+        await copyProjectLaunchRuntimeHistoryDirectory(sourcePath, destinationPath, false, sourceRoot, destinationRoot, sourceInspection.targetStat);
+      } catch (error) {
+        if (isDiscardableHistoryCopyError(error)) continue;
+        throw error;
+      }
       continue;
     }
     if (entryName === "history.jsonl" || entryName === "session_index.jsonl") {
-      await persistProjectLaunchRuntimeJsonlArtifact(sourcePath, destinationPath, sourceRoot, destinationRoot);
+      try {
+        await persistProjectLaunchRuntimeJsonlArtifact(sourcePath, destinationPath, sourceRoot, destinationRoot);
+      } catch (error) {
+        if (isDiscardableHistoryCopyError(error)) continue;
+        throw error;
+      }
       continue;
     }
     if (sourceInspection.targetStat.isFile()) {
-      await copyFilePreservingTimestamps(sourcePath, destinationPath, {
-        sourceRoot,
-        destinationRoot,
-        expectedSourceStat: sourceInspection.targetStat,
-      });
+      try {
+        await copyFilePreservingTimestamps(sourcePath, destinationPath, {
+          sourceRoot,
+          destinationRoot,
+          expectedSourceStat: sourceInspection.targetStat,
+        });
+      } catch (error) {
+        if (isDiscardableHistoryCopyError(error)) continue;
+        throw error;
+      }
     }
   }
 }
@@ -1480,13 +1496,19 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         await rm(destination, { recursive: true, force: true });
       }
       await mkdir(destination, { recursive: true });
-      await copyProjectLaunchRuntimeHistoryDirectory(
-        sourceInspection.targetRealpath ?? source,
-        destination,
-        false,
-        sourceInspection.targetRealpath ?? source,
-        destinationRoot,
-      );
+      try {
+        await copyProjectLaunchRuntimeHistoryDirectory(
+          sourceInspection.targetRealpath ?? source,
+          destination,
+          false,
+          sourceInspection.targetRealpath ?? source,
+          destinationRoot,
+          sourceStat,
+        );
+      } catch (error) {
+        if (isDiscardableHistoryCopyError(error)) continue;
+        throw error;
+      }
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
@@ -1503,39 +1525,67 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       const destinationStat = destinationLinkStat;
       if (!destinationStat.isFile()) {
         await rm(destination, { recursive: true, force: true });
-        await copyFilePreservingTimestamps(
-          sourceInspection.targetRealpath ?? source,
-          destination,
-          { allowTopLevelSymlink: false, sourceRoot: sourceInspection.targetRealpath ?? source, destinationRoot },
-        );
+        try {
+          await copyFilePreservingTimestamps(
+            sourceInspection.targetRealpath ?? source,
+            destination,
+            {
+              allowTopLevelSymlink: false,
+              sourceRoot: sourceInspection.targetRealpath ?? source,
+              destinationRoot,
+              expectedSourceStat: sourceStat,
+            },
+          );
+        } catch (error) {
+          if (isDiscardableHistoryCopyError(error)) continue;
+          throw error;
+        }
         mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
-      const existing = await readHistoryFileWithoutSymlink(destination, false, destinationRoot);
-      const addition = await readHistoryFileWithoutSymlink(
-        sourceInspection.targetRealpath ?? source,
-        false,
-        sourceInspection.targetRealpath ?? source,
-      );
+      let existing: string;
+      let addition: string;
+      try {
+        existing = await readHistoryFileWithoutSymlink(destination, false, destinationRoot);
+        addition = await readHistoryFileWithoutSymlink(
+          sourceInspection.targetRealpath ?? source,
+          false,
+          sourceInspection.targetRealpath ?? source,
+        );
+      } catch (error) {
+        if (isDiscardableHistoryCopyError(error)) continue;
+        throw error;
+      }
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";
-      await writeHistoryFileAtomically(
-        destination,
-        `${existing}${separator}${addition}`,
-        destinationStat.mode & 0o7777,
-        destinationRoot,
-      );
+      try {
+        await writeHistoryFileAtomically(
+          destination,
+          `${existing}${separator}${addition}`,
+          destinationStat.mode & 0o7777,
+          destinationRoot,
+        );
+      } catch (error) {
+        if (isDiscardableHistoryCopyError(error)) continue;
+        throw error;
+      }
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
-    await copyFilePreservingTimestamps(
-      sourceInspection.targetRealpath ?? source,
-      destination,
-      {
-        allowTopLevelSymlink: false,
-        sourceRoot: sourceInspection.targetRealpath ?? source,
-        destinationRoot,
-      },
-    );
+    try {
+      await copyFilePreservingTimestamps(
+        sourceInspection.targetRealpath ?? source,
+        destination,
+        {
+          allowTopLevelSymlink: false,
+          sourceRoot: sourceInspection.targetRealpath ?? source,
+          destinationRoot,
+          expectedSourceStat: sourceStat,
+        },
+      );
+    } catch (error) {
+      if (isDiscardableHistoryCopyError(error)) continue;
+      throw error;
+    }
     mergedHistorySourceRealpaths.add(sourceRealpath);
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -969,8 +969,10 @@ async function copyFilePreservingTimestamps(
   } = {},
 ): Promise<void> {
   const sourcePath = options.allowTopLevelSymlink === true ? await realpath(source) : source;
-  if (options.sourceRoot) await assertHistoryPathWithin(sourcePath, options.sourceRoot);
-  if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
+  const sourceRoot = options.sourceRoot ? await realpath(options.sourceRoot) : undefined;
+  const destinationRoot = options.destinationRoot ? await realpath(options.destinationRoot) : undefined;
+  if (sourceRoot) await assertHistoryPathWithin(sourcePath, sourceRoot);
+  if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
   const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | historyNoFollowFlag());
   let destinationHandle;
   const temporary = `${destination}.omx-history-${randomUUID()}`;
@@ -980,7 +982,7 @@ async function copyFilePreservingTimestamps(
     if (options.expectedSourceStat && !hasSameHistoryIdentity(sourceStat, options.expectedSourceStat)) {
       throw new HistoryEntryChangedError(`history source changed during copy: ${source}`);
     }
-    if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
+    if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
     await mkdir(dirname(destination), { recursive: true });
     destinationHandle = await open(
       temporary,
@@ -1008,7 +1010,7 @@ async function copyFilePreservingTimestamps(
     if (!stagedStat.isFile() || stagedStat.isSymbolicLink() || stagedStat.nlink !== 1) {
       throw new Error(`history staging path is not a regular file: ${temporary}`);
     }
-    if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
+    if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
     await rm(destination, { recursive: true, force: true });
     await rename(temporary, destination);
   } finally {
@@ -1024,7 +1026,8 @@ async function readHistoryFileWithoutSymlink(
   sourceRoot?: string,
 ): Promise<string> {
   const sourcePath = allowTopLevelSymlink === true ? await realpath(source) : source;
-  if (sourceRoot) await assertHistoryPathWithin(sourcePath, sourceRoot);
+  const canonicalSourceRoot = sourceRoot ? await realpath(sourceRoot) : undefined;
+  if (canonicalSourceRoot) await assertHistoryPathWithin(sourcePath, canonicalSourceRoot);
   const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | historyNoFollowFlag());
   try {
     const sourceStat = await sourceHandle.stat();
@@ -1041,7 +1044,8 @@ async function writeHistoryFileAtomically(
   mode: number,
   destinationRoot?: string,
 ): Promise<void> {
-  if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
+  const canonicalDestinationRoot = destinationRoot ? await realpath(destinationRoot) : undefined;
+  if (canonicalDestinationRoot) await assertHistoryDestinationParentWithin(destination, canonicalDestinationRoot);
   const temporary = `${destination}.omx-history-${randomUUID()}`;
   let destinationHandle;
   try {
@@ -1055,7 +1059,7 @@ async function writeHistoryFileAtomically(
     await destinationHandle.close();
     destinationHandle = undefined;
     await rm(destination, { recursive: true, force: true });
-    if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
+    if (canonicalDestinationRoot) await assertHistoryDestinationParentWithin(destination, canonicalDestinationRoot);
     await rename(temporary, destination);
   } finally {
     await destinationHandle?.close().catch(() => undefined);
@@ -1398,6 +1402,8 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   destinationRoot = destination,
   expectedSourceStat?: { dev: number; ino: number },
 ): Promise<void> {
+  sourceRoot = await realpath(sourceRoot);
+  destinationRoot = await realpath(destinationRoot);
   const sourceStat = allowTopLevelSymlink ? await stat(source) : await lstat(source);
   if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) return;
   if (expectedSourceStat && !hasSameHistoryIdentity(sourceStat, expectedSourceStat)) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1030,8 +1030,7 @@ async function copyFilePreservingTimestamps(
       throw new Error(`history staging path is not a regular file: ${temporary}`);
     }
     if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
-    await rm(destination, { recursive: true, force: true });
-    await rename(temporary, destination);
+    await publishHistoryReplacement(temporary, destination, false);
   } finally {
     await destinationHandle?.close().catch(() => undefined);
     await rm(temporary, { force: true }).catch(() => undefined);
@@ -1078,9 +1077,8 @@ async function writeHistoryFileAtomically(
     await destinationHandle.chmod(destinationMode);
     await destinationHandle.close();
     destinationHandle = undefined;
-    await rm(destination, { recursive: true, force: true });
     if (canonicalDestinationRoot) await assertHistoryDestinationParentWithin(destination, canonicalDestinationRoot);
-    await rename(temporary, destination);
+    await publishHistoryReplacement(temporary, destination, false);
   } finally {
     await destinationHandle?.close().catch(() => undefined);
     await rm(temporary, { force: true }).catch(() => undefined);
@@ -1173,6 +1171,29 @@ async function chmodHistoryDestination(
     if (tolerateForeignOwner && (error as NodeJS.ErrnoException).code === "EPERM") return;
     throw error;
   }
+}
+
+async function publishHistoryReplacement(
+  temporary: string,
+  destination: string,
+  recursive: boolean,
+): Promise<void> {
+  try {
+    await rename(temporary, destination);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "EEXIST" && code !== "EPERM" && code !== "ENOTEMPTY") throw error;
+  }
+  const backup = `${destination}.omx-history-backup-${randomUUID()}`;
+  await rename(destination, backup);
+  try {
+    await rename(temporary, destination);
+  } catch (error) {
+    await rename(backup, destination).catch(() => undefined);
+    throw error;
+  }
+  await rm(backup, { recursive, force: true }).catch(() => undefined);
 }
 
 function isUnresolvableHistoryLinkError(error: unknown): boolean {
@@ -1296,6 +1317,7 @@ export async function acquireHistoryPersistenceLock(
   root: string,
   options: HistoryPersistenceLockOptions = {},
 ): Promise<HistoryPersistenceLockLease> {
+  root = await realpath(root);
   const lockPath = join(root, ".omx-history.lock");
   const ownerPath = join(lockPath, "owner.json");
   const timeoutMs = options.timeoutMs ?? HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS;
@@ -1625,7 +1647,6 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
       continue;
     }
     try {
-      await rm(destination, { recursive: true, force: true });
       const sourceStat = sourceInspection.targetStat;
       if (!sourceStat) continue;
       const sourcePath = sourceInspection.targetRealpath ?? source;
@@ -1768,9 +1789,7 @@ async function replaceProjectLaunchRuntimeHistoryDirectory(
       throw new Error(`history staging path is not a directory: ${temporary}`);
     }
     await assertHistoryDestinationParentWithin(destination, destinationRoot);
-    await rm(destination, { recursive: true, force: true });
-    await assertHistoryDestinationParentWithin(destination, destinationRoot);
-    await rename(temporary, destination);
+    await publishHistoryReplacement(temporary, destination, true);
   } finally {
     await rm(temporary, { recursive: true, force: true }).catch(() => undefined);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1132,7 +1132,11 @@ function historyNoFollowFlag(): number {
 }
 
 function isHistoryPathWithin(candidate: string, root: string): boolean {
-  const path = relative(root, candidate);
+  const normalizedRoot = process.platform === "win32" ? win32.normalize(root).toLowerCase() : root;
+  const normalizedCandidate = process.platform === "win32" ? win32.normalize(candidate).toLowerCase() : candidate;
+  const path = process.platform === "win32"
+    ? win32.relative(normalizedRoot, normalizedCandidate)
+    : relative(normalizedRoot, normalizedCandidate);
   const escapes = path === ".." || path.startsWith(`..${sep}`);
   return path === "" || (!escapes && !isAbsolute(path));
 }
@@ -1167,6 +1171,20 @@ async function chmodHistoryDestination(
 ): Promise<void> {
   try {
     await chmod(destination, mode);
+  } catch (error) {
+    if (tolerateForeignOwner && (error as NodeJS.ErrnoException).code === "EPERM") return;
+    throw error;
+  }
+}
+
+async function utimesHistoryDestination(
+  destination: string,
+  atime: Date,
+  mtime: Date,
+  tolerateForeignOwner: boolean,
+): Promise<void> {
+  try {
+    await utimes(destination, atime, mtime);
   } catch (error) {
     if (tolerateForeignOwner && (error as NodeJS.ErrnoException).code === "EPERM") return;
     throw error;
@@ -1755,7 +1773,12 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
   await chmodHistoryDestination(destination, destinationMode ?? sourceDestinationMode, destinationWasExistingDirectory);
   await assertHistoryDestinationDirectorySafe(destination, destinationRoot);
-  await utimes(destination, sourceStat.atime, sourceStat.mtime);
+  await utimesHistoryDestination(
+    destination,
+    sourceStat.atime,
+    sourceStat.mtime,
+    destinationWasExistingDirectory,
+  );
 }
 
 async function replaceProjectLaunchRuntimeHistoryDirectory(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { basename, dirname, isAbsolute, join, posix, relative, resolve, win32 } from "path";
+import { basename, dirname, isAbsolute, join, posix, relative, resolve, sep, win32 } from "path";
 import { appendFileSync, chmodSync, closeSync, constants as fsConstants, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { chmod, copyFile, cp, lstat, mkdir, open, readFile, readdir, realpath, rename, rm, stat, symlink, utimes, writeFile } from "fs/promises";
 import { constants as osConstants, homedir } from "os";
@@ -1101,17 +1101,16 @@ function historyNoFollowFlag(): number {
 
 function isHistoryPathWithin(candidate: string, root: string): boolean {
   const path = relative(root, candidate);
-  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+  const escapes = path === ".." || path.startsWith(`..${sep}`);
+  return path === "" || (!escapes && !isAbsolute(path));
 }
 
 async function assertHistoryPathWithin(path: string, root: string, allowMissing = false): Promise<void> {
-  const [canonicalRoot, canonicalPath] = await Promise.all([
-    realpath(root),
-    realpath(path).catch((error) => {
+  const canonicalRoot = root;
+  const canonicalPath = await realpath(path).catch((error) => {
       if (allowMissing && isUnresolvableHistoryLinkError(error)) return undefined;
       throw error;
-    }),
-  ]);
+    });
   if (canonicalPath && !isHistoryPathWithin(canonicalPath, canonicalRoot)) {
     throw new Error(`history path escapes its authorized root: ${path}`);
   }
@@ -1252,6 +1251,7 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
   options: MaterializeProjectLaunchRuntimeHistoryOptions = {},
 ): Promise<Set<string>> {
   const skipEntryNames = new Set<string>();
+  const destinationRoot = await realpath(runtimeCodexHome);
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
     const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
@@ -1268,31 +1268,39 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
       skipEntryNames.add(entryName);
       continue;
     }
-    await rm(destination, { recursive: true, force: true });
-    const sourceStat = sourceInspection.targetStat;
-    if (!sourceStat) continue;
-    const sourcePath = sourceInspection.targetRealpath ?? source;
-    if (sourceStat.isDirectory()) {
-      await replaceProjectLaunchRuntimeHistoryDirectory(
-        sourcePath,
-        destination,
-        false,
-        runtimeCodexHome,
-        options.afterStage
-          ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
-          : undefined,
-      );
-      continue;
-    }
-    if (sourceStat.isFile()) {
-      await copyFilePreservingTimestamps(sourcePath, destination, {
-        allowTopLevelSymlink: false,
-        sourceRoot: sourcePath,
-        destinationRoot: runtimeCodexHome,
-        afterStage: options.afterStage
-          ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
-          : undefined,
-      });
+    try {
+      await rm(destination, { recursive: true, force: true });
+      const sourceStat = sourceInspection.targetStat;
+      if (!sourceStat) continue;
+      const sourcePath = sourceInspection.targetRealpath ?? source;
+      if (sourceStat.isDirectory()) {
+        await replaceProjectLaunchRuntimeHistoryDirectory(
+          sourcePath,
+          destination,
+          false,
+          destinationRoot,
+          options.afterStage
+            ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
+            : undefined,
+        );
+        continue;
+      }
+      if (sourceStat.isFile()) {
+        await copyFilePreservingTimestamps(sourcePath, destination, {
+          allowTopLevelSymlink: false,
+          sourceRoot: sourcePath,
+          destinationRoot,
+          afterStage: options.afterStage
+            ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
+            : undefined,
+        });
+      }
+    } catch (error) {
+      if (isUnresolvableHistoryLinkError(error)) {
+        skipEntryNames.add(entryName);
+        continue;
+      }
+      throw error;
     }
   }
   return skipEntryNames;
@@ -1373,11 +1381,18 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
   sourceCodexHome: string,
   mergedHistorySourceRealpaths: Set<string>,
 ): Promise<void> {
+  const destinationRoot = await realpath(runtimeCodexHome);
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
     const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
     if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
-    const sourceRealpath = sourceInspection.targetRealpath ?? realpathSync(source);
+    const sourceRealpath =
+      sourceInspection.targetRealpath ??
+      await realpath(source).catch((error) => {
+        if (isUnresolvableHistoryLinkError(error)) return undefined;
+        throw error;
+      });
+    if (!sourceRealpath) continue;
     if (mergedHistorySourceRealpaths.has(sourceRealpath)) continue;
     if (!(await historyEntryStillMatches(source, sourceInspection))) continue;
     const destination = join(runtimeCodexHome, entryName);
@@ -1397,7 +1412,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         destination,
         false,
         sourceInspection.targetRealpath ?? source,
-        runtimeCodexHome,
+        destinationRoot,
       );
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
@@ -1418,12 +1433,12 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         await copyFilePreservingTimestamps(
           sourceInspection.targetRealpath ?? source,
           destination,
-          { allowTopLevelSymlink: false, sourceRoot: sourceInspection.targetRealpath ?? source, destinationRoot: runtimeCodexHome },
+          { allowTopLevelSymlink: false, sourceRoot: sourceInspection.targetRealpath ?? source, destinationRoot },
         );
         mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
-      const existing = await readHistoryFileWithoutSymlink(destination, false, runtimeCodexHome);
+      const existing = await readHistoryFileWithoutSymlink(destination, false, destinationRoot);
       const addition = await readHistoryFileWithoutSymlink(
         sourceInspection.targetRealpath ?? source,
         false,
@@ -1434,7 +1449,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         destination,
         `${existing}${separator}${addition}`,
         destinationStat.mode & 0o7777,
-        runtimeCodexHome,
+        destinationRoot,
       );
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
@@ -1445,7 +1460,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       {
         allowTopLevelSymlink: false,
         sourceRoot: sourceInspection.targetRealpath ?? source,
-        destinationRoot: runtimeCodexHome,
+        destinationRoot,
       },
     );
     mergedHistorySourceRealpaths.add(sourceRealpath);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1408,15 +1408,6 @@ export async function acquireHistoryPersistenceLock(
   }
 }
 
-async function withHistoryPersistenceLock<T>(root: string, action: () => Promise<T>): Promise<T> {
-  const lease = await acquireHistoryPersistenceLock(root);
-  try {
-    return await action();
-  } finally {
-    await releaseHistoryPersistenceLock(lease);
-  }
-}
-
 function hasSameHistoryIdentity(
   actual: { dev: number; ino: number },
   expected: { dev: number; ino: number },
@@ -1525,19 +1516,34 @@ async function persistProjectLaunchRuntimeJsonlArtifact(
 async function resolveHistoryPersistenceLockRoot(
   projectCodexHome: string,
   destinationRoot: string,
-): Promise<string> {
+): Promise<string[]> {
   const candidates: string[] = [];
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const destination = join(projectCodexHome, entryName);
     const inspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
     const target = inspection?.targetRealpath;
     if (!target) continue;
-    const anchor = inspection.targetStat?.isDirectory() ? target : dirname(target);
-    const canonicalAnchor = await realpath(anchor).catch(() => undefined);
-    if (!canonicalAnchor) continue;
-    if (await access(canonicalAnchor, fsConstants.W_OK).then(() => true, () => false)) candidates.push(canonicalAnchor);
+    const anchors = [dirname(target), ...(inspection.targetStat?.isDirectory() ? [target] : [])];
+    for (const anchor of anchors) {
+      const canonicalAnchor = await realpath(anchor).catch(() => undefined);
+      if (!canonicalAnchor) continue;
+      if (await access(canonicalAnchor, fsConstants.W_OK).then(() => true, () => false)) {
+        candidates.push(canonicalAnchor);
+        break;
+      }
+    }
   }
-  return candidates.sort()[0] ?? destinationRoot;
+  return (candidates.length > 0 ? [...new Set(candidates)] : [destinationRoot]).sort();
+}
+
+async function withHistoryPersistenceLocks<T>(roots: string[], action: () => Promise<T>): Promise<T> {
+  const leases: HistoryPersistenceLockLease[] = [];
+  try {
+    for (const root of [...new Set(roots)].sort()) leases.push(await acquireHistoryPersistenceLock(root));
+    return await action();
+  } finally {
+    for (const lease of leases.reverse()) await releaseHistoryPersistenceLock(lease);
+  }
 }
 
 async function persistProjectLaunchRuntimeHistoryArtifacts(
@@ -1548,9 +1554,9 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
   if (!existsSync(runtimeCodexHome)) return true;
   await mkdir(projectCodexHome, { recursive: true });
   const destinationRoot = await realpath(projectCodexHome);
-  const lockRoot = await resolveHistoryPersistenceLockRoot(projectCodexHome, destinationRoot);
+  const lockRoots = await resolveHistoryPersistenceLockRoot(projectCodexHome, destinationRoot);
 
-  return withHistoryPersistenceLock(lockRoot, async () => {
+  return withHistoryPersistenceLocks(lockRoots, async () => {
     let complete = true;
     for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(runtimeCodexHome, entryName);
@@ -1768,6 +1774,7 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
     destinationWasExistingDirectory,
   );
   for (const entry of await readdir(source, { withFileTypes: true })) {
+    if (entry.name === ".omx-history.lock" || entry.name.startsWith(".omx-history.lock.")) continue;
     const sourceEntry = join(source, entry.name);
     const destinationEntry = join(destination, entry.name);
     const entryStat = await lstat(sourceEntry).catch((error) => {
@@ -2305,7 +2312,7 @@ async function prepareResumeCodexHomeForLaunch(
       args: selection.args,
       prepared: {
         codexHomeOverride: runtimeCodexHome,
-        projectLocalCodexHomeForCleanup: resolveProjectLocalCodexHomeForLaunch(cwd, env),
+        projectLocalCodexHomeForCleanup: projectHomes[0].path,
         runtimeCodexHomeForCleanup: runtimeCodexHome,
       },
     };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1351,7 +1351,7 @@ export async function acquireHistoryPersistenceLock(
       }
       await assertHistoryPathWithin(lockPath, root);
       const lockIdentity = { dev: lockStat.dev, ino: lockStat.ino };
-      if ((lockStat.mode & 0o077) !== 0) {
+      if (process.platform !== "win32" && (lockStat.mode & 0o077) !== 0) {
         throw new Error(`history persistence lock is not private: ${lockPath}`);
       }
       const token = randomUUID();
@@ -1405,7 +1405,9 @@ export async function acquireHistoryPersistenceLock(
         await retireHistoryLock(lockPath, root, lockStat ? { dev: lockStat.dev, ino: lockStat.ino } : { dev: -1, ino: -1 });
         continue;
       }
-      if ((lockStat.mode & 0o077) !== 0) throw new Error(`history persistence lock is not private: ${lockPath}`);
+      if (process.platform !== "win32" && (lockStat.mode & 0o077) !== 0) {
+        throw new Error(`history persistence lock is not private: ${lockPath}`);
+      }
       if (Date.now() >= deadline) throw new Error(`timed out waiting for history persistence lock: ${lockPath}`);
       await new Promise((resolve) => setTimeout(resolve, 20));
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1046,16 +1046,17 @@ async function writeHistoryFileAtomically(
 ): Promise<void> {
   const canonicalDestinationRoot = destinationRoot ? await realpath(destinationRoot) : undefined;
   if (canonicalDestinationRoot) await assertHistoryDestinationParentWithin(destination, canonicalDestinationRoot);
+  const destinationMode = historyDestinationMode(mode);
   const temporary = `${destination}.omx-history-${randomUUID()}`;
   let destinationHandle;
   try {
     destinationHandle = await open(
       temporary,
       fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | historyNoFollowFlag(),
-      mode & 0o7777,
+      destinationMode,
     );
     await destinationHandle.writeFile(contents, "utf-8");
-    await destinationHandle.chmod(mode & 0o7777);
+    await destinationHandle.chmod(destinationMode);
     await destinationHandle.close();
     destinationHandle = undefined;
     await rm(destination, { recursive: true, force: true });
@@ -1104,7 +1105,7 @@ function isRegularHistoryTarget(sourceStat: { isDirectory(): boolean; isFile(): 
   return sourceStat.isDirectory() || sourceStat.isFile();
 }
 
-function historyDestinationMode(sourceMode: number): number {
+export function historyDestinationMode(sourceMode: number): number {
   const permissions = sourceMode & 0o777;
   return (sourceMode & 0o7000) | permissions | ((permissions & 0o070) << 3) | ((permissions & 0o007) << 6);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1173,23 +1173,52 @@ interface HistoryPersistenceLockLease {
   heartbeat: ReturnType<typeof setInterval>;
 }
 
-async function readHistoryPersistenceLockOwner(lockPath: string): Promise<{ token: string; pid: number } | undefined> {
+interface HistoryPersistenceLockOwner {
+  token: string;
+  pid: number;
+  startIdentity?: string;
+}
+
+async function readHistoryPersistenceLockOwner(
+  lockPath: string,
+): Promise<HistoryPersistenceLockOwner | null | undefined> {
   try {
-    const owner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf-8")) as { token?: unknown; pid?: unknown };
-    if (typeof owner.token !== "string" || typeof owner.pid !== "number") return undefined;
-    return { token: owner.token, pid: owner.pid };
+    const owner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf-8")) as {
+      token?: unknown;
+      pid?: unknown;
+      startIdentity?: unknown;
+    };
+    if (typeof owner.token !== "string" || typeof owner.pid !== "number") return null;
+    if (owner.startIdentity !== undefined && typeof owner.startIdentity !== "string") return null;
+    return { token: owner.token, pid: owner.pid, startIdentity: owner.startIdentity };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    return null;
+  }
+}
+
+async function historyProcessStartIdentity(pid: number): Promise<string | undefined> {
+  if (process.platform !== "linux") return undefined;
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, "utf-8");
+    const fields = stat.slice(stat.lastIndexOf(") ") + 2).split(" ");
+    return fields[19] ? `${pid}:${fields[19]}` : undefined;
   } catch {
     return undefined;
   }
 }
 
-function isHistoryProcessAlive(pid: number): boolean {
+async function isHistoryProcessAlive(owner: HistoryPersistenceLockOwner): Promise<boolean | undefined> {
   try {
-    process.kill(pid, 0);
-    return true;
+    process.kill(owner.pid, 0);
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    return true;
   }
+  if (!owner.startIdentity) return undefined;
+  const currentIdentity = await historyProcessStartIdentity(owner.pid);
+  if (!currentIdentity) return undefined;
+  return currentIdentity === owner.startIdentity;
 }
 
 export async function releaseHistoryPersistenceLock(lease: HistoryPersistenceLockLease): Promise<void> {
@@ -1218,14 +1247,27 @@ export async function acquireHistoryPersistenceLock(
       }
       await assertHistoryPathWithin(lockPath, root);
       const token = randomUUID();
-      await writeFile(ownerPath, JSON.stringify({ token, pid: process.pid, heartbeatAt: Date.now() }), { flag: "wx" });
+      const startIdentity = await historyProcessStartIdentity(process.pid);
+      await writeFile(
+        ownerPath,
+        JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
+        { flag: "wx" },
+      );
       const heartbeat = setInterval(async () => {
+        let temporaryOwnerPath: string | undefined;
         try {
           const owner = await readHistoryPersistenceLockOwner(lockPath);
           if (owner?.token !== token) return;
-          await writeFile(ownerPath, JSON.stringify({ token, pid: process.pid, heartbeatAt: Date.now() }));
+          temporaryOwnerPath = `${ownerPath}.${randomUUID()}.tmp`;
+          await writeFile(
+            temporaryOwnerPath,
+            JSON.stringify({ token, pid: process.pid, startIdentity, heartbeatAt: Date.now() }),
+            { flag: "wx" },
+          );
+          await rename(temporaryOwnerPath, ownerPath);
         } catch {
           // A contender may have removed a dead owner's lock between checks.
+          if (temporaryOwnerPath) await rm(temporaryOwnerPath, { force: true }).catch(() => undefined);
         }
       }, heartbeatMs);
       heartbeat.unref?.();
@@ -1236,13 +1278,13 @@ export async function acquireHistoryPersistenceLock(
       if (lockStat?.isSymbolicLink()) throw new Error(`history persistence lock is a symlink: ${lockPath}`);
       const owner = await readHistoryPersistenceLockOwner(lockPath);
       const lockAge = lockStat ? Date.now() - lockStat.mtimeMs : 0;
-      if (owner && !isHistoryProcessAlive(owner.pid)) {
+      if (owner && owner !== null && (await isHistoryProcessAlive(owner)) === false) {
         const ownerStat = await stat(join(lockPath, "owner.json")).catch(() => undefined);
         if (ownerStat && Date.now() - ownerStat.mtimeMs > staleMs) {
           await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
           continue;
         }
-      } else if (!owner && lockAge > staleMs) {
+      } else if (owner === undefined && lockAge > staleMs) {
         await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
         continue;
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -965,6 +965,7 @@ async function copyFilePreservingTimestamps(
     afterStage?: (temporary: string, destination: string) => Promise<void>;
     sourceRoot?: string;
     destinationRoot?: string;
+    expectedSourceStat?: { dev: number; ino: number };
   } = {},
 ): Promise<void> {
   const sourcePath = options.allowTopLevelSymlink === true ? await realpath(source) : source;
@@ -976,6 +977,9 @@ async function copyFilePreservingTimestamps(
   try {
     const sourceStat = await sourceHandle.stat();
     if (!sourceStat.isFile()) throw new Error(`history source is not a regular file: ${source}`);
+    if (options.expectedSourceStat && !hasSameHistoryIdentity(sourceStat, options.expectedSourceStat)) {
+      throw new HistoryEntryChangedError(`history source changed during copy: ${source}`);
+    }
     await mkdir(dirname(destination), { recursive: true });
     destinationHandle = await open(
       temporary,
@@ -1000,7 +1004,7 @@ async function copyFilePreservingTimestamps(
     destinationHandle = undefined;
     await options.afterStage?.(temporary, destination);
     const stagedStat = await lstat(temporary);
-    if (!stagedStat.isFile() || stagedStat.isSymbolicLink()) {
+    if (!stagedStat.isFile() || stagedStat.isSymbolicLink() || stagedStat.nlink !== 1) {
       throw new Error(`history staging path is not a regular file: ${temporary}`);
     }
     if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
@@ -1126,6 +1130,21 @@ function isUnresolvableHistoryLinkError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
 }
 
+class HistoryEntryChangedError extends Error {
+  code = "ESTALE";
+}
+
+function isDiscardableHistoryCopyError(error: unknown): boolean {
+  return isUnresolvableHistoryLinkError(error) || error instanceof HistoryEntryChangedError;
+}
+
+function hasSameHistoryIdentity(
+  actual: { dev: number; ino: number },
+  expected: { dev: number; ino: number },
+): boolean {
+  return actual.dev === expected.dev && actual.ino === expected.ino;
+}
+
 async function inspectProjectLaunchRuntimeHistoryEntry(source: string) {
   // Durable history names are an explicit allowlist. Follow only the named
   // entry's top-level link so a directory link is classified as a directory;
@@ -1174,12 +1193,27 @@ function uniqueJsonlLines(contents: string): string[] {
   return lines;
 }
 
-async function persistProjectLaunchRuntimeJsonlArtifact(source: string, destination: string): Promise<void> {
-  const existing = existsSync(destination) ? await readFile(destination, "utf-8").catch(() => "") : "";
-  const sourceContents = await readFile(source, "utf-8");
+async function persistProjectLaunchRuntimeJsonlArtifact(
+  source: string,
+  destination: string,
+  sourceRoot: string,
+  destinationRoot: string,
+): Promise<void> {
+  const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
+  if (destinationInspection && !destinationInspection.targetStat?.isFile()) return;
+  const destinationPath = destinationInspection?.targetRealpath ?? destination;
+  await assertHistoryPathWithin(destinationPath, destinationRoot, true);
+  const existing = destinationInspection ? await readHistoryFileWithoutSymlink(destinationPath, false, destinationRoot) : "";
+  const sourceContents = await readHistoryFileWithoutSymlink(source, false, sourceRoot);
   const separator = existing === "" || existing.endsWith("\n") || sourceContents === "" ? "" : "\n";
   const lines = uniqueJsonlLines(`${existing}${separator}${sourceContents}`);
-  await writeFile(destination, lines.length > 0 ? `${lines.join("\n")}\n` : "", "utf-8");
+  const mode = destinationInspection?.targetStat?.mode ?? 0o600;
+  await writeHistoryFileAtomically(
+    destinationPath,
+    lines.length > 0 ? `${lines.join("\n")}\n` : "",
+    mode,
+    destinationRoot,
+  );
 }
 
 async function persistProjectLaunchRuntimeHistoryArtifacts(
@@ -1189,23 +1223,34 @@ async function persistProjectLaunchRuntimeHistoryArtifacts(
   if (!runtimeCodexHome || !projectCodexHome) return;
   if (!existsSync(runtimeCodexHome)) return;
   await mkdir(projectCodexHome, { recursive: true });
+  const destinationRoot = await realpath(projectCodexHome);
 
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(runtimeCodexHome, entryName);
-    if (!existsSync(source)) continue;
-    const sourceStat = await lstat(source);
-    if (sourceStat.isSymbolicLink()) continue;
+    const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
+    if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
+    const sourcePath = sourceInspection.targetRealpath ?? source;
+    const sourceRoot = sourceInspection.targetRealpath ?? source;
+    if (!(await historyEntryStillMatches(source, sourceInspection))) continue;
     const destination = join(projectCodexHome, entryName);
-    if (sourceStat.isDirectory()) {
-      await cp(source, destination, { recursive: true, force: true, preserveTimestamps: true, verbatimSymlinks: true });
+    const destinationInspection = await inspectProjectLaunchRuntimeHistoryEntry(destination);
+    if (destinationInspection && !destinationInspection.targetStat) continue;
+    const destinationPath = destinationInspection?.targetRealpath ?? destination;
+    await assertHistoryPathWithin(destinationPath, destinationRoot, true);
+    if (sourceInspection.targetStat.isDirectory()) {
+      await copyProjectLaunchRuntimeHistoryDirectory(sourcePath, destinationPath, false, sourceRoot, destinationRoot, sourceInspection.targetStat);
       continue;
     }
     if (entryName === "history.jsonl" || entryName === "session_index.jsonl") {
-      await persistProjectLaunchRuntimeJsonlArtifact(source, destination);
+      await persistProjectLaunchRuntimeJsonlArtifact(sourcePath, destinationPath, sourceRoot, destinationRoot);
       continue;
     }
-    if (sourceStat.isFile()) {
-      await copyFilePreservingTimestamps(source, destination);
+    if (sourceInspection.targetStat.isFile()) {
+      await copyFilePreservingTimestamps(sourcePath, destinationPath, {
+        sourceRoot,
+        destinationRoot,
+        expectedSourceStat: sourceInspection.targetStat,
+      });
     }
   }
 }
@@ -1279,6 +1324,7 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
           destination,
           false,
           destinationRoot,
+          sourceStat,
           options.afterStage
             ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
             : undefined,
@@ -1290,13 +1336,14 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
           allowTopLevelSymlink: false,
           sourceRoot: sourcePath,
           destinationRoot,
+          expectedSourceStat: sourceStat,
           afterStage: options.afterStage
             ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
             : undefined,
         });
       }
     } catch (error) {
-      if (isUnresolvableHistoryLinkError(error)) {
+      if (isDiscardableHistoryCopyError(error)) {
         skipEntryNames.add(entryName);
         continue;
       }
@@ -1312,9 +1359,13 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   allowTopLevelSymlink = false,
   sourceRoot = source,
   destinationRoot = destination,
+  expectedSourceStat?: { dev: number; ino: number },
 ): Promise<void> {
   const sourceStat = allowTopLevelSymlink ? await stat(source) : await lstat(source);
   if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) return;
+  if (expectedSourceStat && !hasSameHistoryIdentity(sourceStat, expectedSourceStat)) {
+    throw new HistoryEntryChangedError(`history source changed during directory copy: ${source}`);
+  }
   await assertHistoryPathWithin(source, sourceRoot);
   const destinationStat = await lstat(destination).catch((error) => {
     if (isUnresolvableHistoryLinkError(error)) return undefined;
@@ -1339,9 +1390,20 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
     });
     if (!entryStat || entryStat.isSymbolicLink()) continue;
     if (entryStat.isDirectory()) {
-      await copyProjectLaunchRuntimeHistoryDirectory(sourceEntry, destinationEntry, false, sourceRoot, destinationRoot);
+      await copyProjectLaunchRuntimeHistoryDirectory(
+        sourceEntry,
+        destinationEntry,
+        false,
+        sourceRoot,
+        destinationRoot,
+        entryStat,
+      );
     } else if (entryStat.isFile()) {
-      await copyFilePreservingTimestamps(sourceEntry, destinationEntry, { sourceRoot, destinationRoot });
+      await copyFilePreservingTimestamps(sourceEntry, destinationEntry, {
+        sourceRoot,
+        destinationRoot,
+        expectedSourceStat: entryStat,
+      });
     }
   }
   await chmod(destination, destinationMode ?? (sourceStat.mode & 0o7777));
@@ -1353,6 +1415,7 @@ async function replaceProjectLaunchRuntimeHistoryDirectory(
   destination: string,
   allowTopLevelSymlink: boolean,
   destinationRoot: string,
+  expectedSourceStat: { dev: number; ino: number },
   afterStage?: (temporary: string, destination: string) => Promise<void>,
 ): Promise<void> {
   const temporary = `${destination}.omx-history-${randomUUID()}`;
@@ -1361,7 +1424,17 @@ async function replaceProjectLaunchRuntimeHistoryDirectory(
     if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) {
       throw new Error(`history source is not a directory: ${source}`);
     }
-    await copyProjectLaunchRuntimeHistoryDirectory(source, temporary, allowTopLevelSymlink, source, dirname(destination));
+    if (!hasSameHistoryIdentity(sourceStat, expectedSourceStat)) {
+      throw new HistoryEntryChangedError(`history source changed during directory publication: ${source}`);
+    }
+    await copyProjectLaunchRuntimeHistoryDirectory(
+      source,
+      temporary,
+      allowTopLevelSymlink,
+      source,
+      destinationRoot,
+      sourceStat,
+    );
     await afterStage?.(temporary, destination);
     const stagedStat = await lstat(temporary);
     if (!stagedStat.isDirectory() || stagedStat.isSymbolicLink()) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -963,10 +963,14 @@ async function copyFilePreservingTimestamps(
   options: {
     allowTopLevelSymlink?: boolean;
     afterStage?: (temporary: string, destination: string) => Promise<void>;
+    sourceRoot?: string;
+    destinationRoot?: string;
   } = {},
 ): Promise<void> {
   const sourcePath = options.allowTopLevelSymlink === true ? await realpath(source) : source;
-  const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  if (options.sourceRoot) await assertHistoryPathWithin(sourcePath, options.sourceRoot);
+  if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
+  const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | historyNoFollowFlag());
   let destinationHandle;
   const temporary = `${destination}.omx-history-${randomUUID()}`;
   try {
@@ -975,7 +979,7 @@ async function copyFilePreservingTimestamps(
     await mkdir(dirname(destination), { recursive: true });
     destinationHandle = await open(
       temporary,
-      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | historyNoFollowFlag(),
       sourceStat.mode & 0o7777,
     );
     const buffer = Buffer.alloc(64 * 1024);
@@ -999,6 +1003,7 @@ async function copyFilePreservingTimestamps(
     if (!stagedStat.isFile() || stagedStat.isSymbolicLink()) {
       throw new Error(`history staging path is not a regular file: ${temporary}`);
     }
+    if (options.destinationRoot) await assertHistoryDestinationParentWithin(destination, options.destinationRoot);
     await rm(destination, { recursive: true, force: true });
     await rename(temporary, destination);
   } finally {
@@ -1008,9 +1013,14 @@ async function copyFilePreservingTimestamps(
   }
 }
 
-async function readHistoryFileWithoutSymlink(source: string, allowTopLevelSymlink = false): Promise<string> {
+async function readHistoryFileWithoutSymlink(
+  source: string,
+  allowTopLevelSymlink = false,
+  sourceRoot?: string,
+): Promise<string> {
   const sourcePath = allowTopLevelSymlink === true ? await realpath(source) : source;
-  const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  if (sourceRoot) await assertHistoryPathWithin(sourcePath, sourceRoot);
+  const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | historyNoFollowFlag());
   try {
     const sourceStat = await sourceHandle.stat();
     if (!sourceStat.isFile()) throw new Error(`history source is not a regular file: ${source}`);
@@ -1024,13 +1034,15 @@ async function writeHistoryFileAtomically(
   destination: string,
   contents: string,
   mode: number,
+  destinationRoot?: string,
 ): Promise<void> {
+  if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
   const temporary = `${destination}.omx-history-${randomUUID()}`;
   let destinationHandle;
   try {
     destinationHandle = await open(
       temporary,
-      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | historyNoFollowFlag(),
       mode & 0o7777,
     );
     await destinationHandle.writeFile(contents, "utf-8");
@@ -1038,6 +1050,7 @@ async function writeHistoryFileAtomically(
     await destinationHandle.close();
     destinationHandle = undefined;
     await rm(destination, { recursive: true, force: true });
+    if (destinationRoot) await assertHistoryDestinationParentWithin(destination, destinationRoot);
     await rename(temporary, destination);
   } finally {
     await destinationHandle?.close().catch(() => undefined);
@@ -1080,6 +1093,32 @@ function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
 
 function isRegularHistoryTarget(sourceStat: { isDirectory(): boolean; isFile(): boolean }): boolean {
   return sourceStat.isDirectory() || sourceStat.isFile();
+}
+
+function historyNoFollowFlag(): number {
+  return process.platform === "win32" ? 0 : (fsConstants.O_NOFOLLOW ?? 0);
+}
+
+function isHistoryPathWithin(candidate: string, root: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+async function assertHistoryPathWithin(path: string, root: string, allowMissing = false): Promise<void> {
+  const [canonicalRoot, canonicalPath] = await Promise.all([
+    realpath(root),
+    realpath(path).catch((error) => {
+      if (allowMissing && isUnresolvableHistoryLinkError(error)) return undefined;
+      throw error;
+    }),
+  ]);
+  if (canonicalPath && !isHistoryPathWithin(canonicalPath, canonicalRoot)) {
+    throw new Error(`history path escapes its authorized root: ${path}`);
+  }
+}
+
+async function assertHistoryDestinationParentWithin(destination: string, root: string): Promise<void> {
+  await assertHistoryPathWithin(dirname(destination), root);
 }
 
 function isUnresolvableHistoryLinkError(error: unknown): boolean {
@@ -1238,6 +1277,7 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
         sourcePath,
         destination,
         false,
+        runtimeCodexHome,
         options.afterStage
           ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
           : undefined,
@@ -1247,6 +1287,8 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
     if (sourceStat.isFile()) {
       await copyFilePreservingTimestamps(sourcePath, destination, {
         allowTopLevelSymlink: false,
+        sourceRoot: sourcePath,
+        destinationRoot: runtimeCodexHome,
         afterStage: options.afterStage
           ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
           : undefined,
@@ -1260,9 +1302,12 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   source: string,
   destination: string,
   allowTopLevelSymlink = false,
+  sourceRoot = source,
+  destinationRoot = destination,
 ): Promise<void> {
   const sourceStat = allowTopLevelSymlink ? await stat(source) : await lstat(source);
   if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) return;
+  await assertHistoryPathWithin(source, sourceRoot);
   const destinationStat = await lstat(destination).catch((error) => {
     if (isUnresolvableHistoryLinkError(error)) return undefined;
     throw error;
@@ -1270,7 +1315,11 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   if (destinationStat && (!destinationStat.isDirectory() || destinationStat.isSymbolicLink())) {
     await rm(destination, { recursive: true, force: true });
   }
-  const destinationMode = destinationStat ? destinationStat.mode & 0o7777 : undefined;
+  await assertHistoryDestinationParentWithin(destination, destinationRoot);
+  const destinationMode =
+    destinationStat && destinationStat.isDirectory() && !destinationStat.isSymbolicLink()
+      ? destinationStat.mode & sourceStat.mode & 0o7777
+      : undefined;
   await mkdir(destination, { recursive: true, mode: destinationMode ?? 0o700 });
   await chmod(destination, (destinationMode ?? 0o700) | 0o700);
   for (const entry of await readdir(source, { withFileTypes: true })) {
@@ -1282,9 +1331,9 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
     });
     if (!entryStat || entryStat.isSymbolicLink()) continue;
     if (entryStat.isDirectory()) {
-      await copyProjectLaunchRuntimeHistoryDirectory(sourceEntry, destinationEntry);
+      await copyProjectLaunchRuntimeHistoryDirectory(sourceEntry, destinationEntry, false, sourceRoot, destinationRoot);
     } else if (entryStat.isFile()) {
-      await copyFilePreservingTimestamps(sourceEntry, destinationEntry);
+      await copyFilePreservingTimestamps(sourceEntry, destinationEntry, { sourceRoot, destinationRoot });
     }
   }
   await chmod(destination, destinationMode ?? (sourceStat.mode & 0o7777));
@@ -1295,6 +1344,7 @@ async function replaceProjectLaunchRuntimeHistoryDirectory(
   source: string,
   destination: string,
   allowTopLevelSymlink: boolean,
+  destinationRoot: string,
   afterStage?: (temporary: string, destination: string) => Promise<void>,
 ): Promise<void> {
   const temporary = `${destination}.omx-history-${randomUUID()}`;
@@ -1303,13 +1353,15 @@ async function replaceProjectLaunchRuntimeHistoryDirectory(
     if (!sourceStat.isDirectory() || (!allowTopLevelSymlink && sourceStat.isSymbolicLink())) {
       throw new Error(`history source is not a directory: ${source}`);
     }
-    await copyProjectLaunchRuntimeHistoryDirectory(source, temporary, allowTopLevelSymlink);
+    await copyProjectLaunchRuntimeHistoryDirectory(source, temporary, allowTopLevelSymlink, source, dirname(destination));
     await afterStage?.(temporary, destination);
     const stagedStat = await lstat(temporary);
     if (!stagedStat.isDirectory() || stagedStat.isSymbolicLink()) {
       throw new Error(`history staging path is not a directory: ${temporary}`);
     }
+    await assertHistoryDestinationParentWithin(destination, destinationRoot);
     await rm(destination, { recursive: true, force: true });
+    await assertHistoryDestinationParentWithin(destination, destinationRoot);
     await rename(temporary, destination);
   } finally {
     await rm(temporary, { recursive: true, force: true }).catch(() => undefined);
@@ -1344,6 +1396,8 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         sourceInspection.targetRealpath ?? source,
         destination,
         false,
+        sourceInspection.targetRealpath ?? source,
+        runtimeCodexHome,
       );
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
@@ -1364,18 +1418,23 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         await copyFilePreservingTimestamps(
           sourceInspection.targetRealpath ?? source,
           destination,
-          { allowTopLevelSymlink: false },
+          { allowTopLevelSymlink: false, sourceRoot: sourceInspection.targetRealpath ?? source, destinationRoot: runtimeCodexHome },
         );
         mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
-      const existing = await readHistoryFileWithoutSymlink(destination);
-      const addition = await readHistoryFileWithoutSymlink(source, true);
+      const existing = await readHistoryFileWithoutSymlink(destination, false, runtimeCodexHome);
+      const addition = await readHistoryFileWithoutSymlink(
+        sourceInspection.targetRealpath ?? source,
+        false,
+        sourceInspection.targetRealpath ?? source,
+      );
       const separator = existing === "" || existing.endsWith("\n") || addition === "" ? "" : "\n";
       await writeHistoryFileAtomically(
         destination,
         `${existing}${separator}${addition}`,
         destinationStat.mode & 0o7777,
+        runtimeCodexHome,
       );
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
@@ -1383,7 +1442,11 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
     await copyFilePreservingTimestamps(
       sourceInspection.targetRealpath ?? source,
       destination,
-      { allowTopLevelSymlink: false },
+      {
+        allowTopLevelSymlink: false,
+        sourceRoot: sourceInspection.targetRealpath ?? source,
+        destinationRoot: runtimeCodexHome,
+      },
     );
     mergedHistorySourceRealpaths.add(sourceRealpath);
   }
@@ -1472,7 +1535,15 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     const mergedHistorySourceRealpaths = new Set<string>();
     for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
       const source = join(projectCodexHome, entryName);
-      if (existsSync(source)) mergedHistorySourceRealpaths.add(realpathSync(source));
+      const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
+      if (!sourceInspection?.targetStat || !isRegularHistoryTarget(sourceInspection.targetStat)) continue;
+      const sourceRealpath =
+        sourceInspection.targetRealpath ??
+        await realpath(source).catch((error) => {
+          if (isUnresolvableHistoryLinkError(error)) return undefined;
+          throw error;
+        });
+      if (sourceRealpath) mergedHistorySourceRealpaths.add(sourceRealpath);
     }
     skippedHistoryEntryNames = await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome, {
       onlySymlinks: !mergingHistory,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1159,10 +1159,56 @@ function isDiscardableHistoryCopyError(error: unknown): boolean {
 
 const HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS = 5_000;
 const HISTORY_PERSISTENCE_LOCK_STALE_MS = 30_000;
+const HISTORY_PERSISTENCE_LOCK_HEARTBEAT_MS = 5_000;
 
-async function withHistoryPersistenceLock<T>(root: string, action: () => Promise<T>): Promise<T> {
+interface HistoryPersistenceLockOptions {
+  timeoutMs?: number;
+  staleMs?: number;
+  heartbeatMs?: number;
+}
+
+interface HistoryPersistenceLockLease {
+  lockPath: string;
+  token: string;
+  heartbeat: ReturnType<typeof setInterval>;
+}
+
+async function readHistoryPersistenceLockOwner(lockPath: string): Promise<{ token: string; pid: number } | undefined> {
+  try {
+    const owner = JSON.parse(await readFile(join(lockPath, "owner.json"), "utf-8")) as { token?: unknown; pid?: unknown };
+    if (typeof owner.token !== "string" || typeof owner.pid !== "number") return undefined;
+    return { token: owner.token, pid: owner.pid };
+  } catch {
+    return undefined;
+  }
+}
+
+function isHistoryProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export async function releaseHistoryPersistenceLock(lease: HistoryPersistenceLockLease): Promise<void> {
+  clearInterval(lease.heartbeat);
+  const owner = await readHistoryPersistenceLockOwner(lease.lockPath);
+  if (owner?.token !== lease.token) return;
+  await rm(lease.lockPath, { recursive: true, force: true }).catch(() => undefined);
+}
+
+export async function acquireHistoryPersistenceLock(
+  root: string,
+  options: HistoryPersistenceLockOptions = {},
+): Promise<HistoryPersistenceLockLease> {
   const lockPath = join(root, ".omx-history.lock");
-  const deadline = Date.now() + HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS;
+  const ownerPath = join(lockPath, "owner.json");
+  const timeoutMs = options.timeoutMs ?? HISTORY_PERSISTENCE_LOCK_TIMEOUT_MS;
+  const staleMs = options.staleMs ?? HISTORY_PERSISTENCE_LOCK_STALE_MS;
+  const heartbeatMs = options.heartbeatMs ?? HISTORY_PERSISTENCE_LOCK_HEARTBEAT_MS;
+  const deadline = Date.now() + timeoutMs;
   while (true) {
     try {
       await mkdir(lockPath);
@@ -1171,22 +1217,47 @@ async function withHistoryPersistenceLock<T>(root: string, action: () => Promise
         throw new Error(`history persistence lock is not a private directory: ${lockPath}`);
       }
       await assertHistoryPathWithin(lockPath, root);
-      try {
-        return await action();
-      } finally {
-        await rm(lockPath, { recursive: true, force: true });
-      }
+      const token = randomUUID();
+      await writeFile(ownerPath, JSON.stringify({ token, pid: process.pid, heartbeatAt: Date.now() }), { flag: "wx" });
+      const heartbeat = setInterval(async () => {
+        try {
+          const owner = await readHistoryPersistenceLockOwner(lockPath);
+          if (owner?.token !== token) return;
+          await writeFile(ownerPath, JSON.stringify({ token, pid: process.pid, heartbeatAt: Date.now() }));
+        } catch {
+          // A contender may have removed a dead owner's lock between checks.
+        }
+      }, heartbeatMs);
+      heartbeat.unref?.();
+      return { lockPath, token, heartbeat };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       const lockStat = await lstat(lockPath).catch(() => undefined);
       if (lockStat?.isSymbolicLink()) throw new Error(`history persistence lock is a symlink: ${lockPath}`);
-      if (lockStat && Date.now() - lockStat.mtimeMs > HISTORY_PERSISTENCE_LOCK_STALE_MS) {
+      const owner = await readHistoryPersistenceLockOwner(lockPath);
+      const lockAge = lockStat ? Date.now() - lockStat.mtimeMs : 0;
+      if (owner && !isHistoryProcessAlive(owner.pid)) {
+        const ownerStat = await stat(join(lockPath, "owner.json")).catch(() => undefined);
+        if (ownerStat && Date.now() - ownerStat.mtimeMs > staleMs) {
+          await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+          continue;
+        }
+      } else if (!owner && lockAge > staleMs) {
         await rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
         continue;
       }
       if (Date.now() >= deadline) throw new Error(`timed out waiting for history persistence lock: ${lockPath}`);
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
+  }
+}
+
+async function withHistoryPersistenceLock<T>(root: string, action: () => Promise<T>): Promise<T> {
+  const lease = await acquireHistoryPersistenceLock(root);
+  try {
+    return await action();
+  } finally {
+    await releaseHistoryPersistenceLock(lease);
   }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -992,28 +992,28 @@ function shouldPersistProjectLaunchRuntimeEntry(entryName: string): boolean {
   return PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES.has(entryName);
 }
 
-function isMissingPathError(error: unknown): boolean {
+function isUnresolvableHistoryLinkError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = (error as NodeJS.ErrnoException).code;
-  return code === "ENOENT" || code === "ENOTDIR";
+  return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
 }
 
-async function resolveProjectLaunchRuntimeHistoryEntryStat(source: string) {
+async function inspectProjectLaunchRuntimeHistoryEntry(source: string) {
   // Durable history names are an explicit allowlist. Follow only the named
   // entry's top-level link so a directory link is classified as a directory;
   // the destination remains the fixed runtime history path below.
-  let sourceStat;
+  let linkStat;
   try {
-    sourceStat = await lstat(source);
+    linkStat = await lstat(source);
   } catch (error) {
-    if (isMissingPathError(error)) return undefined;
+    if (isUnresolvableHistoryLinkError(error)) return undefined;
     throw error;
   }
-  if (!sourceStat.isSymbolicLink()) return sourceStat;
+  if (!linkStat.isSymbolicLink()) return { linkStat, targetStat: linkStat };
   try {
-    return await stat(source);
+    return { linkStat, targetStat: await stat(source) };
   } catch (error) {
-    if (isMissingPathError(error)) return undefined;
+    if (isUnresolvableHistoryLinkError(error)) return { linkStat, targetStat: undefined };
     throw error;
   }
 }
@@ -1074,11 +1074,8 @@ async function ensureProjectLaunchRuntimeHistoryLinks(
     const runtimeEntry = join(runtimeCodexHome, entryName);
     if (existsSync(runtimeEntry)) continue;
     const projectEntry = join(projectCodexHome, entryName);
-    const projectEntryLinkStat = await lstat(projectEntry).catch((error) => {
-      if (isMissingPathError(error)) return undefined;
-      throw error;
-    });
-    if (projectEntryLinkStat?.isSymbolicLink() && !(await resolveProjectLaunchRuntimeHistoryEntryStat(projectEntry))) {
+    const projectEntryInspection = await inspectProjectLaunchRuntimeHistoryEntry(projectEntry);
+    if (projectEntryInspection?.linkStat.isSymbolicLink() && !projectEntryInspection.targetStat) {
       continue;
     }
     if (entryName === "sessions") {
@@ -1093,18 +1090,39 @@ async function ensureProjectLaunchRuntimeHistoryLinks(
 async function materializeProjectLaunchRuntimeHistoryEntries(
   runtimeCodexHome: string,
   sourceCodexHome: string,
+  options: { onlySymlinks?: boolean } = {},
 ): Promise<void> {
   for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
     const source = join(sourceCodexHome, entryName);
-    const sourceStat = await resolveProjectLaunchRuntimeHistoryEntryStat(source);
-    if (!sourceStat) continue;
+    const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
+    if (!sourceInspection || !sourceInspection.targetStat) continue;
+    if (options.onlySymlinks === true && !sourceInspection.linkStat.isSymbolicLink()) continue;
     const destination = join(runtimeCodexHome, entryName);
     await rm(destination, { recursive: true, force: true });
+    const sourceStat = sourceInspection.targetStat;
     if (sourceStat.isDirectory()) {
-      await cp(source, destination, { recursive: true, force: true, dereference: true, preserveTimestamps: true });
+      await copyProjectLaunchRuntimeHistoryDirectory(source, destination);
       continue;
     }
     if (sourceStat.isFile()) await copyFilePreservingTimestamps(source, destination);
+  }
+}
+
+async function copyProjectLaunchRuntimeHistoryDirectory(source: string, destination: string): Promise<void> {
+  await mkdir(destination, { recursive: true });
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    const sourceEntry = join(source, entry.name);
+    const destinationEntry = join(destination, entry.name);
+    const entryStat = await lstat(sourceEntry).catch((error) => {
+      if (isUnresolvableHistoryLinkError(error)) return undefined;
+      throw error;
+    });
+    if (!entryStat || entryStat.isSymbolicLink()) continue;
+    if (entryStat.isDirectory()) {
+      await copyProjectLaunchRuntimeHistoryDirectory(sourceEntry, destinationEntry);
+    } else if (entryStat.isFile()) {
+      await copyFilePreservingTimestamps(sourceEntry, destinationEntry);
+    }
   }
 }
 
@@ -1122,7 +1140,7 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
     const sourceStat = await stat(source);
     if (sourceStat.isDirectory()) {
       await mkdir(destination, { recursive: true });
-      await cp(source, destination, { recursive: true, force: true, dereference: true, preserveTimestamps: true });
+      await copyProjectLaunchRuntimeHistoryDirectory(source, destination);
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
@@ -1193,11 +1211,9 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     if (PROJECT_LAUNCH_RUNTIME_SKIPPED_ENTRY_NAMES.has(entry.name)) continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
-    if (
-      PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entry.name) &&
-      !(await resolveProjectLaunchRuntimeHistoryEntryStat(source))
-    ) {
-      continue;
+    if (PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entry.name)) {
+      const sourceInspection = await inspectProjectLaunchRuntimeHistoryEntry(source);
+      if (!sourceInspection?.targetStat) continue;
     }
     if (entry.name === "config.toml") {
       const projectHooksPath = join(projectCodexHome, "hooks.json");
@@ -1219,14 +1235,18 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     await linkOrCopyCodexHomeEntry(source, destination);
   }
   await ensureProjectLaunchRuntimeHistoryLinks(runtimeCodexHome, projectCodexHome);
-  if (options.includeHistoryArtifacts === true && (options.extraHistoryCodexHomes?.length ?? 0) > 0) {
+  if (options.includeHistoryArtifacts === true) {
+    const extraHistoryCodexHomes = options.extraHistoryCodexHomes ?? [];
+    const mergingHistory = extraHistoryCodexHomes.length > 0;
     const mergedHistorySourceRealpaths = new Set<string>();
     for (const entryName of PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES) {
       const source = join(projectCodexHome, entryName);
       if (existsSync(source)) mergedHistorySourceRealpaths.add(realpathSync(source));
     }
-    await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome);
-    for (const extraCodexHome of options.extraHistoryCodexHomes ?? []) {
+    await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome, {
+      onlySymlinks: !mergingHistory,
+    });
+    for (const extraCodexHome of extraHistoryCodexHomes) {
       await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);
     }
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -960,7 +960,10 @@ async function linkOrCopyCodexHomeEntry(
 async function copyFilePreservingTimestamps(
   source: string,
   destination: string,
-  options: { allowTopLevelSymlink?: boolean } = {},
+  options: {
+    allowTopLevelSymlink?: boolean;
+    afterStage?: (temporary: string, destination: string) => Promise<void>;
+  } = {},
 ): Promise<void> {
   const sourcePath = options.allowTopLevelSymlink === true ? await realpath(source) : source;
   const sourceHandle = await open(sourcePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
@@ -987,10 +990,15 @@ async function copyFilePreservingTimestamps(
       }
       position += bytesRead;
     }
+    await destinationHandle.chmod(sourceStat.mode & 0o7777);
+    await destinationHandle.utimes(sourceStat.atime, sourceStat.mtime);
     await destinationHandle.close();
     destinationHandle = undefined;
-    await chmod(temporary, sourceStat.mode & 0o7777);
-    await utimes(temporary, sourceStat.atime, sourceStat.mtime);
+    await options.afterStage?.(temporary, destination);
+    const stagedStat = await lstat(temporary);
+    if (!stagedStat.isFile() || stagedStat.isSymbolicLink()) {
+      throw new Error(`history staging path is not a regular file: ${temporary}`);
+    }
     await rm(destination, { recursive: true, force: true });
     await rename(temporary, destination);
   } finally {
@@ -1026,9 +1034,9 @@ async function writeHistoryFileAtomically(
       mode & 0o7777,
     );
     await destinationHandle.writeFile(contents, "utf-8");
+    await destinationHandle.chmod(mode & 0o7777);
     await destinationHandle.close();
     destinationHandle = undefined;
-    await chmod(temporary, mode & 0o7777);
     await rm(destination, { recursive: true, force: true });
     await rename(temporary, destination);
   } finally {
@@ -1195,6 +1203,8 @@ async function ensureProjectLaunchRuntimeHistoryLinks(
 interface MaterializeProjectLaunchRuntimeHistoryOptions {
   onlySymlinks?: boolean;
   beforeCopy?: (entryName: string, source: string, destination: string) => Promise<void>;
+  afterValidation?: (entryName: string, source: string, destination: string) => Promise<void>;
+  afterStage?: (entryName: string, temporary: string, destination: string) => Promise<void>;
 }
 
 async function materializeProjectLaunchRuntimeHistoryEntries(
@@ -1214,19 +1224,33 @@ async function materializeProjectLaunchRuntimeHistoryEntries(
       skipEntryNames.add(entryName);
       continue;
     }
+    await options.afterValidation?.(entryName, source, destination);
+    if (!(await historyEntryStillMatches(source, sourceInspection))) {
+      skipEntryNames.add(entryName);
+      continue;
+    }
     await rm(destination, { recursive: true, force: true });
     const sourceStat = sourceInspection.targetStat;
     if (!sourceStat) continue;
+    const sourcePath = sourceInspection.targetRealpath ?? source;
     if (sourceStat.isDirectory()) {
       await replaceProjectLaunchRuntimeHistoryDirectory(
-        source,
+        sourcePath,
         destination,
-        sourceInspection.linkStat.isSymbolicLink(),
+        false,
+        options.afterStage
+          ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
+          : undefined,
       );
       continue;
     }
     if (sourceStat.isFile()) {
-      await copyFilePreservingTimestamps(source, destination, { allowTopLevelSymlink: true });
+      await copyFilePreservingTimestamps(sourcePath, destination, {
+        allowTopLevelSymlink: false,
+        afterStage: options.afterStage
+          ? (temporary, stagedDestination) => options.afterStage!(entryName, temporary, stagedDestination)
+          : undefined,
+      });
     }
   }
   return skipEntryNames;
@@ -1246,8 +1270,9 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
   if (destinationStat && (!destinationStat.isDirectory() || destinationStat.isSymbolicLink())) {
     await rm(destination, { recursive: true, force: true });
   }
-  await mkdir(destination, { recursive: true, mode: sourceStat.mode & 0o7777 });
-  await chmod(destination, sourceStat.mode & 0o7777);
+  const destinationMode = destinationStat ? destinationStat.mode & 0o7777 : undefined;
+  await mkdir(destination, { recursive: true, mode: destinationMode ?? 0o700 });
+  await chmod(destination, (destinationMode ?? 0o700) | 0o700);
   for (const entry of await readdir(source, { withFileTypes: true })) {
     const sourceEntry = join(source, entry.name);
     const destinationEntry = join(destination, entry.name);
@@ -1262,15 +1287,15 @@ async function copyProjectLaunchRuntimeHistoryDirectory(
       await copyFilePreservingTimestamps(sourceEntry, destinationEntry);
     }
   }
-  const finalSourceStat = await stat(source);
-  await chmod(destination, finalSourceStat.mode & 0o7777);
-  await utimes(destination, finalSourceStat.atime, finalSourceStat.mtime);
+  await chmod(destination, destinationMode ?? (sourceStat.mode & 0o7777));
+  await utimes(destination, sourceStat.atime, sourceStat.mtime);
 }
 
 async function replaceProjectLaunchRuntimeHistoryDirectory(
   source: string,
   destination: string,
   allowTopLevelSymlink: boolean,
+  afterStage?: (temporary: string, destination: string) => Promise<void>,
 ): Promise<void> {
   const temporary = `${destination}.omx-history-${randomUUID()}`;
   try {
@@ -1279,6 +1304,11 @@ async function replaceProjectLaunchRuntimeHistoryDirectory(
       throw new Error(`history source is not a directory: ${source}`);
     }
     await copyProjectLaunchRuntimeHistoryDirectory(source, temporary, allowTopLevelSymlink);
+    await afterStage?.(temporary, destination);
+    const stagedStat = await lstat(temporary);
+    if (!stagedStat.isDirectory() || stagedStat.isSymbolicLink()) {
+      throw new Error(`history staging path is not a directory: ${temporary}`);
+    }
     await rm(destination, { recursive: true, force: true });
     await rename(temporary, destination);
   } finally {
@@ -1310,7 +1340,11 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
         await rm(destination, { recursive: true, force: true });
       }
       await mkdir(destination, { recursive: true });
-      await copyProjectLaunchRuntimeHistoryDirectory(source, destination, sourceInspection.linkStat.isSymbolicLink());
+      await copyProjectLaunchRuntimeHistoryDirectory(
+        sourceInspection.targetRealpath ?? source,
+        destination,
+        false,
+      );
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
@@ -1327,7 +1361,11 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       const destinationStat = destinationLinkStat;
       if (!destinationStat.isFile()) {
         await rm(destination, { recursive: true, force: true });
-        await copyFilePreservingTimestamps(source, destination, { allowTopLevelSymlink: true });
+        await copyFilePreservingTimestamps(
+          sourceInspection.targetRealpath ?? source,
+          destination,
+          { allowTopLevelSymlink: false },
+        );
         mergedHistorySourceRealpaths.add(sourceRealpath);
         continue;
       }
@@ -1342,7 +1380,11 @@ async function mergeProjectLaunchRuntimeHistoryEntries(
       mergedHistorySourceRealpaths.add(sourceRealpath);
       continue;
     }
-    await copyFilePreservingTimestamps(source, destination, { allowTopLevelSymlink: true });
+    await copyFilePreservingTimestamps(
+      sourceInspection.targetRealpath ?? source,
+      destination,
+      { allowTopLevelSymlink: false },
+    );
     mergedHistorySourceRealpaths.add(sourceRealpath);
   }
 }
@@ -1372,6 +1414,8 @@ export interface PrepareRuntimeCodexHomeForProjectLaunchOptions {
   extraHistoryCodexHomes?: string[];
   createSymlink?: typeof symlink;
   beforeHistoryEntryCopy?: MaterializeProjectLaunchRuntimeHistoryOptions["beforeCopy"];
+  afterHistoryEntryValidation?: MaterializeProjectLaunchRuntimeHistoryOptions["afterValidation"];
+  afterHistoryEntryStage?: MaterializeProjectLaunchRuntimeHistoryOptions["afterStage"];
 }
 
 export async function prepareRuntimeCodexHomeForProjectLaunch(
@@ -1433,6 +1477,8 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
     skippedHistoryEntryNames = await materializeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, projectCodexHome, {
       onlySymlinks: !mergingHistory,
       beforeCopy: options.beforeHistoryEntryCopy,
+      afterValidation: options.afterHistoryEntryValidation,
+      afterStage: options.afterHistoryEntryStage,
     });
     for (const extraCodexHome of extraHistoryCodexHomes) {
       await mergeProjectLaunchRuntimeHistoryEntries(runtimeCodexHome, extraCodexHome, mergedHistorySourceRealpaths);

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -328,6 +328,14 @@ describe('CI Rust gates', () => {
       assert.match(jobBlock(workflow, jobName), /uses:\s*Swatinem\/rust-cache@v2/);
     }
 
+    const windowsHistoryJob = jobBlock(workflow, 'test-windows-js');
+    assert.match(windowsHistoryJob, /runs-on:\s*windows-latest/);
+    assert.match(windowsHistoryJob, /timeout-minutes:\s*30/);
+    assert.match(windowsHistoryJob, /run:\s*npm ci --ignore-scripts/);
+    assert.match(windowsHistoryJob, /node --test/);
+    assert.match(windowsHistoryJob, /serializes concurrent JSONL cleanup appends/);
+    assert.match(windowsHistoryJob, /runs project resume integration on Windows/);
+
     assert.match(
       workflow,
       /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, test-windows-js, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,

--- a/src/verification/__tests__/ci-rust-gates.test.ts
+++ b/src/verification/__tests__/ci-rust-gates.test.ts
@@ -287,7 +287,7 @@ describe('CI Rust gates', () => {
     assert.match(nativeCacheJob, /node --test\s*\\\n\s+dist\/cli\/__tests__\/native-assets\.test\.js\s*\\\n\s+dist\/cli\/__tests__\/sparkshell-cli\.test\.js\s*\\\n\s+dist\/cli\/__tests__\/api\.test\.js\s*\\\n\s+dist\/scripts\/__tests__\/verify-native-release-assets\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/native-release-manifest\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/explore-harness-release-workflow\.test\.js\s*\\\n\s+dist\/verification\/__tests__\/ci-rust-gates\.test\.js/);
 
     assert.match(ciStatusJob, /^    if: always\(\)$/m);
-    assert.match(ciStatusJob, /^    needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]$/m);
+    assert.match(ciStatusJob, /^    needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, test-windows-js, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]$/m);
     assert.match(ciStatusJob, /NATIVE_CACHE_INTEGRITY_RESULT: \$\{\{ needs\.native-cache-integrity\.result \}\}/);
     assert.match(ciStatusJob, /if \[\[ "\$FULL_SUITE" == "true" \]\] \|\| bool_any "\$TS_CHANGED" "\$NATIVE_CHANGED" "\$SHARED_CONFIG_CHANGED"; then native_cache_integrity_active=true; fi/);
     assert.match(ciStatusJob, /check_job native-cache-integrity "\$NATIVE_CACHE_INTEGRITY_RESULT" "\$native_cache_integrity_active"/);
@@ -313,7 +313,7 @@ describe('CI Rust gates', () => {
   it('uses npm package caching without skipping clean dependency installs', () => {
     const workflow = readCiWorkflow();
 
-    for (const jobName of ['lint', 'typecheck', 'build-dist', 'test', 'coverage-team-critical', 'ralph-persistence-gate', 'native-cache-integrity', 'build']) {
+    for (const jobName of ['lint', 'typecheck', 'build-dist', 'test', 'test-windows-js', 'coverage-team-critical', 'ralph-persistence-gate', 'native-cache-integrity', 'build']) {
       const job = jobBlock(workflow, jobName);
 
       assert.match(job, /uses:\s*actions\/setup-node@v7/);
@@ -330,7 +330,7 @@ describe('CI Rust gates', () => {
 
     assert.match(
       workflow,
-      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, test-windows-js, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
     );
   });
 
@@ -358,6 +358,7 @@ describe('CI Rust gates', () => {
       'build-dist',
       'ralplan-preflight-macos',
       'test',
+      'test-windows-js',
       'coverage-team-critical',
       'ralph-persistence-gate',
       'native-cache-integrity',
@@ -366,7 +367,7 @@ describe('CI Rust gates', () => {
 
     assert.match(
       ciStatusJob,
-      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
+      /needs:\s*\[changes, docs-check, rustfmt, clippy, rust-tests, native-rust-darwin, native-rust-windows, lint, typecheck, build-dist, ralplan-preflight-macos, test, test-windows-js, coverage-team-critical, ralph-persistence-gate, native-cache-integrity, build\]/,
     );
 
     for (const jobName of requiredJobs) {


### PR DESCRIPTION
## Summary

Fixes #3581.

`resume --project` can discover an older runtime `CODEX_HOME` whose durable `sessions` entry is a symlink to a directory. History materialization now classifies the resolved target instead of passing the link itself to `copyFile()`.

The change:

- follows only the fixed allowlisted durable history entries;
- materializes a symlinked directory or regular file into the generated runtime destination rather than preserving the link;
- skips broken history links without failing launch preparation;
- preserves existing merge and timestamp behavior for regular history entries.

## Verification

- `npm run build`
- `npm run lint`
- `npm run check:no-unused`
- `node dist/scripts/run-test-files.js dist/cli/__tests__/index.test.js dist/cli/__tests__/resume.test.js`
- exact CLI-shaped `--madmax resume --project` reproduction with a discovered symlinked `sessions` directory

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
