### PR TITLE
fix: ralph deadlock issue on windows

### DIFF
--- a/docs/codex-native-hooks.md
+++ b/docs/codex-native-hooks.md
@@ -139,6 +139,8 @@ or child-write allowance exists in this Option C implementation.
 
 The native planning/Conductor boundary retains one narrowly authenticated recovery surface: exact canonical `omx cancel` and workflow-supported `omx cancel --force`. An inherited non-empty `NODE_EXTRA_CA_CERTS` does not independently block that exact command because it supplies TLS trust material rather than executable, shell-startup, or loader substitution. Every independent raw-command, canonical executable, PATH/PATHEXT, shell function/startup, `NODE_OPTIONS`, loader/import, `OPENSSL_CONF`, output, dynamic-loader, assignment, chaining, and workflow-force check remains fail-closed.
 
+On Windows, cancellation and native-owner validation treat a path `lstat()` device value of zero and a populated opened-handle device value as the same file only when the nonzero inode also matches. The reverse mismatch, different nonzero devices, zero inode, and changed inode remain rejected.
+
 When a resumed session has current pointer/native-owner/target agreement but a stale top-level `owner_codex_session_id` in session-scoped `skill-active-state.json`, exact cancellation may replace that one field inside its existing exact-session transaction. The stale value never becomes an alias or authority; nested, live, malformed, ambiguous, or cross-session evidence denies without successful mutation. OMX does not infer root `SessionStart` authority for this repair because documented native hooks cannot distinguish a root event from unreadable or malformed child evidence. The transaction provides frozen all-target validation and in-process reverse rollback, not crash-atomic multi-file visibility.
 
 ## Document-refresh warning MVP

