### PR TITLE
fix: prevent duplicate Team wakes and retire terminal projections

### DIFF
--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -109,7 +109,7 @@ async function teamStateAllowsLeaderNudge(stateDir, teamName) {
 
   const phase = await readJsonIfExists(join(teamDir, 'phase.json'), null);
   const currentPhase = safeString(phase?.current_phase || phase?.phase || '').trim();
-  if (currentPhase && isTerminalPhase(currentPhase)) return false;
+  if (phase?.terminal_epoch || (currentPhase && isTerminalPhase(currentPhase))) return false;
 
   return true;
 }

--- a/src/scripts/notify-hook/team-leader-nudge.ts
+++ b/src/scripts/notify-hook/team-leader-nudge.ts
@@ -24,7 +24,7 @@ import { readLatestTeamProgressEvidenceMs } from '../../team/progress-evidence.j
 import { validateSessionId } from '../../mcp/state-paths.js';
 import { TEAM_NAME_SAFE_PATTERN } from '../../team/contracts.js';
 import { isDeepInterviewStateActive } from './auto-nudge.js';
-import { registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
+import { confirmTeamNoticeWake, registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
 const LEADER_PANE_MISSING_NO_INJECTION_REASON = 'leader_pane_missing_no_injection';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 const TEAM_SHUTDOWN_NO_INJECTION_REASON = 'team_state_gone_or_shutdown';
@@ -1236,6 +1236,10 @@ export async function maybeNudgeTeamLeader({
         });
         if (!sendResult.ok) {
           throw new Error(sendResult.error || sendResult.reason);
+        }
+        if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId
+          && !await confirmTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId)) {
+          throw new Error('team_notice_wake_confirmation_failed');
         }
         deliveryMode = 'queued';
         queuedNoticeRegistration = null;

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -32,7 +32,7 @@ async function teamStateAllowsWorkerStopNudge(stateDir, teamName) {
 
   const phase = await readJsonIfExists(join(teamDir, 'phase.json'), null);
   const currentPhase = safeString(phase?.current_phase || phase?.phase || '').trim();
-  if (currentPhase && isTerminalPhase(currentPhase)) return false;
+  if (phase?.terminal_epoch || (currentPhase && isTerminalPhase(currentPhase))) return false;
 
   return true;
 }

--- a/src/scripts/notify-hook/team-worker-stop.ts
+++ b/src/scripts/notify-hook/team-worker-stop.ts
@@ -16,7 +16,7 @@ import { readJsonIfExists } from './state-io.js';
 import { logTmuxHookEvent } from './log.js';
 import { evaluatePaneInjectionReadiness, normalizeExactPaneId, sendPaneInput } from './team-tmux-guard.js';
 import { readTeamWorkersForIdleCheck } from './team-worker.js';
-import { registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
+import { confirmTeamNoticeWake, registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
 
 const STOP_NUDGE_COOLDOWN_MS = 30_000;
 const SOURCE_TYPE = 'worker_stop';
@@ -388,6 +388,10 @@ export async function maybeNudgeLeaderForAllowedWorkerStop({
       expectedHudPaneId: teamInfo.hudPaneId,
     });
     if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId
+      && !await confirmTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId)) {
+      throw new Error('team_notice_wake_confirmation_failed');
+    }
     queuedNoticeRegistration = null;
     const deliveryMode = leaderHasActiveTask ? 'steered' : 'sent';
 

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -17,7 +17,7 @@ import {
   resolveWorkerIdleIntent,
 } from './orchestration-intent.js';
 import { DEFAULT_MARKER, paneHasActiveTask } from '../tmux-hook-engine.js';
-import { registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
+import { confirmTeamNoticeWake, registerTeamNotice, releaseTeamNoticeWake } from '../../team/notice-ledger.js';
 const LEADER_PANE_SHELL_NO_INJECTION_REASON = 'leader_pane_shell_no_injection';
 
 function positivePanePid(value) {
@@ -482,6 +482,10 @@ export async function maybeNotifyLeaderAllWorkersIdle({ cwd, stateDir, logsDir, 
       expectedHudPaneId: hudPaneId,
     });
     if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId
+      && !await confirmTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId)) {
+      throw new Error('team_notice_wake_confirmation_failed');
+    }
     queuedNoticeRegistration = null;
 
     const nextIdleState = {
@@ -700,6 +704,10 @@ export async function maybeNotifyLeaderWorkerIdle({ cwd, stateDir, logsDir, pars
       expectedHudPaneId: hudPaneId,
     });
     if (!sendResult.ok) throw new Error(sendResult.error || sendResult.reason || 'send_failed');
+    if (queuedNoticeRegistration?.targetKey && queuedNoticeRegistration?.wakeId
+      && !await confirmTeamNoticeWake(stateDir, queuedNoticeRegistration.targetKey, queuedNoticeRegistration.wakeId)) {
+      throw new Error('team_notice_wake_confirmation_failed');
+    }
     queuedNoticeRegistration = null;
 
     // Update cooldown state

--- a/src/scripts/notify-hook/team-worker.ts
+++ b/src/scripts/notify-hook/team-worker.ts
@@ -106,7 +106,7 @@ async function readTeamPhaseSnapshot(stateDir, teamName, nowIso = new Date().toI
     const currentPhase = safeString(parsed && parsed.current_phase).trim();
     return {
       currentPhase,
-      terminal: isTerminalPhase(currentPhase),
+      terminal: Boolean(parsed && parsed.terminal_epoch) || isTerminalPhase(currentPhase),
       completedAt: resolveTerminalAtFromPhaseDoc(parsed, nowIso),
     };
   } catch {

--- a/src/team/__tests__/notice-ledger.test.ts
+++ b/src/team/__tests__/notice-ledger.test.ts
@@ -67,13 +67,16 @@ describe('team notice ledger', () => {
     const { root, stateRoot } = await fixture();
     try {
       await Promise.all([liveTeam(stateRoot, 'live'), liveTeam(stateRoot, 'terminal'), liveTeam(stateRoot, 'removed')]);
-      await writeFile(join(stateRoot, 'team', 'terminal', 'phase.json'), JSON.stringify({ current_phase: 'complete' }));
+      await writeFile(join(stateRoot, 'team', 'terminal', 'phase.json'), JSON.stringify({ current_phase: 'team-exec', terminal_epoch: '2026-09-02T00:00:00.000Z' }));
       const targetId = 'leader';
-      for (const name of ['live', 'terminal', 'removed']) await registerTeamNotice(registration(stateRoot, name, targetId, '1'));
+      const terminal = await registerTeamNotice(registration(stateRoot, 'terminal', targetId, '1'));
+      assert.equal(terminal.queued, false);
+      await registerTeamNotice(registration(stateRoot, 'live', targetId, '1'));
+      await registerTeamNotice(registration(stateRoot, 'removed', targetId, '1'));
       await rm(join(stateRoot, 'team', 'removed'), { recursive: true, force: true });
       const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: teamNoticeTargetKey(targetId) });
       assert.deepEqual(result.context.map((notice) => notice.teamName), ['live']);
-      assert.equal(result.discarded, 2);
+      assert.equal(result.discarded, 1);
       assert.doesNotMatch(await readFile(teamNoticeLedgerPath(stateRoot), 'utf8'), /terminal|removed/);
     } finally { await rm(root, { recursive: true, force: true }); }
   });

--- a/src/team/__tests__/notice-ledger.test.ts
+++ b/src/team/__tests__/notice-ledger.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   buildTeamNoticeLedgerPrompt,
+  confirmTeamNoticeWake,
+  discardTeamNoticesForTeam,
   parseTeamNoticeLedgerPrompt,
   reconcileTeamNoticeLedger,
   registerTeamNotice,
