### PR TITLE
release: promote v0.21.2 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project are documented in this file.
 
 ## [Unreleased]
+## [0.21.2] - 2026-09-01
+
+Patch release for `v0.21.1..04533ebfc887643586e37180ec3270473948115a` (11 commits, 29 files, +1,245/−10).
+
+### Added
+
+- **Optional GitGuardex HUD finish progress** — live review/autofix progress with project-root configuration, bounded stream discovery, and animation that advances at the one-second HUD watch cadence (#3601).
+- **Bahasa Indonesia README** — Indonesian translation with synchronized localized language navigation (#3599).
+
+### Fixed
+
+- **macOS arm64 `omx-runtime` hydration** — global install/reinstall and immediate/deferred script-suppressed updates hydrate the verified versioned native cache, with bounded non-fatal network waits (#3602).
+
 ## [0.21.1] - 2026-08-31
 
 Patch release for `v0.21.0..abf2393af1e1f9355adfe43166432462a86d2e54` (125 commits, 116 changed files, +23,996/−1,141, 28 commit-subject references plus linked issues #3587/#3589).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.21.1"
+version = "0.21.2"
 
 edition = "2021"
 rust-version = "1.73"

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ These are operator/support surfaces:
 - `.omx-config.json` model/env routing is documented in [the model/env routing reference](./docs/reference/omx-config-schema-routing.md); only edit keys supported by your installed OMX version
 - `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
+- GitGuardex finish progress is opt-in. Add `"guardex": { "enabled": true }` to the project-local `.omx/hud-config.json` to show `gx:<step>/<total> <phase>`; running review/autofix phases animate in the HUD. OMX does not read Guardex state when this flag is absent or false.
 
 For non-team sessions, native Codex hooks are now the canonical lifecycle surface:
 - `plugins/oh-my-codex/hooks/hooks.json` = official plugin-scoped hook registrations for plugin installs

--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ If this happens, try:
 - [Ελληνικά](./docs/readme/README.el.md)
 - [Polski](./docs/readme/README.pl.md)
 - [Українська](./docs/readme/README.uk.md)
+- [Bahasa Indonesia](./docs/readme/README.id.md)
 
 ## Contributors
 

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,26 +1,23 @@
-# oh-my-codex 0.21.1
+# oh-my-codex 0.21.2
 
-`0.21.1` is a patch release for `v0.21.0..abf2393af1e1f9355adfe43166432462a86d2e54` (125 commits, 116 changed files, 28 commit-subject references plus linked issues #3587/#3589).
+`0.21.2` is a patch release for `v0.21.1..04533ebfc887643586e37180ec3270473948115a` (11 commits, 29 changed files, PRs #3599/#3601/#3602).
 
 ## Highlights
 
-- **Ralplan Advisory / Contract A** — cooperative Planner → Architect → Critic evidence without execution authority, global suppression, or automatic implementation handoff; lifecycle evidence, reviewer-time artifacts, crash recovery, and cross-platform state mirrors fail closed (#3594).
-- **HUD and detached session reliability** — exact pane ownership, failure cleanup, rendering refresh, split/non-split layout reconciliation, stable hook identity, and contention re-arming (#3577, #3578, #3584, #3587, #3588, #3595).
-- **Team legacy HUD compatibility** — startup safely recognizes and retires both same-session and leader-only legacy HUD panes before topology freeze (#3597).
-- **Trusted publishing and provenance** — immutable tag/main ancestry and SHA checks, verified native assets, trusted npm publication, and retirement of manual token publishing; plugin/cache/launcher provenance rejects symlink and namespace confusion (#3552, #3566, #3570, #3571, #3572).
-- **State/process authority** — exact process incarnation, canonical lease recovery, Windows/macOS durability, and session pointer cleanup are hardened (#3558, #3561, #3581, #3582).
-- **Compatibility fixes** — Ralph native deadlock recovery, SparkShell tail validation, empty hooks-state recovery, and generated configuration trust checks (#3589, #3590, #3592).
+- **macOS arm64 runtime hydration** — global install/reinstall and immediate/deferred updates hydrate the verified `omx-runtime` cache with bounded non-fatal network behavior (#3602).
+- **GitGuardex HUD progress** — optional live review/autofix progress with nested-path config discovery, bounded metadata reads, and watch-cadence-safe animation (#3601).
+- **Indonesian localization** — Bahasa Indonesia README plus synchronized navigation across localized documentation (#3599).
 
 ## Compatibility
 
-Patch release. Ralplan Advisory is additive and non-authorizing. Existing standard workflows remain independent. The tag workflow publishes GitHub Release/native assets; npm publication uses the exact tag/SHA-bound OIDC trusted-publish job in the CI workflow.
+Patch release. Guardex HUD integration is opt-in. Native hydration remains integrity-verified and non-fatal when unavailable.
 
 ## Contributors
 
-Thanks to Bellman (@Yeachan-Heo), @FacuVCanale, @NagyVikt, @berahac, @XCRobert, @colanx, @wangxingzhen, @chenjiaming-kezaihui, @app/dependabot, and the gaebal-gajae (clawdbot) release and repair lanes.
+Thanks to Bellman (@Yeachan-Heo), @NagyVikt, Dendroculus, and the gaebal-gajae (clawdbot) release and repair lanes.
 
 ## Frozen-range acknowledgements
 
-The release PR must be merged with a two-parent merge commit, not squash/rebase, so the complete frozen `dev@abf2393a` history remains reachable from the `v0.21.1` tag. This preserves generated contributor attribution for every frozen-range contributor, including @wangxingzhen for #3597. Immediately before merge, the tag gate fetches `+refs/heads/release/0.21.1:refs/remotes/origin/release/0.21.1`, records that exact remote head, and verifies both it and frozen dev `abf2393a` are ancestors of the tagged `main` commit.
+Merge this release PR with a two-parent merge commit so frozen `dev@04533ebf` remains reachable. Immediately before merge, force-fetch and record the exact `origin/release/0.21.2` head; verify both it and frozen dev are ancestors of the tagged main commit.
 
-**Full Changelog**: [`v0.21.0...v0.21.1`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.21.0...v0.21.1)
+**Full Changelog**: [`v0.21.1...v0.21.2`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.21.1...v0.21.2)

--- a/artifacts/release-0.21.2/inventory.md
+++ b/artifacts/release-0.21.2/inventory.md
@@ -1,0 +1,22 @@
+# Release inventory — v0.21.1..dev@04533ebf
+
+- Previous tag: `v0.21.1` = `8513abf70609061770a97100ef8964c8ebb40700`.
+- Candidate: `dev@04533ebfc887643586e37180ec3270473948115a`.
+- Range: 11 commits, 29 files, +1,245/−10.
+- Merge commits: 5 (three PR merges plus release/main-to-dev reconciliation merges).
+- Referenced PRs: #3599, #3601, #3602.
+- Contributors from git shortlog: Bellman, NagyVikt, gaebal-gajae, and Dendroculus.
+
+## Included work
+
+- #3599 — Indonesian README translation and synchronized localized navigation.
+- #3601 — optional bounded GitGuardex finish progress in the HUD.
+- #3602 — bounded `omx-runtime` hydration for global install/reinstall and immediate/deferred updates.
+
+## Reproduction
+
+```sh
+git rev-list --count v0.21.1..04533ebfc887643586e37180ec3270473948115a
+git diff --shortstat v0.21.1..04533ebfc887643586e37180ec3270473948115a
+git log --pretty='%s' v0.21.1..04533ebfc887643586e37180ec3270473948115a | grep -oE '#[0-9]+' | sort -u
+```

--- a/docs/qa/release-readiness-0.21.2.md
+++ b/docs/qa/release-readiness-0.21.2.md
@@ -1,0 +1,32 @@
+# Release readiness — 0.21.2
+
+## Identity
+
+- Release: `0.21.2` patch.
+- Previous tag: `v0.21.1` (`8513abf70609061770a97100ef8964c8ebb40700`).
+- Frozen dev: `04533ebfc887643586e37180ec3270473948115a`.
+- Range: 11 commits, 29 files, +1,245/−10, PRs #3599/#3601/#3602.
+- Owner authorization: direct `ㄱㄱ` in the OmX v0.21.2 readiness thread.
+- Backlog at freeze: open PR 0, open issue 0.
+
+## Version carriers
+
+- package.json / package-lock.json → 0.21.2
+- Cargo.toml workspace package → 0.21.2
+- plugins/oh-my-codex/.codex-plugin/plugin.json → 0.21.2
+
+## Gates
+
+| Gate | Status |
+|---|---|
+| Frozen dev CI `33406782191` | Passed |
+| Version sync / build / static / generated | Pending release validation |
+| Full tests and package/native smoke | Pending release validation |
+| Exact-head PR to main, CI, adversarial review | Pending |
+| Main CI, tag `v0.21.2`, GitHub Release/native assets | Pending |
+| Exact tag/SHA-bound OIDC npm trusted publish | Pending |
+| npm `oh-my-codex@0.21.2` and latest | Pending |
+
+## Publish contract
+
+Merge the release PR using a two-parent merge commit. Immediately before merge, force-fetch `+refs/heads/release/0.21.2:refs/remotes/origin/release/0.21.2` and record the exact release head. Before tagging, verify that recorded release head and frozen dev `04533ebf` are ancestors of the merged main commit. Use the tag-triggered Release workflow for GitHub assets and the CI workflow's exact `release_tag`/`release_sha` OIDC trusted-publish job for npm. No token/manual publisher.

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -258,6 +258,26 @@ npm test
 
 Inspiriert von [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), angepasst für Codex CLI.
 
+## Sprachen
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Lizenz
 
 MIT

--- a/docs/readme/README.el.md
+++ b/docs/readme/README.el.md
@@ -216,6 +216,9 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 - [Français](./README.fr.md)
 - [Italiano](./README.it.md)
 - [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
 
 ## Συνεισφέροντες
 

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -258,6 +258,26 @@ npm test
 
 Inspirado en [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adaptado para Codex CLI.
 
+## Idiomas
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Licencia
 
 MIT

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -258,6 +258,26 @@ npm test
 
 Inspiré par [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adapté pour Codex CLI.
 
+## Langues
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Licence
 
 MIT

--- a/docs/readme/README.id.md
+++ b/docs/readme/README.id.md
@@ -1,0 +1,531 @@
+# oh-my-codex (OMX)
+
+<p align="center">
+  <img src="https://yeachan-heo.github.io/oh-my-codex-website/omx-character-nobg.png" alt="oh-my-codex character" width="280">
+  <br>
+  <em>Mulai sesi Codex dengan lebih mantap, lalu biarkan OMX menambahkan prompt, workflow, dan bantuan runtime yang lebih baik saat pekerjaan makin besar.</em>
+  <br><br>
+  <strong>Suka OmX tetapi terasa agak berlebihan? <a href="https://github.com/Yeachan-Heo/gajae-code">Coba gajae-code</a>.</strong><br>
+  <sub>Pertahankan Codex OAuth dengan jalur berbasis SDK yang lebih cepat, lebih murah, lebih sederhana, dan lebih powerful untuk OpenClaw, Hermes, Grokbot, serta integrasi lainnya.</sub>
+</p>
+
+[![npm version](https://img.shields.io/npm/v/oh-my-codex)](https://www.npmjs.com/package/oh-my-codex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+[![Discord](https://img.shields.io/discord/1452487457085063218?color=5865F2&logo=discord&logoColor=white&label=Discord)](https://discord.gg/wSyUQYfhAw)
+
+**Website:** https://yeachan-heo.github.io/oh-my-codex-website/
+
+**Dokumentasi:** [Memulai](../getting-started.html) · [Agent](../agents.html) · [Skill](../skills.html) · [Integrasi](../integrations.html) · [Demo](../../DEMO.md) · [Panduan OpenClaw](../openclaw-integration.md)
+
+**Komunitas:** [Discord](https://discord.gg/wSyUQYfhAw) — server komunitas Gajae bersama untuk oh-my-codex, [gajae-code](https://github.com/Yeachan-Heo/gajae-code), dan tooling terkait.
+
+## Proyek dan package resmi
+
+Proyek OMX resmi/orisinal adalah repository ini, [`Yeachan-Heo/oh-my-codex`](https://github.com/Yeachan-Heo/oh-my-codex), dan package npm resmi untuk proyek ini adalah [`oh-my-codex`](https://www.npmjs.com/package/oh-my-codex). Instal proyek ini dengan `npm install -g oh-my-codex` (atau bersama Codex CLI seperti ditunjukkan di bawah).
+
+Proyek pihak ketiga atau fork yang menggunakan nama seperti “OMX v2” bukan kelanjutan, pengganti, atau jalur release resmi repository ini kecuali README atau dokumentasi ini menyatakannya secara eksplisit. Jika ragu, percayai repository ini dan package `oh-my-codex` sebagai target instalasi resmi.
+
+OMX adalah layer workflow untuk [OpenAI Codex CLI](https://github.com/openai/codex).
+
+<table>
+<tr>
+<td><strong>🚨 PERHATIAN — DEFAULT YANG DIREKOMENDASIKAN HANYALAH macOS atau Linux dengan Codex CLI.</strong><br><br><strong>OMX terutama dirancang dan secara aktif dioptimalkan untuk jalur tersebut.</strong><br><strong>Windows native dan Codex App bukan pengalaman default, dapat bermasalah atau berperilaku tidak konsisten, dan saat ini mendapat dukungan yang lebih terbatas.</strong></td>
+</tr>
+</table>
+
+OMX mempertahankan Codex sebagai execution engine dan mempermudah Anda untuk:
+- memulai sesi Codex yang lebih kuat secara default
+- menjalankan satu workflow yang konsisten dari klarifikasi hingga selesai
+- menjalankan workflow kanonis dengan `$plan`, `$ultragoal`, `$team`, `$code-review`, dan `$ultraqa` — masing-masing dapat dipakai secara independen, tanpa urutan tetap
+- menyimpan panduan proyek, rencana, log, dan state di `.omx/`
+
+## Maintainer Utama
+
+| Peran | Nama | GitHub |
+| --- | --- | --- |
+| Kreator & Lead | Yeachan Heo | [@Yeachan-Heo](https://github.com/Yeachan-Heo) |
+| Maintainer | Doyun Ha | [@HaD0Yun](https://github.com/HaD0Yun) |
+| Maintainer | Valeriy Pavlovich | [@iqdoctor](https://github.com/iqdoctor) |
+
+## Duta
+
+| Nama | GitHub |
+| --- | --- |
+| Sigrid Jin | [@sigridjineth](https://github.com/sigridjineth) |
+
+## Kolaborator Utama
+
+| Nama | GitHub |
+| --- | --- |
+| Doyun Ha | [@HaD0Yun](https://github.com/HaD0Yun) |
+| Junho Yeo | [@junhoyeo](https://github.com/junhoyeo) |
+| JiHongKim98 | [@JiHongKim98](https://github.com/JiHongKim98) |
+| Lor | [@gobylor](https://github.com/gobylor) |
+| HyunjunJeon | [@HyunjunJeon](https://github.com/HyunjunJeon) |
+
+## Alur default yang direkomendasikan
+
+Jika Anda menginginkan pengalaman OMX default, mulai dari sini:
+
+Pilih satu jalur instalasi. Jika Codex CLI sudah terinstal (Homebrew, npm, atau metode lain yang didukung):
+
+```bash
+codex --version
+npm install -g oh-my-codex
+# from the git project you want Codex to edit; choose a task-specific name
+omx --worktree=feat/task --madmax --xhigh
+```
+
+Jika Anda belum memiliki Codex CLI dan ingin npm yang mengelolanya:
+
+```bash
+npm install -g @openai/codex
+npm install -g oh-my-codex
+```
+
+Jangan menjalankan gabungan `npm install -g @openai/codex oh-my-codex` di atas binary `codex` yang sudah dimiliki Homebrew seperti `/opt/homebrew/bin/codex`; npm dapat gagal dengan `EEXIST` saat `@openai/codex` mencoba membuat binary yang sama. OMX hanya membutuhkan perintah `codex` yang berfungsi dan sudah terautentikasi di `PATH`; Codex tidak harus diinstal melalui npm.
+
+Pada bump versi `oh-my-codex` yang sebenarnya, instalasi npm global sekarang mencetak pengingat eksplisit alih-alih menjalankan setup secara otomatis. Saat siap, jalankan perintah setup dengan scope di bawah atau gunakan `omx update` untuk memeriksa npm lalu menjalankan jalur refresh setup yang sama.
+
+OMX juga memeriksa update npm saat launch dengan frekuensi yang dibatasi dan meminta konfirmasi sebelum menjadwalkan update setelah sesi saat ini selesai. Set `OMX_AUTO_UPDATE=0` untuk menonaktifkan pemeriksaan saat launch, atau set `OMX_AUTO_UPDATE=defer` untuk menjadwalkan update tertunda yang sama tanpa prompt konfirmasi.
+
+Pilih scope setup dengan sengaja:
+- Gunakan `omx setup --scope project --merge-agents` dari proyek git tempat OMX akan bekerja ketika repository tersebut seharusnya memiliki panduan `AGENTS.md` yang persisten.
+- Gunakan `omx setup --scope user` untuk setup Codex tingkat user saat Anda tidak sedang menyiapkan direktori saat ini sebagai proyek OMX.
+- Hindari menjalankan setup dengan scope project dari direktori home yang luas atau hub operasional, kecuali direktori tersebut memang sengaja menjadi proyek yang sedang ditinjau. `AGENTS.md` tingkat home sering berisi aturan keselamatan dan routing global; simpan panduan runtime OMX yang spesifik proyek di repository yang sebenarnya.
+
+### Mempertahankan kebijakan merge AGENTS secara eksplisit
+
+`omx setup --merge-agents`, `omx setup --no-merge-agents`, dan `omx setup --clear-merge-agents-policy` adalah satu-satunya selector kebijakan; gunakan bentuk polosnya (bukan bentuk `=value`). Mengulang selector yang sama tidak masalah, tetapi mencampur pilihan set dan clear akan gagal sebelum setup mengubah apa pun. Set eksplisit akan mengesampingkan kebijakan yang tersimpan.
+
+Set eksplisit yang berhasil mencatat `mergeAgents: true` atau `false` di `./.omx/setup-scope.json` pada working root saat ini, bahkan ketika scope setup adalah `user`; kebijakan ini tidak pernah menjadi preferensi user global atau bocor ke root lain. `omx update` berikutnya akan memutar ulang kebijakan valid yang cocok untuk refresh langsung maupun tertunda.
+
+`true` menggunakan branch merge yang sudah ada. `false` hanya menekan branch tersebut: nilai ini tidak menjanjikan preservasi, penggantian, atau mode keselamatan baru, sehingga perilaku prompt, skip, managed-refresh, plugin-default, dan force yang sudah ada tetap berlaku. Review dengan scope yang cocok mempertahankan kebijakan saat pengaturan lain berubah. Reset atau perubahan scope menghapus kebijakan warisan kecuali run setup yang sama secara eksplisit menetapkan `true` atau `false`; clear selalu menghapus kebijakan dan tidak dapat digabungkan dengan selector set.
+Data tersimpan yang malformed, tidak dikenal, bukan boolean, atau memiliki scope yang salah akan diabaikan dengan aman.
+
+`--force` bersifat independen dan sementara: flag ini tidak dicatat maupun diputar ulang, dan tidak mengesampingkan kebijakan merge eksplisit. Setup menyimpan intent set atau clear eksplisit secara atomik hanya setelah seluruh pekerjaan setup berhasil, termasuk ketika safeguard sesi aktif atau symlink plugin melewati penulisan `AGENTS.md` saat ini, sehingga refresh berikutnya dapat menghormati kebijakan yang diminta. Hal ini tidak menjadikan merge sebagai default atau menghidupkan kembali pendekatan merge-by-default #2892 yang ditolak.
+Versi OMX yang lebih lama akan mengabaikan field tersebut dengan aman, tetapi mungkin menghapusnya saat menulis ulang preferensi setup yang dikenalnya.
+
+
+**Catatan instalasi plugin Codex:** repo ini juga menyediakan layout plugin Codex resmi di `plugins/oh-my-codex` dengan metadata marketplace di `.agents/plugins/marketplace.json`. Plugin tersebut membundel permukaan skill yang dicerminkan beserta metadata pendamping dengan scope plugin untuk lifecycle hook resmi Codex, server kompatibilitas MCP opsional, dan app.
+Plugin ini tetap **bukan** pengganti CLI global `oh-my-codex` plus setup dengan scope: hook dengan scope plugin menjalankan CLI `omx` yang terinstal, mode setup legacy menginstal agent dan prompt native, sedangkan mode setup plugin mengandalkan discovery plugin untuk skill yang dibundel sambil mengarsipkan/menghapus prompt dan TOML native-agent lama yang dikelola OMX agar file role usang tidak membayangi perilaku plugin.
+Mode plugin tetap membutuhkan `AGENTS.md` dengan scope persisten (`~/.codex/AGENTS.md` untuk setup user atau `./AGENTS.md` untuk setup project) sebagai layer panduan orkestrasi yang persisten; file AGENTS dengan scope sesi hanya menggabungkan panduan persisten tersebut dengan overlay runtime dan bukan penggantinya.
+
+Kemudian bekerja seperti biasa di dalam Codex:
+
+```text
+# Durable objective/checkpoints for a long task:
+/goal Create a safe authentication refactor plan, implement it, and verify login, logout, and refresh-token behavior.
+
+$deep-interview "clarify the authentication change"
+$ralplan "approve the auth plan and review tradeoffs"
+$ultragoal "turn the approved plan into durable Codex goals"
+```
+
+Itulah jalur utamanya.
+Sebelum menganggap runtime siap, jalankan smoke test quick-start di bawah: `omx doctor` memverifikasi bentuk instalasi, sementara `omx exec` membuktikan bahwa runtime Codex aktif benar-benar dapat melakukan autentikasi dan menyelesaikan model call dari environment saat ini.
+Mulai OMX dengan konfigurasi yang kuat, lakukan klarifikasi lebih dulu bila diperlukan, setujui rencana, lalu gunakan `$ultragoal` sebagai wrapper penyelesaian persisten default. Gunakan `$team` di dalam jalur eksekusi tersebut hanya ketika story Ultragoal tertentu membutuhkan pekerjaan paralel yang terkoordinasi; gunakan `$ralph` ketika Anda memang menginginkan loop penyelesaian dengan satu pemilik alih-alih run multi-goal yang persisten.
+
+## Untuk apa OMX digunakan
+
+Gunakan OMX jika Anda sudah menyukai Codex dan menginginkan runtime harian yang lebih baik di sekitarnya:
+- workflow standar yang dibangun di sekitar `$deep-interview` -> `$ralplan` -> `$ultragoal`
+- batasan research: gunakan `$best-practice-research` untuk evidence resmi/upstream biasa sebelum planning, `$autoresearch` untuk artifact research yang dibatasi dan melewati validator gate, `$autoresearch-goal` untuk mission research dalam goal mode, lalu masukkan temuan research ke `$ralplan` untuk sintesis arsitektur
+- handoff multi-goal persisten dengan `$ultragoal` dan artifact `.omx/ultragoal` sebagai jalur penyelesaian default setelah planning
+- role spesialis dan skill pendukung saat tugas membutuhkannya
+- panduan proyek melalui `AGENTS.md` dengan scope
+- state persisten di `.omx/` untuk rencana, log, memory, dan pelacakan mode
+
+Jika Anda menginginkan Codex polos tanpa layer workflow tambahan, kemungkinan Anda tidak memerlukan OMX.
+
+## Mulai cepat
+
+### Persyaratan
+
+- Node.js 20+
+- Codex CLI terinstal, diverifikasi dengan `codex --version`, dan terautentikasi (Homebrew maupun npm sama-sama boleh; jangan instal ulang `@openai/codex` dengan npm jika Homebrew sudah memiliki `codex`)
+- autentikasi Codex terkonfigurasi dan terlihat di shell/profile yang sama yang akan menjalankan OMX
+- `tmux` di macOS/Linux jika Anda menginginkan runtime team persisten yang direkomendasikan
+- `psmux` di Windows native hanya jika Anda memang menginginkan jalur team Windows yang dukungannya lebih terbatas
+
+### Sesi pertama yang baik
+
+Setelah instalasi, periksa kedua batas ini:
+
+```bash
+omx doctor
+codex login status
+omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"
+```
+
+`omx doctor` mendeteksi file OMX, hook, dan prerequisite runtime yang hilang. Smoke test sebenarnya mendeteksi masalah auth, profile, serta provider/base-URL yang baru muncul ketika Codex benar-benar melakukan request.
+
+Launch OMX dengan cara yang direkomendasikan dari proyek git:
+
+```bash
+omx --worktree=feat/task --madmax --xhigh
+```
+
+Pada terminal interaktif macOS/Linux dengan `tmux` tersedia, ini memulai
+leader di tmux detached yang dikelola OMX secara default agar pane HUD/runtime dapat
+dibuat dan dipulihkan. `--worktree` juga memindahkan launch ke checkout git
+terpisah, yang merupakan default lebih aman saat menggunakan `--madmax`. Ganti
+`feat/task` dengan nama seperti branch untuk tugas tersebut.
+
+### Percakapan standar secara bersamaan
+
+Launch standar memiliki satu pointer sesi yang dapat ditulis di bawah `OMX_ROOT` yang dipilih. Karena itu, launch `omx` biasa kedua dari checkout yang sama akan fail-closed alih-alih berbagi atau diam-diam mengubah root tersebut. Berikan root eksplisit yang berbeda untuk setiap percakapan tambahan:
+
+```bash
+omx
+OMX_ROOT="$HOME/.omx/instances/second-conversation" omx
+OMX_ROOT="$HOME/.omx/instances/third-conversation" omx
+```
+
+PowerShell:
+
+```powershell
+$env:OMX_ROOT = "$HOME/.omx/instances/second-conversation"
+omx
+```
+
+Command Prompt:
+
+```bat
+set "OMX_ROOT=%USERPROFILE%\.omx\instances\second-conversation"
+omx
+```
+
+Root yang ditentukan user bersifat literal: menjalankan dua kali dengan `OMX_ROOT` eksplisit yang sama tetap menghasilkan konflik owner fatal. Checkout terpisah memiliki root default terpisah, sementara `--worktree` dan `--madmax` mempertahankan perilaku isolasi yang sudah ada.
+
+### Keamanan launch Madmax dan worktree
+
+`--madmax` adalah shorthand OMX untuk Codex
+`--dangerously-bypass-approvals-and-sandbox`. Flag ini menghapus guardrail approval dan
+sandbox normal, jadi gunakan hanya di repository dan environment tepercaya.
+`--high` dan `--xhigh` adalah shorthand untuk `-c model_reasoning_effort="high|xhigh"`; sesi kuat normal adalah `omx --madmax --xhigh` (atau `omx --worktree=feat/task --madmax --xhigh` dari proyek git).
+
+Saat menggunakan `--madmax` dari repository git, pilih launch worktree alih-alih
+menjalankannya langsung di checkout saat ini. Untuk pekerjaan yang dapat diulang atau berjalan bersamaan,
+gunakan worktree bernama:
+
+```bash
+omx --worktree=feature/auth --madmax --xhigh
+```
+
+Jika Anda berada di luar repository git, hilangkan `--worktree`; launch worktree
+memerlukan Git.
+
+Untuk beberapa sesi `--madmax` yang berjalan bersamaan, **jangan** jalankan semuanya di
+direktori yang sama. Berikan masing-masing sesi worktree bernama sendiri:
+
+```bash
+omx --worktree=feature/auth --madmax --xhigh
+omx --worktree=fix/flaky-tests --madmax --xhigh
+```
+
+`--worktree` / `-w` tanpa nama membuat atau menggunakan kembali worktree launch detached di
+`../<repo>.omx-worktrees/launch-detached`. `--worktree=<name>`,
+`--worktree <name>`, atau `-w <name>` membuat atau menggunakan kembali worktree launch bernama
+di bawah `../<repo>.omx-worktrees/` dan checkout nama branch tersebut. OMX mengonsumsi
+flag worktree sebelum memulai Codex; flag ini tidak diteruskan ke Codex.
+Perlakukan bentuk detached tanpa nama sebagai kemudahan sekali pakai: jika source checkout
+maju setelah worktree tersebut dibuat, launch tanpa nama berikutnya dapat gagal dengan
+`worktree_target_mismatch` karena `launch-detached` masih menunjuk ke HEAD
+lama. Gunakan worktree bernama untuk pekerjaan berulang, atau hapus worktree detached
+lama sebelum mencoba lagi.
+Jika target worktree launch sudah dirty, OMX memperingatkan dan menjalankannya apa adanya, jadi
+bersihkan, commit, atau stash worktree tersebut sebelum mengandalkannya untuk isolasi.
+
+Untuk `omx team`, worker sudah menggunakan worktree khusus secara otomatis secara
+default; `--worktree` pada `omx team` hanya merupakan override yang kompatibel dengan legacy.
+
+Tool yang sadar repository menerima konteks kanonis yang sama pada runtime launch, team-worker, dan autoresearch: `OMX_REPO_ROOT`, `OMX_WORKTREE_ROOT`, `OMX_GIT_COMMON_DIR`, `OMX_WORKTREE_SCOPE`, `OMX_CODEGRAPH_MODE`, dan `OMX_CODEGRAPH_PROJECT_PATH`. `OMX_CODEGRAPH_MODE=auto` memilih `.codegraph/codegraph.db` lokal-worktree terlebih dahulu, lalu `.codegraph/codegraph.db` milik leader/repo, dan jika tidak ada akan menjadi `off`. Nilai eksplisit `shared`, `local`, dan `off` dihormati.
+OMX tidak menginstal CodeGraph, melakukan auto-index worktree, atau menyalin/membuat symlink `.codegraph`; index leader bersama berguna untuk navigasi baseline tetapi tidak akurat terhadap branch untuk perubahan yang hanya ada di worktree.
+
+Jika Anda menginginkan launch sekali pakai tanpa pengelolaan tmux/HUD OMX, gunakan `--direct`:
+
+```bash
+omx --direct --yolo
+```
+
+Untuk preferensi shell/profile yang persisten, set kebijakan environment:
+
+```bash
+OMX_LAUNCH_POLICY=direct omx --yolo
+```
+
+Kembali ke perilaku auto/default dengan:
+
+```bash
+unset OMX_LAUNCH_POLICY
+```
+
+Flag kebijakan CLI mengalahkan environment, dan flag kebijakan CLI terakhir sebelum
+`--` yang berlaku:
+
+```bash
+OMX_LAUNCH_POLICY=direct omx --tmux --yolo
+```
+
+Gunakan `OMX_LAUNCH_POLICY=direct|tmux|detached-tmux|auto`. Iterasi ini hanya
+menambahkan kontrol CLI dan environment; secara sengaja tidak menambahkan pengaturan config-file.
+Jika Anda menjalankan `--direct` dari dalam pane tmux yang sudah ada, OMX tidak akan
+membuat split HUD, mengaktifkan mouse mode, atau membungkus handling extended-key, tetapi
+proses tetap berjalan di dalam pane terminal yang sudah terbuka tersebut.
+
+Kemudian coba workflow kanonis:
+
+```text
+# Copy/pasteable durable-goal example:
+/goal Ship the checkout bug fix with a durable objective, checkpoints for reproduction, implementation, regression tests, and final verification.
+
+$plan "approve the checkout bug-fix plan and review tradeoffs"
+$ultragoal "execute the approved checkout fix with checkpoint evidence"
+```
+
+Gunakan `$team` ketika story Ultragoal aktif membutuhkan pekerjaan paralel yang terkoordinasi.
+
+### `/goal` dan pemilihan skill
+
+Mulai sesi kuat normal dengan `omx --madmax --xhigh` (atau tambahkan `--worktree=<task>` di repo git). Di dalam sesi tersebut, lakukan eksekusi langsung atau gunakan `$ultragoal` untuk run multi-goal persisten, `$team` untuk pekerjaan paralel terkoordinasi, atau `$plan` saat tugas membutuhkan planning eksplisit terlebih dahulu. Gunakan `/goal` ketika tugas itu sendiri memerlukan struktur objektif/checkpoint persisten yang harus terus direkonsiliasi Codex lintas turn.
+
+Tambahkan hanya 2-5 skill yang relevan secara default. Lebih banyak skill boleh digunakan jika scope tugas memang membutuhkannya, tetapi memuat katalog besar biasanya menjadi masalah context budget dan kualitas perhatian, bukan hard blocker parser/runtime. Perlakukan ini sebagai blocker runtime konkret hanya ketika sebuah perintah benar-benar error.
+
+Pola yang perlu dihindari:
+
+```text
+omx --madmax --xhigh
+# Then immediately load 20 skills "just in case" before stating the task.
+# This bloats session context and makes the model spend attention on irrelevant workflows.
+```
+
+## Model mental sederhana
+
+OMX **tidak** menggantikan Codex.
+
+OMX menambahkan layer kerja yang lebih baik di sekitarnya:
+- **Codex** melakukan pekerjaan agent yang sebenarnya
+- **keyword role OMX** membuat role yang berguna dapat digunakan kembali
+- **skill OMX** membuat workflow umum dapat digunakan kembali
+- **`.omx/`** menyimpan rencana, log, memory, dan state runtime
+
+Sebagian besar user sebaiknya memandang OMX sebagai **routing tugas yang lebih baik + workflow yang lebih baik + runtime yang lebih baik**, bukan sebagai antarmuka command yang harus dioperasikan manual sepanjang hari.
+
+## Mulai dari sini jika Anda baru menggunakan OMX
+
+1. Jika Codex CLI sudah ada, verifikasi dengan `codex --version` lalu instal atau update OMX dengan `npm install -g oh-my-codex`; jika belum, instal `@openai/codex` secara terpisah terlebih dahulu jika Anda ingin npm mengelola Codex
+2. Setelah instalasi atau bump versi OMX yang sebenarnya, jalankan `omx setup --scope project --merge-agents` dari proyek git target atau `omx setup --scope user` untuk setup Codex tingkat user, atau gunakan `omx update` ketika Anda juga ingin npm memeriksa dan menginstal build terbaru sebelum me-refresh setup
+3. Jalankan `omx doctor`
+4. Jalankan smoke test eksekusi nyata: `codex login status` dan `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"`
+5. Launch dengan worktree bernama dari repo git, misalnya `omx --worktree=feat/task --madmax --xhigh`; jika Anda menjalankan beberapa sesi `--madmax` bersamaan, gunakan worktree bernama berbeda seperti `--worktree=feature/auth`
+6. Gunakan `$deep-interview "..."` ketika request atau batasan masih belum jelas
+7. Gunakan `$ralplan "..."` untuk menyetujui rencana dan meninjau tradeoff
+8. Gunakan `$ultragoal` atau `$team` ketika tugas membutuhkan eksekusi persisten atau paralel; tambahkan `/goal` ketika struktur objektif/checkpoint persisten perlu dibuat eksplisit
+
+## Workflow yang direkomendasikan
+
+`$autopilot` adalah orchestrator kanonis kelas utama untuk workflow bertahap `$deep-interview -> $ralplan -> $ultragoal`. Rangkaian ini adalah default yang mendefinisikannya, sementara setiap tahap tetap dapat dijalankan secara independen ketika kontrak input dari tahap sebelumnya sudah terpenuhi.
+
+1. `$deep-interview` — klarifikasi ambiguitas secara Sokratik dan iteratif, state yang dapat dilanjutkan, serta artifact requirement yang siap dieksekusi.
+2. `$ralplan` — planning arsitektur, feasibility, dan konsensus berdasarkan artifact deep-interview.
+3. `$ultragoal` — eksekusi multi-goal persisten dengan checkpoint ledger `.omx/ultragoal`.
+4. `$team` — eksekusi paralel terkoordinasi ketika sebuah story mendapat manfaat dari beberapa lane.
+
+`$deep-interview` adalah tahap requirement independen, bukan alias untuk `$plan --interview`, dan tidak pernah langsung mengimplementasikan. Skill planning berhenti pada artifact planning; perubahan kode membutuhkan lane eksekusi eksplisit (`$ultragoal` atau `$team`).
+
+Di dalam story Ultragoal, gunakan `$team` hanya ketika story tersebut mendapat manfaat dari eksekusi paralel yang terkoordinasi.
+
+## Antarmuka umum dalam sesi
+
+| Permukaan | Gunakan untuk |
+| --- | --- |
+| `$plan "..."` | planning dan klarifikasi opsional (mode `--interview`) |
+| `$ultragoal "..."` | penyelesaian multi-goal persisten setelah rencana disetujui |
+| `$team "..."` | eksekusi paralel terkoordinasi ketika pekerjaan cukup besar |
+| `/skills` | menjelajahi skill terinstal dan helper pendukung |
+| `/goal ...` | struktur objektif/checkpoint persisten untuk tugas yang harus merekonsiliasi progress lintas turn |
+| `omx mission <file>` | run batch prompt/checklist berurutan melalui `omx exec`, dengan artifact operator `.omx/missions/<slug>/summary.json` dan `ledger.jsonl` |
+
+## Antarmuka advanced / operator
+
+Ini berguna, tetapi bukan jalur onboarding utama.
+
+### Runner mission queue
+
+Gunakan `omx mission` ketika Anda memiliki checklist singkat prompt OmX/Codex yang harus dijalankan satu per satu alih-alih membuka perintah shell terpisah untuk setiap prompt. Mulai dengan `omx mission plan ./mission.md` atau `omx mission ./mission.md --dry-run` untuk memvalidasi parsing dan memeriksa summary persisten, lalu jalankan `omx mission run ./mission.md -- --model gpt-5` ketika prompt sudah siap.
+Run yang terinterupsi dapat diperiksa dengan `omx mission status ./mission.md`, dilanjutkan dengan `omx mission resume ./mission.md`, diblokir operator dengan `omx mission mark ./mission.md --task task-002 --status blocked`, dan diperbaiki per task dengan `omx mission rerun ./mission.md --task task-002`. Lihat [`docs/mission.md`](../mission.md) untuk format input, output status, dan detail artifact.
+
+### Runtime team
+
+Gunakan runtime team ketika Anda memang membutuhkan koordinasi tmux/worktree yang persisten, bukan sebagai cara default untuk mulai menggunakan OMX. Di Codex App atau sesi biasa di luar tmux, perlakukan `omx team` sebagai antarmuka shell runtime tmux, bukan workflow yang langsung tersedia di dalam app; launch OMX CLI dari shell terlebih dahulu jika Anda memang ingin menjalankan team.
+
+Ketika Team berjalan di dalam story Ultragoal, Ultragoal tetap menjadi state milik leader: worker melaporkan evidence yang siap menjadi checkpoint ke atas alih-alih memutasi `.omx/ultragoal` secara langsung. Startup Team menoleransi artifact Ultragoal yang stale atau malformed untuk pekerjaan yang tidak terkait, tetapi launch Team yang secara eksplisit terhubung ke Ultragoal tetap fail-closed.
+Startup Team juga menulis `.omx/state/team/<team-name>/preflight-context.json` sehingga run Team besar dapat dilanjutkan setelah compaction dengan task awal, pembagian worker, konteks Ultragoal, dan checklist verifikasi.
+
+Untuk pekerjaan atomik yang sangat kecil, Team dapat membatasi fanout implisit menjadi satu worker dan mencetak peringatan over-orchestration; berikan jumlah worker eksplisit hanya ketika biaya koordinasi tambahan memang disengaja.
+
+```bash
+omx team 3:executor "fix the failing tests with verification"
+omx team status <team-name>
+omx team resume <team-name>
+omx team shutdown <team-name>
+```
+
+### Setup, doctor, dan HUD
+
+Ini adalah antarmuka operator/dukungan:
+- discovery/instalasi marketplace plugin Codex dapat menyimpan cache plugin di `${CODEX_HOME:-~/.codex}/plugins/cache/$MARKETPLACE_NAME/oh-my-codex/$VERSION/` (instalasi lokal dapat menggunakan `local` sebagai identifier versi); plugin terpaket tersebut menyertakan metadata pendamping dengan scope plugin untuk lifecycle hook resmi Codex, server kompatibilitas MCP opsional, dan app (MCP/app dinonaktifkan secara default), sehingga tetap dipasangkan dengan CLI `omx` yang terinstal untuk eksekusi runtime
+- Setup dengan scope menginstal prompt, skill, scaffolding AGENTS, `.codex/config.toml`, dan (untuk instalasi legacy atau Codex lama tanpa `plugin_hooks`) hook native Codex yang dikelola OMX di `.codex/hooks.json`
+  - refresh setup mempertahankan entry hook non-OMX di `.codex/hooks.json` dan hanya menulis ulang wrapper yang dikelola OMX
+  - setup plugin mempertahankan `AGENTS.md` sebagai panduan persisten walaupun skill/hook yang dibundel berasal dari cache plugin; `omx doctor` menganggap hilangnya `AGENTS.md` dengan scope persisten dalam mode plugin sebagai check yang gagal karena file AGENTS dengan scope sesi jika tidak demikian hanya akan berisi panduan overlay runtime
+  - `omx setup --merge-agents` mempertahankan panduan `AGENTS.md` proyek yang sudah ada sambil menyisipkan atau me-refresh bagian OMX yang dihasilkan di antara `<!-- OMX:AGENTS:START -->` / `<!-- OMX:AGENTS:END -->`; `--no-merge-agents` mencatat pilihan contextual non-merge secara eksplisit, dan `--clear-merge-agents-policy` selalu menghapus pilihan yang tercatat serta tidak dapat digabungkan dengan selector set.
+Kebijakan disimpan per working root (bahkan untuk scope user), diputar ulang oleh update langsung maupun tertunda hanya ketika scope tersimpannya valid dan cocok, dan tidak pernah menjadi kebijakan force/default.
+  - `omx uninstall` menghapus wrapper yang dikelola OMX dari `.codex/hooks.json` tetapi mempertahankan file tersebut ketika hook user masih ada
+- `omx update` langsung memeriksa npm, menginstal build OMX global terbaru, lalu menjalankan kembali jalur refresh setup interaktif yang sama
+- pemeriksaan update saat launch dibatasi frekuensinya dan meminta konfirmasi secara default; gunakan `OMX_AUTO_UPDATE=0` untuk menonaktifkannya atau `OMX_AUTO_UPDATE=defer` untuk menjadwalkan update tertunda tanpa prompt
+- seeding config baru yang dikelola OMX untuk `gpt-5.6-sol` sekarang merekomendasikan `model_context_window = 250000` dan `model_auto_compact_token_limit = 200000`, tetapi hanya ketika key tersebut belum ada
+- routing model/env `.omx-config.json` didokumentasikan di [referensi routing model/env](../reference/omx-config-schema-routing.md); hanya edit key yang didukung oleh versi OMX terinstal Anda
+- `omx doctor` memverifikasi instalasi ketika ada sesuatu yang tampak salah; ini tidak membuktikan bahwa profile Codex aktif dapat melakukan model call yang terautentikasi
+- `omx hud --watch` adalah antarmuka monitoring/status, bukan workflow utama user
+
+Untuk sesi non-team, hook native Codex sekarang menjadi antarmuka lifecycle kanonis:
+- `plugins/oh-my-codex/hooks/hooks.json` = registrasi hook resmi dengan scope plugin untuk instalasi plugin
+- `.codex/hooks.json` = registrasi hook native Codex legacy/fallback yang dipertahankan untuk instalasi legacy dan versi Codex lama
+- `.omx/hooks/*.mjs` = hook plugin OMX
+- `omx tmux-hook` / notify-hook / derived watcher = jalur fallback tmux + runtime
+
+Lihat [pemetaan hook native Codex](../codex-native-hooks.md) untuk matriks native / fallback saat ini.
+
+
+### Troubleshooting readiness yang terlihat hijau padahal gagal
+
+`omx doctor` yang hijau berarti instalasi dan wiring runtime lokal terlihat sehat. Jika eksekusi nyata masih gagal, periksa environment yang benar-benar digunakan Codex:
+
+- Jalankan `codex login status` dan `omx exec --skip-git-repo-check -C . "Reply with exactly OMX-EXEC-OK"` dari shell/profile yang sama yang akan menjalankan OMX.
+- Di shell dengan HOME, profile, container, atau service kustom, pastikan `~/.codex` aktif (atau `CODEX_HOME`) adalah yang memiliki auth dan config yang diharapkan. Jangan berasumsi `~/.codex` user normal Anda terlihat di sana.
+- Jika Anda bergantung pada proxy lokal yang kompatibel dengan OpenAI, pastikan `~/.codex/config.toml` aktif menyertakan `openai_base_url` yang diharapkan; jika tidak, key yang diterbitkan proxy dapat dikirim ke endpoint default dan gagal dengan `401 Unauthorized`, `Missing bearer or basic authentication in header`, atau `Incorrect API key provided`.
+- Jika `omx doctor --team` atau resume melaporkan team stale seperti `resume_blocker` atau sesi tmux yang hilang, bersihkan state runtime mati sebelum mencoba lagi:
+
+```bash
+omx team shutdown <team-name> --force --confirm-issues
+omx cancel
+omx doctor --team
+```
+
+Gunakan forced team shutdown hanya untuk team yang sudah Anda pastikan mati atau sengaja ditinggalkan.
+
+Jika `Shift+Enter` masih mengirim alih-alih memasukkan newline di dalam sesi tmux yang dikelola OMX, lihat [Troubleshooting kesiapan eksekusi](../troubleshooting.md#shiftenter-submits-instead-of-inserting-a-newline-in-tmux-backed-omx-sessions). OMX saat ini sudah mengaktifkan forwarding extended-key tmux di sekitar jalur launch Codex miliknya, jadi kegagalan persisten biasanya merupakan masalah capability/discovery terminal tmux, bukan kekurangan fitur OMX baru.
+
+### Sparkshell
+
+- `omx sparkshell <command>` digunakan untuk inspeksi shell-native dan verifikasi berbatas
+- untuk lookup repository read-only, gunakan tool/subagent inspeksi repository Codex biasa (perintah `omx explore` yang deprecated telah dihapus)
+- override env sparkshell sengaja dibatasi: `OMX_SPARKSHELL_BIN` memilih path sidecar native, `OMX_SPARKSHELL_MODEL` memilih model summary utama, `OMX_SPARKSHELL_FALLBACK_MODEL` memilih model retry, `OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE` memilih instruksi summary, dan `OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS` mengontrol timeout summary API lokal
+
+Contoh:
+
+```bash
+omx sparkshell git status
+omx sparkshell --tmux-pane %12 --tail-lines 400
+```
+
+### Wiki
+
+- `omx wiki` adalah antarmuka JSON berbasis CLI untuk operasi wiki; MCP `omx_wiki` hanya untuk kompatibilitas eksplisit
+- data wiki tersimpan sebagai knowledge proyek repository di bawah `omx_wiki/`
+- wiki bersifat markdown-first dan search-first, bukan vector-first
+
+Contoh:
+
+```bash
+omx wiki list --json
+omx wiki query --input '{"query":"session-start lifecycle"}' --json
+omx wiki lint --json
+omx wiki refresh --json
+```
+
+### Catatan platform untuk mode team
+
+`omx team` bekerja paling baik di macOS/Linux dengan `tmux`.
+Windows native tetap menjadi jalur sekunder, dan WSL2 umumnya merupakan pilihan yang lebih baik jika Anda menginginkan setup yang di-host Windows.
+Di Windows native, OMX menerima `psmux` sebagai binary yang kompatibel dengan tmux untuk jalur berbasis tmux yang sudah digunakannya.
+
+| Platform | Instalasi |
+| --- | --- |
+| macOS | `brew install tmux` |
+| Ubuntu/Debian | `sudo apt install tmux` |
+| Fedora | `sudo dnf install tmux` |
+| Arch | `sudo pacman -S tmux` |
+| Windows | `winget install psmux` |
+| Windows (WSL2) | `sudo apt install tmux` |
+
+## Masalah yang diketahui
+
+### Intel Mac: CPU `syspolicyd` / `trustd` tinggi saat startup
+
+Di beberapa Intel Mac, startup OMX — terutama dengan `--madmax --high` — dapat menyebabkan penggunaan CPU `syspolicyd` / `trustd` melonjak ketika macOS Gatekeeper memvalidasi banyak process launch secara bersamaan.
+
+Jika ini terjadi, coba:
+- `xattr -dr com.apple.quarantine $(which omx)`
+- tambahkan aplikasi terminal Anda ke allowlist Developer Tools di pengaturan Security macOS
+- gunakan concurrency yang lebih rendah (misalnya, hindari `--madmax --high`)
+
+## Dokumentasi
+
+- [Memulai](../getting-started.html)
+- [Panduan demo](../../DEMO.md)
+- [Fitur wiki](../wiki-feature.md)
+- [Katalog agent](../agents.html)
+- [Referensi skill](../skills.html)
+- [Pemetaan hook native Codex](../codex-native-hooks.md)
+- [Pipeline identitas GitHub / PR / package](../pipeline/github-pr-package-identity.md)
+- [Integrasi](../integrations.html)
+- [Troubleshooting kesiapan eksekusi](../troubleshooting.md)
+- [Panduan OpenClaw / notification gateway](../openclaw-integration.md)
+- [Kontribusi](../../CONTRIBUTING.md)
+- [Changelog](../../CHANGELOG.md)
+
+## Bahasa
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
+## Kontributor
+
+| Peran | Nama | GitHub |
+| --- | --- | --- |
+| Kreator & Lead | Yeachan Heo | [@Yeachan-Heo](https://github.com/Yeachan-Heo) |
+| Maintainer | Doyun Ha | [@HaD0Yun](https://github.com/HaD0Yun) |
+| Maintainer | Valeriy Pavlovich | [@iqdoctor](https://github.com/iqdoctor) |
+
+## Riwayat Star
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-codex&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-codex&type=date&legend=top-left)
+
+## Lisensi
+
+MIT
+
+## Benchmark visibilitas GEO
+
+OmX menyertakan spec produk [`geobench`](https://github.com/NomaDamas/geobench) untuk mengukur hit rate LLM, MRR, share of voice, dan citation.
+
+- Spec: [`geobench/oh-my-codex.yaml`](../../geobench/oh-my-codex.yaml)
+- Runbook: [`docs/geobench.md`](../geobench.md)

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -258,6 +258,26 @@ npm test
 
 Ispirato da [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adattato per Codex CLI.
 
+## Lingue
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Licenza
 
 MIT

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -259,6 +259,26 @@ npm test
 
 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)にインスパイアされ、Codex CLI向けに適応されました。
 
+## 言語
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## ライセンス
 
 MIT

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -259,6 +259,26 @@ npm test
 
 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)에서 영감을 받아 Codex CLI용으로 적응하였습니다.
 
+## 언어
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## 라이선스
 
 MIT

--- a/docs/readme/README.md
+++ b/docs/readme/README.md
@@ -38,6 +38,7 @@ The repository root keeps only the canonical `README.md` so the top level stays 
 | 简体中文            | [README.zh.md](./README.zh.md)       |
 | Українська          | [README.uk.md](./README.uk.md)       |
 | 繁體中文            | [README.zh-TW.md](./README.zh-TW.md) |
+| Bahasa Indonesia    | [README.id.md](./README.id.md)       |
 
 ## Maintenance rules
 

--- a/docs/readme/README.pl.md
+++ b/docs/readme/README.pl.md
@@ -208,7 +208,10 @@ Jeśli to widzisz:
 - [Deutsch](./README.de.md)
 - [Français](./README.fr.md)
 - [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
 - [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
 
 ## Współtwórcy
 

--- a/docs/readme/README.pt.md
+++ b/docs/readme/README.pt.md
@@ -258,6 +258,26 @@ npm test
 
 Inspirado em [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), adaptado para Codex CLI.
 
+## Idiomas
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Licença
 
 MIT

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -258,6 +258,26 @@ npm test
 
 Вдохновлено проектом [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode), адаптировано для Codex CLI.
 
+## Языки
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Лицензия
 
 MIT

--- a/docs/readme/README.tr.md
+++ b/docs/readme/README.tr.md
@@ -258,6 +258,26 @@ npm test
 
 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)'dan ilham alınmıştır, Codex CLI için uyarlanmıştır.
 
+## Diller
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## Lisans
 
 MIT

--- a/docs/readme/README.uk.md
+++ b/docs/readme/README.uk.md
@@ -254,6 +254,7 @@ omx sparkshell --tmux-pane %12 --tail-lines 400
 - [Ελληνικά](./README.el.md)
 - [Polski](./README.pl.md)
 - [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
 
 ## Учасники
 

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -216,6 +216,8 @@ Nếu gặp tình trạng này, thử:
 - [Italiano](./README.it.md)
 - [Ελληνικά](./README.el.md)
 - [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
 
 ## Đóng góp
 

--- a/docs/readme/README.zh-TW.md
+++ b/docs/readme/README.zh-TW.md
@@ -288,6 +288,26 @@ npm test
 
 靈感來自 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode)，為 Codex CLI 量身改編。
 
+## 語言
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## 授權條款
 
 MIT

--- a/docs/readme/README.zh.md
+++ b/docs/readme/README.zh.md
@@ -259,6 +259,26 @@ npm test
 
 受 [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) 启发，为 Codex CLI 适配。
 
+## 语言
+
+- [English](../../README.md)
+- [한국어](./README.ko.md)
+- [日本語](./README.ja.md)
+- [简体中文](./README.zh.md)
+- [繁體中文](./README.zh-TW.md)
+- [Tiếng Việt](./README.vi.md)
+- [Español](./README.es.md)
+- [Português](./README.pt.md)
+- [Русский](./README.ru.md)
+- [Türkçe](./README.tr.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Italiano](./README.it.md)
+- [Ελληνικά](./README.el.md)
+- [Polski](./README.pl.md)
+- [Українська](./README.uk.md)
+- [Bahasa Indonesia](./README.id.md)
+
 ## 许可证
 
 MIT

--- a/docs/release-notes-0.21.2.md
+++ b/docs/release-notes-0.21.2.md
@@ -1,0 +1,25 @@
+# oh-my-codex 0.21.2 release notes
+
+Release date: 2026-09-01
+
+`0.21.2` is a patch release covering `v0.21.1..04533ebfc887643586e37180ec3270473948115a`: 11 commits, 29 changed files (+1,245/−10), and three merged PRs (#3599, #3601, #3602).
+
+## Highlights
+
+- **macOS arm64 native runtime hydration** — global installs and same-version reinstalls hydrate `omx-runtime` into the verified native cache. Immediate and deferred `omx update` paths also hydrate after their script-suppressed install, with bounded non-fatal network behavior (#3602).
+- **GitGuardex finish progress in HUD** — optional project-local HUD integration shows live review/autofix finish progress, resolves configuration from nested worktree paths, bounds metadata reads before stat calls, and uses a spinner cadence that advances under the one-second HUD watch interval (#3601).
+- **Indonesian README** — adds a Bahasa Indonesia translation and synchronizes language navigation across every localized README (#3599).
+
+## Compatibility
+
+Patch release. GitGuardex integration is disabled by default and requires explicit project HUD configuration. Runtime hydration preserves fail-closed checksum/cache verification and does not make package installation fatal when assets or network access are unavailable.
+
+## Inventory
+
+The reproducible range is recorded in `artifacts/release-0.21.2/inventory.md`.
+
+## Contributors
+
+Thanks to Bellman (@Yeachan-Heo), @NagyVikt, Dendroculus, and the gaebal-gajae (clawdbot) release and repair lanes.
+
+**Full Changelog**: [`v0.21.1...v0.21.2`](https://github.com/Yeachan-Heo/oh-my-codex/compare/v0.21.1...v0.21.2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",

--- a/src/cli/native-assets.ts
+++ b/src/cli/native-assets.ts
@@ -41,6 +41,7 @@ export interface HydrateNativeBinaryOptions {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   arch?: string;
+  signal?: AbortSignal;
 }
 
 export interface NativeBinaryCandidateOptions {
@@ -236,9 +237,10 @@ export async function loadNativeReleaseManifest(
   packageRoot = getPackageRoot(),
   version?: string,
   env: NodeJS.ProcessEnv = process.env,
+  signal?: AbortSignal,
 ): Promise<NativeReleaseManifest> {
   const url = await resolveNativeManifestUrl(packageRoot, version, env);
-  const response = await fetch(url);
+  const response = await fetch(url, { signal });
   if (!response.ok) {
     throw new Error(`[native-assets] failed to fetch native release manifest (${response.status} ${response.statusText}) from ${url}`);
   }
@@ -260,8 +262,8 @@ function isUnavailableArchiveError(error: unknown): boolean {
     || /fetch failed/i.test(error.message);
 }
 
-async function downloadFile(url: string, destinationPath: string): Promise<void> {
-  const response = await fetch(url);
+async function downloadFile(url: string, destinationPath: string, signal?: AbortSignal): Promise<void> {
+  const response = await fetch(url, { signal });
   if (!response.ok || !response.body) {
     throw new Error(`[native-assets] failed to download ${url} (${response.status} ${response.statusText})`);
   }
@@ -689,6 +691,7 @@ export async function hydrateNativeBinary(
     env = process.env,
     platform = process.platform,
     arch = process.arch,
+    signal,
   } = options;
 
   if (env[NATIVE_AUTO_FETCH_ENV]?.trim() === '0') return undefined;
@@ -703,7 +706,7 @@ export async function hydrateNativeBinary(
 
   let manifest: NativeReleaseManifest;
   try {
-    manifest = await loadNativeReleaseManifest(packageRoot, version, env);
+    manifest = await loadNativeReleaseManifest(packageRoot, version, env, signal);
   } catch (error) {
     if (isUnavailableManifestError(error)) return undefined;
     throw error;
@@ -729,7 +732,7 @@ export async function hydrateNativeBinary(
         inferNativeAssetLibc(asset),
       );
       try {
-        await downloadFile(asset.download_url, archivePath);
+        await downloadFile(asset.download_url, archivePath, signal);
         const archiveStat = await stat(archivePath);
         if (typeof asset.size === 'number' && asset.size > 0 && archiveStat.size !== asset.size) {
           throw new Error(`[native-assets] downloaded archive size mismatch for ${asset.archive}`);

--- a/src/cli/update-worker.ts
+++ b/src/cli/update-worker.ts
@@ -5,6 +5,7 @@ import { basename, isAbsolute, join, relative } from 'node:path';
 
 import { isCompletePackageManagerOwnership, runNpmCommand, validatePackageManagerOwnership, type PackageManagerOwnership } from './package-manager-ownership.js';
 import { writeUserInstallStamp } from '../scripts/postinstall-advisory.js';
+import { hydrateOmxRuntimeNonFatal } from '../scripts/postinstall.js';
 import { omxUserInstallStampPath } from '../utils/paths.js';
 
 type DeferredUpdatePayload = { cwd: string; logPath: string; parentPid: number; ownership: PackageManagerOwnership; setupArgs: string[] };
@@ -111,6 +112,14 @@ async function main(): Promise<void> {
     if (result.error || result.status !== 0) throw new Error(String(result.stderr || result.error?.message || 'controller install failed'));
     const cliEntry = await validatePackageManagerOwnership(payload.ownership);
     if (!cliEntry) throw new Error('Frozen manager, package root, or bin ownership validation failed after update.');
+    // The package was installed with --ignore-scripts. Hydrate before setup so
+    // setup failure still leaves the installed version with a repaired runtime
+    // cache and the recovery command does not repeat the omission.
+    await hydrateOmxRuntimeNonFatal({
+      packageRoot: payload.ownership.packageRoot,
+      env: payload.ownership.environment,
+      log: (message) => appendFile(payload!.logPath, `${message}\n`).then(() => undefined),
+    });
     const setup = spawnSync(process.execPath, [cliEntry, ...payload.setupArgs], { cwd: payload.cwd, env: { ...payload.ownership.environment, [SKIP_NATIVE_AGENT_REFRESH_ENV]: '1' }, stdio: 'inherit', windowsHide: true });
     if (setup.error || setup.status !== 0) throw new Error(setup.error?.message || `setup exited ${setup.status}`);
     await finalizeSuccessfulUpdate(payload.ownership);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -33,6 +33,7 @@ import {
   writeUserInstallStamp,
   type UserInstallStamp,
 } from '../scripts/postinstall-advisory.js';
+import { hydrateOmxRuntimeNonFatal } from '../scripts/postinstall.js';
 export {
   isInstallVersionBump,
   readUserInstallStamp,
@@ -569,6 +570,7 @@ interface UpdateDependencies {
   runGlobalUpdate: (installSource: string, ownership?: PackageManagerOwnership) => RunGlobalUpdateResult;
   runDeferredGlobalUpdate: (cwd: string, ownership?: PackageManagerOwnership) => RunDeferredUpdateResult;
   runSetupRefresh: (cwd: string, ownership?: PackageManagerOwnership) => Promise<RunSetupRefreshResult>;
+  hydrateRuntime: (ownership?: PackageManagerOwnership) => Promise<string | undefined>;
   writeUpdateState: typeof writeUpdateState;
 }
 
@@ -591,6 +593,10 @@ const defaultUpdateDependencies: UpdateDependencies = {
   runGlobalUpdate: (installSource, ownership) => runGlobalUpdate(installSource, spawnSync, process.platform, ownership),
   runDeferredGlobalUpdate: (cwd, ownership) => runDeferredGlobalUpdate(cwd, spawn, process.platform, process.pid, ownership),
   runSetupRefresh,
+  hydrateRuntime: (ownership) => hydrateOmxRuntimeNonFatal({
+    packageRoot: ownership?.packageRoot,
+    env: ownership?.environment,
+  }),
   writeUpdateState,
 }
 
@@ -897,6 +903,11 @@ async function executeUpdate(
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
 
+  // Installation already replaced the package with --ignore-scripts. Repair
+  // the version-keyed native cache before setup so a setup failure cannot
+  // strand the successfully installed package without omx-runtime.
+  await dependencies.hydrateRuntime(ownership ?? undefined);
+
   const setupRefreshResult = await dependencies.runSetupRefresh(cwd, ownership ?? undefined);
   if (!setupRefreshResult.ok) {
     console.log(
@@ -904,7 +915,6 @@ async function executeUpdate(
     );
     return { status: 'failed', currentVersion: current, latestVersion: latest };
   }
-
   const installedVersion = await dependencies.getInstalledVersionAfterUpdate(ownership ?? undefined);
   const installedRevision = channelConfig.channel === 'dev'
     ? ((await dependencies.getInstalledRevisionAfterUpdate(ownership ?? undefined)) ?? result.revision ?? null)

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -96,6 +96,70 @@ describe('renderHud – gitBranch', () => {
   });
 });
 
+// ── GitGuardex finish ─────────────────────────────────────────────────────────────
+
+describe('renderHud – GitGuardex finish', () => {
+  it('renders the current finish step in every preset', () => {
+    const ctx = {
+      ...emptyCtx(),
+      guardexFinish: {
+        active: true as const,
+        stage: 'ci',
+        state: 'running',
+        index: 6,
+        total: 8,
+        label: 'CI checks',
+        updatedAt: new Date().toISOString(),
+      },
+    };
+
+    for (const preset of ['minimal', 'focused', 'full'] as const) {
+      assert.ok(stripSgr(renderHud(ctx, preset)).includes('gx:6/8 ci'));
+    }
+  });
+
+  it('animates review while it is running', () => {
+    const ctx = {
+      ...emptyCtx(),
+      guardexFinish: {
+        active: true as const,
+        stage: 'review',
+        state: 'running',
+        index: 4,
+        total: 8,
+        label: 'AI review',
+        updatedAt: new Date().toISOString(),
+      },
+    };
+    mock.method(Date, 'now', () => 0);
+    const first = stripSgr(renderHud(ctx, 'focused'));
+    mock.restoreAll();
+    mock.method(Date, 'now', () => 250);
+    const second = stripSgr(renderHud(ctx, 'focused'));
+
+    assert.match(first, /gx:4\/8 review [◐◓◑◒]/u);
+    assert.match(second, /gx:4\/8 review [◐◓◑◒]/u);
+    assert.notEqual(first, second);
+  });
+
+  it('does not animate a settled review phase', () => {
+    const ctx = {
+      ...emptyCtx(),
+      guardexFinish: {
+        active: true as const,
+        stage: 'review',
+        state: 'complete',
+        index: 4,
+        total: 8,
+        label: 'AI review',
+        updatedAt: new Date().toISOString(),
+      },
+    };
+
+    assert.equal(stripSgr(renderHud(ctx, 'focused')).includes('◐'), false);
+  });
+});
+
 // ── Ralph ─────────────────────────────────────────────────────────────────────
 
 describe('renderHud – ralph', () => {

--- a/src/hud/__tests__/render.test.ts
+++ b/src/hud/__tests__/render.test.ts
@@ -118,7 +118,7 @@ describe('renderHud – GitGuardex finish', () => {
     }
   });
 
-  it('animates review while it is running', () => {
+  it('advances review animation at the one-second watch cadence', () => {
     const ctx = {
       ...emptyCtx(),
       guardexFinish: {
@@ -134,7 +134,7 @@ describe('renderHud – GitGuardex finish', () => {
     mock.method(Date, 'now', () => 0);
     const first = stripSgr(renderHud(ctx, 'focused'));
     mock.restoreAll();
-    mock.method(Date, 'now', () => 250);
+    mock.method(Date, 'now', () => 1000);
     const second = stripSgr(renderHud(ctx, 'focused'));
 
     assert.match(first, /gx:4\/8 review [◐◓◑◒]/u);

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -20,6 +20,7 @@ import {
   readAutoresearchState,
   readUltraqaState,
   readGuardexFinishState,
+  readHudConfig,
   normalizeHudConfig,
 } from '../state.js';
 
@@ -128,6 +129,20 @@ describe('readGuardexFinishState', () => {
       ]);
 
       assert.equal(await readGuardexFinishState(cwd), null);
+    });
+  });
+});
+
+describe('readHudConfig', () => {
+  it('loads the project-local config when invoked from a nested directory', async () => {
+    await withTempRepo('omx-hud-config-nested-', async (cwd) => {
+      initGitRepo(cwd);
+      const nested = join(cwd, 'packages', 'app');
+      await mkdir(join(cwd, '.omx'), { recursive: true });
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(cwd, '.omx', 'hud-config.json'), JSON.stringify({ guardex: { enabled: true } }));
+
+      assert.equal((await readHudConfig(nested)).guardex?.enabled, true);
     });
   });
 });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -19,6 +19,8 @@ import {
   readDeepInterviewState,
   readAutoresearchState,
   readUltraqaState,
+  readGuardexFinishState,
+  normalizeHudConfig,
 } from '../state.js';
 
 function gitRunnerFromMap(map: Record<string, string | Error>) {
@@ -61,6 +63,74 @@ async function writeModeState(cwd: string, mode: string, state: unknown): Promis
   await mkdir(stateDir, { recursive: true });
   await writeFile(join(stateDir, mode + '-state.json'), JSON.stringify(state));
 }
+
+async function writeGuardexFinishEvents(cwd: string, runId: string, events: unknown[]): Promise<void> {
+  const runDir = join(cwd, '.omx', 'state', 'finish-runs');
+  await mkdir(runDir, { recursive: true });
+  await writeFile(join(runDir, `${runId}.jsonl`), `${events.map(event => JSON.stringify(event)).join('\n')}\n`);
+}
+
+describe('readGuardexFinishState', () => {
+  it('reads the latest non-pending phase from a live finish process', async () => {
+    await withTempRepo('omx-hud-guardex-finish-', async (cwd) => {
+      const runId = `finish-test-${process.pid}-12345678`;
+      const timestamp = new Date().toISOString();
+      await writeGuardexFinishEvents(cwd, runId, [
+        { schemaVersion: 1, runId, timestamp, stage: 'cleanup', state: 'pending', index: 8, total: 8, label: 'Cleanup' },
+        { schemaVersion: 1, runId, timestamp, stage: 'review', state: 'running', index: 4, total: 8, label: 'AI review' },
+      ]);
+
+      assert.deepEqual(await readGuardexFinishState(cwd), {
+        active: true,
+        stage: 'review',
+        state: 'running',
+        index: 4,
+        total: 8,
+        label: 'AI review',
+        updatedAt: timestamp,
+      });
+      assert.equal((await readAllState(cwd)).guardexFinish, null);
+      const enabledConfig = normalizeHudConfig({ guardex: { enabled: true } });
+      assert.equal((await readAllState(cwd, enabledConfig)).guardexFinish?.stage, 'review');
+    });
+  });
+
+  it('hides a finish run after its terminal cleanup event', async () => {
+    await withTempRepo('omx-hud-guardex-finished-', async (cwd) => {
+      const runId = `finish-test-${process.pid}-12345678`;
+      await writeGuardexFinishEvents(cwd, runId, [
+        { schemaVersion: 1, runId, timestamp: new Date().toISOString(), stage: 'cleanup', state: 'finished', index: 8, total: 8, label: 'Cleanup' },
+      ]);
+
+      assert.equal(await readGuardexFinishState(cwd), null);
+    });
+  });
+
+  it('ignores malformed trailing JSON and keeps the last valid live phase', async () => {
+    await withTempRepo('omx-hud-guardex-partial-', async (cwd) => {
+      const runId = `finish-test-${process.pid}-12345678`;
+      const runDir = join(cwd, '.omx', 'state', 'finish-runs');
+      await mkdir(runDir, { recursive: true });
+      await writeFile(join(runDir, `${runId}.jsonl`), [
+        JSON.stringify({ schemaVersion: 1, runId, timestamp: new Date().toISOString(), stage: 'ci', state: 'running', index: 6, total: 8, label: 'CI checks' }),
+        '{"schemaVersion":1,"stage":',
+      ].join('\n'));
+
+      assert.equal((await readGuardexFinishState(cwd))?.stage, 'ci');
+    });
+  });
+
+  it('hides an abandoned run whose finish process is no longer alive', async () => {
+    await withTempRepo('omx-hud-guardex-abandoned-', async (cwd) => {
+      const runId = 'finish-test-2147483647-12345678';
+      await writeGuardexFinishEvents(cwd, runId, [
+        { schemaVersion: 1, runId, timestamp: new Date().toISOString(), stage: 'merge', state: 'running', index: 7, total: 8, label: 'Merge' },
+      ]);
+
+      assert.equal(await readGuardexFinishState(cwd), null);
+    });
+  });
+});
 
 function initGitRepo(cwd: string): void {
   execFileSync('git', ['init'], { cwd, stdio: 'ignore' });

--- a/src/hud/__tests__/state.test.ts
+++ b/src/hud/__tests__/state.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, join, relative } from 'node:path';
 import { renderHud } from '../render.js';
@@ -129,6 +129,30 @@ describe('readGuardexFinishState', () => {
       ]);
 
       assert.equal(await readGuardexFinishState(cwd), null);
+    });
+  });
+
+  it('bounds metadata reads when historical finish streams accumulate', async () => {
+    await withTempRepo('omx-hud-guardex-bounded-', async (cwd) => {
+      const timestamp = new Date().toISOString();
+      for (let index = 0; index < 40; index += 1) {
+        const startedAt = (Date.now() - index).toString(36);
+        const runId = `finish-${startedAt}-${process.pid}-${String(index).padStart(8, '0')}`;
+        await writeGuardexFinishEvents(cwd, runId, [
+          { schemaVersion: 1, runId, timestamp, stage: 'review', state: 'running', index: 4, total: 8, label: 'AI review' },
+        ]);
+      }
+
+      let metadataReads = 0;
+      const state = await readGuardexFinishState(cwd, {
+        statFile: async path => {
+          metadataReads += 1;
+          return stat(path);
+        },
+      });
+
+      assert.equal(state?.stage, 'review');
+      assert.equal(metadataReads, 32);
     });
   });
 });

--- a/src/hud/__tests__/types.test.ts
+++ b/src/hud/__tests__/types.test.ts
@@ -15,6 +15,10 @@ describe('DEFAULT_HUD_CONFIG', () => {
   it('defaults statusLine preset to "focused"', () => {
     assert.equal(DEFAULT_HUD_CONFIG.statusLine.preset, 'focused');
   });
+
+  it('keeps GitGuardex integration disabled by default', () => {
+    assert.deepEqual(DEFAULT_HUD_CONFIG.guardex, { enabled: false });
+  });
 });
 
 describe('normalizeHudConfig', () => {
@@ -28,6 +32,7 @@ describe('normalizeHudConfig', () => {
       preset: 'minimal',
       git: { display: 'repo-branch' },
       statusLine: { preset: 'focused' },
+      guardex: { enabled: false },
     });
   });
 
@@ -47,6 +52,7 @@ describe('normalizeHudConfig', () => {
         repoLabel: 'manual-repo',
       },
       statusLine: { preset: 'focused' },
+      guardex: { enabled: false },
     });
   });
 
@@ -84,5 +90,10 @@ describe('normalizeHudConfig', () => {
     });
     assert.equal(resolved.preset, 'minimal');
     assert.equal(resolved.statusLine.preset, 'full');
+  });
+
+  it('enables GitGuardex progress only when explicitly configured', () => {
+    assert.equal(normalizeHudConfig({ guardex: { enabled: true } }).guardex?.enabled, true);
+    assert.equal(normalizeHudConfig({ guardex: { enabled: 'yes' as never } }).guardex?.enabled, false);
   });
 });

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -56,6 +56,21 @@ function renderGitBranch(ctx: HudRenderContext): string | null {
   return cyan(gitBranch);
 }
 
+const GUARDEX_SPINNER_FRAMES = ['◐', '◓', '◑', '◒'] as const;
+
+function renderGuardexFinish(ctx: HudRenderContext): string | null {
+  if (!ctx.guardexFinish?.active) return null;
+  const { index, total, state } = ctx.guardexFinish;
+  if (!Number.isSafeInteger(index) || !Number.isSafeInteger(total) || index <= 0 || total <= 0 || index > total) return null;
+  const stage = sanitizeDynamicText(ctx.guardexFinish.stage).slice(0, 40);
+  if (!stage) return null;
+  const animates = state === 'running' && (stage === 'review' || stage === 'autofix');
+  const frame = animates
+    ? ` ${GUARDEX_SPINNER_FRAMES[Math.floor(Date.now() / 250) % GUARDEX_SPINNER_FRAMES.length]}`
+    : '';
+  return yellow(`gx:${index}/${total} ${stage}${frame}`);
+}
+
 function renderRalph(ctx: HudRenderContext): string | null {
   if (!ctx.ralph) return null;
   const { iteration, max_iterations } = ctx.ralph;
@@ -299,6 +314,7 @@ type ElementRenderer = (ctx: HudRenderContext) => string | null;
 
 const MINIMAL_ELEMENTS: ElementRenderer[] = [
   renderGitBranch,
+  renderGuardexFinish,
   renderRalph,
   renderUltrawork,
   renderRalplan,
@@ -313,6 +329,7 @@ const MINIMAL_ELEMENTS: ElementRenderer[] = [
 
 const FOCUSED_ELEMENTS: ElementRenderer[] = [
   renderGitBranch,
+  renderGuardexFinish,
   renderRalph,
   renderUltrawork,
   renderAutopilot,
@@ -332,6 +349,7 @@ const FOCUSED_ELEMENTS: ElementRenderer[] = [
 
 const FULL_ELEMENTS: ElementRenderer[] = [
   renderGitBranch,
+  renderGuardexFinish,
   renderRalph,
   renderUltrawork,
   renderAutopilot,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -57,6 +57,7 @@ function renderGitBranch(ctx: HudRenderContext): string | null {
 }
 
 const GUARDEX_SPINNER_FRAMES = ['◐', '◓', '◑', '◒'] as const;
+const GUARDEX_SPINNER_FRAME_MS = 400;
 
 function renderGuardexFinish(ctx: HudRenderContext): string | null {
   if (!ctx.guardexFinish?.active) return null;
@@ -66,7 +67,7 @@ function renderGuardexFinish(ctx: HudRenderContext): string | null {
   if (!stage) return null;
   const animates = state === 'running' && (stage === 'review' || stage === 'autofix');
   const frame = animates
-    ? ` ${GUARDEX_SPINNER_FRAMES[Math.floor(Date.now() / 250) % GUARDEX_SPINNER_FRAMES.length]}`
+    ? ` ${GUARDEX_SPINNER_FRAMES[Math.floor(Date.now() / GUARDEX_SPINNER_FRAME_MS) % GUARDEX_SPINNER_FRAMES.length]}`
     : '';
   return yellow(`gx:${index}/${total} ${stage}${frame}`);
 }

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -438,7 +438,8 @@ export async function readSessionState(cwd: string): Promise<SessionStateForHud 
 }
 
 export async function readHudConfig(cwd: string): Promise<ResolvedHudConfig> {
-  const config = await readJsonFile<HudConfig>(join(cwd, '.omx', 'hud-config.json'));
+  const repoRoot = findGitLayout(cwd)?.worktreeRoot ?? cwd;
+  const config = await readJsonFile<HudConfig>(join(repoRoot, '.omx', 'hud-config.json'));
   return normalizeHudConfig(config);
 }
 

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -4,7 +4,7 @@
  * Reads .omx/state/ files to build HUD render context.
  */
 
-import { readFile } from 'fs/promises';
+import { open, readFile, readdir, stat } from 'fs/promises';
 import { execFileSync } from 'child_process';
 import { join, basename } from 'path';
 import { findGitLayout, readGitLayoutFile } from '../utils/git-layout.js';
@@ -39,6 +39,7 @@ import type {
   ResolvedHudConfig,
   HudGitDisplay,
   LateGateHudSource,
+  GuardexFinishStateForHud,
 } from './types.js';
 import { DEFAULT_HUD_CONFIG } from './types.js';
 
@@ -74,6 +75,122 @@ function sanitizeOptionalString(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+const GUARDEX_FINISH_TAIL_BYTES = 64 * 1024;
+const GUARDEX_FINISH_MAX_CANDIDATES = 32;
+const GUARDEX_FINISH_MAX_AGE_MS = 24 * 60 * 60 * 1_000;
+const GUARDEX_FINISH_RUN_ID_RE = /^finish-[^-]+-(\d+)-/;
+const GUARDEX_TERMINAL_STATES = new Set(['failed', 'finished']);
+
+interface RawGuardexFinishEvent {
+  schemaVersion?: unknown;
+  runId?: unknown;
+  timestamp?: unknown;
+  stage?: unknown;
+  state?: unknown;
+  index?: unknown;
+  total?: unknown;
+  label?: unknown;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+async function readFileTail(path: string): Promise<string> {
+  const handle = await open(path, 'r');
+  try {
+    const fileStat = await handle.stat();
+    const length = Math.min(fileStat.size, GUARDEX_FINISH_TAIL_BYTES);
+    if (length <= 0) return '';
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, fileStat.size - length);
+    return buffer.toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+function normalizeGuardexFinishEvent(raw: RawGuardexFinishEvent): GuardexFinishStateForHud | null {
+  if (raw.schemaVersion !== 1) return null;
+  const runId = sanitizeOptionalString(raw.runId);
+  const timestamp = sanitizeOptionalString(raw.timestamp);
+  const stage = sanitizeOptionalString(raw.stage);
+  const state = sanitizeOptionalString(raw.state);
+  const label = sanitizeOptionalString(raw.label);
+  const index = Number(raw.index);
+  const total = Number(raw.total);
+  const pidMatch = runId?.match(GUARDEX_FINISH_RUN_ID_RE);
+  const pid = Number(pidMatch?.[1]);
+  const updatedAt = timestamp ? Date.parse(timestamp) : Number.NaN;
+
+  if (!runId || !timestamp || !stage || stage === 'finish' || !state || state === 'pending' || !label) return null;
+  if (!Number.isSafeInteger(index) || index <= 0 || !Number.isSafeInteger(total) || total <= 0 || index > total) return null;
+  if (!Number.isSafeInteger(pid) || pid <= 0 || !isProcessAlive(pid)) return null;
+  if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > GUARDEX_FINISH_MAX_AGE_MS) return null;
+  if (GUARDEX_TERMINAL_STATES.has(state)) return null;
+
+  return {
+    active: true,
+    stage: stage.slice(0, 40),
+    state: state.slice(0, 40),
+    index,
+    total,
+    label: label.slice(0, 80),
+    updatedAt: timestamp,
+  };
+}
+
+async function readGuardexFinishFile(path: string): Promise<GuardexFinishStateForHud | null> {
+  try {
+    const lines = (await readFileTail(path)).split('\n');
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index]?.trim();
+      if (!line) continue;
+      try {
+        const event = JSON.parse(line) as RawGuardexFinishEvent;
+        const state = normalizeGuardexFinishEvent(event);
+        if (state) return state;
+        if (event.schemaVersion === 1 && GUARDEX_TERMINAL_STATES.has(String(event.state || ''))) return null;
+      } catch {
+        // The writer may be appending the trailing JSON line while the HUD reads it.
+      }
+    }
+  } catch {
+    // Optional observability must remain fail-open for missing or unreadable files.
+  }
+  return null;
+}
+
+/** Read the newest active GitGuardex branch-finish event stream. */
+export async function readGuardexFinishState(cwd: string): Promise<GuardexFinishStateForHud | null> {
+  // Guardex writes to the repository-local state directory, independent of
+  // OMX session/team state-root overrides inherited by the HUD process.
+  const repoRoot = findGitLayout(cwd)?.worktreeRoot ?? cwd;
+  const directory = join(repoRoot, '.omx', 'state', 'finish-runs');
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const candidates = await Promise.all(entries
+      .filter(entry => entry.isFile() && entry.name.startsWith('finish-') && entry.name.endsWith('.jsonl'))
+      .map(async entry => ({
+        path: join(directory, entry.name),
+        modifiedAt: (await stat(join(directory, entry.name))).mtimeMs,
+      })));
+    candidates.sort((left, right) => right.modifiedAt - left.modifiedAt);
+    for (const candidate of candidates.slice(0, GUARDEX_FINISH_MAX_CANDIDATES)) {
+      const state = await readGuardexFinishFile(candidate.path);
+      if (state) return state;
+    }
+  } catch {
+    // GitGuardex is optional; repos without its state directory render normally.
+  }
+  return null;
+}
+
 export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedHudConfig {
   const normalized: ResolvedHudConfig = {
     preset: DEFAULT_HUD_CONFIG.preset,
@@ -82,6 +199,9 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
     },
     statusLine: {
       preset: DEFAULT_HUD_CONFIG.statusLine.preset,
+    },
+    guardex: {
+      enabled: DEFAULT_HUD_CONFIG.guardex?.enabled === true,
     },
   };
 
@@ -107,6 +227,10 @@ export function normalizeHudConfig(raw: HudConfig | null | undefined): ResolvedH
     if (isValidPreset(raw.statusLine.preset)) {
       normalized.statusLine.preset = raw.statusLine.preset;
     }
+  }
+
+  if (raw.guardex && typeof raw.guardex === 'object' && typeof raw.guardex.enabled === 'boolean') {
+    normalized.guardex = { enabled: raw.guardex.enabled };
   }
 
   return normalized;
@@ -614,12 +738,13 @@ function codeReviewFromSubagentEvidence(
 export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFAULT_HUD_CONFIG): Promise<HudRenderContext> {
   const version = readVersion();
   const gitBranch = buildGitBranchLabel(cwd, config);
-  const [metrics, hudNotify, session, currentSessionId, subagentTracking] = await Promise.all([
+  const [metrics, hudNotify, session, currentSessionId, subagentTracking, guardexFinish] = await Promise.all([
     readMetrics(cwd),
     readHudNotifyState(cwd),
     readSessionState(cwd),
     readCurrentSessionId(cwd),
     readSubagentTrackingState(cwd),
+    config.guardex?.enabled === true ? readGuardexFinishState(cwd) : Promise.resolve(null),
   ]);
   const stateDir = getBaseStateDir(cwd);
   const canonicalSkillState = await readVisibleSkillActiveStateForStateDir(stateDir, currentSessionId);
@@ -733,6 +858,7 @@ export async function readAllState(cwd: string, config: ResolvedHudConfig = DEFA
     codeReview,
     ultraqa,
     team,
+    guardexFinish,
     metrics,
     hudNotify,
     session,

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -79,7 +79,12 @@ const GUARDEX_FINISH_TAIL_BYTES = 64 * 1024;
 const GUARDEX_FINISH_MAX_CANDIDATES = 32;
 const GUARDEX_FINISH_MAX_AGE_MS = 24 * 60 * 60 * 1_000;
 const GUARDEX_FINISH_RUN_ID_RE = /^finish-[^-]+-(\d+)-/;
+const GUARDEX_FINISH_FILE_RE = /^finish-([0-9a-z]+)-\d+-[^/]+\.jsonl$/;
 const GUARDEX_TERMINAL_STATES = new Set(['failed', 'finished']);
+
+interface GuardexFinishStateDependencies {
+  statFile?: (path: string) => Promise<{ mtimeMs: number }>;
+}
 
 interface RawGuardexFinishEvent {
   schemaVersion?: unknown;
@@ -167,21 +172,36 @@ async function readGuardexFinishFile(path: string): Promise<GuardexFinishStateFo
 }
 
 /** Read the newest active GitGuardex branch-finish event stream. */
-export async function readGuardexFinishState(cwd: string): Promise<GuardexFinishStateForHud | null> {
+export async function readGuardexFinishState(
+  cwd: string,
+  dependencies: GuardexFinishStateDependencies = {},
+): Promise<GuardexFinishStateForHud | null> {
   // Guardex writes to the repository-local state directory, independent of
   // OMX session/team state-root overrides inherited by the HUD process.
   const repoRoot = findGitLayout(cwd)?.worktreeRoot ?? cwd;
   const directory = join(repoRoot, '.omx', 'state', 'finish-runs');
   try {
     const entries = await readdir(directory, { withFileTypes: true });
-    const candidates = await Promise.all(entries
-      .filter(entry => entry.isFile() && entry.name.startsWith('finish-') && entry.name.endsWith('.jsonl'))
+    // Guardex encodes the run start time as base36 in each filename. Bound the
+    // newest run IDs before metadata reads so one HUD tick stays O(1).
+    const recentEntries = entries
+      .flatMap(entry => {
+        if (!entry.isFile()) return [];
+        const match = entry.name.match(GUARDEX_FINISH_FILE_RE);
+        if (!match) return [];
+        const startedAt = Number.parseInt(match[1], 36);
+        return Number.isSafeInteger(startedAt) ? [{ name: entry.name, startedAt }] : [];
+      })
+      .sort((left, right) => right.startedAt - left.startedAt || right.name.localeCompare(left.name))
+      .slice(0, GUARDEX_FINISH_MAX_CANDIDATES);
+    const statFile = dependencies.statFile ?? stat;
+    const candidates = await Promise.all(recentEntries
       .map(async entry => ({
         path: join(directory, entry.name),
-        modifiedAt: (await stat(join(directory, entry.name))).mtimeMs,
+        modifiedAt: (await statFile(join(directory, entry.name))).mtimeMs,
       })));
     candidates.sort((left, right) => right.modifiedAt - left.modifiedAt);
-    for (const candidate of candidates.slice(0, GUARDEX_FINISH_MAX_CANDIDATES)) {
+    for (const candidate of candidates) {
       const state = await readGuardexFinishFile(candidate.path);
       if (state) return state;
     }

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -103,6 +103,17 @@ export interface TeamStateForHud {
   team_name?: string;
 }
 
+/** Active GitGuardex branch-finish progress for HUD display. */
+export interface GuardexFinishStateForHud {
+  active: true;
+  stage: string;
+  state: string;
+  index: number;
+  total: number;
+  label: string;
+  updatedAt: string;
+}
+
 /** Metrics tracked by notify hook */
 export interface HudMetrics {
   total_turns: number;
@@ -142,6 +153,7 @@ export interface HudRenderContext {
   codeReview?: CodeReviewStateForHud | null;
   ultraqa: UltraqaStateForHud | null;
   team: TeamStateForHud | null;
+  guardexFinish?: GuardexFinishStateForHud | null;
   metrics: HudMetrics | null;
   hudNotify: HudNotifyState | null;
   session: SessionStateForHud | null;
@@ -166,11 +178,17 @@ export interface HudStatusLineConfig {
   preset?: HudPreset;
 }
 
+export interface HudGuardexConfig {
+  /** Read repository-local `gx branch finish` progress into the HUD. */
+  enabled?: boolean;
+}
+
 /** HUD configuration stored in .omx/hud-config.json */
 export interface HudConfig {
   preset?: HudPreset;
   git?: HudGitConfig;
   statusLine?: HudStatusLineConfig;
+  guardex?: HudGuardexConfig;
 }
 
 export interface ResolvedHudGitConfig {
@@ -183,10 +201,15 @@ export interface ResolvedHudStatusLineConfig {
   preset: HudPreset;
 }
 
+export interface ResolvedHudGuardexConfig {
+  enabled: boolean;
+}
+
 export interface ResolvedHudConfig {
   preset: HudPreset;
   git: ResolvedHudGitConfig;
   statusLine: ResolvedHudStatusLineConfig;
+  guardex?: ResolvedHudGuardexConfig;
 }
 
 /** Default HUD configuration */
@@ -197,6 +220,9 @@ export const DEFAULT_HUD_CONFIG: ResolvedHudConfig = {
   },
   statusLine: {
     preset: 'focused',
+  },
+  guardex: {
+    enabled: false,
   },
 };
 

--- a/src/scripts/__tests__/postinstall.test.ts
+++ b/src/scripts/__tests__/postinstall.test.ts
@@ -33,6 +33,7 @@ describe("runPostinstall", () => {
       const result = await runPostinstall({
         env: { npm_config_global: "true" },
         getCurrentVersion: async () => "0.14.1",
+        hydrateRuntime: async () => "/cache/omx-runtime",
         log: (message) => logs.push(message),
         readStamp: async () => ({
           installed_version: "0.14.0",
@@ -44,6 +45,7 @@ describe("runPostinstall", () => {
       });
 
       assert.equal(result.status, "hinted");
+      assert.match(logs.join("\n"), /Hydrated omx-runtime/);
       assert.match(logs.join("\n"), /OMX setup is explicit opt-in; run `omx setup` or `omx update` when you're ready/);
 
       const stamp = JSON.parse(await readFile(stampPath, "utf-8")) as {
@@ -68,6 +70,7 @@ describe("runPostinstall", () => {
       const result = await runPostinstall({
         env: { npm_config_global: "true" },
         getCurrentVersion: async () => "0.14.1",
+        hydrateRuntime: async () => "/cache/omx-runtime",
         log: (message) => logs.push(message),
         readStamp: async () => ({
           installed_version: "0.14.0",
@@ -100,6 +103,7 @@ describe("runPostinstall", () => {
         npm_config_user_agent: "bun/1.2.0 npm/? node/v22.0.0 linux x64",
       },
       getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => "/cache/omx-runtime",
       readStamp: async () => null,
       writeStamp: async (stamp) => {
         writtenStamp = stamp;
@@ -114,15 +118,21 @@ describe("runPostinstall", () => {
     const result = await runPostinstall({
       env: { npm_config_global: "false" },
       getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => "/cache/omx-runtime",
     });
 
     assert.equal(result.status, "noop-local");
   });
 
   it("does not rerun setup when the installed version matches the saved stamp", async () => {
+    let hydrated = false;
     const result = await runPostinstall({
       env: { npm_config_global: "true" },
       getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => {
+        hydrated = true;
+        return "/cache/omx-runtime";
+      },
       readStamp: async () => ({
         installed_version: "0.14.1",
         setup_completed_version: "0.14.1",
@@ -131,5 +141,23 @@ describe("runPostinstall", () => {
     });
 
     assert.equal(result.status, "noop-same-version");
+    assert.equal(hydrated, true, "same-version reinstalls must repair a missing native runtime cache");
+  });
+
+  it("keeps global installation non-fatal when runtime hydration fails", async () => {
+    const logs: string[] = [];
+    const result = await runPostinstall({
+      env: { npm_config_global: "true" },
+      getCurrentVersion: async () => "0.14.1",
+      hydrateRuntime: async () => {
+        throw new Error("offline");
+      },
+      log: (message) => logs.push(message),
+      readStamp: async () => null,
+      writeStamp: async () => {},
+    });
+
+    assert.equal(result.status, "hinted");
+    assert.match(logs.join("\n"), /hydration failed non-fatally: offline/);
   });
 });

--- a/src/scripts/postinstall.ts
+++ b/src/scripts/postinstall.ts
@@ -8,6 +8,7 @@ import {
   writeUserInstallStamp,
 } from './postinstall-advisory.js';
 import { getPackageRoot } from "../utils/package.js";
+import { hydrateNativeBinary } from "../cli/native-assets.js";
 
 type PostinstallStatus =
   | "noop-local"
@@ -24,8 +25,38 @@ interface PostinstallDependencies {
   env: NodeJS.ProcessEnv;
   getCurrentVersion: () => Promise<string | null>;
   log: (message: string) => void;
+  hydrateRuntime: () => Promise<string | undefined>;
   readStamp: () => Promise<UserInstallStamp | null>;
   writeStamp: (stamp: UserInstallStamp) => Promise<void>;
+}
+
+const RUNTIME_HYDRATION_TIMEOUT_MS = 15_000;
+
+export async function hydrateOmxRuntimeNonFatal(options: {
+  packageRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  log?: (message: string) => void;
+  timeoutMs?: number;
+} = {}): Promise<string | undefined> {
+  const log = options.log ?? ((message: string) => console.log(message));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? RUNTIME_HYDRATION_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    const runtimePath = await hydrateNativeBinary("omx-runtime", {
+      packageRoot: options.packageRoot,
+      env: options.env,
+      signal: controller.signal,
+    });
+    if (runtimePath) log(`[omx] Hydrated omx-runtime for this platform: ${runtimePath}`);
+    else log("[omx] omx-runtime was not available for this platform; native runtime features remain disabled.");
+    return runtimePath;
+  } catch (error) {
+    log(`[omx] omx-runtime hydration failed non-fatally: ${error instanceof Error ? error.message : String(error)}`);
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function stripLeadingV(version: string): string {
@@ -55,6 +86,7 @@ const defaultDependencies: PostinstallDependencies = {
   env: process.env,
   getCurrentVersion,
   log: (message) => console.log(message),
+  hydrateRuntime: () => hydrateOmxRuntimeNonFatal(),
   readStamp: () => readUserInstallStamp(),
   writeStamp: (stamp) => writeUserInstallStamp(stamp),
 };
@@ -75,6 +107,20 @@ export async function runPostinstall(
   }
 
   const currentStampVersion = stripLeadingV(currentVersion);
+  try {
+    const runtimePath = await resolved.hydrateRuntime();
+    if (runtimePath) {
+      resolved.log(`[omx] Hydrated omx-runtime for this platform: ${runtimePath}`);
+    } else {
+      resolved.log(
+        "[omx] omx-runtime was not available for this platform; native runtime features remain disabled.",
+      );
+    }
+  } catch (error) {
+    resolved.log(
+      `[omx] omx-runtime hydration failed non-fatally: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   const existingStamp = await resolved.readStamp();
   if (!isInstallVersionBump(currentVersion, existingStamp)) {
     return { status: "noop-same-version", version: currentStampVersion };


### PR DESCRIPTION
Promotes verified OmX `v0.21.2` from frozen `dev@04533ebfc887643586e37180ec3270473948115a` to `main`.

Release scope: 11 commits, 29 files, +1,245/−10; PRs #3599/#3601/#3602.

- version carriers synchronized to 0.21.2;
- exact inventory, release notes, readiness, changelog and release body prepared;
- full build/version-sync/native/generated/plugin/capability/prompt/no-unused/lint/test gates passed;
- `npm pack --dry-run`: 0.21.2, 3,589 files, 6.2MB packed / 39.7MB unpacked;
- frozen dev CI `33406782191` green.

After exact-head PR CI/review, owner authorization covers merge-commit promotion to main, annotated `v0.21.2`, tag Release workflow/assets, and exact tag/SHA-bound OIDC npm trusted-publish dispatch. No manual/token publisher. Release remains incomplete until GitHub Release assets and npm 0.21.2/latest are externally verified.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
