### PR TITLE
fix(sparkshell): reject malformed tail-line values

### DIFF
--- a/src/cli/__tests__/sparkshell-cli.test.ts
+++ b/src/cli/__tests__/sparkshell-cli.test.ts
@@ -529,6 +529,17 @@ describe('parseSparkShellFallbackInvocation', () => {
       { kind: 'tmux-pane', argv: ['tmux', 'capture-pane', '-t', '%12', '-p', '-S', '-400'] },
     );
   });
+
+  it('rejects tail line values that are not entirely integers', () => {
+    assert.throws(
+      () => parseSparkShellFallbackInvocation(['--tmux-pane', '%12', '--tail-lines', '400junk']),
+      /--tail-lines must be an integer between 100 and 1000/,
+    );
+    assert.throws(
+      () => parseSparkShellFallbackInvocation(['--tmux-pane=%12', '--tail-lines=400.5']),
+      /--tail-lines must be an integer between 100 and 1000/,
+    );
+  });
 });
 
 describe('omx sparkshell', () => {

--- a/src/cli/sparkshell.ts
+++ b/src/cli/sparkshell.ts
@@ -294,6 +294,14 @@ function stripSparkShellWrapperOptions(args: readonly string[]): string[] {
   return [];
 }
 
+function parseTailLines(value: string): number {
+  const parsed = Number(value);
+  if (!/^\d+$/.test(value) || !Number.isInteger(parsed) || parsed < 100 || parsed > 1000) {
+    throw new Error(`--tail-lines must be an integer between 100 and 1000.\n${SPARKSHELL_USAGE}`);
+  }
+  return parsed;
+}
+
 export function parseSparkShellFallbackInvocation(
   args: readonly string[],
   options: ParseSparkShellFallbackOptions = {},
@@ -343,21 +351,13 @@ export function parseSparkShellFallbackInvocation(
     if (token === '--tail-lines') {
       const next = args[index + 1];
       if (!next || next.startsWith('-')) throw new Error(`--tail-lines requires a numeric value.\n${SPARKSHELL_USAGE}`);
-      const parsed = Number.parseInt(next, 10);
-      if (!Number.isFinite(parsed) || parsed < 100 || parsed > 1000) {
-        throw new Error(`--tail-lines must be an integer between 100 and 1000.\n${SPARKSHELL_USAGE}`);
-      }
-      tailLines = parsed;
+      tailLines = parseTailLines(next);
       sawTailLines = true;
       index += 1;
       continue;
     }
     if (token.startsWith('--tail-lines=')) {
-      const parsed = Number.parseInt(token.slice('--tail-lines='.length), 10);
-      if (!Number.isFinite(parsed) || parsed < 100 || parsed > 1000) {
-        throw new Error(`--tail-lines must be an integer between 100 and 1000.\n${SPARKSHELL_USAGE}`);
-      }
-      tailLines = parsed;
+      tailLines = parseTailLines(token.slice('--tail-lines='.length));
       sawTailLines = true;
       continue;
     }


### PR DESCRIPTION
## Summary

- reject `--tail-lines` values that contain trailing characters or fractional syntax instead of silently truncating them
- use the same strict integer validation for split and inline flag forms
- add regression coverage for both malformed input shapes

## Validation

- `npm run build`
- `npx biome lint src/cli/sparkshell.ts src/cli/__tests__/sparkshell-cli.test.ts`
- `node --test dist/cli/__tests__/sparkshell-cli.test.js` (31 tests passed)

Documentation was not changed because the existing CLI usage already documents `--tail-lines` as an integer between 100 and 1000.