@@ -102,6 +104,59 @@ describe('team notice ledger', () => {
       assert.equal(retry.queued, true);
       const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: retry.targetKey });
       assert.deepEqual(result.context.map((notice) => notice.teamName).sort(), ['alpha', 'bravo']);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('does not re-elect a successfully queued wake after the original lease timeout', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await liveTeam(stateRoot, 'slow');
+      const first = await registerTeamNotice(registration(stateRoot, 'slow', 'leader', '1'));
+      assert.equal(await confirmTeamNoticeWake(stateRoot, first.targetKey, first.wakeId!), true);
+      const ledger = JSON.parse(await readFile(teamNoticeLedgerPath(stateRoot), 'utf8')) as any;
+      ledger.wakes[first.targetKey].createdAtMs = Date.now() - 31_000;
+      await writeFile(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+
+      const later = await registerTeamNotice(registration(stateRoot, 'slow', 'leader', '2', 'all_idle'));
+      assert.equal(later.queued, false);
+      assert.equal(later.wakeId, first.wakeId);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('re-elects an unconfirmed stale wake and rejects confirmation of the replaced lease', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await liveTeam(stateRoot, 'retry');
+      const first = await registerTeamNotice(registration(stateRoot, 'retry', 'leader', '1'));
+      const ledger = JSON.parse(await readFile(teamNoticeLedgerPath(stateRoot), 'utf8')) as any;
+      ledger.wakes[first.targetKey].createdAtMs = Date.now() - 31_000;
+      await writeFile(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+
+      const retry = await registerTeamNotice(registration(stateRoot, 'retry', 'leader', '2'));
+      assert.equal(retry.queued, true);
+      assert.notEqual(retry.wakeId, first.wakeId);
+      assert.equal(await confirmTeamNoticeWake(stateRoot, first.targetKey, first.wakeId!), false);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('discards one Team while preserving shared-target notices and wake for another Team', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await Promise.all([liveTeam(stateRoot, 'alpha'), liveTeam(stateRoot, 'bravo')]);
+      const first = await registerTeamNotice(registration(stateRoot, 'alpha', 'leader', '1'));
+      await registerTeamNotice(registration(stateRoot, 'bravo', 'leader', '1', 'worker_stop'));
+      assert.deepEqual(await discardTeamNoticesForTeam(stateRoot, 'alpha'), { notices: 1, wakes: 0 });
+      const result = await reconcileTeamNoticeLedger({ stateRoot, targetKey: first.targetKey });
+      assert.deepEqual(result.context.map((notice) => notice.teamName), ['bravo']);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('discards an orphaned wake with the last notice for a Team', async () => {
+    const { root, stateRoot } = await fixture();
+    try {
+      await liveTeam(stateRoot, 'alpha');
+      await registerTeamNotice(registration(stateRoot, 'alpha', 'leader', '1'));
+      assert.deepEqual(await discardTeamNoticesForTeam(stateRoot, 'alpha'), { notices: 1, wakes: 1 });
     } finally { await rm(root, { recursive: true, force: true }); }
   });
 

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -904,15 +904,19 @@ async function withNativeWindowsPlatform<T>(run: () => Promise<T>): Promise<T> {
 }
 
 const ORIGINAL_OMX_TEAM_STATE_ROOT = process.env.OMX_TEAM_STATE_ROOT;
+const ORIGINAL_OMX_RUNTIME_BRIDGE = process.env.OMX_RUNTIME_BRIDGE;
 
 beforeEach(() => {
   delete process.env.OMX_TEAM_STATE_ROOT;
+  process.env.OMX_RUNTIME_BRIDGE = '0';
 });
 
 afterEach(() => {
   setTerminalEpochStartedHookForTest(null);
   if (typeof ORIGINAL_OMX_TEAM_STATE_ROOT === 'string') process.env.OMX_TEAM_STATE_ROOT = ORIGINAL_OMX_TEAM_STATE_ROOT;
   else delete process.env.OMX_TEAM_STATE_ROOT;
+  if (typeof ORIGINAL_OMX_RUNTIME_BRIDGE === 'string') process.env.OMX_RUNTIME_BRIDGE = ORIGINAL_OMX_RUNTIME_BRIDGE;
+  else delete process.env.OMX_RUNTIME_BRIDGE;
 });
 
 describe('runtime', () => {

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { execFileSync, spawn, spawnSync } from 'child_process';
-import { mkdtemp, rm, writeFile, readFile, mkdir, chmod, readdir } from 'fs/promises';
+import { mkdtemp, rm, unlink, writeFile, readFile, mkdir, chmod, readdir } from 'fs/promises';
 import { join, relative, dirname } from 'path';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
@@ -7614,6 +7614,31 @@ exec "${realGit}" "$@"
       await markDetachedSessionAbsent(teamName, cwd);
       await writeFile(join(cwd, '.omx', 'state', 'mailbox.json'), JSON.stringify({ records: 'malformed' }));
       process.env.OMX_RUNTIME_BRIDGE = '1';
+
+      await assert.rejects(
+        shutdownWithoutTmuxSession(teamName, cwd),
+        /authoritative_mailbox_retirement_discovery_failed/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', teamName)), true);
+    } finally {
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam preserves Team state when mailbox compatibility output is absent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-mailbox-missing-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    const teamName = 'shutdown-mailbox-missing';
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await initTeamState(teamName, 'shutdown mailbox missing test', 'executor', 1, cwd);
+      await sendDirectMessage(teamName, 'leader-fixed', 'worker-1', 'pending result', cwd);
+      await writeFile(join(cwd, '.omx', 'state', 'mailbox.json'), JSON.stringify({ records: [] }));
+      await unlink(join(cwd, '.omx', 'state', 'mailbox.json'));
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      await markDetachedSessionAbsent(teamName, cwd);
 
       await assert.rejects(
         shutdownWithoutTmuxSession(teamName, cwd),

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -62,6 +62,7 @@ import { buildInternalTeamName, resolveTeamIdentityScope } from '../team-identit
 import { writePersistedApprovedTeamExecutionBinding } from '../approved-execution.js';
 import { planWorktreeTarget } from '../worktree.js';
 import { scaleDown } from '../scaling.js';
+import { registerTeamNotice, teamNoticeLedgerPath, teamNoticeTargetKey } from '../notice-ledger.js';
 
 const coverageRun = process.env.NODE_V8_COVERAGE ? true : false;
 const skipSlowLifecycleUnderCoverage = coverageRun
@@ -7559,6 +7560,69 @@ exec "${realGit}" "$@"
       const teamRoot = join(cwd, '.omx', 'state', 'team', 'team-shutdown');
       assert.equal(existsSync(teamRoot), false);
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam discards terminal Team notices before deleting ownership evidence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-notices-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await initTeamState('team-shutdown-notices', 'shutdown notice cleanup test', 'executor', 1, cwd);
+      await markDetachedSessionAbsent('team-shutdown-notices', cwd);
+      const notice = await registerTeamNotice({
+        cwd,
+        targetId: 'leader-pane-owner',
+        teamName: 'team-shutdown-notices',
+        noticeClass: 'terminal',
+        generation: 'done',
+        source: { kind: 'test' },
+      });
+      assert.equal(notice.targetKey, teamNoticeTargetKey('leader-pane-owner'));
+
+      await shutdownWithoutTmuxSession('team-shutdown-notices', cwd);
+
+      const ledger = JSON.parse(await readFile(teamNoticeLedgerPath(join(cwd, '.omx', 'state')), 'utf8')) as {
+        notices: Record<string, { teamName: string }>;
+        wakes: Record<string, unknown>;
+      };
+      assert.equal(Object.values(ledger.notices).some((entry) => entry.teamName === 'team-shutdown-notices'), false);
+      assert.equal(ledger.wakes[notice.targetKey], undefined);
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', 'team-shutdown-notices')), false);
+    } finally {
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('shutdownTeam preserves Team state when global mailbox retirement cannot be proven', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-runtime-shutdown-mailbox-fail-closed-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    const teamName = 'shutdown-mailbox-fail-closed';
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await initTeamState(teamName, 'shutdown mailbox cleanup test', 'executor', 1, cwd);
+      await sendDirectMessage(
+        teamName,
+        'leader-fixed',
+        'worker-1',
+        'pending result',
+        cwd,
+      );
+      await markDetachedSessionAbsent(teamName, cwd);
+      await writeFile(join(cwd, '.omx', 'state', 'mailbox.json'), JSON.stringify({ records: 'malformed' }));
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+
+      await assert.rejects(
+        shutdownWithoutTmuxSession(teamName, cwd),
+        /authoritative_mailbox_retirement_discovery_failed/,
+      );
+      assert.equal(existsSync(join(cwd, '.omx', 'state', 'team', teamName)), true);
+    } finally {
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/shutdown-fallback.test.ts
+++ b/src/team/__tests__/shutdown-fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
@@ -7,6 +7,17 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { readTeamConfig, saveTeamConfig } from '../state.js';
 import { shutdownTeam, startTeam, type TeamRuntime } from '../runtime.js';
+
+const ORIGINAL_OMX_RUNTIME_BRIDGE = process.env.OMX_RUNTIME_BRIDGE;
+
+beforeEach(() => {
+  process.env.OMX_RUNTIME_BRIDGE = '0';
+});
+
+afterEach(() => {
+  if (typeof ORIGINAL_OMX_RUNTIME_BRIDGE === 'string') process.env.OMX_RUNTIME_BRIDGE = ORIGINAL_OMX_RUNTIME_BRIDGE;
+  else delete process.env.OMX_RUNTIME_BRIDGE;
+});
 
 async function initRepo(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'omx-shutdown-fallback-'));

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -54,6 +54,7 @@ import {
   resolveDispatchLockTimeoutMs,
   writeTeamManifestV2,
   removeDispatchRequestsForWorkers,
+  retireTeamMailboxMessages,
   withScalingLock,
 
 } from '../state.js';
@@ -1917,6 +1918,59 @@ exit 1
       const parsed = JSON.parse(mailboxDisk) as { messages: Array<{ delivered_at?: string }> };
       assert.ok(parsed.messages.some((m) => typeof m.delivered_at === 'string'));
     } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('retires only mailbox IDs proven by the selected Team shadow', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-'));
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      process.env.OMX_RUNTIME_BRIDGE = '0';
+      await Promise.all([
+        initTeamState('team-retire-a', 't', 'executor', 1, cwd),
+        initTeamState('team-retire-b', 't', 'executor', 1, cwd),
+      ]);
+      const alpha = await sendDirectMessage('team-retire-a', 'leader-fixed', 'worker-1', 'alpha', cwd);
+      const bravo = await sendDirectMessage('team-retire-b', 'leader-fixed', 'worker-1', 'bravo', cwd);
+
+      assert.equal(await retireTeamMailboxMessages('team-retire-a', [], cwd), 1);
+      const alphaMailbox = await listMailboxMessages('team-retire-a', 'worker-1', cwd);
+      const bravoMailbox = await listMailboxMessages('team-retire-b', 'worker-1', cwd);
+      assert.equal(typeof alphaMailbox.find((message) => message.message_id === alpha.message_id)?.delivered_at, 'string');
+      assert.equal(bravoMailbox.find((message) => message.message_id === bravo.message_id)?.delivered_at, undefined);
+    } finally {
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('retires a proven Team mailbox message through the authoritative bridge', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-bridge-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      await initTeamState('team-retire-bridge', 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      const message = await sendDirectMessage('team-retire-bridge', 'leader-fixed', 'worker-1', 'done', cwd);
+
+      assert.equal(await retireTeamMailboxMessages('team-retire-bridge', ['worker-1'], cwd), 1);
+      const compat = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'mailbox.json'), 'utf8')) as {
+        records: Array<{ message_id: string; delivered_at: string | null }>;
+      };
+      assert.equal(typeof compat.records.find((record) => record.message_id === message.message_id)?.delivered_at, 'string');
+      assert.match(await readFile(runtimeLogPath, 'utf8'), /MarkMailboxDelivered/);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
       await rm(cwd, { recursive: true, force: true });
     }
   });

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -2011,6 +2011,40 @@ exit 1
     }
   });
 
+  it('fails closed when a matching authoritative mailbox record is malformed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-malformed-record-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      await initTeamState('team-retire-malformed-record', 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      const message = await sendDirectMessage('team-retire-malformed-record', 'leader-fixed', 'worker-1', 'pending', cwd);
+      const compatPath = join(cwd, '.omx', 'state', 'mailbox.json');
+      const compat = JSON.parse(await readFile(compatPath, 'utf8')) as { records: Array<Record<string, unknown>> };
+      const record = compat.records.find((entry) => entry.message_id === message.message_id);
+      assert.ok(record);
+      record.body = null;
+      await writeFile(compatPath, JSON.stringify(compat, null, 2));
+
+      await assert.rejects(
+        retireTeamMailboxMessages('team-retire-malformed-record', ['worker-1'], cwd),
+        /authoritative_mailbox_retirement_discovery_failed/,
+      );
+      assert.equal((await readFile(runtimeLogPath, 'utf8')).split('MarkMailboxDelivered').length - 1, 0);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when authoritative mailbox compatibility output is absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-missing-compat-'));
     const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -2045,6 +2045,39 @@ exit 1
     }
   });
 
