### PR TITLE
feat(hud): add optional GitGuardex finish progress

### DIFF
--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -118,7 +118,7 @@ describe('renderHud – GitGuardex finish', () => {
     }
   });
 
-  it('animates review while it is running', () => {
+  it('advances review animation at the one-second watch cadence', () => {
     const ctx = {
       ...emptyCtx(),
       guardexFinish: {
@@ -134,7 +134,7 @@ describe('renderHud – GitGuardex finish', () => {
     mock.method(Date, 'now', () => 0);
     const first = stripSgr(renderHud(ctx, 'focused'));
     mock.restoreAll();
-    mock.method(Date, 'now', () => 250);
+    mock.method(Date, 'now', () => 1000);
     const second = stripSgr(renderHud(ctx, 'focused'));
 
     assert.match(first, /gx:4\/8 review [◐◓◑◒]/u);

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -20,6 +20,7 @@ import {
   readAutoresearchState,
   readUltraqaState,
   readGuardexFinishState,
+  readHudConfig,
   normalizeHudConfig,
 } from '../state.js';
 
@@ -128,6 +129,20 @@ describe('readGuardexFinishState', () => {
       ]);
 
       assert.equal(await readGuardexFinishState(cwd), null);
+    });
+  });
+});
+
+describe('readHudConfig', () => {
+  it('loads the project-local config when invoked from a nested directory', async () => {
+    await withTempRepo('omx-hud-config-nested-', async (cwd) => {
+      initGitRepo(cwd);
+      const nested = join(cwd, 'packages', 'app');
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(cwd, '.omx', 'hud-config.json'), JSON.stringify({ guardex: { enabled: true } }));
+
+      assert.equal((await readHudConfig(nested)).guardex?.enabled, true);
     });
   });
 });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join, relative } from 'node:path';
 import { renderHud } from '../render.js';
@@ -129,6 +129,30 @@ describe('readGuardexFinishState', () => {
       ]);
 
       assert.equal(await readGuardexFinishState(cwd), null);
