### PR TITLE
fix(hud): parse quoted tmux ownership commands

### DIFF
--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -12,6 +12,7 @@ import {
   findHudSplitOperationMarkerPaneId,
   findLegacyFocusedHudWatchPaneIds,
   findHudWatchPaneIds,
+  hasValidHudOwnerMarker,
   hudPaneMatchesOwner,
   listCurrentWindowHudPaneIds,
   OMX_TMUX_HUD_LEADER_PANE_ENV,
@@ -278,6 +279,54 @@ describe('HUD pane ownership helpers', () => {
       sessionId: 'sess-a',
       leaderPaneId: '%1',
     });
+  });
+
+  it('reads ownership from tmux outer quoting with escaped nested quotes', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%9\tnode\t"env OMX_DETACHED_HUD_OPERATION='op' /bin/zsh -c 'exec env OMX_SESSION_ID=\\"sess-a\\" OMX_TMUX_HUD_OWNER=\\"1\\" ${OMX_TMUX_HUD_LEADER_PANE_ENV}=\\"%1\\" node omx hud --watch'"`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: 'sess-a',
+      leaderPaneId: '%1',
+    });
+    assert.equal(hasValidHudOwnerMarker(pane!), true);
+  });
+
+  it('collects owner assignments after leading non-owner assignments before exec env', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%9\tnode\tOMX_TMUX_SPLIT_OPERATION_MARKER='op' exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: 'sess-a',
+      leaderPaneId: '%1',
+    });
+    assert.equal(hasValidHudOwnerMarker(pane!), true);
+  });
+
+  it('accepts the valid initial empty leader metadata', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%9\tnode\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='' node omx hud --watch`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: 'sess-a',
+      leaderPaneId: undefined,
+    });
+    assert.equal(hasValidHudOwnerMarker(pane!), true);
+  });
+
+  it('rejects ambiguous repeated ownership assignments', () => {
+    const [pane] = parseTmuxPaneSnapshot(
+      `%9\tnode\texec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%2' node omx hud --watch`,
+    );
+
+    assert.deepEqual(readHudPaneOwner(pane!), {
+      sessionId: undefined,
+      leaderPaneId: undefined,
+    });
+    assert.equal(hasValidHudOwnerMarker(pane!), false);
   });
 
   it('splits tmux octal-escaped control separators from live list-panes output', () => {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -311,10 +311,35 @@ function lexPosixWords(command: string): string[] | null {
   return words;
 }
 
+function normalizeTmuxPaneStartCommand(command: string): string {
+  const trimmed = command.trim();
+  if (trimmed.length < 2 || trimmed[0] !== '"') return command;
+
+  let escaped = false;
+  for (let index = 1; index < trimmed.length; index += 1) {
+    const char = trimmed[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      const body = trimmed.slice(1, index).replace(/\\(["\\])/g, '$1');
+      return `${body}${trimmed.slice(index + 1)}`.trim();
+    }
+  }
+
+  return command;
+}
+
 function parsePosixHudEnvAssignments(command: string): PosixHudEnvAssignments {
   const values = new Map<string, string[]>();
-  const attempted = HUD_OWNER_ENV_KEYS.some((key) => command.includes(key));
-  const words = lexPosixWords(command);
+  const normalizedCommand = normalizeTmuxPaneStartCommand(command);
+  const attempted = HUD_OWNER_ENV_KEYS.some((key) => normalizedCommand.includes(key));
+  const words = lexPosixWords(normalizedCommand);
   if (!words) return { attempted, valid: false, values };
 
   const inspect = (tokens: string[]): boolean => {
@@ -330,6 +355,7 @@ function parsePosixHudEnvAssignments(command: string): PosixHudEnvAssignments {
         values.set(key, existing);
         continue;
       }
+      if (assignment && (!commandStarted || acceptsEnvAssignments)) continue;
       if (token === '-c' && index + 1 < tokens.length) {
         const nested = lexPosixWords(tokens[index + 1]!);
         if (!nested || !inspect(nested)) return false;
@@ -457,7 +483,8 @@ function hasHudOwnerMetadataAttempt(command: string): boolean {
 }
 
 function isInvalidHudOwnerValue(key: string, value: string): boolean {
-  return value === '' || (key === OMX_TMUX_HUD_OWNER_ENV && value !== '1');
+  return (key === OMX_TMUX_HUD_OWNER_ENV && value !== '1')
+    || (key !== OMX_TMUX_HUD_LEADER_PANE_ENV && value === '');
 }
 
 function parseHudEnvAssignment(command: string, key: string): string | undefined {


### PR DESCRIPTION
## Summary

Fixes #3587.

- Normalize tmux's outer double-quoted `pane_start_command` representation while preserving nested shell quoting.
- Continue parsing ownership assignments across leading non-owner environment assignments and `exec env`.
- Accept the intentionally empty initial HUD leader value while retaining ambiguity rejection for repeated/conflicting metadata.
- Add parser regressions for quoted commands, escaped nested quotes, assignment prefixes, initial empty metadata, and malformed ambiguity.

## Validation

- `npm run check:no-unused`
- `npm run lint`
- `npm run build`
- `node dist/scripts/run-test-files.js dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js`
- `node dist/scripts/run-test-files.js dist/hud/__tests__ dist/team/__tests__/tmux-session.test.js`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