+  it('reconciles an authoritative pending record after a delivered shadow fallback', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-shadow-fallback-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      await initTeamState('team-retire-shadow-fallback', 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      const message = await sendDirectMessage('team-retire-shadow-fallback', 'leader-fixed', 'worker-1', 'pending', cwd);
+      const shadowPath = join(cwd, '.omx', 'state', 'team', 'team-retire-shadow-fallback', 'mailbox', 'worker-1.json');
+      const shadow = JSON.parse(await readFile(shadowPath, 'utf8')) as { messages: Array<{ message_id: string; delivered_at?: string }> };
+      shadow.messages.find((entry) => entry.message_id === message.message_id)!.delivered_at = new Date().toISOString();
+      await writeFile(shadowPath, JSON.stringify(shadow, null, 2));
+
+      assert.equal(await retireTeamMailboxMessages('team-retire-shadow-fallback', ['worker-1'], cwd), 0);
+      const compat = JSON.parse(await readFile(join(cwd, '.omx', 'state', 'mailbox.json'), 'utf8')) as {
+        records: Array<{ message_id: string; delivered_at: string | null }>;
+      };
+      assert.equal(typeof compat.records.find((record) => record.message_id === message.message_id)?.delivered_at, 'string');
+      assert.equal((await readFile(runtimeLogPath, 'utf8')).split('MarkMailboxDelivered').length - 1, 1);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when authoritative mailbox compatibility output is absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-missing-compat-'));
     const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1975,6 +1975,42 @@ exit 1
     }
   });
 
