### PR TITLE
fix(hud): prevent stale frames across tmux reflow

### DIFF
--- a/src/cli/__tests__/ultragoal.test.ts
+++ b/src/cli/__tests__/ultragoal.test.ts
@@ -14,6 +14,9 @@ import {
   NATIVE_SUBAGENT_ROLE_ROUTING_MARKER_FILE,
   writeRoleRoutingMarker,
 } from '../../subagents/role-routing-marker.js';
+import { readHudConfig, readAllState, readUltragoalState } from '../../hud/state.js';
+import { renderHud } from '../../hud/render.js';
+import { parseCodexGoalSnapshot, reconcileCodexGoalSnapshot } from '../../goal-workflows/codex-goal-snapshot.js';
 import { ultragoalCommand, ULTRAGOAL_HELP } from '../ultragoal.js';
 
 async function withCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
@@ -966,5 +969,83 @@ describe('cli/ultragoal', () => {
         '--json',
       ]));
       assert.equal(strictOk.exitCode, undefined);
+    });
+  });
+
+  it('keeps visible HUD, durable status, and null Codex goal state distinct for legacy plans', async () => {
+    await withCwd(async (cwd) => {
+      const planPath = join(cwd, '.omx', 'ultragoal', 'goals.json');
+      const ledgerPath = join(cwd, '.omx', 'ultragoal', 'ledger.jsonl');
+      const now = '2026-08-26T15:30:00.000Z';
+      const legacyGoal = {
+        id: 'G001-legacy',
+        title: 'Legacy HUD state',
+        objective: 'Reconcile legacy durable state',
+        attempt: 1,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const writePlan = async (goal: Record<string, unknown>, extra: Record<string, unknown> = {}) => {
+        await mkdir(join(cwd, '.omx', 'ultragoal'), { recursive: true });
+        await writeFile(planPath, `${JSON.stringify({
+          version: 1,
+          createdAt: now,
+          updatedAt: now,
+          briefPath: '.omx/ultragoal/brief.md',
+          goalsPath: '.omx/ultragoal/goals.json',
+          ledgerPath: '.omx/ultragoal/ledger.jsonl',
+          codexGoalMode: 'aggregate',
+          codexObjective: 'Complete the durable ultragoal plan in .omx/ultragoal/goals.json.',
+          goals: [goal],
+          ...extra,
+        }, null, 2)}\n`);
+        await writeFile(ledgerPath, '');
+      };
+
+      const nullCodexGoal = parseCodexGoalSnapshot({ goal: null });
+      assert.equal(nullCodexGoal.available, false);
+
+      await writePlan({ ...legacyGoal, status: 'complete', completedAt: now }, {
+        aggregateCompletion: { status: 'complete', completedAt: now, evidence: 'legacy completion receipt' },
+      });
+      const completedHud = await readUltragoalState(cwd);
+      const completedVisible = renderHud({
+        ...(await readAllState(cwd, await readHudConfig(cwd))),
+        ultragoal: completedHud,
+      }, 'focused');
+      const completedStatus = await capture(() => ultragoalCommand(['status', '--json']));
+      const completedStatusJson = JSON.parse(completedStatus.stdout.join('\n')) as {
+        summary: { aggregateComplete: boolean; artifactComplete: boolean };
+      };
+      assert.equal(completedHud?.active, false);
+      assert.doesNotMatch(completedVisible, /ultragoal/);
+      assert.equal(completedStatusJson.summary.aggregateComplete, true);
+      assert.equal(completedStatusJson.summary.artifactComplete, true);
+      assert.equal(reconcileCodexGoalSnapshot(nullCodexGoal, {
+        expectedObjective: 'Complete the durable ultragoal plan in .omx/ultragoal/goals.json.',
+      }).ok, true);
+
+      await writePlan({ ...legacyGoal, status: 'review_blocked', reviewBlockedAt: now }, {
+        activeGoalId: legacyGoal.id,
+      });
+      const blockedHud = await readUltragoalState(cwd);
+      const blockedVisible = renderHud({
+        ...(await readAllState(cwd, await readHudConfig(cwd))),
+        ultragoal: blockedHud,
+      }, 'focused');
+      const blockedStatus = await capture(() => ultragoalCommand(['status', '--json']));
+      const blockedStatusJson = JSON.parse(blockedStatus.stdout.join('\n')) as {
+        summary: { reviewBlocked: number };
+        reconciliation?: { snapshot: { available: boolean }; warnings: string[] };
+      };
+      assert.equal(blockedHud?.active, true);
+      assert.match(blockedVisible, /ultragoal/);
+      assert.equal(blockedStatusJson.summary.reviewBlocked, 1);
+      assert.equal(blockedStatusJson.reconciliation?.snapshot.available, false);
+      assert.match(blockedStatusJson.reconciliation?.warnings.join('\n') ?? '', /call get_goal/);
+
+      const create = await capture(() => ultragoalCommand(['create-goals', '--brief', '- replacement plan']));
+      assert.equal(create.exitCode, 1);
+      assert.match(create.stderr.join('\n'), /Refusing to overwrite existing/);
     });
   });

--- a/src/hud/__tests__/index.test.ts
+++ b/src/hud/__tests__/index.test.ts
@@ -440,6 +440,7 @@ describe('runWatchMode', () => {
   it('resizes an OMX-owned running HUD pane when the adaptive budget changes', async () => {
     const resized: Array<{ paneId: string; heightLines: number }> = [];
     const registered: Array<{ hudPaneId: string; leaderPaneId: string | undefined; heightLines: number }> = [];
+    const events: string[] = [];
     let sigintHandler: (() => void) | undefined;
     let timerTick: (() => void) | undefined;
     let callCount = 0;
@@ -474,7 +475,7 @@ describe('runWatchMode', () => {
       },
       readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'repo-branch' }, statusLine: { preset: 'focused' } }),
       renderHudFn: () => 'frame',
-      writeStdout: () => {},
+      writeStdout: (text) => { events.push(`write:${text}`); },
       writeStderr: () => {},
       registerSigint: (handler) => { sigintHandler = handler; },
       setIntervalFn: (handler) => {
@@ -483,10 +484,16 @@ describe('runWatchMode', () => {
       },
       clearIntervalFn: () => {},
       resizeTmuxPaneFn: (paneId, heightLines) => {
+        events.push(`resize:${heightLines}`);
         resized.push({ paneId, heightLines });
         return true;
       },
+      clearTmuxPaneHistoryFn: (paneId) => {
+        events.push(`history:${paneId}`);
+        return true;
+      },
       registerHudResizeHookFn: (hudPaneId, leaderPaneId, heightLines) => {
+        events.push(`hook:${heightLines}`);
         registered.push({ hudPaneId, leaderPaneId, heightLines });
         return true;
       },
@@ -506,6 +513,13 @@ describe('runWatchMode', () => {
       { hudPaneId: '%hud', leaderPaneId: '%leader', heightLines: 2 },
       { hudPaneId: '%hud', leaderPaneId: '%leader', heightLines: 3 },
     ]);
+    const secondClear = events.findIndex((event, index) => index > 0 && event === 'write:\u001b[3J\u001b[2J\u001b[H');
+    const secondResize = events.indexOf('resize:3');
+    const secondFrame = events.findIndex((event, index) => index > secondResize && event.includes('frame'));
+    assert.ok(secondClear >= 0 && secondClear < secondResize, 'the new frame must clear before pane reflow');
+    assert.ok(secondFrame > secondResize, 'the new frame must publish after pane reflow');
+    const secondHistory = events.findIndex((event, index) => index > secondResize && event === 'history:%hud');
+    assert.ok(secondHistory > secondResize, 'reflowed HUD history must be cleared before frame publication');
   });
 
   it('runs authority tick after each rendered frame', async () => {

--- a/src/hud/__tests__/watch-realtmux.test.ts
+++ b/src/hud/__tests__/watch-realtmux.test.ts
@@ -6,7 +6,9 @@ import { join } from "node:path";
 import { describe, it, type TestContext } from "node:test";
 import { pathToFileURL } from "node:url";
 import {
+	buildPtyScriptCommand,
 	isRealTmuxAvailable,
+	isRealScriptAvailable,
 	type TempTmuxSessionFixture,
 	withTempTmuxSession,
 } from "../../team/__tests__/tmux-test-fixture.js";
@@ -15,13 +17,13 @@ const POLL_INTERVAL_MS = 50;
 const TEST_TIMEOUT_MS = 10_000;
 
 function skipUnlessRealTmux(t: TestContext): boolean {
-	if (isRealTmuxAvailable()) return true;
+	if (isRealTmuxAvailable() && isRealScriptAvailable()) return true;
 	assert.equal(
 		process.env.CI,
 		undefined,
-		"CI must provide tmux for the real-tmux HUD refresh regression",
+		"CI must provide tmux and script for the real-tmux HUD refresh regression",
 	);
-	t.skip("tmux is not installed");
+	t.skip("tmux or script is not installed");
 	return false;
 }
 
@@ -63,7 +65,8 @@ async function waitForTmuxValue(
 
 function startAttachedClient(fixture: TempTmuxSessionFixture): ChildProcess {
 	const command = `exec tmux -f /dev/null -L ${quoteSh(fixture.serverName)} attach-session -t ${quoteSh(fixture.sessionName)}`;
-	const child = spawn("script", ["-q", "-e", "-c", command, "/dev/null"], {
+	const ptyCommand = buildPtyScriptCommand(command);
+	const child = spawn(ptyCommand.executable, ptyCommand.args, {
 		env: {
 			...process.env,
 			TMUX: undefined,

--- a/src/hud/__tests__/watch-realtmux.test.ts
+++ b/src/hud/__tests__/watch-realtmux.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, type TestContext } from "node:test";
+import { pathToFileURL } from "node:url";
+import {
+	isRealTmuxAvailable,
+	type TempTmuxSessionFixture,
+	withTempTmuxSession,
+} from "../../team/__tests__/tmux-test-fixture.js";
+
+const POLL_INTERVAL_MS = 50;
+const TEST_TIMEOUT_MS = 10_000;
+
+function skipUnlessRealTmux(t: TestContext): boolean {
+	if (isRealTmuxAvailable()) return true;
+	assert.equal(
+		process.env.CI,
+		undefined,
+		"CI must provide tmux for the real-tmux HUD refresh regression",
+	);
+	t.skip("tmux is not installed");
+	return false;
+}
+
+function quoteSh(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function waitForFile(
+	path: string,
+	timeoutMs = TEST_TIMEOUT_MS,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await readFile(path, "utf8");
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+		}
+	}
+	throw new Error(`timed out waiting for ${path}`);
+}
+
+async function waitForTmuxValue(
+	fixture: TempTmuxSessionFixture,
+	args: string[],
+	expected: string,
+	timeoutMs = TEST_TIMEOUT_MS,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fixture.run(args) === expected) return;
+		await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+	}
+	throw new Error(
+		`timed out waiting for tmux ${args.join(" ")} to equal ${JSON.stringify(expected)}`,
+	);
+}
+
+function startAttachedClient(fixture: TempTmuxSessionFixture): ChildProcess {
+	const command = `exec tmux -f /dev/null -L ${quoteSh(fixture.serverName)} attach-session -t ${quoteSh(fixture.sessionName)}`;
+	const child = spawn("script", ["-q", "-e", "-c", command, "/dev/null"], {
+		env: {
+			...process.env,
+			TMUX: undefined,
+			TMUX_PANE: undefined,
+			TERM: "xterm",
+		},
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+	return child;
+}
+
+async function stopAttachedClient(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	child.kill("SIGTERM");
+	await new Promise<void>((resolve) => {
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			resolve();
+		}, 1_000);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+}
+
+function buildDeterministicWatchRunner(
+	modulePath: string,
+	markerDir: string,
+): string {
+	return `
+const { runWatchMode } = await import(${JSON.stringify(pathToFileURL(modulePath).href)});
+const { writeFile } = await import('node:fs/promises');
+const markerDir = ${JSON.stringify(markerDir)};
+let readCount = 0;
+const empty = {
+  version: 'test', gitBranch: null, ralph: null, ultrawork: null, autopilot: null,
+  ralplan: null, deepInterview: null, autoresearch: null, ultraqa: null, team: null,
+  metrics: null, hudNotify: null, session: null,
+};
+const activeUltragoal = {
+  active: true, status: 'in_progress', total: 1, complete: 0, pending: 0,
+  inProgress: 1, failed: 0, reviewBlocked: 0, needsUserDecision: 0, progressTotal: 1,
+};
+await runWatchMode(process.cwd(), { watch: true, json: false, tmux: false, preset: 'focused' }, {
+  isTTY: true,
+  env: process.env,
+  readHudConfigFn: async () => ({ preset: 'focused', git: { display: 'branch' }, statusLine: { preset: 'focused' } }),
+  readAllStateFn: async () => {
+    readCount += 1;
+    const marker = 'read-' + readCount;
+    await writeFile(markerDir + '/' + marker, 'started');
+    if (readCount === 2) {
+      while (true) {
+        try {
+          await import('node:fs/promises').then(({ access }) => access(markerDir + '/release'));
+          break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
+    }
+    if (readCount === 3) {
+      while (true) {
+        try {
+          await import('node:fs/promises').then(({ access }) => access(markerDir + '/final-release'));
+          break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+      }
+    }
+    return readCount === 2 ? { ...empty, ultragoal: activeUltragoal } : empty;
+  },
+  renderHudFn: () => readCount === 1
+    ? 'OLD_FRAME_T1\\nOLD_FRAME_T1_TAIL'
+    : readCount === 2
+      ? 'NEW_FRAME_T2\\nNEW_FRAME_T2_BODY\\nNEW_FRAME_T2_TAIL'
+      : 'LATEST_FRAME_T3\\nLATEST_FRAME_T3_TAIL',
+  runAuthorityTickFn: async () => {},
+  registerHudResizeHookFn: () => true,
+});
+`;
+}
+
+describe("HUD watch real PTY/tmux publication", () => {
+	it("publishes only the newest frame across timer ticks, 2↔3 row reflow, and detach/reattach", async (t) => {
+		if (!skipUnlessRealTmux(t)) return;
+
+		const workDir = await mkdtemp(join(tmpdir(), "omx-hud-refresh-realtmux-"));
+		const markerDir = join(workDir, "markers");
+		const runnerPath = join(workDir, "watch-runner.mjs");
+		await import("node:fs/promises").then(({ mkdir }) => mkdir(markerDir));
+
+		let attachedClient: ChildProcess | undefined;
+		try {
+			await writeFile(
+				runnerPath,
+				buildDeterministicWatchRunner(
+					join(process.cwd(), "dist", "hud", "index.js"),
+					markerDir,
+				),
+			);
+			await chmod(runnerPath, 0o755);
+
+			await withTempTmuxSession(async (fixture) => {
+				const hudCommand = `exec env OMX_TMUX_HUD_OWNER=1 OMX_TMUX_HUD_LEADER_PANE=${quoteSh(fixture.leaderPaneId)} node ${quoteSh(runnerPath)}`;
+				const hudPaneId = fixture.run([
+					"split-window",
+					"-v",
+					"-l",
+					"2",
+					"-d",
+					"-P",
+					"-F",
+					"#{pane_id}",
+					"-t",
+					fixture.leaderPaneId,
+					"-c",
+					workDir,
+					hudCommand,
+				]);
+				assert.match(
+					hudPaneId,
+					/^%\d+$/,
+					"real tmux must create one HUD watcher pane",
+				);
+				assert.equal(
+					fixture
+						.run(["list-panes", "-t", fixture.leaderPaneId, "-F", "#{pane_id}"])
+						.split("\n")
+						.filter(Boolean).length,
+					2,
+				);
+
+				await waitForFile(join(markerDir, "read-1"));
+				attachedClient = startAttachedClient(fixture);
+				await waitForTmuxValue(
+					fixture,
+					[
+						"display-message",
+						"-p",
+						"-t",
+						fixture.sessionName,
+						"#{session_attached}",
+					],
+					"1",
+				);
+				await waitForFile(join(markerDir, "read-2"));
+
+				await stopAttachedClient(attachedClient);
+				attachedClient = undefined;
+				await waitForTmuxValue(
+					fixture,
+					[
+						"display-message",
+						"-p",
+						"-t",
+						fixture.sessionName,
+						"#{session_attached}",
+					],
+					"0",
+				);
+				attachedClient = startAttachedClient(fixture);
+				await waitForTmuxValue(
+					fixture,
+					[
+						"display-message",
+						"-p",
+						"-t",
+						fixture.sessionName,
+						"#{session_attached}",
+					],
+					"1",
+				);
+
+				await writeFile(join(markerDir, "release"), "go");
+				await new Promise((resolve) => setTimeout(resolve, 300));
+				assert.equal(
+					fixture.run([
+						"display-message",
+						"-p",
+						"-t",
+						hudPaneId,
+						"#{pane_height}",
+					]),
+					"3",
+				);
+				const afterThreeRowFrame = fixture.run([
+					"capture-pane",
+					"-p",
+					"-t",
+					hudPaneId,
+					"-S",
+					"-",
+				]);
+				assert.match(afterThreeRowFrame, /NEW_FRAME_T2/);
+				assert.doesNotMatch(afterThreeRowFrame, /OLD_FRAME_T1/);
+				await writeFile(join(markerDir, "final-release"), "go");
+				await waitForFile(join(markerDir, "read-3"));
+				await new Promise((resolve) => setTimeout(resolve, 1_200));
+				assert.equal(
+					fixture.run([
+						"display-message",
+						"-p",
+						"-t",
+						hudPaneId,
+						"#{pane_height}",
+					]),
+					"2",
+				);
+
+				const visible = fixture.run(["capture-pane", "-p", "-t", hudPaneId]);
+				const scrollback = fixture.run([
+					"capture-pane",
+					"-p",
+					"-t",
+					hudPaneId,
+					"-S",
+					"-",
+				]);
+				assert.match(visible, /LATEST_FRAME_T3/);
+				assert.doesNotMatch(visible, /OLD_FRAME_T1|NEW_FRAME_T2/);
+				assert.doesNotMatch(scrollback, /OLD_FRAME_T1|NEW_FRAME_T2/);
+				assert.match(scrollback, /LATEST_FRAME_T3/);
+
+				const paneRows = fixture
+					.run(["list-panes", "-t", fixture.leaderPaneId, "-F", "#{pane_id}"])
+					.split("\n")
+					.filter(Boolean);
+				assert.equal(
+					paneRows.length,
+					2,
+					"the regression must keep exactly one leader and one HUD watcher",
+				);
+			});
+		} finally {
+			if (attachedClient) await stopAttachedClient(attachedClient);
+			await rm(workDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/hud/__tests__/watch-realtmux.test.ts
+++ b/src/hud/__tests__/watch-realtmux.test.ts
@@ -93,11 +93,13 @@ async function stopAttachedClient(child: ChildProcess): Promise<void> {
 function buildDeterministicWatchRunner(
 	modulePath: string,
 	markerDir: string,
+	trackDestructiveClear = true,
 ): string {
 	return `
 const { runWatchMode } = await import(${JSON.stringify(pathToFileURL(modulePath).href)});
 const { writeFile } = await import('node:fs/promises');
 const markerDir = ${JSON.stringify(markerDir)};
+const trackDestructiveClear = ${JSON.stringify(trackDestructiveClear)};
 let readCount = 0;
 const empty = {
   version: 'test', gitBranch: null, ralph: null, ultrawork: null, autopilot: null,
@@ -144,6 +146,12 @@ await runWatchMode(process.cwd(), { watch: true, json: false, tmux: false, prese
       ? 'NEW_FRAME_T2\\nNEW_FRAME_T2_BODY\\nNEW_FRAME_T2_TAIL'
       : 'LATEST_FRAME_T3\\nLATEST_FRAME_T3_TAIL',
   runAuthorityTickFn: async () => {},
+  writeStdout: (text) => {
+    if (trackDestructiveClear && text.includes('\\x1b[3J')) {
+      void writeFile(markerDir + '/destructive-clear', 'unexpected');
+    }
+    process.stdout.write(text);
+  },
   registerHudResizeHookFn: () => true,
 });
 `;
@@ -299,6 +307,93 @@ describe("HUD watch real PTY/tmux publication", () => {
 					2,
 					"the regression must keep exactly one leader and one HUD watcher",
 				);
+			});
+		} finally {
+			if (attachedClient) await stopAttachedClient(attachedClient);
+			await rm(workDir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves user scrollback for a non-owned tmux watch pane", async (t) => {
+		if (!skipUnlessRealTmux(t)) return;
+
+		const workDir = await mkdtemp(
+			join(tmpdir(), "omx-hud-refresh-unowned-realtmux-"),
+		);
+		const markerDir = join(workDir, "markers");
+		const runnerPath = join(workDir, "watch-runner.mjs");
+		await import("node:fs/promises").then(({ mkdir }) => mkdir(markerDir));
+		let attachedClient: ChildProcess | undefined;
+		try {
+			await writeFile(
+				runnerPath,
+				buildDeterministicWatchRunner(
+					join(process.cwd(), "dist", "hud", "index.js"),
+					markerDir,
+				),
+			);
+			await chmod(runnerPath, 0o755);
+
+			await withTempTmuxSession(async (fixture) => {
+				const hudCommand = `printf 'USER_SCROLLBACK_SENTINEL\\n'; exec env -u OMX_TMUX_HUD_OWNER -u OMX_TMUX_HUD_LEADER_PANE node ${quoteSh(runnerPath)}`;
+				const hudPaneId = fixture.run([
+					"split-window",
+					"-v",
+					"-l",
+					"2",
+					"-d",
+					"-P",
+					"-F",
+					"#{pane_id}",
+					"-t",
+					fixture.leaderPaneId,
+					"-c",
+					workDir,
+					hudCommand,
+				]);
+				assert.match(hudPaneId, /^%\d+$/);
+				await waitForFile(join(markerDir, "read-1"));
+				attachedClient = startAttachedClient(fixture);
+				await waitForTmuxValue(
+					fixture,
+					[
+						"display-message",
+						"-p",
+						"-t",
+						fixture.sessionName,
+						"#{session_attached}",
+					],
+					"1",
+				);
+				await waitForFile(join(markerDir, "read-2"));
+				await writeFile(join(markerDir, "release"), "go");
+				await new Promise((resolve) => setTimeout(resolve, 300));
+				await writeFile(join(markerDir, "final-release"), "go");
+				await waitForFile(join(markerDir, "read-3"));
+				await new Promise((resolve) => setTimeout(resolve, 1_200));
+
+				assert.equal(
+					fixture.run([
+						"display-message",
+						"-p",
+						"-t",
+						hudPaneId,
+						"#{pane_height}",
+					]),
+					"2",
+				);
+				const scrollback = fixture.run([
+					"capture-pane",
+					"-p",
+					"-t",
+					hudPaneId,
+					"-S",
+					"-",
+				]);
+				const visible = fixture.run(["capture-pane", "-p", "-t", hudPaneId]);
+				assert.match(scrollback, /USER_SCROLLBACK_SENTINEL/);
+				assert.match(visible, /LATEST_FRAME_T3/);
+				await assert.rejects(readFile(join(markerDir, "destructive-clear")));
 			});
 		} finally {
 			if (attachedClient) await stopAttachedClient(attachedClient);

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -259,16 +259,22 @@ export async function runWatchMode(
           maxWidth: process.stdout.columns ?? undefined,
           maxLines,
         });
-        const clearFrame = '\x1b[3J\x1b[2J\x1b[H';
-        if (maxLines !== lastDesiredHeight) {
+        const hudPaneId = dependencies.env.TMUX_PANE?.trim();
+        const ownedHudPane = Boolean(
+          dependencies.env.TMUX
+          && dependencies.env[OMX_TMUX_HUD_OWNER_ENV] === '1'
+          && hudPaneId?.startsWith('%'),
+        );
+        const changingHeight = maxLines !== lastDesiredHeight;
+        const clearFrame = ownedHudPane && changingHeight
+          ? '\x1b[3J\x1b[2J\x1b[H'
+          : '\x1b[2J\x1b[H';
+        if (changingHeight) {
           // Clear before a pane resize so tmux cannot reflow stale HUD rows
           // into visible output or scrollback while changing the pane height.
           dependencies.writeStdout(clearFrame);
           reconcileRunningHudPaneHeight(maxLines, dependencies);
-          if (dependencies.env.TMUX && dependencies.env[OMX_TMUX_HUD_OWNER_ENV] === '1') {
-            const hudPaneId = dependencies.env.TMUX_PANE?.trim();
-            if (hudPaneId?.startsWith('%')) dependencies.clearTmuxPaneHistoryFn(hudPaneId);
-          }
+          if (ownedHudPane && hudPaneId) dependencies.clearTmuxPaneHistoryFn(hudPaneId);
           lastDesiredHeight = maxLines;
           dependencies.writeStdout(`\x1b[H${line}\x1b[K\x1b[J`);
         } else {

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -26,6 +26,7 @@ import {
   OMX_TMUX_HUD_LEADER_PANE_ENV,
   readActiveTmuxPaneId,
   registerHudResizeHook,
+  clearTmuxPaneHistory,
   resizeTmuxPane,
 } from './tmux.js';
 import { OMX_TMUX_HUD_OWNER_ENV, reconcileHudForPromptSubmit } from './reconcile.js';
@@ -79,6 +80,7 @@ interface RunWatchModeDependencies {
   renderHudFn: (ctx: HudRenderContext, preset: HudPreset, options?: { maxWidth?: number; maxLines?: number }) => string;
   runAuthorityTickFn: (options: { cwd: string }) => Promise<void>;
   resizeTmuxPaneFn: (paneId: string, heightLines: number) => boolean;
+  clearTmuxPaneHistoryFn: (paneId: string) => boolean;
   registerHudResizeHookFn: (hudPaneId: string, leaderPaneId: string | undefined, heightLines: number) => boolean;
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
@@ -183,6 +185,7 @@ export async function runWatchMode(
       await runHudAuthorityTick({ cwd: authorityCwd });
     }),
     resizeTmuxPaneFn: deps.resizeTmuxPaneFn ?? resizeTmuxPane,
+    clearTmuxPaneHistoryFn: deps.clearTmuxPaneHistoryFn ?? clearTmuxPaneHistory,
     registerHudResizeHookFn: deps.registerHudResizeHookFn ?? registerHudResizeHook,
     writeStdout: deps.writeStdout ?? ((text: string) => process.stdout.write(text)),
     writeStderr: deps.writeStderr ?? ((text: string) => process.stderr.write(text)),
@@ -248,25 +251,30 @@ export async function runWatchMode(
       }
       const frameCwd = dependencies.resolveWatchCwdFn(cwd);
       if (firstRender || attached) {
-        if (firstRender) {
-          dependencies.writeStdout('\x1b[2J\x1b[H');
-          firstRender = false;
-        } else {
-          dependencies.writeStdout('\x1b[H');
-        }
         const config = await dependencies.readHudConfigFn(frameCwd);
         const ctx = await dependencies.readAllStateFn(frameCwd, config);
         const preset = flags.preset ?? config.preset;
         const maxLines = getHudRenderMaxLines(ctx);
-        if (maxLines !== lastDesiredHeight) {
-          reconcileRunningHudPaneHeight(maxLines, dependencies);
-          lastDesiredHeight = maxLines;
-        }
         const line = dependencies.renderHudFn(ctx, preset, {
           maxWidth: process.stdout.columns ?? undefined,
           maxLines,
         });
-        dependencies.writeStdout(line + '\x1b[K\x1b[J');
+        const clearFrame = '\x1b[3J\x1b[2J\x1b[H';
+        if (maxLines !== lastDesiredHeight) {
+          // Clear before a pane resize so tmux cannot reflow stale HUD rows
+          // into visible output or scrollback while changing the pane height.
+          dependencies.writeStdout(clearFrame);
+          reconcileRunningHudPaneHeight(maxLines, dependencies);
+          if (dependencies.env.TMUX && dependencies.env[OMX_TMUX_HUD_OWNER_ENV] === '1') {
+            const hudPaneId = dependencies.env.TMUX_PANE?.trim();
+            if (hudPaneId?.startsWith('%')) dependencies.clearTmuxPaneHistoryFn(hudPaneId);
+          }
+          lastDesiredHeight = maxLines;
+          dependencies.writeStdout(`\x1b[H${line}\x1b[K\x1b[J`);
+        } else {
+          dependencies.writeStdout(`${clearFrame}${line}\x1b[K\x1b[J`);
+        }
+        firstRender = false;
         renderedThisTick = 'rendered';
       }
       try {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -1676,6 +1676,21 @@ export function resizeTmuxPane(
   }
 }
 
+/** Clears scrollback for an OMX-owned HUD pane after a height reflow. */
+export function clearTmuxPaneHistory(
+  paneId: string,
+  execTmuxSync: TmuxExecSync = defaultExecTmuxSync,
+): boolean {
+  const canonicalPaneId = parseCanonicalTmuxPaneId(paneId);
+  if (!canonicalPaneId) return false;
+  try {
+    execTmuxSync(['clear-history', '-t', canonicalPaneId]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function registerHudResizeHook(
   hudPaneId: string,
   leaderPaneId: string | undefined,


### PR DESCRIPTION
## Summary
- publish each HUD frame only after rendering and any adaptive tmux resize completes
- clear the owned HUD pane before reflow and prune only its tmux history after height changes
- keep direct/non-owned tmux watch mode non-destructive to user scrollback
- add deterministic PTY-backed real-tmux coverage for timer updates, 2↔3 row reflow, detach/reattach, visible output, and scrollback
- add a separate legacy Ultragoal regression comparing rendered HUD state, `omx ultragoal status`, and a null Codex goal snapshot

## Root causes kept distinct
The original #3584 artifact came from homing the cursor before asynchronous state reads and pane resizing. A height change could reflow the prior frame before the replacement was written, leaving stale rows in the pane or history. The fix clears before owned-pane reflow, clears owned tmux history after reflow, then writes the complete frame.

The appended evidence is a separate semantic-state mismatch: a visually clear HUD is derived from durable `.omx/ultragoal/goals.json`, while `omx ultragoal status` can report a legacy completed or review-blocked plan that still blocks `create-goals`, and the Codex goal snapshot can be null. The regression documents this distinction and keeps the semantic defect as bounded follow-up evidence rather than conflating it with terminal rendering.

## Verification
- `npm run lint`
- `npm run check:no-unused`
- affected HUD, real PTY/tmux, detached lifecycle, and Ultragoal tests
- repository-wide `npm test` attempted; it exceeded the local 600-second execution limit after passing earlier suites

Closes #3584

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*