### PR TITLE
fix(config): tolerate bare empty [hooks.state] parent header before managed trust block

### DIFF
--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1323,6 +1323,105 @@ describe("config generator idempotency (#384)", () => {
       "duplicate empty parents must keep the marker-contained conflict classification",
     );
   });
+  it("tolerates the empty parent header when it is itself marker-contained (#3589)", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const merged = buildMergedConfig('model = "x"\n', "/tmp/codex", {
+      codexHomeDir: "/tmp/codex",
+      managedHookTrustState: managedTrustState,
+    });
+    const trustMarker = "# OMX-owned Codex hook trust state";
+    const markerIdx = merged.indexOf(trustMarker);
+    assert.ok(markerIdx > 0, "fixture must contain the managed trust marker");
+    const withParent = `${merged.slice(0, markerIdx)}[hooks.state]\n\n${merged.slice(markerIdx)}`;
+    assert.doesNotThrow(() => TOML.parse(withParent));
+    const stripOptions = {
+      managedTrustState,
+      priorManagedHookTrustState: managedTrustState,
+    };
+    const stripped = stripManagedCodexHookTrustState(withParent, stripOptions);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+    assert.match(stripped, /^\[hooks\.state\]$/m);
+    const upgraded = upsertManagedCodexHookTrustState(withParent, "/tmp/omx", hooksPath, stripOptions);
+    assert.doesNotThrow(() => TOML.parse(upgraded));
+    assert.match(
+      upgraded,
+      /^\[hooks\.state\."\/tmp\/codex\/hooks\.json:session_start:0:0"\]$/m,
+      "managed entries must be re-provisioned after refresh",
+    );
+  });
+
+  it("keeps non-header empty hooks.state forms and duplicates fail-closed (#3589)", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const managed = upsertManagedCodexHookTrustState('model = "x"\n', "/tmp/omx", hooksPath);
+    const trustMarker = "# OMX-owned Codex hook trust state\n";
+    const startIdx = managed.indexOf(trustMarker) + trustMarker.length;
+    const inside = (snippet: string): string =>
+      managed.slice(0, startIdx) + snippet + managed.slice(startIdx);
+    const stripOptions = {
+      managedTrustState,
+      priorManagedHookTrustState: managedTrustState,
+    };
+    const isManagedTrustConflict = (error: unknown): boolean =>
+      error instanceof ManagedCodexHooksPlanError &&
+      error.code === "managed_trust_key_conflict";
+
+    const insideCases = [
+      ["empty dotted assignment", "hooks.state = {}\n"],
+      ["empty inline table", "hooks = { state = {} }\n"],
+      ["[hooks] scope with empty state", "[hooks]\nstate = {}\n"],
+      ["scalar hooks.state", 'hooks.state = "foreign"\n'],
+    ] as const;
+    for (const [name, snippet] of insideCases) {
+      assert.throws(
+        () => stripManagedCodexHookTrustState(inside(snippet), stripOptions),
+        isManagedTrustConflict,
+        `${name} must remain a marker-contained conflict`,
+      );
+    }
+    const trustEndMarker = "# End OMX-owned Codex hook trust state";
+    const secondChildIdx = managed.indexOf(
+      "[hooks.state.",
+      managed.indexOf("[hooks.state.", startIdx) + 1,
+    );
+    // The reported parent sits before the fence; a second definition anywhere inside
+    // (or any whole-config-invalid prelude) must keep base fail-closed behavior.
+    const reported = `${managed.slice(0, managed.indexOf(trustMarker))}[hooks.state]\n\n${managed.slice(managed.indexOf(trustMarker))}`;
+    const reportedTrustsOnlyIdx = reported.indexOf(trustMarker) + trustMarker.length;
+    const duplicateCases = [
+      ["second parent after comments", reported.slice(0, reportedTrustsOnlyIdx) + "[hooks.state]\n" + reported.slice(reportedTrustsOnlyIdx)],
+      ["second parent between children", reported.slice(0, secondChildIdx) + "[hooks.state]\n" + reported.slice(secondChildIdx)],
+      ["second parent before trust end", reported.slice(0, reported.indexOf(trustEndMarker)) + "[hooks.state]\n" + reported.slice(reported.indexOf(trustEndMarker))],
+      ["two parents inside", inside("[hooks.state]\n[hooks.state]\n")],
+    ] as const;
+    for (const [name, config] of duplicateCases) {
+      assert.throws(
+        () => stripManagedCodexHookTrustState(config, stripOptions),
+        isManagedTrustConflict,
+        `${name} must remain a marker-contained conflict`,
+      );
+    }
+
+    // Whole-config-invalid preludes keep base fail-closed behavior.
+    assert.throws(
+      () =>
+        stripManagedCodexHookTrustState(
+          `hooks.state = {}\n\n${inside("[hooks.state]\n")}`,
+          stripOptions,
+        ),
+      isManagedTrustConflict,
+      "an inline-table prelude must keep the header conflict",
+    );
+
+    // A valid, empty-valued foreign sibling outside the fence is user content: it is
+    // preserved and the proven-owned managed children are still refreshed.
+    const withForeignPrelude = `hooks.state.foreign = {}\n\n${inside("[hooks.state]\n")}`;
+    assert.doesNotThrow(() => TOML.parse(withForeignPrelude));
+    const stripped = stripManagedCodexHookTrustState(withForeignPrelude, stripOptions);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+    assert.match(stripped, /^hooks\.state\.foreign = \{\}$/m, "foreign state preserved");
+  });
 
   it("matches managed hooks.state keys case-sensitively", () => {
     const start = "# oh-my-codex (OMX) Configuration";

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1227,6 +1227,102 @@ describe("config generator idempotency (#384)", () => {
       assert.throws(() => buildMergedConfig(config, "/tmp/omx"), isManagedTrustConflict, name);
     }
   });
+  it("tolerates a bare empty [hooks.state] parent header before the managed trust block (#3589)", () => {
+    const hooksPath = "/tmp/codex/hooks.json";
+    const managedTrustState = buildManagedCodexHookTrustState(hooksPath, "/tmp/omx");
+    const managed = upsertManagedCodexHookTrustState(
+      'model = "gpt-5.6-sol"\n\n[desktop]\nenabled = true\n',
+      "/tmp/omx",
+      hooksPath,
+    );
+    const marker = "# OMX-owned Codex hook trust state\n";
+    const markerIdx = managed.indexOf(marker);
+    const markerStart = markerIdx + marker.length;
+    const insideMarker = (snippet: string): string =>
+      managed.slice(0, markerStart) + snippet + managed.slice(markerStart);
+    const withEmptyParent = `${managed.slice(0, markerIdx)}[hooks.state]\n\n${managed.slice(markerIdx)}`;
+    const stripOptions = {
+      managedTrustState,
+      priorManagedHookTrustState: managedTrustState,
+    };
+    const isManagedTrustConflict = (error: unknown): boolean =>
+      error instanceof ManagedCodexHooksPlanError &&
+      error.code === "managed_trust_key_conflict";
+
+    assert.doesNotThrow(() => TOML.parse(withEmptyParent));
+    const stripped = stripManagedCodexHookTrustState(withEmptyParent, stripOptions);
+    assert.doesNotThrow(() => TOML.parse(stripped));
+    assert.match(
+      stripped,
+      /^\[hooks\.state\]$/m,
+      "the user's empty parent header is preserved",
+    );
+    for (const key of Object.keys(managedTrustState)) {
+      assert.ok(!stripped.includes(key), `managed entry ${key} should be stripped`);
+    }
+
+    const merged = buildMergedConfig(withEmptyParent, "/tmp/codex", {
+      codexHomeDir: "/tmp/codex",
+      managedHookTrustState: managedTrustState,
+      priorManagedHookTrustState: managedTrustState,
+    });
+    assert.doesNotThrow(() => TOML.parse(merged));
+    const parsedMerged = TOML.parse(merged) as {
+      hooks?: { state?: Record<string, unknown> };
+    };
+    assert.equal(
+      Object.keys(parsedMerged.hooks?.state ?? {}).length,
+      Object.keys(managedTrustState).length,
+      "setup must re-provision exactly the managed trust entries",
+    );
+
+    const upgraded = upsertManagedCodexHookTrustState(
+      withEmptyParent,
+      "/tmp/omx",
+      hooksPath,
+      stripOptions,
+    );
+    assert.doesNotThrow(() => TOML.parse(upgraded));
+    assert.match(
+      upgraded,
+      /^\[hooks\.state\]$/m,
+      "the empty parent header survives setup upgrades",
+    );
+
+    assert.throws(
+      () =>
+        stripManagedCodexHookTrustState(withEmptyParent, {
+          managedTrustState: {},
+          priorManagedHookTrustState: {},
+        }),
+      isManagedTrustConflict,
+      "unproven marker-contained state stays fail-closed",
+    );
+
+    const negativeControls = [
+      ["non-empty parent", '[hooks.state]\nforeign = "x"\n'],
+      ["unmanaged child", '[hooks.state."foreign"]\ntrusted_hash = "sha256:foreign"\n'],
+    ] as const;
+    for (const [name, snippet] of negativeControls) {
+      assert.throws(
+        () => stripManagedCodexHookTrustState(insideMarker(snippet), stripOptions),
+        isManagedTrustConflict,
+        `${name} inside the managed block must stay a conflict`,
+      );
+    }
+    assert.throws(
+      () =>
+        stripManagedCodexHookTrustState(
+          insideMarker("[hooks.state]\n[hooks.state]\n"),
+          stripOptions,
+        ),
+      (error: unknown): boolean =>
+        error instanceof ManagedCodexHooksPlanError &&
+        error.code === "managed_trust_key_conflict" &&
+        error.message.includes("marker-contained hooks.state"),
+      "duplicate empty parents must keep the marker-contained conflict classification",
+    );
+  });
 
   it("matches managed hooks.state keys case-sensitively", () => {
     const start = "# oh-my-codex (OMX) Configuration";

--- a/src/config/__tests__/generator-idempotent.test.ts
+++ b/src/config/__tests__/generator-idempotent.test.ts
@@ -1381,14 +1381,14 @@ describe("config generator idempotency (#384)", () => {
       );
     }
     const trustEndMarker = "# End OMX-owned Codex hook trust state";
-    const secondChildIdx = managed.indexOf(
-      "[hooks.state.",
-      managed.indexOf("[hooks.state.", startIdx) + 1,
-    );
     // The reported parent sits before the fence; a second definition anywhere inside
     // (or any whole-config-invalid prelude) must keep base fail-closed behavior.
     const reported = `${managed.slice(0, managed.indexOf(trustMarker))}[hooks.state]\n\n${managed.slice(managed.indexOf(trustMarker))}`;
     const reportedTrustsOnlyIdx = reported.indexOf(trustMarker) + trustMarker.length;
+    const secondChildIdx = reported.indexOf(
+      "[hooks.state.",
+      reported.indexOf("[hooks.state.", reportedTrustsOnlyIdx) + 1,
+    );
     const duplicateCases = [
       ["second parent after comments", reported.slice(0, reportedTrustsOnlyIdx) + "[hooks.state]\n" + reported.slice(reportedTrustsOnlyIdx)],
       ["second parent between children", reported.slice(0, secondChildIdx) + "[hooks.state]\n" + reported.slice(secondChildIdx)],

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -1788,7 +1788,6 @@ interface TomlSourceArrayTableOpener {
   firstKey: TomlSourceKeySegment | undefined;
   openerOnly: boolean;
 }
-
 /**
  * Detects a potential array-table opener without accepting malformed spacing
  * or extra opening brackets as TOML syntax. Array tables rooted at `hooks`
@@ -2163,15 +2162,55 @@ function recordManagedMarkerHooksStateSourceSpan(
   end: number,
   parsed: Record<string, unknown> | undefined,
   insideManagedMarkerBlock: boolean,
+  tolerance?: ManagedMarkerHooksStateSpanTolerance,
 ): void {
   if (!insideManagedMarkerBlock) return;
   const state = tomlHooksStateValue(parsed);
   if (state === undefined) return;
+  if (
+    isPlainTomlRecord(state) &&
+    Object.keys(state).length === 0 &&
+    isExactlyEmptyHooksStateParentHeader(parsed) &&
+    !(tolerance?.emptyParentHeaderSeen ?? false)
+  ) {
+    if (tolerance) tolerance.emptyParentHeaderSeen = true;
+    // A bare empty parent header such as `[hooks.state]` is semantically empty TOML
+    // structure: it owns no trust entries, and child tables restate `hooks.state` in
+    // their own headers. It cannot hide unmanaged state, so it is not a conflict.
+    return;
+  }
   const span = { start, end };
   spans.push(span);
   if (!isPlainTomlRecord(state) || Object.keys(state).length === 0) {
     invalidSpans.push(span);
   }
+}
+
+/**
+ * Tracks whether the exact semantically empty parent-table shape `[hooks.state]` has
+ * already been tolerated inside the managed marker block. Only the first occurrence is
+ * benign; a second bare header (with or without children redefining it) is a real TOML
+ * duplicate-table definition, so later empty-parent spans stay invalid.
+ */
+interface ManagedMarkerHooksStateSpanTolerance {
+  emptyParentHeaderSeen: boolean;
+}
+
+/**
+ * Accepts only the exact whole-statement parse of a bare empty parent table header,
+ * `[hooks.state]`. Anything beyond that shape — nested tables under a deeper header,
+ * sibling `hooks` tables with other keys, or unrelated statements — stays fail-closed.
+ */
+function isExactlyEmptyHooksStateParentHeader(
+  parsed: Record<string, unknown> | undefined,
+): boolean {
+  if (!parsed) return false;
+  return Object.keys(parsed).length === 1 &&
+    isPlainTomlRecord(parsed.hooks) &&
+    Object.keys(parsed.hooks).length === 1 &&
+    Object.hasOwn(parsed.hooks, "state") &&
+    isPlainTomlRecord(parsed.hooks.state) &&
+    Object.keys(parsed.hooks.state).length === 0;
 }
 
 function addManagedHookTrustStateSourceRepresentations(
@@ -2283,6 +2322,9 @@ function collectManagedHookTrustStateSourceRepresentations(
   const markerContainedHooksStateSpans: SourceSpan[] = [];
   const invalidMarkerContainedHooksStateSpans: SourceSpan[] = [];
   const parsedStatementSpans: SourceSpan[] = [];
+  const emptyParentHeaderTolerance: ManagedMarkerHooksStateSpanTolerance = {
+    emptyParentHeaderSeen: false,
+  };
 
   const managedMarkerRanges = [
     ...collectMarkerRanges(
@@ -2367,6 +2409,7 @@ function collectManagedHookTrustStateSourceRepresentations(
       end,
       tableScope.parsed,
       insideManagedMarkerBlock,
+      emptyParentHeaderTolerance,
     );
     const headerState = tomlHooksStateEntries(header.parsed);
     const directKeys = Object.keys(headerState ?? {});

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -2158,22 +2158,25 @@ function collectMarkerRanges(
 function recordManagedMarkerHooksStateSourceSpan(
   spans: SourceSpan[],
   invalidSpans: SourceSpan[],
+  source: TomlSourceLexicalAnalysis,
   start: number,
   end: number,
   parsed: Record<string, unknown> | undefined,
   insideManagedMarkerBlock: boolean,
-  tolerance?: ManagedMarkerHooksStateSpanTolerance,
+  emptyParentHeaderTolerance?: ManagedMarkerHooksStateSpanTolerance,
 ): void {
   if (!insideManagedMarkerBlock) return;
   const state = tomlHooksStateValue(parsed);
   if (state === undefined) return;
   if (
+    emptyParentHeaderTolerance !== undefined &&
+    !emptyParentHeaderTolerance.emptyParentHeaderSeen &&
+    emptyParentHeaderTolerance.uniqueEmptyParentHeader &&
     isPlainTomlRecord(state) &&
     Object.keys(state).length === 0 &&
-    isExactlyEmptyHooksStateParentHeader(parsed) &&
-    !(tolerance?.emptyParentHeaderSeen ?? false)
+    isEmptyParentHeaderStatementSpan(source, start, end)
   ) {
-    if (tolerance) tolerance.emptyParentHeaderSeen = true;
+    emptyParentHeaderTolerance.emptyParentHeaderSeen = true;
     // A bare empty parent header such as `[hooks.state]` is semantically empty TOML
     // structure: it owns no trust entries, and child tables restate `hooks.state` in
     // their own headers. It cannot hide unmanaged state, so it is not a conflict.
@@ -2187,19 +2190,22 @@ function recordManagedMarkerHooksStateSourceSpan(
 }
 
 /**
- * Tracks whether the exact semantically empty parent-table shape `[hooks.state]` has
- * already been tolerated inside the managed marker block. Only the first occurrence is
- * benign; a second bare header (with or without children redefining it) is a real TOML
- * duplicate-table definition, so later empty-parent spans stay invalid.
+ * Eligibility gate for tolerating one bare empty `[hooks.state]` parent header inside
+ * the managed marker block. `emptyParentHeaderSeen` grants the tolerance at most once;
+ * `uniqueEmptyParentHeader` is proven file-wide before any span is tolerated, so a
+ * second definition (a real TOML duplicate-table error) never qualifies. Absence of a
+ * tolerance object — for example for plain assignments — never authorizes a skip.
  */
 interface ManagedMarkerHooksStateSpanTolerance {
   emptyParentHeaderSeen: boolean;
+  uniqueEmptyParentHeader: boolean;
 }
 
 /**
  * Accepts only the exact whole-statement parse of a bare empty parent table header,
- * `[hooks.state]`. Anything beyond that shape — nested tables under a deeper header,
- * sibling `hooks` tables with other keys, or unrelated statements — stays fail-closed.
+ * `[hooks.state]` (quoted-key variants included). Anything beyond that shape — empty
+ * assignments or inline tables, a `[hooks]` scope holding an empty `state`, nested
+ * tables under a deeper header, or unrelated statements — stays fail-closed.
  */
 function isExactlyEmptyHooksStateParentHeader(
   parsed: Record<string, unknown> | undefined,
@@ -2213,6 +2219,43 @@ function isExactlyEmptyHooksStateParentHeader(
     Object.keys(parsed.hooks.state).length === 0;
 }
 
+/**
+ * Proves a span's statements reduce to exactly one lexically real empty `[hooks.state]`
+ * table header line plus blank/comment lines. Parsed-shape equality alone is not
+ * enough: `hooks.state = {}`, `hooks = { state = {} }`, and `[hooks]` scopes holding
+ * `state = {}` parse to the same object but are not parent headers.
+ */
+function isEmptyParentHeaderStatementSpan(
+  source: TomlSourceLexicalAnalysis,
+  start: number,
+  end: number,
+): boolean {
+  let sawHeader = false;
+  for (let index = start; index < end; index += 1) {
+    if (!source.lineStartsOutsideMultiline[index]) return false;
+    const line = source.lines[index] ?? "";
+    if (isTomlSourceBlankOrComment(line)) continue;
+    if (sawHeader) return false;
+    const header = parseTomlSourceTableHeader(line);
+    if (!header || !isExactlyEmptyHooksStateParentHeader(header.parsed)) return false;
+    sawHeader = true;
+  }
+  return sawHeader;
+}
+
+function countExactEmptyParentHeaderLines(
+  source: TomlSourceLexicalAnalysis,
+): number {
+  let count = 0;
+  for (const [index, line] of source.lines.entries()) {
+    if (!source.lineStartsOutsideMultiline[index]) continue;
+    if (isTomlSourceBlankOrComment(line)) continue;
+    const header = parseTomlSourceTableHeader(line);
+    if (header && isExactlyEmptyHooksStateParentHeader(header.parsed)) count += 1;
+  }
+  return count;
+}
+
 function addManagedHookTrustStateSourceRepresentations(
   representations: Map<string, ManagedHookTrustStateSourceRepresentation[]>,
   markerContainedHooksStateSpans: SourceSpan[],
@@ -2224,14 +2267,17 @@ function addManagedHookTrustStateSourceRepresentations(
   insideManagedMarkerBlock: boolean,
   containingTableScope?: TomlSourceTableScope,
   fallbackKeys: readonly string[] = [],
+  emptyParentHeaderTolerance?: ManagedMarkerHooksStateSpanTolerance,
 ): void {
   recordManagedMarkerHooksStateSourceSpan(
     markerContainedHooksStateSpans,
     invalidMarkerContainedHooksStateSpans,
+    source,
     start,
     end,
     parsed,
     insideManagedMarkerBlock,
+    emptyParentHeaderTolerance,
   );
   const state = tomlHooksStateEntries(parsed);
   const hasComment = sourceRangeHasTomlComment(source, start, end);
@@ -2324,6 +2370,8 @@ function collectManagedHookTrustStateSourceRepresentations(
   const parsedStatementSpans: SourceSpan[] = [];
   const emptyParentHeaderTolerance: ManagedMarkerHooksStateSpanTolerance = {
     emptyParentHeaderSeen: false,
+    uniqueEmptyParentHeader: countExactEmptyParentHeaderLines(source) === 1 &&
+      safeParseToml(config) !== undefined,
   };
 
   const managedMarkerRanges = [
@@ -2355,6 +2403,7 @@ function collectManagedHookTrustStateSourceRepresentations(
       if (
         !source.lineStartsOutsideMultiline[cursor] ||
         line.trim().length === 0 ||
+        isTomlSourceBlankOrComment(line) ||
         line.trim() === OMX_HOOK_TRUST_START_MARKER ||
         line.trim() === OMX_CONFIG_START_MARKER
       ) {
@@ -2405,6 +2454,7 @@ function collectManagedHookTrustStateSourceRepresentations(
     recordManagedMarkerHooksStateSourceSpan(
       markerContainedHooksStateSpans,
       invalidMarkerContainedHooksStateSpans,
+      source,
       index,
       end,
       tableScope.parsed,


### PR DESCRIPTION
Closes #3589

## Summary

`omx setup` 0.20.5 refused a valid, duplicate-free `config.toml` with `managed_trust_key_conflict` for `marker-contained hooks.state` when a semantically empty parent table header `[hooks.state]` sat immediately before the OMX-managed trust marker block, even though every managed child entry inside the block was proven-owned. Removing only the empty header made setup pass unchanged — exactly as reported.

## Root cause (independently reproduced at `dev@4b52bd27980b5e02a63809a7c377b16106905ec0`)

In `stripManagedCodexHookTrustState` → `collectManagedHookTrustStateSourceRepresentations`, the whole-table slice for the bare `[hooks.state]` header parses to exactly `{ hooks: { state: {} } }` (empty record; the managed children are separate sibling tables). `recordManagedMarkerHooksStateSourceSpan` classifies any marker-contained `hooks.state` record that is not a non-empty plain record as invalid, so `managedMarkerTrustStateConflicts` added `marker-contained hooks.state` — the reporter's hypothesis, confirmed by span-level instrumentation.

## Fix

The bare header is semantically empty TOML structure: it owns no trust entries and children restate `hooks.state` in their own headers, so it cannot hide unmanaged state. `recordManagedMarkerHooksStateSourceSpan` now tolerates only the first exact whole-statement empty-parent parse inside the managed marker block (new `ManagedMarkerHooksStateSpanTolerance` guard). A second bare header remains a real TOML duplicate-table error and still throws; unproven managed state, non-empty parents, unmanaged children, scalars, malformed TOML, and ambiguous marker boundaries all remain fail-closed (verified against base before/after via stash).

## Regression coverage

New focused test `tolerates a bare empty [hooks.state] parent header before the managed trust block (#3589)` in `generator-idempotent.test.ts`: reported adjacency through `stripManagedCodexHookTrustState`, `buildMergedConfig` (re-provisions exactly the managed entries), idempotent `upsertManagedCodexHookTrustState` upgrade, unproven-state negative control, inside-marker non-empty parent / unmanaged child / duplicate-parent negatives. Independent script `notes/repro-3589.mjs` mirrors the same assertions against `dist/`.

## Verification

- `npx tsc` clean; `npx tsc --noEmit -p tsconfig.no-unused.json` clean; `npx biome lint src` clean (807 files)
- `node --test dist/config/__tests__/*.test.js`: 273 passed, 0 failed
- `node --test` over uninstall/setup-refresh/setup-hooks-trust-e2e/setup-hooks-shared-ownership/hooks: 125 passed, 0 failed, 2 skipped (pre-existing skips)
- `node notes/repro-3589.mjs`: all post-fix assertions passed; control runs at base `4b52bd27980b5e02a63809a7c377b16106905ec0` reproduced the exact reporter error before the fix

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*