+  it('converges when the authoritative mailbox record was already delivered', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-already-delivered-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    try {
+      await initTeamState('team-retire-already-delivered', 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      const message = await sendDirectMessage('team-retire-already-delivered', 'leader-fixed', 'worker-1', 'done', cwd);
+      const compatPath = join(cwd, '.omx', 'state', 'mailbox.json');
+      const compat = JSON.parse(await readFile(compatPath, 'utf8')) as {
+        records: Array<{ message_id: string; delivered_at: string | null }>;
+      };
+      const record = compat.records.find((entry) => entry.message_id === message.message_id);
+      assert.ok(record);
+      record.delivered_at = new Date().toISOString();
+      await writeFile(compatPath, JSON.stringify(compat, null, 2));
+
+      assert.equal(await retireTeamMailboxMessages('team-retire-already-delivered', ['worker-1'], cwd), 1);
+      const shadow = await listMailboxMessages('team-retire-already-delivered', 'worker-1', cwd);
+      assert.equal(typeof shadow.find((entry) => entry.message_id === message.message_id)?.delivered_at, 'string');
+      const deliveredCalls = (await readFile(runtimeLogPath, 'utf8')).split('MarkMailboxDelivered').length - 1;
+      assert.equal(deliveredCalls, 0);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('fails closed when authoritative mailbox compatibility output is absent', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-missing-compat-'));
     const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;

--- a/src/team/__tests__/state.test.ts
+++ b/src/team/__tests__/state.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, rm, writeFile, readFile, mkdir, open, rename, utimes, symlink } from 'fs/promises';
+import { chmod, mkdtemp, rm, unlink, writeFile, readFile, mkdir, open, rename, utimes, symlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { existsSync, readFileSync } from 'fs';
@@ -1966,6 +1966,39 @@ exit 1
       };
       assert.equal(typeof compat.records.find((record) => record.message_id === message.message_id)?.delivered_at, 'string');
       assert.match(await readFile(runtimeLogPath, 'utf8'), /MarkMailboxDelivered/);
+    } finally {
+      if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
+      else delete process.env.OMX_RUNTIME_BINARY;
+      if (typeof previousRuntimeBridge === 'string') process.env.OMX_RUNTIME_BRIDGE = previousRuntimeBridge;
+      else delete process.env.OMX_RUNTIME_BRIDGE;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when authoritative mailbox compatibility output is absent', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-team-mailbox-retire-missing-compat-'));
+    const previousRuntimeBinary = process.env.OMX_RUNTIME_BINARY;
+    const previousRuntimeBridge = process.env.OMX_RUNTIME_BRIDGE;
+    const teamName = 'team-retire-missing-compat';
+    try {
+      await initTeamState(teamName, 't', 'executor', 1, cwd);
+      const fakeBinDir = join(cwd, 'fake-bin');
+      const runtimeLogPath = join(cwd, 'runtime.log');
+      await mkdir(fakeBinDir, { recursive: true });
+      await writeCompatRuntimeFixture(join(fakeBinDir, 'omx-runtime'), runtimeLogPath);
+      process.env.OMX_RUNTIME_BINARY = join(fakeBinDir, 'omx-runtime');
+      process.env.OMX_RUNTIME_BRIDGE = '1';
+      const message = await sendDirectMessage(teamName, 'leader-fixed', 'worker-1', 'pending', cwd);
+      const compatPath = join(cwd, '.omx', 'state', 'mailbox.json');
+      await unlink(compatPath);
+
+      await assert.rejects(
+        retireTeamMailboxMessages(teamName, ['worker-1'], cwd),
+        /authoritative_mailbox_retirement_discovery_failed/,
+      );
+      const shadow = await listMailboxMessages(teamName, 'worker-1', cwd);
+      assert.equal(shadow.find((entry) => entry.message_id === message.message_id)?.delivered_at, undefined);
+      assert.doesNotMatch(await readFile(runtimeLogPath, 'utf8'), /MarkMailboxDelivered/);
     } finally {
       if (typeof previousRuntimeBinary === 'string') process.env.OMX_RUNTIME_BINARY = previousRuntimeBinary;
       else delete process.env.OMX_RUNTIME_BINARY;

--- a/src/team/__tests__/team-ops-contract.test.ts
+++ b/src/team/__tests__/team-ops-contract.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_STATE_RE_EXPORTS = {
   teamListMailbox: 'listMailboxMessages',
   teamMarkMessageDelivered: 'markMessageDelivered',
   teamMarkMessageNotified: 'markMessageNotified',
+  teamRetireMailboxMessages: 'retireTeamMailboxMessages',
   teamEnqueueDispatchRequest: 'enqueueDispatchRequest',
   teamListDispatchRequests: 'listDispatchRequests',
   teamReadDispatchRequest: 'readDispatchRequest',

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm, writeFile, readFile, mkdir, chmod } from 'fs/promises';
 import { join } from 'path';
@@ -19,6 +19,17 @@ import {
 } from '../runtime.js';
 import { scaleUp } from '../scaling.js';
 import { resolveTeamLowComplexityDefaultModel } from '../model-contract.js';
+
+const ORIGINAL_OMX_RUNTIME_BRIDGE = process.env.OMX_RUNTIME_BRIDGE;
+
+beforeEach(() => {
+  process.env.OMX_RUNTIME_BRIDGE = '0';
+});
+
+afterEach(() => {
+  if (typeof ORIGINAL_OMX_RUNTIME_BRIDGE === 'string') process.env.OMX_RUNTIME_BRIDGE = ORIGINAL_OMX_RUNTIME_BRIDGE;
+  else delete process.env.OMX_RUNTIME_BRIDGE;
+});
 
 function expectedLowComplexityModel(codexHomeOverride?: string): string {
   return resolveTeamLowComplexityDefaultModel(codexHomeOverride);

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -13,6 +13,7 @@ import {
 } from './team-ops.js';
 import { appendTeamDeliveryLogForCwd } from './delivery-log.js';
 import type { TeamReminderIntent } from './reminder-intents.js';
+import { withTeamTaskBarrier } from './state.js';
 
 export interface TeamNotifierTarget {
   workerName: string;
@@ -237,6 +238,7 @@ interface QueueDirectMessageParams {
 }
 
 export async function queueDirectMailboxMessage(params: QueueDirectMessageParams): Promise<DispatchOutcome> {
+  return await withTeamTaskBarrier(params.teamName, params.cwd, async () => {
   const message = await sendDirectMessage(params.teamName, params.fromWorker, params.toWorker, params.body, params.cwd);
   if (message.notified_at && !message.delivered_at) {
     const outcome = {
@@ -350,6 +352,7 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
     transportPreference: params.transportPreference,
   });
   return outcome;
+  });
 }
 
 interface QueueBroadcastParams {
@@ -366,6 +369,7 @@ interface QueueBroadcastParams {
 }
 
 export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams): Promise<DispatchOutcome[]> {
+  return await withTeamTaskBarrier(params.teamName, params.cwd, async () => {
   const messages = await broadcastMessage(params.teamName, params.fromWorker, params.body, params.cwd);
   const recipientByName = new Map(params.recipients.map((r) => [r.workerName, r]));
   const outcomes: DispatchOutcome[] = [];
@@ -451,6 +455,7 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
   }
 
   return outcomes;
+  });
 }
 
 export async function waitForDispatchReceipt(

--- a/src/team/notice-ledger.ts
+++ b/src/team/notice-ledger.ts
@@ -218,6 +218,9 @@ export async function registerTeamNotice(registration: TeamNoticeRegistration): 
   return await withLedgerLock(stateRoot, async () => {
     const ledger = await readLedger(stateRoot);
     const targetKey = teamNoticeTargetKey(registration.targetId);
+    if (!await teamIsLive(stateRoot, registration.teamName)) {
+      return { generation, queued: false, prompt: null, targetKey, wakeId: null };
+    }
     // A later source-proven event confirms the previous presented batch reached a model turn.
     for (const [key, notice] of Object.entries(ledger.notices)) {
       if (notice.targetKey === targetKey && notice.presentedAt) delete ledger.notices[key];
@@ -309,8 +312,12 @@ async function teamIsLive(stateRoot: string, teamName: string): Promise<boolean>
     }
   }
   try {
-    const phase = JSON.parse(await readFile(join(teamDir, 'phase.json'), 'utf8')) as { current_phase?: unknown };
-    return !(typeof phase.current_phase === 'string' && TERMINAL_PHASES.has(phase.current_phase));
+    const phase = JSON.parse(await readFile(join(teamDir, 'phase.json'), 'utf8')) as {
+      current_phase?: unknown;
+      terminal_epoch?: unknown;
+    };
+    return phase.terminal_epoch === undefined
+      && !(typeof phase.current_phase === 'string' && TERMINAL_PHASES.has(phase.current_phase));
   } catch (error) { return (error as NodeJS.ErrnoException).code === 'ENOENT'; }
 }
 

--- a/src/team/notice-ledger.ts
+++ b/src/team/notice-ledger.ts
@@ -57,6 +57,7 @@ interface LedgerNotice extends TeamNoticeContext {
 interface WakeLease {
   wakeId: string;
   createdAtMs: number;
+  confirmedAtMs?: number;
 }
 
 interface NoticeLedger {
@@ -144,10 +145,15 @@ function normalizeLedger(raw: unknown): NoticeLedger {
   for (const [targetKey, rawWake] of Object.entries(parsed.wakes)) {
     if (!TARGET_KEY_PATTERN.test(targetKey) || !rawWake || typeof rawWake !== 'object') throw new Error('invalid_team_notice_wake');
     const wake = rawWake as Partial<WakeLease>;
-    if (typeof wake.wakeId !== 'string' || typeof wake.createdAtMs !== 'number' || !Number.isSafeInteger(wake.createdAtMs)) {
+    if (typeof wake.wakeId !== 'string' || typeof wake.createdAtMs !== 'number' || !Number.isSafeInteger(wake.createdAtMs)
+      || (wake.confirmedAtMs !== undefined && (typeof wake.confirmedAtMs !== 'number' || !Number.isSafeInteger(wake.confirmedAtMs)))) {
       throw new Error('invalid_team_notice_wake');
     }
-    ledger.wakes[targetKey] = { wakeId: wake.wakeId, createdAtMs: wake.createdAtMs };
+    ledger.wakes[targetKey] = {
+      wakeId: wake.wakeId,
+      createdAtMs: wake.createdAtMs,
+      ...(wake.confirmedAtMs !== undefined ? { confirmedAtMs: wake.confirmedAtMs } : {}),
+    };
   }
   return ledger;
 }
@@ -226,7 +232,7 @@ export async function registerTeamNotice(registration: TeamNoticeRegistration): 
     }
     const now = Date.now();
     const existingWake = ledger.wakes[targetKey];
-    if (existingWake && now - existingWake.createdAtMs <= WAKE_STALE_MS) {
+    if (existingWake && (existingWake.confirmedAtMs !== undefined || now - existingWake.createdAtMs <= WAKE_STALE_MS)) {
       await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
       return { generation, queued: false, prompt: null, targetKey, wakeId: existingWake.wakeId };
     }
@@ -234,6 +240,18 @@ export async function registerTeamNotice(registration: TeamNoticeRegistration): 
     ledger.wakes[targetKey] = { wakeId, createdAtMs: now };
     await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
     return { generation, queued: true, prompt: buildTeamNoticeLedgerPrompt(targetKey), targetKey, wakeId };
+  });
+}
+
+export async function confirmTeamNoticeWake(stateRoot: string, targetKey: string, wakeId: string): Promise<boolean> {
+  if (!TARGET_KEY_PATTERN.test(targetKey) || !wakeId) return false;
+  return await withLedgerLock(stateRoot, async () => {
+    const ledger = await readLedger(stateRoot);
+    const wake = ledger.wakes[targetKey];
+    if (wake?.wakeId !== wakeId) return false;
+    wake.confirmedAtMs ??= Date.now();
+    await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+    return true;
   });
 }
 
@@ -245,6 +263,36 @@ export async function releaseTeamNoticeWake(stateRoot: string, targetKey: string
     delete ledger.wakes[targetKey];
     await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
     return true;
+  });
+}
+
+export async function discardTeamNoticesForTeam(
+  stateRoot: string,
+  teamName: string,
+): Promise<{ notices: number; wakes: number }> {
+  if (!teamName) return { notices: 0, wakes: 0 };
+  return await withLedgerLock(stateRoot, async () => {
+    const ledger = await readLedger(stateRoot);
+    const affectedTargets = new Set<string>();
+    let notices = 0;
+    for (const [key, notice] of Object.entries(ledger.notices)) {
+      if (notice.teamName !== teamName) continue;
+      affectedTargets.add(notice.targetKey);
+      delete ledger.notices[key];
+      notices += 1;
+    }
+    let wakes = 0;
+    for (const targetKey of affectedTargets) {
+      const targetStillHasNotices = Object.values(ledger.notices).some((notice) => notice.targetKey === targetKey);
+      if (!targetStillHasNotices && ledger.wakes[targetKey]) {
+        delete ledger.wakes[targetKey];
+        wakes += 1;
+      }
+    }
+    if (notices > 0 || wakes > 0) {
+      await writeAtomic(teamNoticeLedgerPath(stateRoot), JSON.stringify(ledger, null, 2));
+    }
+    return { notices, wakes };
   });
 }
 

--- a/src/team/notice-ledger.ts
+++ b/src/team/notice-ledger.ts
@@ -218,7 +218,7 @@ export async function registerTeamNotice(registration: TeamNoticeRegistration): 
   return await withLedgerLock(stateRoot, async () => {
     const ledger = await readLedger(stateRoot);
     const targetKey = teamNoticeTargetKey(registration.targetId);
-    if (!await teamIsLive(stateRoot, registration.teamName)) {
+    if (!await teamAllowsNoticeRegistration(stateRoot, registration.teamName)) {
       return { generation, queued: false, prompt: null, targetKey, wakeId: null };
     }
     // A later source-proven event confirms the previous presented batch reached a model turn.
@@ -319,6 +319,28 @@ async function teamIsLive(stateRoot: string, teamName: string): Promise<boolean>
     return phase.terminal_epoch === undefined
       && !(typeof phase.current_phase === 'string' && TERMINAL_PHASES.has(phase.current_phase));
   } catch (error) { return (error as NodeJS.ErrnoException).code === 'ENOENT'; }
+}
+
+async function teamAllowsNoticeRegistration(stateRoot: string, teamName: string): Promise<boolean> {
+  const teamDir = join(stateRoot, 'team', teamName);
+  try {
+    if (!(await stat(teamDir)).isDirectory()) return false;
+  } catch { return false; }
+  for (const shutdownName of ['shutdown.json', 'shutdown']) {
+    try { await stat(join(teamDir, shutdownName)); return false; } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+    }
+  }
+  try {
+    const phase = JSON.parse(await readFile(join(teamDir, 'phase.json'), 'utf8')) as {
+      current_phase?: unknown;
+      terminal_epoch?: unknown;
+    };
+    return phase.terminal_epoch === undefined
+      && !(typeof phase.current_phase === 'string' && TERMINAL_PHASES.has(phase.current_phase));
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT';
+  }
 }
 
 export async function reconcileTeamNoticeLedger(options: ReconcileTeamNoticeOptions): Promise<ReconcileTeamNoticeResult> {

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -70,10 +70,13 @@ import {
   teamListMailbox as listMailboxMessages,
   teamMarkMessageDelivered as markMessageDelivered,
   teamMarkMessageNotified as markMessageNotified,
+  teamRetireMailboxMessages as retireTeamMailboxMessages,
   teamEnqueueDispatchRequest as enqueueDispatchRequest,
   teamMarkDispatchRequestNotified as markDispatchRequestNotified,
   teamTransitionDispatchRequest as transitionDispatchRequest,
   teamReadDispatchRequest as readDispatchRequest,
+  teamListDispatchRequests as listDispatchRequests,
+  teamRemoveDispatchRequestsForWorkers as removeDispatchRequestsForWorkers,
   teamCleanup as cleanupTeamState,
   teamSaveConfig as saveTeamConfig,
   teamWriteShutdownRequest as writeShutdownRequest,
@@ -98,6 +101,7 @@ import {
   type TeamPolicy,
   type TeamDispatchRequest,
 } from './team-ops.js';
+import { discardTeamNoticesForTeam } from './notice-ledger.js';
 import {
   commitTeamMembershipTaskTransaction,
   teamContinuationRequiredDiagnostic,
@@ -5596,13 +5600,37 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     }
   }
 
-  // 7. Cleanup state
-  let teamStateCleaned = false;
+  // 7. Retire Team-scoped global projections before deleting the exact state
+  // that proves their ownership. A failed retirement preserves that evidence.
+  const terminalProjectionErrors: string[] = [];
+  const terminalTargets = new Set(['leader-fixed', ...config.workers.map((worker) => worker.name)]);
   try {
-    await cleanupTeamState(sanitized, cwd);
-    teamStateCleaned = true;
+    for (const request of await listDispatchRequests(sanitized, cwd)) terminalTargets.add(request.to_worker);
+    await removeDispatchRequestsForWorkers(sanitized, [...terminalTargets], cwd);
   } catch (err) {
-    cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+    terminalProjectionErrors.push(`removeDispatchRequestsForWorkers: ${String(err)}`);
+  }
+  try {
+    await retireTeamMailboxMessages(sanitized, [...terminalTargets], cwd);
+  } catch (err) {
+    terminalProjectionErrors.push(`retireTeamMailboxMessages: ${String(err)}`);
+  }
+  try {
+    await discardTeamNoticesForTeam(config.team_state_root ?? resolveCanonicalTeamStateRoot(cwd), sanitized);
+  } catch (err) {
+    terminalProjectionErrors.push(`discardTeamNoticesForTeam: ${String(err)}`);
+  }
+  cleanupErrors.push(...terminalProjectionErrors);
+
+  // 8. Cleanup exact Team state only after its global projections are retired.
+  let teamStateCleaned = false;
+  if (terminalProjectionErrors.length === 0) {
+    try {
+      await cleanupTeamState(sanitized, cwd);
+      teamStateCleaned = true;
+    } catch (err) {
+      cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+    }
   }
   if (teamStateCleaned) {
     await syncTeamModeStateOnShutdown(sanitized, cwd, leaderSessionId);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -5601,40 +5601,43 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
   }
 
   // 7. Retire Team-scoped global projections before deleting the exact state
-  // that proves their ownership. A failed retirement preserves that evidence.
-  const terminalProjectionErrors: string[] = [];
-  const terminalTargets = new Set(['leader-fixed', ...config.workers.map((worker) => worker.name)]);
-  try {
-    for (const request of await listDispatchRequests(sanitized, cwd)) terminalTargets.add(request.to_worker);
-    await removeDispatchRequestsForWorkers(sanitized, [...terminalTargets], cwd);
-  } catch (err) {
-    terminalProjectionErrors.push(`removeDispatchRequestsForWorkers: ${String(err)}`);
-  }
-  try {
-    await retireTeamMailboxMessages(sanitized, [...terminalTargets], cwd);
-  } catch (err) {
-    terminalProjectionErrors.push(`retireTeamMailboxMessages: ${String(err)}`);
-  }
-  try {
-    await discardTeamNoticesForTeam(config.team_state_root ?? resolveCanonicalTeamStateRoot(cwd), sanitized);
-  } catch (err) {
-    terminalProjectionErrors.push(`discardTeamNoticesForTeam: ${String(err)}`);
-  }
-  cleanupErrors.push(...terminalProjectionErrors);
-
-  // 8. Cleanup exact Team state only after its global projections are retired.
-  let teamStateCleaned = false;
-  if (terminalProjectionErrors.length === 0) {
+  // that proves their ownership. Hold the Team barrier across retirement and
+  // deletion so a concurrent send cannot publish after the final scan.
+  await withTeamTaskMembershipBarrier(sanitized, cwd, async () => {
+    const terminalProjectionErrors: string[] = [];
+    const terminalTargets = new Set(['leader-fixed', ...config.workers.map((worker) => worker.name)]);
     try {
-      await cleanupTeamState(sanitized, cwd);
-      teamStateCleaned = true;
+      for (const request of await listDispatchRequests(sanitized, cwd)) terminalTargets.add(request.to_worker);
+      await removeDispatchRequestsForWorkers(sanitized, [...terminalTargets], cwd);
     } catch (err) {
-      cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+      terminalProjectionErrors.push(`removeDispatchRequestsForWorkers: ${String(err)}`);
     }
-  }
-  if (teamStateCleaned) {
-    await syncTeamModeStateOnShutdown(sanitized, cwd, leaderSessionId);
-  }
+    try {
+      await retireTeamMailboxMessages(sanitized, [...terminalTargets], cwd);
+    } catch (err) {
+      terminalProjectionErrors.push(`retireTeamMailboxMessages: ${String(err)}`);
+    }
+    try {
+      await discardTeamNoticesForTeam(config.team_state_root ?? resolveCanonicalTeamStateRoot(cwd), sanitized);
+    } catch (err) {
+      terminalProjectionErrors.push(`discardTeamNoticesForTeam: ${String(err)}`);
+    }
+    cleanupErrors.push(...terminalProjectionErrors);
+
+    // 8. Cleanup exact Team state only after its global projections are retired.
+    let teamStateCleaned = false;
+    if (terminalProjectionErrors.length === 0) {
+      try {
+        await cleanupTeamState(sanitized, cwd);
+        teamStateCleaned = true;
+      } catch (err) {
+        cleanupErrors.push(`cleanupTeamState: ${String(err)}`);
+      }
+    }
+    if (teamStateCleaned) {
+      await syncTeamModeStateOnShutdown(sanitized, cwd, leaderSessionId);
+    }
+  });
 
   if (cleanupErrors.length > 0) {
     throw new Error(cleanupErrors.join(' | '));

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2446,8 +2446,7 @@ export async function retireTeamMailboxMessages(
   for (const workerName of targets) {
     await withMailboxLock(teamName, workerName, cwd, async () => {
       const mailbox = await readLegacyMailbox(teamName, workerName, cwd);
-      const pending = mailbox.messages.filter((message) => !message.delivered_at);
-      if (pending.length === 0) return;
+      if (mailbox.messages.length === 0) return;
 
       if (isBridgeEnabled()) {
         const stateDir = resolveBridgeStateDir(cwd);
@@ -2469,13 +2468,19 @@ export async function retireTeamMailboxMessages(
           throw new Error('authoritative_mailbox_retirement_discovery_failed');
         }
         const bridgeIds = new Set(bridgeRecords.map((record) => record.message_id));
-        const unproven = pending.filter((message) => !bridgeIds.has(message.message_id));
+        const unproven = mailbox.messages.filter((message) => !message.delivered_at && !bridgeIds.has(message.message_id));
         if (unproven.length > 0) {
           throw new Error(`authoritative_mailbox_retirement_discovery_failed:${unproven.map((message) => message.message_id).join(',')}`);
         }
-        for (const message of pending) {
+        let changed = false;
+        let retiredFromAuthoritative = 0;
+        for (const message of mailbox.messages) {
           const authoritative = bridgeRecords.find((record) => record.message_id === message.message_id);
-          if (!authoritative?.delivered_at) {
+          if (!authoritative) continue;
+          if (authoritative.to_worker !== workerName) {
+            throw new Error(`authoritative_mailbox_retirement_discovery_failed:${message.message_id}`);
+          }
+          if (!authoritative.delivered_at) {
             const event = bridge.execCommand({ command: 'MarkMailboxDelivered', message_id: message.message_id });
             if (event.event !== 'MailboxDelivered' || event.message_id !== message.message_id) {
               throw new Error(`authoritative_mailbox_retirement_failed:${message.message_id}`);
@@ -2485,9 +2490,21 @@ export async function retireTeamMailboxMessages(
           if (!verified?.delivered_at) {
             throw new Error(`authoritative_mailbox_retirement_verification_failed:${message.message_id}`);
           }
+          if (!message.delivered_at) {
+            message.delivered_at = new Date().toISOString();
+            changed = true;
+            retiredFromAuthoritative += 1;
+          }
         }
+        if (changed) {
+          await writeMailbox(teamName, mailbox, cwd);
+          retired += retiredFromAuthoritative;
+        }
+        return;
       }
 
+      const pending = mailbox.messages.filter((message) => !message.delivered_at);
+      if (pending.length === 0) return;
       const deliveredAt = new Date().toISOString();
       for (const message of pending) message.delivered_at = deliveredAt;
       await writeMailbox(teamName, mailbox, cwd);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2343,7 +2343,7 @@ export async function sendDirectMessage(
   body: string,
   cwd: string
 ): Promise<TeamMailboxMessage> {
-  return await sendDirectMessageImpl(fromWorker, toWorker, body, {
+  return await withTeamTaskBarrier(teamName, cwd, async () => await sendDirectMessageImpl(fromWorker, toWorker, body, {
     teamName,
     cwd,
     withMailboxLock,
@@ -2352,7 +2352,7 @@ export async function sendDirectMessage(
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,
-  });
+  }));
 }
 
 export async function broadcastMessage(
@@ -2361,7 +2361,7 @@ export async function broadcastMessage(
   body: string,
   cwd: string
 ): Promise<TeamMailboxMessage[]> {
-  return await broadcastMessageImpl(fromWorker, body, {
+  return await withTeamTaskBarrier(teamName, cwd, async () => await broadcastMessageImpl(fromWorker, body, {
     teamName,
     cwd,
     withMailboxLock,
@@ -2370,7 +2370,7 @@ export async function broadcastMessage(
     writeMailbox,
     appendTeamEvent,
     readTeamConfig,
-  });
+  }));
 }
 
 export async function markMessageDelivered(
@@ -2458,6 +2458,16 @@ export async function retireTeamMailboxMessages(
           throw new Error('authoritative_mailbox_retirement_discovery_failed');
         }
         const bridgeRecords = bridge.readMailboxRecords();
+        if (bridgeRecords.some((record) => !record
+          || typeof record.message_id !== 'string'
+          || typeof record.from_worker !== 'string'
+          || typeof record.to_worker !== 'string'
+          || typeof record.body !== 'string'
+          || typeof record.created_at !== 'string'
+          || (record.notified_at !== null && typeof record.notified_at !== 'string')
+          || (record.delivered_at !== null && typeof record.delivered_at !== 'string'))) {
+          throw new Error('authoritative_mailbox_retirement_discovery_failed');
+        }
         const bridgeIds = new Set(bridgeRecords.map((record) => record.message_id));
         const unproven = pending.filter((message) => !bridgeIds.has(message.message_id));
         if (unproven.length > 0) {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2454,12 +2454,16 @@ export async function retireTeamMailboxMessages(
         const bridge = getDefaultBridge(stateDir);
         const compatPath = join(stateDir, 'mailbox.json');
         const compat = bridge.readCompatFile<{ records?: unknown[] }>('mailbox.json');
-        if (existsSync(compatPath) && !Array.isArray(compat?.records)) {
+        if (!existsSync(compatPath) || !Array.isArray(compat?.records)) {
           throw new Error('authoritative_mailbox_retirement_discovery_failed');
         }
-        const bridgeIds = new Set(bridge.readMailboxRecords().map((record) => record.message_id));
+        const bridgeRecords = bridge.readMailboxRecords();
+        const bridgeIds = new Set(bridgeRecords.map((record) => record.message_id));
+        const unproven = pending.filter((message) => !bridgeIds.has(message.message_id));
+        if (unproven.length > 0) {
+          throw new Error(`authoritative_mailbox_retirement_discovery_failed:${unproven.map((message) => message.message_id).join(',')}`);
+        }
         for (const message of pending) {
-          if (!bridgeIds.has(message.message_id)) continue;
           const event = bridge.execCommand({ command: 'MarkMailboxDelivered', message_id: message.message_id });
           if (event.event !== 'MailboxDelivered' || event.message_id !== message.message_id) {
             throw new Error(`authoritative_mailbox_retirement_failed:${message.message_id}`);

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2464,9 +2464,12 @@ export async function retireTeamMailboxMessages(
           throw new Error(`authoritative_mailbox_retirement_discovery_failed:${unproven.map((message) => message.message_id).join(',')}`);
         }
         for (const message of pending) {
-          const event = bridge.execCommand({ command: 'MarkMailboxDelivered', message_id: message.message_id });
-          if (event.event !== 'MailboxDelivered' || event.message_id !== message.message_id) {
-            throw new Error(`authoritative_mailbox_retirement_failed:${message.message_id}`);
+          const authoritative = bridgeRecords.find((record) => record.message_id === message.message_id);
+          if (!authoritative?.delivered_at) {
+            const event = bridge.execCommand({ command: 'MarkMailboxDelivered', message_id: message.message_id });
+            if (event.event !== 'MailboxDelivered' || event.message_id !== message.message_id) {
+              throw new Error(`authoritative_mailbox_retirement_failed:${message.message_id}`);
+            }
           }
           const verified = bridge.readMailboxRecords().find((record) => record.message_id === message.message_id);
           if (!verified?.delivered_at) {

--- a/src/team/state.ts
+++ b/src/team/state.ts
@@ -2179,6 +2179,13 @@ export async function removeDispatchRequestsForWorkers(
     if (isBridgeEnabled()) {
       const stateDir = resolveBridgeStateDir(cwd);
       const bridge = getDefaultBridge(stateDir);
+      const compat = bridge.readCompatFile<{ records?: unknown[] }>('dispatch.json');
+      const compatPath = join(stateDir, 'dispatch.json');
+      if (legacyRequestIds.length === 0
+        && (!existsSync(compatPath) || (Array.isArray(compat?.records) && compat.records.length === 0))) {
+        await writeAtomic(dispatchRequestsPath(teamName, cwd), JSON.stringify(requests, null, 2));
+        return;
+      }
       const snapshot = bridge.execCommand({ command: 'CaptureSnapshot' });
       if (snapshot.event !== 'SnapshotCaptured') {
         throw new Error(`authoritative_dispatch_rollback_discovery_failed:${[...names].join(',')}`);
@@ -2417,6 +2424,60 @@ export async function listMailboxMessages(
     appendTeamEvent,
     readTeamConfig,
   });
+}
+
+/** Retire only mailbox messages proven by this Team's per-target compatibility shadows. */
+export async function retireTeamMailboxMessages(
+  teamName: string,
+  workerNames: readonly string[],
+  cwd: string,
+): Promise<number> {
+  let retired = 0;
+  const targets = new Set(workerNames);
+  try {
+    for (const entry of await readdir(join(teamDir(teamName, cwd), 'mailbox'))) {
+      if (!entry.endsWith('.json')) continue;
+      const workerName = entry.slice(0, -'.json'.length);
+      if (WORKER_NAME_SAFE_PATTERN.test(workerName)) targets.add(workerName);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  for (const workerName of targets) {
+    await withMailboxLock(teamName, workerName, cwd, async () => {
+      const mailbox = await readLegacyMailbox(teamName, workerName, cwd);
+      const pending = mailbox.messages.filter((message) => !message.delivered_at);
+      if (pending.length === 0) return;
+
+      if (isBridgeEnabled()) {
+        const stateDir = resolveBridgeStateDir(cwd);
+        const bridge = getDefaultBridge(stateDir);
+        const compatPath = join(stateDir, 'mailbox.json');
+        const compat = bridge.readCompatFile<{ records?: unknown[] }>('mailbox.json');
+        if (existsSync(compatPath) && !Array.isArray(compat?.records)) {
+          throw new Error('authoritative_mailbox_retirement_discovery_failed');
+        }
+        const bridgeIds = new Set(bridge.readMailboxRecords().map((record) => record.message_id));
+        for (const message of pending) {
+          if (!bridgeIds.has(message.message_id)) continue;
+          const event = bridge.execCommand({ command: 'MarkMailboxDelivered', message_id: message.message_id });
+          if (event.event !== 'MailboxDelivered' || event.message_id !== message.message_id) {
+            throw new Error(`authoritative_mailbox_retirement_failed:${message.message_id}`);
+          }
+          const verified = bridge.readMailboxRecords().find((record) => record.message_id === message.message_id);
+          if (!verified?.delivered_at) {
+            throw new Error(`authoritative_mailbox_retirement_verification_failed:${message.message_id}`);
+          }
+        }
+      }
+
+      const deliveredAt = new Date().toISOString();
+      for (const message of pending) message.delivered_at = deliveredAt;
+      await writeMailbox(teamName, mailbox, cwd);
+      retired += pending.length;
+    });
+  }
+  return retired;
 }
 
 export async function writeTaskApproval(

--- a/src/team/state/mailbox.ts
+++ b/src/team/state/mailbox.ts
@@ -106,6 +106,23 @@ export async function sendDirectMessage(
     }
 
     const msgId = randomUUID();
+    const provisionalMessage: TeamMailboxMessage = {
+      message_id: msgId,
+      from_worker: fromWorker,
+      to_worker: toWorker,
+      body,
+      created_at: new Date().toISOString(),
+    };
+    const shadowMailbox = {
+      worker: legacyMailbox.worker,
+      messages: [...legacyMailbox.messages, provisionalMessage],
+    };
+    // Publish Team ownership evidence before creating the authoritative
+    // record. A crash after authoritative creation must leave enough durable
+    // evidence for shutdown to reconcile the record safely.
+    await deps.writeMailbox(deps.teamName, shadowMailbox, deps.cwd);
+    msg = provisionalMessage;
+    created = true;
     if (executeBridgeCommand(deps.cwd, {
       command: 'CreateMailboxMessage',
       message_id: msgId,
@@ -121,32 +138,15 @@ export async function sendDirectMessage(
           ...bridgeMessage,
           body: bridgeMessage.body || body,
         };
-        const shadowMailbox = {
+        const updatedShadowMailbox = {
           worker: legacyMailbox.worker,
-          messages: [...legacyMailbox.messages],
+          messages: [...shadowMailbox.messages],
         };
-        const shadowIndex = shadowMailbox.messages.findIndex((candidate) => candidate.message_id === msgId);
-        if (shadowIndex >= 0) shadowMailbox.messages[shadowIndex] = msg;
-        else shadowMailbox.messages.push(msg);
-        await deps.writeMailbox(deps.teamName, shadowMailbox, deps.cwd);
-        created = true;
-        return;
+        const shadowIndex = updatedShadowMailbox.messages.findIndex((candidate) => candidate.message_id === msgId);
+        if (shadowIndex >= 0) updatedShadowMailbox.messages[shadowIndex] = msg;
+        await deps.writeMailbox(deps.teamName, updatedShadowMailbox, deps.cwd);
       }
     }
-
-    msg = {
-      message_id: msgId,
-      from_worker: fromWorker,
-      to_worker: toWorker,
-      body,
-      created_at: new Date().toISOString(),
-    };
-    const shadowMailbox = {
-      worker: legacyMailbox.worker,
-      messages: [...legacyMailbox.messages, msg],
-    };
-    await deps.writeMailbox(deps.teamName, shadowMailbox, deps.cwd);
-    created = true;
   });
 
   if (!msg) {

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -89,6 +89,7 @@ export { broadcastMessage as teamBroadcast } from './state.js';
 export { listMailboxMessages as teamListMailbox } from './state.js';
 export { markMessageDelivered as teamMarkMessageDelivered } from './state.js';
 export { markMessageNotified as teamMarkMessageNotified } from './state.js';
+export { retireTeamMailboxMessages as teamRetireMailboxMessages } from './state.js';
 export { enqueueDispatchRequest as teamEnqueueDispatchRequest } from './state.js';
 export { listDispatchRequests as teamListDispatchRequests } from './state.js';
 export { readDispatchRequest as teamReadDispatchRequest } from './state.js';


### PR DESCRIPTION
## Summary

Fix two Team lifecycle defects observed in a live long-running tmux session:

1. Busy-pane Team notices were re-elected every 30 seconds even after `sendPaneInput` succeeded, because an accepted TUI queue entry was indistinguishable from an abandoned wake lease. One incident accumulated 18 identical follow-up prompts for only two logical notice targets.
2. `shutdownTeam` deleted Team-local state without first retiring that Team's global dispatch, mailbox, and notice projections. The incident left three dispatch records and five undelivered mailbox records after the Team had reached a terminal phase and its panes/state were removed.

## Changes

- Add an explicit confirmed state to Team notice wake leases.
  - Successful busy-pane sends confirm the exact wake ID.
  - Confirmed wakes remain coalesced until the prompt is reconciled or the Team is retired.
  - Failed sends/confirmations still release the lease for retry.
- Retire terminal Team projections before deleting their ownership evidence.
  - Remove exact Team-scoped dispatch records, including leader targets.
  - Mark only mailbox IDs proven by the Team's compatibility shadows as delivered.
  - Discard only the terminating Team's notices and remove a wake only when no other Team shares its target.
  - Preserve Team state fail-closed when authoritative retirement cannot be verified.
- Add regression coverage for stale confirmed wakes, stale unconfirmed retry, shared-target isolation, bridge mailbox retirement, terminal notice cleanup, and fail-closed shutdown ordering.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] Focused notice/state/runtime/gateway tests: 19 passed
- [x] Focused notify-hook suites: 113 passed
- [x] Team-critical coverage thresholds met: statements/lines 86.37%, functions 93.56%, branches 80.29%
- [ ] `npm test`
  - The Team-critical run initially reported four failing files. The branch-owned gateway contract mismatch was fixed and passes targeted validation.
  - The remaining three failures reproduce unchanged on a detached clean `origin/dev` worktree on this macOS host: `/var` vs `/private/var` state-root alias expectation, real-tmux source-authority race, and Darwin high-contention mode-lock stress.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs reviewed; no operator-facing command or configuration changed
- [x] Backward compatibility considered: ledger schema remains v2 and `confirmedAtMs` is optional

Document-refresh: not-needed | Internal Team lifecycle semantics only; no operator-facing command or configuration changed.
