### PR TITLE
fix(hud): keep OMX HUD attached after pane splits

### DIFF
--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -12,7 +12,10 @@ import { OMX_TMUX_HUD_LEADER_PANE_ENV } from '../tmux.js';
 const noOpRegisterHudResizeHook = () => true;
 const noOpUnregisterHudResizeHook = () => true;
 
-async function writeHudReconcileLock(cwd: string, owner: Record<string, unknown>): Promise<string> {
+async function writeHudReconcileLock(
+  cwd: string,
+  owner: Record<string, unknown>,
+): Promise<string> {
   const lockPath = join(cwd, '.omx', 'state', 'hud-reconcile.lock');
   await mkdir(dirname(lockPath), { recursive: true });
   await mkdir(lockPath, { recursive: true });
@@ -197,6 +200,81 @@ describe('reconcileHudForPromptSubmit', () => {
       assert.deepEqual(created, ['create']);
       assert.equal(existsSync(lockPath), false);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent HUD owners without dropping the second reconciliation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-owner-locks-'));
+    const hudConfig = { preset: 'focused' as const, git: { display: 'branch' as const }, statusLine: { preset: 'focused' as const } };
+    const hudState = {
+      version: null,
+      gitBranch: null,
+      ralph: null,
+      ultragoal: null,
+      ultrawork: null,
+      autopilot: null,
+      ralplan: null,
+      deepInterview: null,
+      autoresearch: null,
+      ultraqa: null,
+      team: null,
+      metrics: null,
+      hudNotify: null,
+      session: null,
+    };
+    let enterFirst: () => void = () => {};
+    let releaseFirst: () => void = () => {};
+    const firstEntered = new Promise<void>((resolve) => {
+      enterFirst = resolve;
+    });
+    const firstCanContinue = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    try {
+      const first = reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: 'socket,100,0', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-shared', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        listCurrentWindowPanes: () => [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }],
+        readHudConfig: async () => hudConfig,
+        readAllState: async () => {
+          enterFirst();
+          await firstCanContinue;
+          return hudState;
+        },
+        createHudWatchPane: () => '%3',
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      });
+
+      await firstEntered;
+      let secondResolved = false;
+      const secondPromise = reconcileHudForPromptSubmit(cwd, {
+        env: { TMUX: 'socket,100,0', TMUX_PANE: '%2', OMX_SESSION_ID: 'sess-shared', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+        listCurrentWindowPanes: () => [{ paneId: '%2', currentCommand: 'codex', startCommand: 'codex' }],
+        readHudConfig: async () => hudConfig,
+        readAllState: async () => hudState,
+        createHudWatchPane: () => '%4',
+        resizeTmuxPane: () => true,
+        unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+        registerHudResizeHook: noOpRegisterHudResizeHook,
+        resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+      }).then((result) => {
+        secondResolved = true;
+        return result;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      assert.equal(secondResolved, false);
+      releaseFirst();
+      const [firstResult, second] = await Promise.all([first, secondPromise]);
+
+      assert.equal(firstResult.status, 'recreated');
+      assert.equal(second.status, 'recreated');
+    } finally {
+      releaseFirst();
       await rm(cwd, { recursive: true, force: true });
     }
   });
@@ -1542,7 +1620,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const result = await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 50 - HUD_TMUX_HEIGHT_LINES, paneBottom: 49 - HUD_TMUX_HEIGHT_LINES, windowWidth: 160, windowHeight: 50 },
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 49 - HUD_TMUX_HEIGHT_LINES, paneBottom: 48 - HUD_TMUX_HEIGHT_LINES, windowWidth: 160, windowHeight: 50 },
         {
           paneId: '%2',
           currentCommand: 'node',
@@ -1576,6 +1654,48 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.deepEqual(killed, []);
     assert.deepEqual(created, []);
     assert.deepEqual(resized, []);
+  });
+
+  it('recreates a bottom HUD when a new pane separates it from its owner', async () => {
+    const killed: string[] = [];
+    const created: Array<{ options?: { heightLines?: number; fullWidth?: boolean; targetPaneId?: string } }> = [];
+
+    const result = await reconcileHudForPromptSubmit('/repo', {
+      env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
+      listCurrentWindowPanes: () => [
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 20, paneBottom: 19, windowWidth: 160, windowHeight: 50 },
+        { paneId: '%3', currentCommand: 'fish', startCommand: 'fish', paneLeft: 0, paneTop: 21, paneWidth: 160, paneHeight: 26, paneBottom: 46, windowWidth: 160, windowHeight: 50 },
+        {
+          paneId: '%2',
+          currentCommand: 'node',
+          startCommand: `env OMX_SESSION_ID='sess-a' ${OMX_TMUX_HUD_LEADER_PANE_ENV}='%1' node omx hud --watch`,
+          paneLeft: 0,
+          paneTop: 48,
+          paneWidth: 160,
+          paneHeight: HUD_TMUX_HEIGHT_LINES,
+          paneBottom: 49,
+          windowWidth: 160,
+          windowHeight: 50,
+        },
+      ],
+      unregisterHudResizeHook: noOpUnregisterHudResizeHook,
+      killTmuxPane: (paneId) => {
+        killed.push(paneId);
+        return true;
+      },
+      createHudWatchPane: (_cwd, _cmd, options) => {
+        created.push({ options });
+        return '%9';
+      },
+      resizeTmuxPane: () => true,
+      registerHudResizeHook: noOpRegisterHudResizeHook,
+      resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
+    });
+
+    assert.equal(result.status, 'recreated');
+    assert.deepEqual(killed, ['%2']);
+    assert.equal(created[0]?.options?.targetPaneId, '%1');
+    assert.equal(created[0]?.options?.fullWidth, true);
   });
 
   it('recreates a single owned HUD pane when tmux layout narrows it below the window width', async () => {
@@ -1689,7 +1809,7 @@ describe('reconcileHudForPromptSubmit', () => {
     const result = await reconcileHudForPromptSubmit('/repo', {
       env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
       listCurrentWindowPanes: () => [
-        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 47, paneBottom: 46, windowWidth: 160, windowHeight: 50 },
+        { paneId: '%1', currentCommand: 'codex', startCommand: 'codex', paneLeft: 0, paneTop: 0, paneWidth: 160, paneHeight: 46, paneBottom: 45, windowWidth: 160, windowHeight: 50 },
         {
           paneId: '%2',
           currentCommand: 'node',

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -89,7 +89,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(resized.length, 0);
   });
 
-  it('skips concurrent reconciliation for a stale lock whose holder pid is still live without mutating panes or lock metadata', async () => {
+  it('re-arms the existing HUD hook when a live holder blocks reconciliation', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-hud-reconcile-live-lock-'));
     try {
       const lockPath = await writeHudReconcileLock(cwd, {
@@ -102,6 +102,7 @@ describe('reconcileHudForPromptSubmit', () => {
       let killed = false;
       let created = false;
       let resized = false;
+      const registered: Array<{ hudPaneId: string; leaderPaneId: string | undefined; heightLines: number }> = [];
 
       const result = await reconcileHudForPromptSubmit(cwd, {
         env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
@@ -112,7 +113,15 @@ describe('reconcileHudForPromptSubmit', () => {
         },
         listCurrentWindowPanes: () => {
           listed = true;
-          return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
+          return [
+            { paneId: '%1', currentCommand: 'codex', startCommand: 'codex' },
+            {
+              paneId: '%9',
+              currentCommand: 'node',
+              startCommand: "exec env OMX_SESSION_ID='sess-a' OMX_TMUX_HUD_OWNER='1' OMX_TMUX_HUD_LEADER_PANE='%1' node omx.js hud --watch",
+              paneHeight: 4,
+            },
+          ];
         },
         killTmuxPane: () => {
           killed = true;
@@ -126,15 +135,20 @@ describe('reconcileHudForPromptSubmit', () => {
           resized = true;
           return true;
         },
+        registerHudResizeHook: (hudPaneId, leaderPaneId, heightLines) => {
+          registered.push({ hudPaneId, leaderPaneId, heightLines });
+          return true;
+        },
         resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
       });
 
       assert.equal(result.status, 'skipped_concurrent');
       assert.equal(result.paneId, null);
-      assert.equal(listed, false);
+      assert.equal(listed, true);
       assert.equal(killed, false);
       assert.equal(created, false);
       assert.equal(resized, false);
+      assert.deepEqual(registered, [{ hudPaneId: '%9', leaderPaneId: '%1', heightLines: 4 }]);
       assert.deepEqual(await readLockOwner(lockPath), originalOwner);
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -151,17 +165,20 @@ describe('reconcileHudForPromptSubmit', () => {
       });
       const originalOwner = await readLockOwner(lockPath);
 
+      let listed = false;
       const result = await reconcileHudForPromptSubmit(cwd, {
         env: { TMUX: '1', TMUX_PANE: '%1', OMX_SESSION_ID: 'sess-a', [OMX_TMUX_HUD_OWNER_ENV]: '1' },
         nowMs: () => 20_000,
         isProcessLive: () => null,
         listCurrentWindowPanes: () => {
-          assert.fail('unknown liveness must not enter reconciliation');
+          listed = true;
+          return [{ paneId: '%1', currentCommand: 'codex', startCommand: 'codex' }];
         },
         resolveOmxCliEntryPath: () => '/repo/dist/cli/omx.js',
       });
 
       assert.equal(result.status, 'skipped_concurrent');
+      assert.equal(listed, true);
       assert.deepEqual(await readLockOwner(lockPath), originalOwner);
     } finally {
       await rm(cwd, { recursive: true, force: true });

--- a/src/hud/__tests__/reconcile.test.ts
+++ b/src/hud/__tests__/reconcile.test.ts
@@ -1695,7 +1695,7 @@ describe('reconcileHudForPromptSubmit', () => {
     assert.equal(result.status, 'recreated');
     assert.deepEqual(killed, ['%2']);
     assert.equal(created[0]?.options?.targetPaneId, '%1');
-    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
   });
 
   it('recreates a single owned HUD pane when tmux layout narrows it below the window width', async () => {
@@ -1797,7 +1797,7 @@ describe('reconcileHudForPromptSubmit', () => {
 
     assert.equal(result.status, 'recreated');
     assert.deepEqual(killed, ['%2']);
-    assert.equal(created[0]?.options?.fullWidth, true);
+    assert.equal(Object.hasOwn(created[0]?.options ?? {}, 'fullWidth'), false);
     assert.equal(created[0]?.options?.targetPaneId, '%1');
   });
 

--- a/src/hud/__tests__/tmux-split-realtmux.test.ts
+++ b/src/hud/__tests__/tmux-split-realtmux.test.ts
@@ -66,6 +66,7 @@ async function waitForReconciledHud(
   leaderPaneId: string,
   oldHudPaneId: string,
   sessionId: string,
+  operation = 'layout mutation',
 ): Promise<string> {
   const deadline = Date.now() + HUD_RECONCILE_TIMEOUT_MS;
   let lastSnapshot = '';
@@ -87,7 +88,20 @@ async function waitForReconciledHud(
     ) return hud.paneId;
     await new Promise((resolve) => setTimeout(resolve, PANE_READY_INTERVAL_MS));
   }
-  throw new Error(`timed out waiting for automatic HUD topology reconciliation: ${lastSnapshot}`);
+  throw new Error(`timed out waiting for automatic HUD topology reconciliation after ${operation}: ${lastSnapshot}`);
+}
+
+async function waitForRegisteredLayoutHooks(fixture: TempTmuxSessionFixture): Promise<void> {
+  const deadline = Date.now() + HUD_RECONCILE_TIMEOUT_MS;
+  let lastHooks = '';
+  while (Date.now() < deadline) {
+    const sessionHooks = fixture.run(['show-hooks', '-t', fixture.sessionName]);
+    const windowHooks = fixture.run(['show-hooks', '-w', '-t', fixture.leaderPaneId]);
+    lastHooks = `${sessionHooks}\n${windowHooks}`;
+    if (/^after-split-window\[/m.test(sessionHooks) && /^window-layout-changed\[/m.test(windowHooks)) return;
+    await new Promise((resolve) => setTimeout(resolve, PANE_READY_INTERVAL_MS));
+  }
+  throw new Error(`timed out waiting for split and window layout hooks: ${lastHooks}`);
 }
 
 describe('createHudWatchPane real private-server split transaction', () => {
@@ -217,4 +231,81 @@ describe('createHudWatchPane real private-server split transaction', () => {
       await rm(workDir, { recursive: true, force: true });
     }
   });
+
+  for (const mutation of ['join-pane', 'move-pane', 'swap-pane', 'select-layout'] as const) {
+    it(`reconciles HUD placement after ${mutation}`, async (t) => {
+      if (!skipUnlessPrivateRealTmux(t)) return;
+
+      const workDir = await mkdtemp(join(tmpdir(), `omx-hud-${mutation}-realtmux-`));
+      try {
+        await withTempTmuxSession({ serverLog: true }, async (fixture) => {
+          const sessionId = `omx-hud-${mutation}-${process.pid}`;
+          const omxEntry = join(process.cwd(), 'dist', 'cli', 'omx.js');
+          const peerPaneId = fixture.run([
+            'split-window', '-d', '-P', '-F', '#{pane_id}', '-h',
+            '-t', fixture.leaderPaneId, 'sleep 300',
+          ]);
+          const hudCommand = [
+            'env',
+            'OMX_TMUX_HUD_OWNER=1',
+            `OMX_SESSION_ID=${quoteSh(sessionId)}`,
+            `OMX_TMUX_HUD_LEADER_PANE=${quoteSh(fixture.leaderPaneId)}`,
+            `OMX_ROOT=${quoteSh(workDir)}`,
+            quoteSh(process.execPath),
+            quoteSh(omxEntry),
+            'hud',
+            '--watch',
+          ].join(' ');
+          const hudPaneId = fixture.run([
+            'split-window', '-d', '-P', '-F', '#{pane_id}', '-v', '-l', '2',
+            '-t', fixture.leaderPaneId, hudCommand,
+          ]);
+          await waitForPaneReady(fixture, peerPaneId);
+          await waitForPaneReady(fixture, hudPaneId);
+
+          assert.equal(registerHudResizeHook(
+            hudPaneId,
+            fixture.leaderPaneId,
+            2,
+            {
+              cwd: workDir,
+              env: {
+                ...process.env,
+                ...fixture.env,
+                OMX_ENTRY_PATH: omxEntry,
+                OMX_STARTUP_CWD: process.cwd(),
+                OMX_SESSION_ID: sessionId,
+                OMX_ROOT: workDir,
+              },
+            },
+          ), true);
+          await waitForRegisteredLayoutHooks(fixture);
+
+          if (mutation === 'join-pane' || mutation === 'move-pane') {
+            const sourcePaneId = fixture.run([
+              'new-window', '-d', '-P', '-F', '#{pane_id}',
+              '-t', fixture.sessionName, 'sleep 300',
+            ]);
+            fixture.run([mutation, '-d', '-v', '-s', sourcePaneId, '-t', fixture.leaderPaneId]);
+          } else if (mutation === 'swap-pane') {
+            fixture.run(['swap-pane', '-d', '-s', hudPaneId, '-t', peerPaneId]);
+          } else {
+            fixture.run(['select-layout', '-t', fixture.leaderPaneId, 'even-horizontal']);
+          }
+
+          const newHudPaneId = await waitForReconciledHud(
+            fixture.leaderPaneId,
+            hudPaneId,
+            sessionId,
+            mutation,
+          );
+          assert.notEqual(newHudPaneId, hudPaneId, `${mutation} must trigger HUD recreation`);
+          await waitForRegisteredLayoutHooks(fixture);
+          assert.doesNotMatch(await fixture.readServerLog(), /too many arguments|unknown hook/i);
+        });
+      } finally {
+        await rm(workDir, { recursive: true, force: true });
+      }
+    });
+  }
 });

--- a/src/hud/__tests__/tmux-split-realtmux.test.ts
+++ b/src/hud/__tests__/tmux-split-realtmux.test.ts
@@ -3,12 +3,19 @@ import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, type TestContext } from 'node:test';
-import { createHudWatchPane, findHudSplitOperationMarkerPaneId } from '../tmux.js';
+import {
+  createHudWatchPane,
+  findHudSplitOperationMarkerPaneId,
+  findHudWatchPaneIds,
+  listCurrentWindowPanes,
+  registerHudResizeHook,
+} from '../tmux.js';
 import { isRealTmuxAvailable, type TempTmuxSessionFixture, withTempTmuxSession } from '../../team/__tests__/tmux-test-fixture.js';
 
 const PANE_READY_TIMEOUT_MS = 1_000;
 const PANE_READY_INTERVAL_MS = 50;
 const ENV_FILE_TIMEOUT_MS = 3_000;
+const HUD_RECONCILE_TIMEOUT_MS = 5_000;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 function skipUnlessPrivateRealTmux(t: TestContext): boolean {
@@ -53,6 +60,34 @@ async function waitForFileContent(filePath: string): Promise<string> {
     await new Promise((resolve) => setTimeout(resolve, PANE_READY_INTERVAL_MS));
   }
   throw new Error(`timed out waiting for pane env marker file: ${filePath} (last: ${JSON.stringify(lastContent)})`);
+}
+
+async function waitForReconciledHud(
+  leaderPaneId: string,
+  oldHudPaneId: string,
+  sessionId: string,
+): Promise<string> {
+  const deadline = Date.now() + HUD_RECONCILE_TIMEOUT_MS;
+  let lastSnapshot = '';
+  while (Date.now() < deadline) {
+    const panes = listCurrentWindowPanes(undefined, leaderPaneId);
+    const leader = panes.find((pane) => pane.paneId === leaderPaneId);
+    const hudPaneIds = findHudWatchPaneIds(panes, leaderPaneId, { leaderPaneId, sessionId });
+    const hud = hudPaneIds.length === 1
+      ? panes.find((pane) => pane.paneId === hudPaneIds[0])
+      : undefined;
+    lastSnapshot = JSON.stringify({ leader, hudPaneIds, hud });
+    if (
+      leader
+      && hud
+      && hud.paneId !== oldHudPaneId
+      && hud.paneTop === (leader.paneBottom ?? -2) + 2
+      && hud.paneLeft === leader.paneLeft
+      && hud.paneWidth === leader.paneWidth
+    ) return hud.paneId;
+    await new Promise((resolve) => setTimeout(resolve, PANE_READY_INTERVAL_MS));
+  }
+  throw new Error(`timed out waiting for automatic HUD topology reconciliation: ${lastSnapshot}`);
 }
 
 describe('createHudWatchPane real private-server split transaction', () => {
@@ -120,6 +155,65 @@ describe('createHudWatchPane real private-server split transaction', () => {
     } finally {
       if (typeof previousPath === 'string') process.env.PATH = previousPath;
       else delete process.env.PATH;
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('recreates and rearms a HUD directly below its owner after another pane is split', async (t) => {
+    if (!skipUnlessPrivateRealTmux(t)) return;
+
+    const workDir = await mkdtemp(join(tmpdir(), 'omx-hud-layout-realtmux-'));
+    try {
+      await withTempTmuxSession({ serverLog: true }, async (fixture) => {
+        const sessionId = `omx-hud-layout-${process.pid}`;
+        const omxEntry = join(process.cwd(), 'dist', 'cli', 'omx.js');
+        const hudCommand = [
+          'env',
+          'OMX_TMUX_HUD_OWNER=1',
+          `OMX_SESSION_ID=${quoteSh(sessionId)}`,
+          `OMX_TMUX_HUD_LEADER_PANE=${quoteSh(fixture.leaderPaneId)}`,
+          `OMX_ROOT=${quoteSh(workDir)}`,
+          quoteSh(process.execPath),
+          quoteSh(omxEntry),
+          'hud',
+          '--watch',
+        ].join(' ');
+        const oldHudPaneId = fixture.run([
+          'split-window', '-d', '-P', '-F', '#{pane_id}', '-v', '-l', '2',
+          '-t', fixture.leaderPaneId, hudCommand,
+        ]);
+        await waitForPaneReady(fixture, oldHudPaneId);
+
+        assert.equal(registerHudResizeHook(
+          oldHudPaneId,
+          fixture.leaderPaneId,
+          2,
+          {
+            cwd: workDir,
+            env: {
+              ...process.env,
+              ...fixture.env,
+              OMX_ENTRY_PATH: omxEntry,
+              OMX_STARTUP_CWD: process.cwd(),
+              OMX_SESSION_ID: sessionId,
+              OMX_ROOT: workDir,
+            },
+          },
+        ), true);
+        assert.match(fixture.run(['show-hooks', '-t', fixture.sessionName]), /^after-split-window\[/m);
+
+        fixture.run(['split-window', '-d', '-v', '-t', fixture.leaderPaneId, 'sleep 300']);
+        const newHudPaneId = await waitForReconciledHud(fixture.leaderPaneId, oldHudPaneId, sessionId);
+
+        assert.notEqual(newHudPaneId, oldHudPaneId);
+        assert.match(
+          fixture.run(['show-hooks', '-t', fixture.sessionName]),
+          /^after-split-window\[/m,
+          'one-shot split hook must be rearmed after reconciliation',
+        );
+        assert.doesNotMatch(await fixture.readServerLog(), /too many arguments|unknown hook/i);
+      });
+    } finally {
       await rm(workDir, { recursive: true, force: true });
     }
   });

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -203,7 +203,7 @@ describe('HUD resize hook helpers', () => {
       assert.ok(match);
       const option = `@omx_hook_identity_${match[1]!.replaceAll('-', '_')}_${match[2]}`;
       let hash = 2166136261;
-      for (const character of `omx_hud_resize_7_3_1:1:1:${hookSlot}`) {
+      for (const character of `omx_hud_resize_7_3_1:${hookSlot}`) {
         hash = Math.imul(hash ^ character.charCodeAt(0), 16777619);
       }
       return { option, predicate: `#{==:${option},omx-${(hash >>> 0).toString(16)}}` };
@@ -223,6 +223,32 @@ describe('HUD resize hook helpers', () => {
           : `set-hook -u -t $7 ${hookSlot} ; set-option -u -t $7 ${identity.option}`,
       );
       assert.equal(guarded[index]?.[6], '');
+    }
+  });
+
+  it('reuses registered hook identities during cleanup without live pane PIDs', () => {
+    const registrationCalls: string[][] = [];
+    assert.equal(registerHudResizeHook('%9', '%1', 3, (args) => {
+      registrationCalls.push(args);
+      return hookAuthority(args) ?? '';
+    }), true);
+
+    const identitiesBySlot = new Map<string, string>();
+    for (const args of registrationCalls.filter((call) => call[0] === 'set-hook')) {
+      const slotIndex = args[1] === '-w' ? 4 : 3;
+      identitiesBySlot.set(args[slotIndex]!, args.at(-1)!);
+    }
+
+    const cleanupCalls: string[][] = [];
+    assert.equal(unregisterHudResizeHook('%1', (args) => {
+      cleanupCalls.push(args);
+      return hookAuthority(args) ?? '';
+    }), true);
+
+    for (const args of cleanupCalls.filter((call) => call[0] === 'if-shell')) {
+      const hookSlot = [...identitiesBySlot.keys()].find((slot) => args[5]?.includes(slot));
+      assert.ok(hookSlot);
+      assert.match(args[4] ?? '', new RegExp(`${identitiesBySlot.get(hookSlot)}\\}$`));
     }
   });
 
@@ -263,8 +289,8 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%10', '%1', 3, sameLeader), true);
     const recreatedResizeSlots = recreated.filter((args) => args[3]?.startsWith('client-resized['));
     assert.equal(recreatedResizeSlots[0]?.[3], recreatedResizeSlots[1]?.[3]);
-    assert.notEqual(recreated[0]?.at(-1), recreated[2]?.at(-1));
-    assert.notEqual(recreated[1]?.at(-1), recreated[3]?.at(-1));
+    assert.equal(recreated[0]?.at(-1), recreated[2]?.at(-1));
+    assert.equal(recreated[1]?.at(-1), recreated[3]?.at(-1));
   });
 });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -7,6 +7,7 @@ import {
   buildHudLayoutHookSlot,
   buildHudResizeHookName,
   buildHudResizeHookSlot,
+  buildHudSplitHookSlot,
   buildHudWatchCommand,
   createHudWatchPane,
   findHudSplitOperationMarkerPaneId,
@@ -39,8 +40,12 @@ describe('HUD resize hook helpers', () => {
   it('builds deterministic bounded hook names and slots', () => {
     const hookName = buildHudResizeHookName('$7', '@3', '%1');
     assert.equal(hookName, 'omx_hud_resize_7_3_1');
-    for (const slot of [buildHudResizeHookSlot(hookName), buildHudLayoutHookSlot(hookName)]) {
-      assert.match(slot, /^(?:client-resized|after-split-window)\[\d+\]$/);
+    for (const slot of [
+      buildHudResizeHookSlot(hookName),
+      buildHudLayoutHookSlot(hookName),
+      buildHudSplitHookSlot(hookName),
+    ]) {
+      assert.match(slot, /^(?:client-resized|window-layout-changed|after-split-window)\[\d+\]$/);
       const index = Number.parseInt(slot.replace(/^.*\[|\]$/g, ''), 10);
       assert.ok(index >= 0 && index < 2147483647);
     }
@@ -61,6 +66,7 @@ describe('HUD resize hook helpers', () => {
       hookName: 'omx_hud_resize_7_3_1',
       hookSlot: buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
       layoutHookSlot: buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
+      splitHookSlot: buildHudSplitHookSlot('omx_hud_resize_7_3_1'),
     });
     assert.equal(parseHudResizeHookContext('$7; touch /tmp/owned\t@3\n', '%1'), null);
     assert.equal(parseHudResizeHookContext('$7\t@3$(touch /tmp/owned)\n', '%1'), null);
@@ -75,28 +81,36 @@ describe('HUD resize hook helpers', () => {
     });
     const hookSlot = buildHudResizeHookSlot('omx_hud_resize_7_3_1');
     const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
-    const registrations = calls.filter((args) => args[0] === 'set-hook' && args[1] === '-t');
+    const splitHookSlot = buildHudSplitHookSlot('omx_hud_resize_7_3_1');
+    const registrations = calls.filter((args) => args[0] === 'set-hook');
+    const registrationSlot = (args: string[]): string | undefined => args[1] === '-w' ? args[4] : args[3];
+    const registrationCommand = (args: string[]): string | undefined => args[1] === '-w' ? args[5] : args[4];
 
     assert.equal(result, true);
     assert.deepEqual(calls[0], ['list-panes', '-a', '-F', '#{pane_id} #{pane_dead} #{pane_pid}']);
     assert.deepEqual(calls[1], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
-    assert.equal(registrations[0]?.[2], '$7');
-    assert.equal(registrations[0]?.[3], hookSlot);
-    assert.match(registrations[0]?.[4] ?? '', /^run-shell -b /);
+    assert.deepEqual(registrations[0]?.slice(1, 4), ['-t', '$7', hookSlot]);
+    assert.match(registrationCommand(registrations[0]!) ?? '', /^run-shell -b /);
     for (const token of ['if-shell', 'pane_id', '%1', 'pane_pid', '101', '%9', '109']) {
-      assert.match(registrations[0]?.[4] ?? '', new RegExp(token));
+      assert.match(registrationCommand(registrations[0]!) ?? '', new RegExp(token));
     }
-    assert.match(registrations[0]?.[4] ?? '', /resize-pane/);
-    assert.match(registrations[0]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
+    assert.match(registrationCommand(registrations[0]!) ?? '', /resize-pane/);
+    assert.match(registrationCommand(registrations[0]!) ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
     for (const registration of registrations) {
-      assert.equal(registration[5], ';');
-      assert.deepEqual(registration.slice(6, 9), ['set-option', '-t', '$7']);
+      const suffixIndex = registration[1] === '-w' ? 6 : 5;
+      assert.equal(registration[suffixIndex], ';');
+      assert.deepEqual(registration.slice(suffixIndex + 1, suffixIndex + 4), ['set-option', '-t', '$7']);
     }
-    assert.equal(registrations[1]?.[3], layoutHookSlot);
-    assert.match(layoutHookSlot, /^after-split-window\[/);
-    assert.match(registrations[1]?.[4] ?? '', /--reconcile-tmux/);
-    assert.match(registrations[1]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
-    assert.doesNotMatch(registrations[1]?.[4] ?? '', /\\; /);
+    assert.deepEqual(
+      registrations.slice(1).map(registrationSlot),
+      [splitHookSlot, layoutHookSlot],
+    );
+    assert.deepEqual(registrations[2]?.slice(1, 5), ['-w', '-t', '@3', layoutHookSlot]);
+    for (const registration of registrations.slice(1)) {
+      assert.match(registrationCommand(registration) ?? '', /--reconcile-tmux/);
+      assert.match(registrationCommand(registration) ?? '', /OMX_TMUX_HUD_OWNER/);
+      assert.doesNotMatch(registrationCommand(registration) ?? '', /\\; /);
+    }
   });
 
   it('guards registered hooks against recycled leader or HUD pane IDs', () => {
@@ -106,8 +120,8 @@ describe('HUD resize hook helpers', () => {
       return hookAuthority(args) ?? '';
     }), true);
     const commands = calls
-      .filter((args) => args[0] === 'set-hook' && args[1] === '-t')
-      .map((args) => args[4] ?? '');
+      .filter((args) => args[0] === 'set-hook')
+      .map((args) => args[1] === '-w' ? (args[5] ?? '') : (args[4] ?? ''));
     assert.ok(commands.length >= 1);
     for (const command of commands) {
       for (const token of ['pane_id', '%1', 'pane_pid', '101', '%9', '109']) {
@@ -164,12 +178,12 @@ describe('HUD resize hook helpers', () => {
     const layoutHookSlot = buildHudLayoutHookSlot('omx_hud_resize_7_3_1');
     const result = registerHudResizeHook('%9', '%1', 3, (args) => {
       calls.push(args);
-      if (args[0] === 'set-hook' && args[3] === layoutHookSlot) throw new Error('layout hook rejected');
+      if (args[0] === 'set-hook' && args.includes(layoutHookSlot)) throw new Error('layout hook rejected');
       return hookAuthority(args) ?? '';
     });
     assert.equal(result, false);
     assert.ok(calls.some((args) => args[0] === 'set-hook' && args[3] === buildHudResizeHookSlot('omx_hud_resize_7_3_1')));
-    assert.ok(calls.some((args) => args[0] === 'set-hook' && args[3] === layoutHookSlot));
+    assert.ok(calls.some((args) => args[0] === 'set-hook' && args.includes(layoutHookSlot)));
   });
 
 
@@ -181,15 +195,15 @@ describe('HUD resize hook helpers', () => {
     }), true);
     assert.deepEqual(calls[0], ['display-message', '-p', '-t', '%1', '#{session_id}\t#{window_id}']);
     const guarded = calls.filter((args) => args[0] === 'if-shell');
-    assert.equal(guarded.length, 2);
-    assert.deepEqual(guarded.map((args) => args[3]), ['$7', '$7']);
+    assert.equal(guarded.length, 3);
+    assert.deepEqual(guarded.map((args) => args[3]), ['$7', '$7', '$7']);
 
     const expectedIdentity = (hookSlot: string): { option: string; predicate: string } => {
-      const match = /^(client-resized|after-split-window)\[([0-9]+)\]$/.exec(hookSlot);
+      const match = /^(client-resized|window-layout-changed|after-split-window)\[([0-9]+)\]$/.exec(hookSlot);
       assert.ok(match);
       const option = `@omx_hook_identity_${match[1]!.replaceAll('-', '_')}_${match[2]}`;
       let hash = 2166136261;
-      for (const character of `omx_hud_resize_7_3_1:${hookSlot}`) {
+      for (const character of `omx_hud_resize_7_3_1:1:1:${hookSlot}`) {
         hash = Math.imul(hash ^ character.charCodeAt(0), 16777619);
       }
       return { option, predicate: `#{==:${option},omx-${(hash >>> 0).toString(16)}}` };
@@ -197,13 +211,16 @@ describe('HUD resize hook helpers', () => {
 
     for (const [index, hookSlot] of [
       buildHudResizeHookSlot('omx_hud_resize_7_3_1'),
+      buildHudSplitHookSlot('omx_hud_resize_7_3_1'),
       buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
     ].entries()) {
       const identity = expectedIdentity(hookSlot);
       assert.equal(guarded[index]?.[4], identity.predicate);
       assert.equal(
         guarded[index]?.[5],
-        `set-hook -u -t $7 ${hookSlot} ; set-option -u -t $7 ${identity.option}`,
+        hookSlot.startsWith('window-layout-changed[')
+          ? `set-hook -u -w -t @3 ${hookSlot} ; set-option -u -t $7 ${identity.option}`
+          : `set-hook -u -t $7 ${hookSlot} ; set-option -u -t $7 ${identity.option}`,
       );
       assert.equal(guarded[index]?.[6], '');
     }
@@ -218,7 +235,12 @@ describe('HUD resize hook helpers', () => {
       return hookAuthority(args) ?? '';
     });
     assert.equal(result, false);
-    assert.ok(calls.some((args) => args[0] === 'if-shell' && (args[5] ?? '').includes(buildHudLayoutHookSlot('omx_hud_resize_7_3_1'))));
+    for (const hookSlot of [
+      buildHudSplitHookSlot('omx_hud_resize_7_3_1'),
+      buildHudLayoutHookSlot('omx_hud_resize_7_3_1'),
+    ]) {
+      assert.ok(calls.some((args) => args[0] === 'if-shell' && (args[5] ?? '').includes(hookSlot)));
+    }
   });
 
   it('uses distinct slots across windows and leaders while retaining a leader slot across HUD recreation', () => {
@@ -241,6 +263,8 @@ describe('HUD resize hook helpers', () => {
     assert.equal(registerHudResizeHook('%10', '%1', 3, sameLeader), true);
     const recreatedResizeSlots = recreated.filter((args) => args[3]?.startsWith('client-resized['));
     assert.equal(recreatedResizeSlots[0]?.[3], recreatedResizeSlots[1]?.[3]);
+    assert.notEqual(recreated[0]?.at(-1), recreated[2]?.at(-1));
+    assert.notEqual(recreated[1]?.at(-1), recreated[3]?.at(-1));
   });
 });
 

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -88,6 +88,10 @@ describe('HUD resize hook helpers', () => {
     }
     assert.match(registrations[0]?.[4] ?? '', /resize-pane/);
     assert.match(registrations[0]?.[4] ?? '', new RegExp(`sleep ${HUD_RESIZE_RECONCILE_DELAY_SECONDS}`));
+    for (const registration of registrations) {
+      assert.equal(registration[5], ';');
+      assert.deepEqual(registration.slice(6, 9), ['set-option', '-t', '$7']);
+    }
     assert.equal(registrations[1]?.[3], layoutHookSlot);
     assert.match(registrations[1]?.[4] ?? '', /--reconcile-tmux/);
     assert.match(registrations[1]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);

--- a/src/hud/__tests__/tmux.test.ts
+++ b/src/hud/__tests__/tmux.test.ts
@@ -40,7 +40,7 @@ describe('HUD resize hook helpers', () => {
     const hookName = buildHudResizeHookName('$7', '@3', '%1');
     assert.equal(hookName, 'omx_hud_resize_7_3_1');
     for (const slot of [buildHudResizeHookSlot(hookName), buildHudLayoutHookSlot(hookName)]) {
-      assert.match(slot, /^(?:client-resized|window-layout-changed)\[\d+\]$/);
+      assert.match(slot, /^(?:client-resized|after-split-window)\[\d+\]$/);
       const index = Number.parseInt(slot.replace(/^.*\[|\]$/g, ''), 10);
       assert.ok(index >= 0 && index < 2147483647);
     }
@@ -93,8 +93,10 @@ describe('HUD resize hook helpers', () => {
       assert.deepEqual(registration.slice(6, 9), ['set-option', '-t', '$7']);
     }
     assert.equal(registrations[1]?.[3], layoutHookSlot);
+    assert.match(layoutHookSlot, /^after-split-window\[/);
     assert.match(registrations[1]?.[4] ?? '', /--reconcile-tmux/);
     assert.match(registrations[1]?.[4] ?? '', /OMX_TMUX_HUD_OWNER/);
+    assert.doesNotMatch(registrations[1]?.[4] ?? '', /\\; /);
   });
 
   it('guards registered hooks against recycled leader or HUD pane IDs', () => {
@@ -111,6 +113,8 @@ describe('HUD resize hook helpers', () => {
       for (const token of ['pane_id', '%1', 'pane_pid', '101', '%9', '109']) {
         assert.match(command, new RegExp(token));
       }
+      assert.match(command, /##\{pane_id}/);
+      assert.match(command, /##\{pane_pid}/);
     }
   });
 
@@ -181,7 +185,7 @@ describe('HUD resize hook helpers', () => {
     assert.deepEqual(guarded.map((args) => args[3]), ['$7', '$7']);
 
     const expectedIdentity = (hookSlot: string): { option: string; predicate: string } => {
-      const match = /^(client-resized|window-layout-changed)\[([0-9]+)\]$/.exec(hookSlot);
+      const match = /^(client-resized|after-split-window)\[([0-9]+)\]$/.exec(hookSlot);
       assert.ok(match);
       const option = `@omx_hook_identity_${match[1]!.replaceAll('-', '_')}_${match[2]}`;
       let hash = 2166136261;
@@ -199,7 +203,7 @@ describe('HUD resize hook helpers', () => {
       assert.equal(guarded[index]?.[4], identity.predicate);
       assert.equal(
         guarded[index]?.[5],
-        `set-hook -u -t $7 ${hookSlot} \\; set-option -u -t $7 ${identity.option}`,
+        `set-hook -u -t $7 ${hookSlot} ; set-option -u -t $7 ${identity.option}`,
       );
       assert.equal(guarded[index]?.[6], '');
     }

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { readAllState, readHudConfig } from './state.js';
 import { getHudRenderMaxLines } from './render.js';
 import { HUD_TMUX_HEIGHT_LINES, isTmuxWindowTooCrampedForHudSplit } from './constants.js';
@@ -189,6 +190,10 @@ function needsHudTopologyRecreate(pane: TmuxPaneSnapshot, leaderPane?: TmuxPaneS
   const expectedLeft = typeof leaderPane?.paneLeft === 'number' ? leaderPane.paneLeft : 0;
   const expectedWidth = typeof leaderPane?.paneWidth === 'number' ? leaderPane.paneWidth : pane.windowWidth;
   const spansExpectedWidth = pane.paneLeft === expectedLeft && pane.paneWidth === expectedWidth;
+  if (typeof pane.paneTop === 'number' && typeof leaderPane?.paneBottom === 'number') {
+    const sitsImmediatelyBelowLeader = pane.paneTop === leaderPane.paneBottom + 2;
+    return !spansExpectedWidth || !sitsImmediatelyBelowLeader;
+  }
   const touchesWindowBottom = pane.paneBottom === (pane.windowHeight ?? 0) - 1;
   return !spansExpectedWidth || !touchesWindowBottom;
 }
@@ -229,6 +234,8 @@ function planOwnedHudPaneDedupe(
 }
 
 const HUD_RECONCILE_LOCK_STALE_MS = 10_000;
+const HUD_RECONCILE_LOCK_RETRY_MS = 50;
+const HUD_RECONCILE_LOCK_WAIT_MS = 2_000;
 
 interface HudReconcileLock {
   path: string;
@@ -339,6 +346,36 @@ async function acquireHudReconcileLock(
   return tryCreateHudReconcileLock(lockPath, nowMs);
 }
 
+async function isFreshHudReconcileLock(
+  lockPath: string,
+  nowMs: number,
+  staleMs: number,
+): Promise<boolean> {
+  const owner = await readHudReconcileLockOwner(lockPath);
+  const lockStat = await stat(lockPath).catch(() => null);
+  if (!lockStat) return true;
+  const acquiredMs = parseIsoMs(owner?.acquired_at);
+  const ageMs = acquiredMs === null ? nowMs - lockStat.mtimeMs : nowMs - acquiredMs;
+  return ageMs <= staleMs;
+}
+
+async function waitForHudReconcileLock(
+  lockPath: string,
+  nowMs: () => number,
+  staleMs: number,
+  isProcessLive: (pid: number) => boolean | null,
+): Promise<HudReconcileLock | null> {
+  const attempts = Math.ceil(HUD_RECONCILE_LOCK_WAIT_MS / HUD_RECONCILE_LOCK_RETRY_MS) + 1;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const observedNow = nowMs();
+    const lock = await acquireHudReconcileLock(lockPath, observedNow, staleMs, isProcessLive);
+    if (lock) return lock;
+    if (!(await isFreshHudReconcileLock(lockPath, observedNow, staleMs))) return null;
+    if (attempt < attempts - 1) await sleep(HUD_RECONCILE_LOCK_RETRY_MS);
+  }
+  return null;
+}
+
 async function releaseHudReconcileLock(lock: HudReconcileLock): Promise<void> {
   const releasePath = `${lock.path}.release.${process.pid}.${Date.now()}.${lock.token}`;
   try {
@@ -396,12 +433,15 @@ export async function reconcileHudForPromptSubmit(
   const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
 
+  // Layout-change hooks for every OMX pane in a window may fire together. Keep
+  // tmux layout mutations serialized, but wait briefly for a fresh holder so a
+  // neighboring leader's one-shot hook does not get dropped as concurrent.
   const lockPath = join(cwd, '.omx', 'state', 'hud-reconcile.lock');
   const lockDirReady = await mkdir(dirname(lockPath), { recursive: true }).then(() => true).catch(() => false);
   const lock = lockDirReady
-    ? await acquireHudReconcileLock(
+    ? await waitForHudReconcileLock(
       lockPath,
-      deps.nowMs?.() ?? Date.now(),
+      deps.nowMs ?? Date.now,
       HUD_RECONCILE_LOCK_STALE_MS,
       deps.isProcessLive ?? defaultIsProcessLive,
     )

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -175,6 +175,34 @@ function ensureHudResizeHook(
   }
 }
 
+function rearmHudResizeHookAfterConcurrentSkip(
+  cwd: string,
+  currentPaneId: string | undefined,
+  owner: HudPaneOwner,
+  listPanes: (currentPaneId?: string) => TmuxPaneSnapshot[],
+  deps: ReconcileHudForPromptSubmitDeps,
+): void {
+  if (!currentPaneId) return;
+  try {
+    const panes = listPanes(currentPaneId);
+    const hudPaneIds = [
+      ...findHudWatchPaneIds(panes, currentPaneId, owner),
+      ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),
+    ];
+    const hudPane = panes.find((pane) => pane.paneId === hudPaneIds[0]);
+    if (!hudPane) return;
+    ensureHudResizeHook(
+      hudPane.paneId,
+      currentPaneId,
+      hudPane.paneHeight ?? HUD_TMUX_HEIGHT_LINES,
+      cwd,
+      deps,
+    );
+  } catch {
+    // Best effort: a concurrent reconciliation still owns the mutation lock.
+  }
+}
+
 function hasCompleteGeometry(pane: TmuxPaneSnapshot): boolean {
   return (
     typeof pane.paneLeft === 'number'
@@ -421,6 +449,20 @@ export async function reconcileHudForPromptSubmit(
   const createPane = deps.createHudWatchPane ?? ((hudCwd, hudCmd, options) => createHudWatchPane(hudCwd, hudCmd, options));
   const killPane = deps.killTmuxPane ?? ((paneId) => killTmuxPane(paneId));
   const resizePane = deps.resizeTmuxPane ?? ((paneId, lines) => resizeTmuxPane(paneId, lines));
+  const currentPaneId = env.TMUX_PANE?.trim();
+  const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
+  const equivalentSessionIds = [
+    resolvedSessionId,
+    env.OMX_SESSION_ID?.trim(),
+    ...(deps.sessionIds ?? []),
+  ]
+    .map((sessionId) => sessionId?.trim() ?? '')
+    .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
+  const owner = {
+    sessionId: resolvedSessionId,
+    sessionIds: equivalentSessionIds,
+    leaderPaneId: currentPaneId,
+  };
 
   // Layout-change hooks for every OMX pane in a window may fire together. Keep
   // tmux layout mutations serialized, but wait briefly for a fresh holder so a
@@ -436,6 +478,7 @@ export async function reconcileHudForPromptSubmit(
     )
     : null;
   if (lockDirReady && !lock) {
+    rearmHudResizeHookAfterConcurrentSkip(cwd, currentPaneId, owner, listPanes, deps);
     return {
       status: 'skipped_concurrent',
       paneId: null,
@@ -445,16 +488,6 @@ export async function reconcileHudForPromptSubmit(
   }
 
   try {
-
-  const currentPaneId = env.TMUX_PANE?.trim();
-  const resolvedSessionId = deps.sessionId?.trim() || env.OMX_SESSION_ID?.trim() || undefined;
-  const equivalentSessionIds = [
-    resolvedSessionId,
-    env.OMX_SESSION_ID?.trim(),
-    ...(deps.sessionIds ?? []),
-  ]
-    .map((sessionId) => sessionId?.trim() ?? '')
-    .filter((sessionId, index, sessionIds) => sessionId !== '' && sessionIds.indexOf(sessionId) === index);
   let panes = listPanes(currentPaneId);
 
   // Reclaim orphaned HUD panes left behind by a destroyed leader before deciding
@@ -487,11 +520,6 @@ export async function reconcileHudForPromptSubmit(
     panes = panes.filter((pane) => !reapedPaneIdSet.has(pane.paneId));
   }
 
-  const owner = {
-    sessionId: resolvedSessionId,
-    sessionIds: equivalentSessionIds,
-    leaderPaneId: currentPaneId,
-  };
   const hudPaneIds = [
     ...findHudWatchPaneIds(panes, currentPaneId, owner),
     ...findLegacyFocusedHudWatchPaneIds(panes, currentPaneId),

--- a/src/hud/reconcile.ts
+++ b/src/hud/reconcile.ts
@@ -198,17 +198,6 @@ function needsHudTopologyRecreate(pane: TmuxPaneSnapshot, leaderPane?: TmuxPaneS
   return !spansExpectedWidth || !touchesWindowBottom;
 }
 
-function shouldCreateFullWidthHud(leaderPane?: TmuxPaneSnapshot): boolean {
-  return Boolean(
-    leaderPane
-    && typeof leaderPane.paneLeft === 'number'
-    && typeof leaderPane.paneWidth === 'number'
-    && typeof leaderPane.windowWidth === 'number'
-    && leaderPane.paneLeft === 0
-    && leaderPane.paneWidth === leaderPane.windowWidth,
-  );
-}
-
 function needsHudHeightResize(pane: TmuxPaneSnapshot, desiredHeight: number): boolean {
   return typeof pane.paneHeight !== 'number' || pane.paneHeight !== desiredHeight;
 }
@@ -561,7 +550,7 @@ export async function reconcileHudForPromptSubmit(
   const createFullWidth = hudPaneIds
     .map((paneId) => panes.find((pane) => pane.paneId === paneId))
     .some((pane) => Boolean(pane && needsHudTopologyRecreate(pane, leaderPane)))
-    && (!leaderPane || shouldCreateFullWidthHud(leaderPane));
+    && !leaderPane;
 
   if (!resolvedSessionId) {
     return {

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -769,18 +769,16 @@ function hudHookIdentityOption(hookSlot: string): string {
   return `@omx_hook_identity_${match[1].replaceAll('-', '_')}_${match[2]}`;
 }
 
-function hudHookIdentityToken(context: HudResizeHookContext, hookSlot: string): string {
+function hudHookIdentityToken(hookName: string, hookSlot: string): string {
   let hash = 2166136261;
-  for (const char of `${context.hookName}:${context.leaderPanePid}:${context.hudPanePid}:${hookSlot}`) {
-    hash = Math.imul(hash ^ char.charCodeAt(0), 16777619);
-  }
+  for (const char of `${hookName}:${hookSlot}`) hash = Math.imul(hash ^ char.charCodeAt(0), 16777619);
   return `omx-${(hash >>> 0).toString(16)}`;
 }
 
 function buildHudHookRegistrationSuffix(context: HudResizeHookContext, hookSlot: string): string[] {
   return [
     ';', 'set-option', '-t', context.sessionId,
-    hudHookIdentityOption(hookSlot), hudHookIdentityToken(context, hookSlot),
+    hudHookIdentityOption(hookSlot), hudHookIdentityToken(context.hookName, hookSlot),
   ];
 }
 
@@ -794,7 +792,7 @@ function buildGuardedHudHookUnregisterArgs(context: HudResizeHookContext, hookSl
   const identityOption = hudHookIdentityOption(hookSlot);
   return [
     'if-shell', '-F', '-t', context.sessionId,
-    `#{==:${identityOption},${hudHookIdentityToken(context, hookSlot)}}`,
+    `#{==:${identityOption},${hudHookIdentityToken(context.hookName, hookSlot)}}`,
     `${buildHudHookUnsetCommand(context, hookSlot)} ; set-option -u -t ${context.sessionId} ${identityOption}`,
     '',
   ];
@@ -918,7 +916,7 @@ function deferTmuxHookFormatExpansion(command: string): string {
 
 function buildHudHookSelfUnregister(context: HudResizeHookContext): string {
   const identityOption = hudHookIdentityOption(context.hookSlot);
-  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`${buildHudHookUnsetCommand(context, context.hookSlot)} ; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
+  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context.hookName, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`${buildHudHookUnsetCommand(context, context.hookSlot)} ; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
 }
 
 function buildAtomicHudHookCommand(

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -752,11 +752,11 @@ export function buildHudLayoutHookSlot(hookName: string): string {
   for (let i = 0; i < hookName.length; i++) {
     hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
   }
-  return `window-layout-changed[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+  return `after-split-window[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 function hudHookIdentityOption(hookSlot: string): string {
-  const match = /^(client-resized|window-layout-changed)\[([0-9]+)\]$/.exec(hookSlot);
+  const match = /^(client-resized|after-split-window)\[([0-9]+)\]$/.exec(hookSlot);
   if (!match) throw new Error('invalid_tmux_hook_slot');
   return `@omx_hook_identity_${match[1].replaceAll('-', '_')}_${match[2]}`;
 }
@@ -779,7 +779,7 @@ function buildGuardedHudHookUnregisterArgs(context: HudResizeHookContext, hookSl
   return [
     'if-shell', '-F', '-t', context.sessionId,
     `#{==:${identityOption},${hudHookIdentityToken(context.hookName, hookSlot)}}`,
-    `set-hook -u -t ${context.sessionId} ${hookSlot} \\; set-option -u -t ${context.sessionId} ${identityOption}`,
+    `set-hook -u -t ${context.sessionId} ${hookSlot} ; set-option -u -t ${context.sessionId} ${identityOption}`,
     '',
   ];
 }
@@ -894,9 +894,13 @@ function buildHudHookIncarnationCondition(paneId: string, panePid: string): stri
   return `#{&&:#{==:#{pane_id},${paneId}},#{&&:#{==:#{pane_dead},0},#{==:#{pane_pid},${panePid}}}}`;
 }
 
+function deferTmuxHookFormatExpansion(command: string): string {
+  return command.replaceAll('#{', '##{');
+}
+
 function buildHudHookSelfUnregister(context: HudResizeHookContext): string {
   const identityOption = hudHookIdentityOption(context.hookSlot);
-  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context.hookName, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`set-hook -u -t ${context.sessionId} ${context.hookSlot} \\; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
+  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context.hookName, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`set-hook -u -t ${context.sessionId} ${context.hookSlot} ; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
 }
 
 function buildAtomicHudHookCommand(
@@ -921,12 +925,13 @@ function buildAtomicHudHookCommand(
   if (process.platform === 'win32') {
     const quotePowerShell = (value: string) => `'${value.replace(/'/g, "''")}'`;
     const invoke = `& ${quotePowerShell(tmuxBin)} ${args.map(quotePowerShell).join(' ')}`;
-    return tmuxEnv
+    const command = tmuxEnv
       ? `& { $env:TMUX = ${quotePowerShell(tmuxEnv)}; ${invoke} } | Out-Null`
       : `${invoke} | Out-Null`;
+    return deferTmuxHookFormatExpansion(command);
   }
   const command = buildNestedTmuxCommand(tmuxBin, args, tmuxEnv);
-  return `${command} >/dev/null 2>&1 || true`;
+  return `${deferTmuxHookFormatExpansion(command)} >/dev/null 2>&1 || true`;
 }
 
 function buildAtomicHudResizeCommand(
@@ -983,10 +988,10 @@ function buildHudLayoutReconcileHookCommand(
   const layoutContext = { ...context, hookSlot: context.layoutHookSlot };
   if (process.platform === 'win32') {
     const nativeReconcile = `Set-Location -LiteralPath '${cwd.replace(/'/g, "''")}'; & '${process.execPath.replace(/'/g, "''")}' '${omxBin.replace(/'/g, "''")}' hud --reconcile-tmux | Out-Null`;
-    const success = `${buildHudHookSelfUnregister(layoutContext)} \\; run-shell -b ${quoteHudHookShellArgument(nativeReconcile)}`;
+    const success = `${buildHudHookSelfUnregister(layoutContext)} ; run-shell -b ${quoteHudHookShellArgument(nativeReconcile)}`;
     return buildAtomicHudHookCommand(tmuxBin, layoutContext, success, env.TMUX);
   }
-  const success = `${buildHudHookSelfUnregister(layoutContext)} \\; run-shell -b ${quoteHudHookShellArgument(`${reconcile} >/dev/null 2>&1`)}`;
+  const success = `${buildHudHookSelfUnregister(layoutContext)} ; run-shell -b ${quoteHudHookShellArgument(`${reconcile} >/dev/null 2>&1`)}`;
   return buildAtomicHudHookCommand(tmuxBin, layoutContext, success, env.TMUX);
 }
 
@@ -1435,7 +1440,7 @@ function rollbackRecoveredHudSplitPane(
     return parseExactTmuxAuthorityScalar(execTmuxSync([
       'if-shell', '-F', '-t', paneId,
       condition,
-      `kill-pane -t ${paneId} \\; display-message -p ${receipt}`,
+      `kill-pane -t ${paneId} ; display-message -p ${receipt}`,
       `display-message -p __omx_hud_rollback_rejected_${receipt}`,
     ])) === receipt;
   } catch {
@@ -1612,7 +1617,7 @@ export function mutateHudWatchPaneIfCurrent(
     const output = execTmuxSync([
       'if-shell', '-F', '-t', canonicalPaneId,
       condition,
-      `${mutation} \\; display-message -p ${marker}`,
+      `${mutation} ; display-message -p ${marker}`,
       `display-message -p __omx_hud_mutation_failed_${marker}`,
     ]);
     return parseExactTmuxAuthorityScalar(output) === marker;
@@ -1635,7 +1640,7 @@ function mutateTmuxPaneIfCurrent(
     const output = execTmuxSync([
       'if-shell', '-F', '-t', canonicalPaneId,
       buildHudHookIncarnationCondition(canonicalPaneId, expectedPanePid),
-      `${mutation} \\; display-message -p ${marker}`,
+      `${mutation} ; display-message -p ${marker}`,
       `display-message -p __omx_hud_mutation_failed_${marker}`,
     ]);
     return parseExactTmuxAuthorityScalar(output) === marker;

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -769,7 +769,7 @@ function hudHookIdentityToken(hookName: string, hookSlot: string): string {
 
 function buildHudHookRegistrationSuffix(context: HudResizeHookContext, hookSlot: string): string[] {
   return [
-    '\\;', 'set-option', '-t', context.sessionId,
+    ';', 'set-option', '-t', context.sessionId,
     hudHookIdentityOption(hookSlot), hudHookIdentityToken(context.hookName, hookSlot),
   ];
 }

--- a/src/hud/tmux.ts
+++ b/src/hud/tmux.ts
@@ -752,34 +752,50 @@ export function buildHudLayoutHookSlot(hookName: string): string {
   for (let i = 0; i < hookName.length; i++) {
     hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
   }
+  return `window-layout-changed[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
+}
+
+export function buildHudSplitHookSlot(hookName: string): string {
+  let hash = 0;
+  for (let i = 0; i < hookName.length; i++) {
+    hash = (hash * 31 + hookName.charCodeAt(i)) | 0;
+  }
   return `after-split-window[${Math.abs(hash) % TMUX_HOOK_INDEX_MAX}]`;
 }
 
 function hudHookIdentityOption(hookSlot: string): string {
-  const match = /^(client-resized|after-split-window)\[([0-9]+)\]$/.exec(hookSlot);
+  const match = /^(client-resized|window-layout-changed|after-split-window)\[([0-9]+)\]$/.exec(hookSlot);
   if (!match) throw new Error('invalid_tmux_hook_slot');
   return `@omx_hook_identity_${match[1].replaceAll('-', '_')}_${match[2]}`;
 }
 
-function hudHookIdentityToken(hookName: string, hookSlot: string): string {
+function hudHookIdentityToken(context: HudResizeHookContext, hookSlot: string): string {
   let hash = 2166136261;
-  for (const char of `${hookName}:${hookSlot}`) hash = Math.imul(hash ^ char.charCodeAt(0), 16777619);
+  for (const char of `${context.hookName}:${context.leaderPanePid}:${context.hudPanePid}:${hookSlot}`) {
+    hash = Math.imul(hash ^ char.charCodeAt(0), 16777619);
+  }
   return `omx-${(hash >>> 0).toString(16)}`;
 }
 
 function buildHudHookRegistrationSuffix(context: HudResizeHookContext, hookSlot: string): string[] {
   return [
     ';', 'set-option', '-t', context.sessionId,
-    hudHookIdentityOption(hookSlot), hudHookIdentityToken(context.hookName, hookSlot),
+    hudHookIdentityOption(hookSlot), hudHookIdentityToken(context, hookSlot),
   ];
+}
+
+function buildHudHookUnsetCommand(context: HudResizeHookContext, hookSlot: string): string {
+  return hookSlot.startsWith('window-layout-changed[')
+    ? `set-hook -u -w -t ${context.windowId} ${hookSlot}`
+    : `set-hook -u -t ${context.sessionId} ${hookSlot}`;
 }
 
 function buildGuardedHudHookUnregisterArgs(context: HudResizeHookContext, hookSlot: string): string[] {
   const identityOption = hudHookIdentityOption(hookSlot);
   return [
     'if-shell', '-F', '-t', context.sessionId,
-    `#{==:${identityOption},${hudHookIdentityToken(context.hookName, hookSlot)}}`,
-    `set-hook -u -t ${context.sessionId} ${hookSlot} ; set-option -u -t ${context.sessionId} ${identityOption}`,
+    `#{==:${identityOption},${hudHookIdentityToken(context, hookSlot)}}`,
+    `${buildHudHookUnsetCommand(context, hookSlot)} ; set-option -u -t ${context.sessionId} ${identityOption}`,
     '',
   ];
 }
@@ -794,6 +810,7 @@ export interface HudResizeHookContext {
   hookName: string;
   hookSlot: string;
   layoutHookSlot: string;
+  splitHookSlot: string;
 }
 
 function readHudResizeHookPaneIncarnations(
@@ -847,6 +864,7 @@ export function parseHudResizeHookContext(
     hookName,
     hookSlot: buildHudResizeHookSlot(hookName),
     layoutHookSlot: buildHudLayoutHookSlot(hookName),
+    splitHookSlot: buildHudSplitHookSlot(hookName),
   };
 }
 
@@ -900,7 +918,7 @@ function deferTmuxHookFormatExpansion(command: string): string {
 
 function buildHudHookSelfUnregister(context: HudResizeHookContext): string {
   const identityOption = hudHookIdentityOption(context.hookSlot);
-  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context.hookName, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`set-hook -u -t ${context.sessionId} ${context.hookSlot} ; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
+  return `if-shell -F -t ${context.sessionId} ${quoteHudHookShellArgument(`#{==:${identityOption},${hudHookIdentityToken(context, context.hookSlot)}}`)} ${quoteHudHookShellArgument(`${buildHudHookUnsetCommand(context, context.hookSlot)} ; set-option -u -t ${context.sessionId} ${identityOption}`)} ''`;
 }
 
 function buildAtomicHudHookCommand(
@@ -963,6 +981,7 @@ function buildHudLayoutReconcileHookCommand(
   omxBin: string,
   leaderPaneId: string,
   context: HudResizeHookContext,
+  hookSlot: string,
   options: RegisterHudResizeHookOptions = {},
 ): string {
   const env = options.env ?? process.env;
@@ -985,7 +1004,7 @@ function buildHudLayoutReconcileHookCommand(
     'hud',
     '--reconcile-tmux',
   ].join(' ');
-  const layoutContext = { ...context, hookSlot: context.layoutHookSlot };
+  const layoutContext = { ...context, hookSlot };
   if (process.platform === 'win32') {
     const nativeReconcile = `Set-Location -LiteralPath '${cwd.replace(/'/g, "''")}'; & '${process.execPath.replace(/'/g, "''")}' '${omxBin.replace(/'/g, "''")}' hud --reconcile-tmux | Out-Null`;
     const success = `${buildHudHookSelfUnregister(layoutContext)} ; run-shell -b ${quoteHudHookShellArgument(nativeReconcile)}`;
@@ -1751,10 +1770,15 @@ export function registerHudResizeHook(
   }
   if (omxBin) {
     try {
-      const reconcileCmd = shellEscapeSingle(
-        buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, canonicalLeaderPaneId, context, options),
-      );
-      execTmuxSync(['set-hook', '-t', context.sessionId, context.layoutHookSlot, `run-shell -b ${reconcileCmd}`, ...buildHudHookRegistrationSuffix(context, context.layoutHookSlot)]);
+      for (const hookSlot of [context.splitHookSlot, context.layoutHookSlot]) {
+        const reconcileCmd = shellEscapeSingle(
+          buildHudLayoutReconcileHookCommand(tmuxBin, omxBin, canonicalLeaderPaneId, context, hookSlot, options),
+        );
+        const targetArgs = hookSlot === context.layoutHookSlot
+          ? ['-w', '-t', context.windowId]
+          : ['-t', context.sessionId];
+        execTmuxSync(['set-hook', ...targetArgs, hookSlot, `run-shell -b ${reconcileCmd}`, ...buildHudHookRegistrationSuffix(context, hookSlot)]);
+      }
     } catch {
       // Keep the resize hook installed so older tmux builds still recover on
       // client resize even when layout-change hook registration is unavailable.
@@ -1790,10 +1814,12 @@ export function unregisterHudResizeHook(
   } catch {
     ok = false;
   }
-  try {
-    execTmuxSync(buildGuardedHudHookUnregisterArgs(context, context.layoutHookSlot));
-  } catch {
-    ok = false;
+  for (const hookSlot of [context.splitHookSlot, context.layoutHookSlot]) {
+    try {
+      execTmuxSync(buildGuardedHudHookUnregisterArgs(context, hookSlot));
+    } catch {
+      ok = false;
+    }
   }
   return ok;
 }


### PR DESCRIPTION
## Summary

> For normal contributions, target base branch `dev`. Use `main` only when a maintainer explicitly asks for it.

Keep each OMX HUD directly attached below its owning pane after another pane/tab is split into the same tmux window.

The bug had several interacting causes: the registered `window-layout-changed` event is not a real tmux hook, stored pane-authority formats were evaluated against the split event before the guarded command ran, command separators were shell-escaped even though tmux received raw argv, and reconciliation accepted/recreated a full-width HUD at the window bottom instead of beneath its owner.

## Changes

- register a real one-shot `after-split-window` hook and rearm it after reconciliation
- defer pane and hook identity formats until the nested guarded tmux command executes
- pass raw tmux command separators in argv and nested command strings
- require owner-aligned, immediately-adjacent HUD geometry
- recreate through the owner pane rather than forcing a window-level split
- serialize simultaneous owner reconciliations without dropping later one-shot hooks
- add focused unit coverage and a private real-tmux split/rearm regression test

## Validation

- [x] `npm run build`
- [ ] `npm test` — attempted; the repo-wide run hit an unrelated existing real-tmux flake in `detached-launch-diagnostics-3578.test.js`. The unchanged `upstream/dev` baseline reproduced the same file failure (24/25 passed).
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node --test dist/hud/__tests__/tmux.test.js dist/hud/__tests__/reconcile.test.js dist/hud/__tests__/tmux-split-realtmux.test.js` — 109/109 passed, including the real private-server split/rearm scenario
- [ ] `omx doctor` (not applicable; no setup/config behavior changed)

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed — not needed; internal HUD lifecycle behavior is regression-covered
- [x] Backward-compatibility impact considered — existing resize fallback remains; the split hook uses a documented tmux hook

## Related

Reproduced from a live multi-pane fish/tmux session where the OMX HUD remained at the global window bottom after a new tab/pane was created.