+    });
+  });
+
+  it('bounds metadata reads when historical finish streams accumulate', async () => {
+    await withTempRepo('omx-hud-guardex-bounded-', async (cwd) => {
+      const timestamp = new Date().toISOString();
+      for (let index = 0; index < 40; index += 1) {
+        const startedAt = (Date.now() - index).toString(36);
+        const runId = `finish-${startedAt}-${process.pid}-${String(index).padStart(8, '0')}`;
+        await writeGuardexFinishEvents(cwd, runId, [
+          { schemaVersion: 1, runId, timestamp, stage: 'review', state: 'running', index: 4, total: 8, label: 'AI review' },
+        ]);
+      }
+
+      let metadataReads = 0;
+      const state = await readGuardexFinishState(cwd, {
+        statFile: async path => {
+          metadataReads += 1;
+          return stat(path);
+        },
+      });
+
+      assert.equal(state?.stage, 'review');
+      assert.equal(metadataReads, 32);
     });
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -57,6 +57,7 @@ function renderGitBranch(ctx: HudRenderContext): string | null {
 }
 
 const GUARDEX_SPINNER_FRAMES = ['◐', '◓', '◑', '◒'] as const;
+const GUARDEX_SPINNER_FRAME_MS = 400;
 
 function renderGuardexFinish(ctx: HudRenderContext): string | null {
   if (!ctx.guardexFinish?.active) return null;
@@ -66,7 +67,7 @@ function renderGuardexFinish(ctx: HudRenderContext): string | null {
   if (!stage) return null;
   const animates = state === 'running' && (stage === 'review' || stage === 'autofix');
   const frame = animates
-    ? ` ${GUARDEX_SPINNER_FRAMES[Math.floor(Date.now() / 250) % GUARDEX_SPINNER_FRAMES.length]}`
+    ? ` ${GUARDEX_SPINNER_FRAMES[Math.floor(Date.now() / GUARDEX_SPINNER_FRAME_MS) % GUARDEX_SPINNER_FRAMES.length]}`
     : '';
   return yellow(`gx:${index}/${total} ${stage}${frame}`);
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -438,7 +438,8 @@ export async function readSessionState(cwd: string): Promise<SessionStateForHud 
 }
 
 export async function readHudConfig(cwd: string): Promise<ResolvedHudConfig> {
-  const config = await readJsonFile<HudConfig>(join(cwd, '.omx', 'hud-config.json'));
+  const repoRoot = findGitLayout(cwd)?.worktreeRoot ?? cwd;
+  const config = await readJsonFile<HudConfig>(join(repoRoot, '.omx', 'hud-config.json'));
   return normalizeHudConfig(config);
 }
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -79,7 +79,12 @@ const GUARDEX_FINISH_TAIL_BYTES = 64 * 1024;
 const GUARDEX_FINISH_MAX_CANDIDATES = 32;
 const GUARDEX_FINISH_MAX_AGE_MS = 24 * 60 * 60 * 1_000;
 const GUARDEX_FINISH_RUN_ID_RE = /^finish-[^-]+-(\d+)-/;
+const GUARDEX_FINISH_FILE_RE = /^finish-([0-9a-z]+)-\d+-[^/]+\.jsonl$/;
 const GUARDEX_TERMINAL_STATES = new Set(['failed', 'finished']);
+
+interface GuardexFinishStateDependencies {
+  statFile?: (path: string) => Promise<{ mtimeMs: number }>;
+}
 
 interface RawGuardexFinishEvent {
   schemaVersion?: unknown;
@@ -167,21 +172,36 @@ async function readGuardexFinishFile(path: string): Promise<GuardexFinishStateFo
 }
 
 /** Read the newest active GitGuardex branch-finish event stream. */
-export async function readGuardexFinishState(cwd: string): Promise<GuardexFinishStateForHud | null> {
+export async function readGuardexFinishState(
+  cwd: string,
+  dependencies: GuardexFinishStateDependencies = {},
+): Promise<GuardexFinishStateForHud | null> {
   // Guardex writes to the repository-local state directory, independent of
   // OMX session/team state-root overrides inherited by the HUD process.
   const repoRoot = findGitLayout(cwd)?.worktreeRoot ?? cwd;
   const directory = join(repoRoot, '.omx', 'state', 'finish-runs');
   try {
     const entries = await readdir(directory, { withFileTypes: true });
-    const candidates = await Promise.all(entries
-      .filter(entry => entry.isFile() && entry.name.startsWith('finish-') && entry.name.endsWith('.jsonl'))
+    // Guardex encodes the run start time as base36 in each filename. Bound the
+    // newest run IDs before metadata reads so one HUD tick stays O(1).
+    const recentEntries = entries
+      .flatMap(entry => {
+        if (!entry.isFile()) return [];
+        const match = entry.name.match(GUARDEX_FINISH_FILE_RE);
+        if (!match) return [];
+        const startedAt = Number.parseInt(match[1], 36);
+        return Number.isSafeInteger(startedAt) ? [{ name: entry.name, startedAt }] : [];
+      })
+      .sort((left, right) => right.startedAt - left.startedAt || right.name.localeCompare(left.name))
+      .slice(0, GUARDEX_FINISH_MAX_CANDIDATES);
+    const statFile = dependencies.statFile ?? stat;
+    const candidates = await Promise.all(recentEntries
       .map(async entry => ({
         path: join(directory, entry.name),
-        modifiedAt: (await stat(join(directory, entry.name))).mtimeMs,
+        modifiedAt: (await statFile(join(directory, entry.name))).mtimeMs,
       })));
     candidates.sort((left, right) => right.modifiedAt - left.modifiedAt);
-    for (const candidate of candidates.slice(0, GUARDEX_FINISH_MAX_CANDIDATES)) {
+    for (const candidate of candidates) {
       const state = await readGuardexFinishFile(candidate.path);
       if (state) return state;
     }


### PR DESCRIPTION
## Summary
- add an opt-in `guardex.enabled` HUD integration, disabled by default
- when enabled, read active GitGuardex `gx branch finish` JSONL progress from the repository-local `.omx/state/finish-runs` directory
- show the current step in every HUD preset as `gx:<step>/<total> <phase>`
- animate running review/autofix phases with Guardex spinner frames
- ignore completed, failed, abandoned, stale, malformed, and partial event streams

Enable per project:

```json
{
  "guardex": { "enabled": true }
}
```

in `.omx/hud-config.json`.

## Verification
- `npm run build`
- clean-environment HUD type/state/render tests (164 passed)
- `npm run lint`
- `npm run check:no-unused`
- live CLI smoke: disabled config showed no `gx:` segment; enabled config changed `gx:4/8 review ◐` to `gx:4/8 review ◓`
