### PR TITLE
fix(runtime): hydrate omx-runtime on global install

### DIFF
--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -41,6 +41,7 @@ export interface HydrateNativeBinaryOptions {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   arch?: string;
+  signal?: AbortSignal;
 }
 
 export interface NativeBinaryCandidateOptions {
@@ -236,9 +237,10 @@ export async function loadNativeReleaseManifest(
   packageRoot = getPackageRoot(),
   version?: string,
   env: NodeJS.ProcessEnv = process.env,
+  signal?: AbortSignal,
 ): Promise<NativeReleaseManifest> {
   const url = await resolveNativeManifestUrl(packageRoot, version, env);
-  const response = await fetch(url);
+  const response = await fetch(url, { signal });
   if (!response.ok) {
     throw new Error(`[native-assets] failed to fetch native release manifest (${response.status} ${response.statusText}) from ${url}`);
   }
@@ -260,8 +262,8 @@ function isUnavailableArchiveError(error: unknown): boolean {
     || /fetch failed/i.test(error.message);
 }
 
-async function downloadFile(url: string, destinationPath: string): Promise<void> {
-  const response = await fetch(url);
+async function downloadFile(url: string, destinationPath: string, signal?: AbortSignal): Promise<void> {
+  const response = await fetch(url, { signal });
   if (!response.ok || !response.body) {
     throw new Error(`[native-assets] failed to download ${url} (${response.status} ${response.statusText})`);
   }
@@ -689,6 +691,7 @@ export async function hydrateNativeBinary(
     env = process.env,
     platform = process.platform,
     arch = process.arch,
+    signal,
   } = options;
 
   if (env[NATIVE_AUTO_FETCH_ENV]?.trim() === '0') return undefined;
@@ -703,7 +706,7 @@ export async function hydrateNativeBinary(
 
   let manifest: NativeReleaseManifest;
   try {
-    manifest = await loadNativeReleaseManifest(packageRoot, version, env);
+    manifest = await loadNativeReleaseManifest(packageRoot, version, env, signal);
   } catch (error) {
     if (isUnavailableManifestError(error)) return undefined;
     throw error;
@@ -729,7 +732,7 @@ export async function hydrateNativeBinary(
         inferNativeAssetLibc(asset),
       );
       try {
-        await downloadFile(asset.download_url, archivePath);
+        await downloadFile(asset.download_url, archivePath, signal);
         const archiveStat = await stat(archivePath);
         if (typeof asset.size === 'number' && asset.size > 0 && archiveStat.size !== asset.size) {
           throw new Error(`[native-assets] downloaded archive size mismatch for ${asset.archive}`);

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -5,6 +5,7 @@ import { basename, isAbsolute, join, relative } from 'node:path';
 
 import { isCompletePackageManagerOwnership, runNpmCommand, validatePackageManagerOwnership, type PackageManagerOwnership } from './package-manager-ownership.js';
 import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
+import { hydrateOmxRuntimeNonFatal } from '../scripts/postinstall.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
 
 type DeferredUpdatePayload = { cwd: string; logPath: string; parentPid: number; ownership: PackageManagerOwnership; setupArgs: string[] };
@@ -111,6 +112,14 @@ async function main(): Promise<void> {
     if (result.error || result.status !== 0) throw new Error(String(result.stderr || result.error?.message || 'controller install failed'));
     const cliEntry = await validatePackageManagerOwnership(payload.ownership);
     if (!cliEntry) throw new Error('Frozen manager, package root, or bin ownership validation failed after update.');
+    // The package was installed with --ignore-scripts. Hydrate before setup so
+    // setup failure still leaves the installed version with a repaired runtime
+    // cache and the recovery command does not repeat the omission.
+    await hydrateOmxRuntimeNonFatal({
+      packageRoot: payload.ownership.packageRoot,
+      env: payload.ownership.environment,
+      log: (message) => appendFile(payload!.logPath, `${message}\n`).then(() => undefined),
+    });
     const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: { ...payload.ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'inherit', windowsHide: true });
     if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);
     await finalizeSuccessfulUpdate(payload.ownership);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -33,6 +33,7 @@ import {
   writeUserInstallStamp,
   type UserInstallStamp,
 } from '../scripts/postinstall-advisory.js';
+import { hydrateOmxRuntimeNonFatal } from '../scripts/postinstall.js';
 export {
   isInstallVersionBump,
   readUserInstallStamp,
@@ -569,6 +570,7 @@ interface UpdateDependencies {
   runGlobalUpdate: (installSource: string, ownership?: PackageManagerOwnership) => RunGlobalUpdateResult;
   runDeferredGlobalUpdate: (cwd: string, ownership?: PackageManagerOwnership) => RunDeferredUpdateResult;
   runSetupRefresh: (cwd: string, ownership?: PackageManagerOwnership) => Promise<RunSetupRefreshResult>;
+  hydrateRuntime: (ownership?: PackageManagerOwnership) => Promise<string | undefined>;
   writeUpdateState: typeof writeUpdateState;
 }
 
@@ -591,6 +593,10 @@ const defaultUpdateDependencies: UpdateDependencies = {
   runGlobalUpdate: (installSource, ownership) => runGlobalUpdate(installSource, spawnSync, process.platform, ownership),
   runDeferredGlobalUpdate: (cwd, ownership) => runDeferredGlobalUpdate(cwd, spawn, process.platform, process.pid, ownership),
   runSetupRefresh,
+  hydrateRuntime: (ownership) => hydrateOmxRuntimeNonFatal({
+    packageRoot: ownership?.packageRoot,
+    env: ownership?.environment,
+  }),
   writeUpdateState,
 }
 
@@ -897,6 +903,11 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
+  // Installation already replaced the package with --ignore-scripts. Repair
+  // the version-keyed native cache before setup so a setup failure cannot
+  // strand the successfully installed package without omx-runtime.
+  await dependencies.hydrateRuntime(ownership ?? undefined);
+
   const setupRefreshResult = await dependencies.runSetupRefresh(cwd, ownership ?? undefined);
   if (!setupRefreshResult.ok) {
     console.log(
@@ -904,7 +915,6 @@ async function executeUpdate(
     );
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
-
   const installedVersion = await dependencies.getInstalledVersionAfterUpdate(ownership ?? undefined);
   const installedRevision = channelConfig.channel === 'dev'
     ? ((await dependencies.getInstalledRevisionAfterUpdate(ownership ?? undefined)) ?? result.revision ?? null)

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -33,6 +33,7 @@ describe("runPostinstall", () => {
       const result = await runPostinstall({
         env: { npm_config_global: "true" },
         getCurrentVersion: async () => "0.14.1",
+        hydrateRuntime: async () => "/cache/omx-runtime",
         log: (message) => logs.push(message),
         readStamp: async () => ({
           installed_version: "0.14.0",
@@ -44,6 +45,7 @@ describe("runPostinstall", () => {
       });
 
       assert.equal(result.status, "hinted");
+      assert.match(logs.join("\n"), /Hydrated omx-runtime/);
       assert.match(logs.join("\n"), /OMX setup is explicit opt-in; run `omx setup` or `omx update` when you're ready/);
 
       const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
@@ -68,6 +70,7 @@ describe("runPostinstall", () => {
       const result = await runPostinstall({
         env: { npm_config_global: "true" },
         getCurrentVersion: async () => "0.14.1",
+        hydrateRuntime: async () => "/cache/omx-runtime",
         log: (message) => logs.push(message),
         readStamp: async () => ({
           installed_version: "0.14.0",
@@ -100,6 +103,7 @@ describe("runPostinstall", () => {
         npm_config_user_agent: "bun/1.2.0 npm/? node/v22.0.0 linux x64",
       },
       getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => "/cache/omx-runtime",
       readStamp: async () => null,
       writeStamp: async (stamp) => {
         writtenStamp = stamp;
@@ -114,15 +118,21 @@ describe("runPostinstall", () => {
     const result = await runPostinstall({
       env: { npm_config_global: "false" },
       getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => "/cache/omx-runtime",
     });
 
     assert.equal(result.status, "noop-local");
   });
 
   it("does not rerun setup when the installed version matches the saved stamp", async () => {
+    let hydrated = false;
     const result = await runPostinstall({
       env: { npm_config_global: "true" },
       getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => {
+        hydrated = true;
+        return "/cache/omx-runtime";
+      },
       readStamp: async () => ({
         installed_version: "0.14.1",
         setup_completed_version: "0.14.1",
@@ -131,5 +141,23 @@ describe("runPostinstall", () => {
     });
 
     assert.equal(result.status, "noop-same-version");
+    assert.equal(hydrated, true, "same-version reinstalls must repair a missing native runtime cache");
+  });
+
+  it("keeps global installation non-fatal when runtime hydration fails", async () => {
+    const logs: string[] = [];
+    const result = await runPostinstall({
+      env: { npm_config_global: "true" },
+      getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => {
+        throw new Error("offline");
+      },
+      log: (message) => logs.push(message),
+      readStamp: async () => null,
+      writeStamp: async () => {},
+    });
+
+    assert.equal(result.status, "hinted");
+    assert.match(logs.join("\n"), /hydration failed non-fatally: offline/);
   });
 });

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -8,6 +8,7 @@ import {
   writeUserInstallStamp,
 } from './postinstall-advisory.js';
 import { getPackageRoot } from "../utils/package.js";
+import { hydrateNativeBinary } from "../cli/native-assets.js";
 
 type PostinstallStatus =
   | "noop-local"
@@ -24,8 +25,38 @@ interface PostinstallDependencies {
   env: NodeJS.ProcessEnv;
   getCurrentVersion: () => Promise<string | null>;
   log: (message: string) => void;
+  hydrateRuntime: () => Promise<string | undefined>;
   readStamp: () => Promise<UserInstallStamp | null>;
   writeStamp: (stamp: UserInstallStamp) => Promise<void>;
+}
+
+const RUNTIME_HYDRATION_TIMEOUT_MS = 15_000;
+
+export async function hydrateOmxRuntimeNonFatal(options: {
+  packageRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  log?: (message: string) => void;
+  timeoutMs?: number;
+} = {}): Promise<string | undefined> {
+  const log = options.log ?? ((message: string) => console.log(message));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? RUNTIME_HYDRATION_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    const runtimePath = await hydrateNativeBinary("omx-runtime", {
+      packageRoot: options.packageRoot,
+      env: options.env,
+      signal: controller.signal,
+    });
+    if (runtimePath) log(`[omx] Hydrated omx-runtime for this platform: ${runtimePath}`);
+    else log("[omx] omx-runtime was not available for this platform; native runtime features remain disabled.");
+    return runtimePath;
+  } catch (error) {
+    log(`[omx] omx-runtime hydration failed non-fatally: ${error instanceof Error ? error.message : String(error)}`);
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function stripLeadingV(version: string): string {
@@ -55,6 +86,7 @@ const defaultDependencies: PostinstallDependencies = {
   env: process.env,
   getCurrentVersion,
   log: (message) => console.log(message),
+  hydrateRuntime: () => hydrateOmxRuntimeNonFatal(),
   readStamp: () => readUserInstallStamp(),
   writeStamp: (stamp) => writeUserInstallStamp(stamp),
 };
@@ -75,6 +107,20 @@ export async function runPostinstall(
   }
 
   const currentStampVersion = stripLeadingV(currentVersion);
+  try {
+    const runtimePath = await resolved.hydrateRuntime();
+    if (runtimePath) {
+      resolved.log(`[omx] Hydrated omx-runtime for this platform: ${runtimePath}`);
+    } else {
+      resolved.log(
+        "[omx] omx-runtime was not available for this platform; native runtime features remain disabled.",
+      );
+    }
+  } catch (error) {
+    resolved.log(
+      `[omx] omx-runtime hydration failed non-fatally: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   const existingStamp = await resolved.readStamp();
   if (!isInstallVersionBump(currentVersion, existingStamp)) {
     return { status: "noop-same-version", version: currentStampVersion };


### PR DESCRIPTION
Fixes #3600.

The published `0.21.0` package contains the generic native hydration implementation and the GitHub release contains `omx-runtime-aarch64-apple-darwin`, but global postinstall only updated the setup stamp and never invoked runtime hydration. Runtime discovery correctly checks the verified native cache, so the cache remained empty after clean installs.

This fix:
- hydrates `omx-runtime` during every global install/reinstall, before the same-version stamp short-circuit;
- preserves non-fatal package installation when the network/platform asset is unavailable, with an explicit diagnostic;
- records successful hydration and repairs same-version reinstalls with a missing cache;
- adds deterministic success, same-version repair, and non-fatal failure coverage.

Validation: build; postinstall suite 9/9; native-assets suite; runtime tests; no-unused; lint; diff hygiene.

This is post-v0.21.1 backlog and was not silently injected into the already-published release.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