--- a/src/cli/__tests__/issue-windows-cancel-identity.test.ts
+++ b/src/cli/__tests__/issue-windows-cancel-identity.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { cancellationFileIdentityMatches } from "../index.js";
+
+describe("Windows cancellation file identity", () => {
+  it("accepts the Windows path-stat versus handle-stat zero-device mismatch", () => {
+    assert.equal(
+      cancellationFileIdentityMatches(
+        { dev: 0, ino: 4242 },
+        { dev: 3188088968, ino: 4242 },
+        "win32",
+      ),
+      true,
+    );
+  });
+
+  it("still rejects inode replacement and nonzero device changes", () => {
+    assert.equal(
+      cancellationFileIdentityMatches(
+        { dev: 0, ino: 4242 },
+        { dev: 3188088968, ino: 4343 },
+        "win32",
+      ),
+      false,
+    );
+    assert.equal(
+      cancellationFileIdentityMatches(
+        { dev: 11, ino: 4242 },
+        { dev: 12, ino: 4242 },
+        "win32",
+      ),
+      false,
+    );
+    assert.equal(
+      cancellationFileIdentityMatches(
+        { dev: 3188088968, ino: 4242 },
+        { dev: 0, ino: 4242 },
+        "win32",
+      ),
+      false,
+    );
+  });
+
+  it("does not relax device matching on non-Windows platforms", () => {
+    assert.equal(
+      cancellationFileIdentityMatches(
+        { dev: 0, ino: 4242 },
+        { dev: 12, ino: 4242 },
+        "linux",
+      ),
+      false,
+    );
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -137,6 +137,7 @@ import {
   readSessionPointer,
   readSessionState,
   resolveSessionPointerContext,
+  sessionOwnerFileIdentityMatches,
   finalizeBoundOnce,
   isSessionPointerLaunchAbort,
   normalizeSessionId,
@@ -10033,6 +10034,19 @@ interface CancellationTestFaults {
   rollbackFailureMode?: string;
 }
 
+interface CancellationFileIdentity {
+  dev: number;
+  ino: number;
+}
+
+export function cancellationFileIdentityMatches(
+  frozen: CancellationFileIdentity,
+  current: CancellationFileIdentity,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return sessionOwnerFileIdentityMatches(frozen, current, platform);
+}
+
 async function cancelModes(
   args: string[] = [],
   options: { cwd?: string; testFaults?: CancellationTestFaults } = {},
@@ -10337,7 +10351,10 @@ async function cancelModes(
         const handle = await open(change.entry.path, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
         const currentStat = await handle.stat();
         const currentContent = await handle.readFile({ encoding: "utf-8" });
-        if (!currentStat.isFile() || currentStat.dev !== change.entry.dev || currentStat.ino !== change.entry.ino) {
+        if (
+          !currentStat.isFile()
+          || !cancellationFileIdentityMatches(change.entry, currentStat)
+        ) {
           await handle.close();
           throw new Error(`Refusing cancellation because state identity changed: ${change.entry.path}.`);
         }

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -29,6 +29,7 @@ import {
   recoverSessionPointerLock,
   resetSessionMetrics,
   resolveSessionPointerContext,
+  sessionOwnerFileIdentityMatches,
   writeSessionEnd,
   writeNativeSessionOwner,
   updateDetachedSessionMetadata,
@@ -37,6 +38,16 @@ import {
   type SessionState,
   type ProcessObservation,
 } from '../session.js';
+
+describe('native session owner file identity', () => {
+  it('accepts only the observed Windows path-zero to handle-nonzero asymmetry', () => {
+    assert.equal(sessionOwnerFileIdentityMatches({ dev: 0, ino: 42 }, { dev: 11, ino: 42 }, 'win32'), true);
+    assert.equal(sessionOwnerFileIdentityMatches({ dev: 11, ino: 42 }, { dev: 0, ino: 42 }, 'win32'), false);
+    assert.equal(sessionOwnerFileIdentityMatches({ dev: 11, ino: 42 }, { dev: 12, ino: 42 }, 'win32'), false);
+    assert.equal(sessionOwnerFileIdentityMatches({ dev: 0, ino: 42 }, { dev: 11, ino: 43 }, 'win32'), false);
+    assert.equal(sessionOwnerFileIdentityMatches({ dev: 0, ino: 42 }, { dev: 11, ino: 42 }, 'linux'), false);
+  });
+});
 
 interface SessionHistoryEntry {
   session_id: string;

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -120,6 +120,23 @@ export interface SessionPointerReadResult {
 
 /** Classified native session-owner sidecar evidence for fail-closed consumers. */
 export interface NativeSessionOwnerEvidence extends SessionPointerReadResult {}
+
+interface SessionOwnerFileIdentity {
+  dev: number;
+  ino: number;
+}
+
+export function sessionOwnerFileIdentityMatches(
+  frozenPath: SessionOwnerFileIdentity,
+  openedHandle: SessionOwnerFileIdentity,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (frozenPath.ino <= 0 || openedHandle.ino !== frozenPath.ino) return false;
+  if (openedHandle.dev === frozenPath.dev) return true;
+  return platform === 'win32'
+    && frozenPath.dev === 0
+    && openedHandle.dev > 0;
+}
 export type SessionPointerTransactionOperation =
   | 'pointer-context-resolve'
   | 'state-dir-create'
@@ -3401,6 +3418,7 @@ export async function readNativeSessionOwnerEvidence(
   const stateRootDir = dirname(sessionsDir);
   const directoryPaths = [stateRootDir, sessionsDir, nativeOwnerDir];
   const directoryIdentities: Array<{ path: string; dev: number; ino: number }> = [];
+  let frozenFileIdentity: SessionOwnerFileIdentity | undefined;
   try {
     for (const directoryPath of directoryPaths) {
       const stat = await transactionDependencies.fs.lstat(directoryPath);
@@ -3409,6 +3427,7 @@ export async function readNativeSessionOwnerEvidence(
     }
     const pathStat = await transactionDependencies.fs.lstat(context.sessionPath);
     if (pathStat.isSymbolicLink() || !pathStat.isFile()) return { status: 'malformed' };
+    frozenFileIdentity = { dev: pathStat.dev, ino: pathStat.ino };
   } catch (error) {
     if (isNotFound(error)) return { status: 'absent' };
     throw error;
@@ -3421,9 +3440,12 @@ export async function readNativeSessionOwnerEvidence(
     if (!openedStat.isFile()) return { status: 'malformed' };
     raw = await handle.readFile({ encoding: 'utf8' });
     const finalPathStat = await transactionDependencies.fs.lstat(context.sessionPath);
-    if (finalPathStat.isSymbolicLink()
-      || finalPathStat.dev !== openedStat.dev
-      || finalPathStat.ino !== openedStat.ino) {
+    if (!frozenFileIdentity
+      || finalPathStat.isSymbolicLink()
+      || !finalPathStat.isFile()
+      || finalPathStat.dev !== frozenFileIdentity.dev
+      || finalPathStat.ino !== frozenFileIdentity.ino
+      || !sessionOwnerFileIdentityMatches(frozenFileIdentity, openedStat, transactionDependencies.runtimePlatform)) {
       return { status: 'malformed', raw };
     }
     for (const identity of directoryIdentities) {

--- a/src/scripts/codex-native-hook.ts
+++ b/src/scripts/codex-native-hook.ts
@@ -57,6 +57,7 @@ import {
   readUsableSessionState,
   reconcileNativeSessionStart,
   resolveSessionPointerContext,
+  sessionOwnerFileIdentityMatches,
   type SessionStartOptions,
   writeNativeSessionOwner,
   type SessionState
@@ -3735,7 +3736,11 @@ function hookCancelIdentity(stats: { dev: number; ino: number; mode: number; uid
   return { dev: stats.dev, ino: stats.ino, mode: stats.mode, uid: stats.uid, size: stats.size, mtimeMs: stats.mtimeMs };
 }
 function hookCancelIdentityMatches(left: HookCancelTargetIdentity, right: HookCancelTargetIdentity): boolean {
-  return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode && left.uid === right.uid && left.size === right.size && left.mtimeMs === right.mtimeMs;
+  return sessionOwnerFileIdentityMatches(left, right, hookCancelPlatform())
+    && left.mode === right.mode
+    && left.uid === right.uid
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs;
 }
 function hookCancelTargetMatches(left: HookCancelTargetIdentity, right: HookCancelTargetIdentity): boolean {
   return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode && left.uid === right.uid;


### PR DESCRIPTION
## Summary

Fix Windows state-file identity validation that can prevent native session-owner recognition and both hook-owned and CLI cancellation. Current `dev` already removes the Ralph Conductor write hard gate through #3497; this PR addresses the remaining Windows cancellation/recovery failure without reintroducing that gate.

## Changes

- accept only the observed Windows path-to-handle identity asymmetry (`lstat.dev === 0`, opened-handle `dev > 0`) when the same nonzero inode matches
- reuse the same fail-closed predicate for native-owner reads, hook cancellation preflight, and CLI cancellation writes
- retain rejection for reverse mismatches, changed inode, zero inode, different nonzero devices, and non-Windows platforms
- document the Windows identity contract and add focused regressions

## Validation

- [x] `npm run build`
- [ ] `npm test` — stopped before tests by existing `capabilities_lock_drift` (`skill_surface_mismatch`, `agent_surface_mismatch`); direct `npm run test:node` subsequently hung without output and was terminated after a bounded wait
- [ ] `omx doctor` (not applicable; no setup/config behavior changed)
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `npx tsc --noEmit`
- [x] 15 focused tests passed: Windows identity, hook-owned cancellation, and existing Ralph deadlock coverage
- [x] expanded cancellation transaction run passed 35/37; only two Windows symlink-creation cases failed with host `EPERM`

`npm ci` installed dependencies but its `prepare` hook failed to spawn `npm.cmd` with `EINVAL`; all validation commands above were then run directly.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed
- [x] Backward-compatibility impact considered

## Related

No issue linked.
