### PR TITLE
docs: prompt composer drift triage + recovery (#3609)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,3 +199,39 @@ A checkout that you run directly, or link into a global root with `npm link`, is
 Update such a build with `git pull && npm run build`. The launch-time check makes the same determination silently and records the cadence, so a linked dev build never nags on startup and never overwrites your tree.
 
 This is distinct from `[omx] Unable to determine whether this global install is owned by npm or Bun`, which means the package root *is* inside a global `node_modules` but neither manager could be validated as its owner — reinstall globally with npm or Bun.
+
+## The prompt input line drifts into the middle of the pane
+
+Symptom: after a multi-agent/review workflow finishes, the Codex composer (`Ask Codex to do anything`) no longer sits directly above the bottom bars — it renders partway up the pane, with unused rows below it.
+
+The composer is drawn by the Codex CLI itself, not by OMX. OMX only mutates the *pane* around it (HUD split, pane teardown, geometry changes, `send-keys` nudges, and the detached-client `clear-history` prune hook). Every one of those mutations was exercised against a live Codex TUI on `codex-cli 0.152.1` / `tmux 3.2a`, both idle and mid-stream, and none of them desynced the composer anchor:
+
+| mutation | idle | mid-stream |
+|---|---|---|
+| HUD-style `split-window -v -f -l <n>` below the pane | anchored | anchored |
+| `kill-pane` on the HUD pane (pane grows back) | anchored | anchored |
+| window shrink 30 → 12 rows, then grow to 40 rows | re-anchors | re-anchors |
+| `clear-history` on the leader pane (detach prune hook) | anchored | anchored |
+| `detach-client` → `clear-history` → reattach | anchored | anchored |
+| nudge transport `C-u` → trigger text → `Tab` → `Enter` | anchored | anchored |
+| `alternate-screen off` + `aggressive-resize on` during the above | anchored | anchored |
+
+So a drift is environment-specific rather than an unconditional OMX layout bug.
+
+### Recovery
+
+Force the TUI to recompute its layout by changing the pane geometry once:
+
+```bash
+tmux resize-pane -D 1 && tmux resize-pane -U 1
+```
+
+If that restores the composer to the bottom, the pane content was fine and only the app's cached bottom anchor was stale (an anchor desync). If the drift survives a resize, it is a genuine layout bug and worth an issue.
+
+### What to attach when reporting it
+
+1. `codex --version` from the affected session (the inline-viewport anchor logic is Codex-side and version-sensitive).
+2. `tmux -V` and `tmux show -g | grep -iE 'aggressive-resize|alternate-screen|default-terminal|terminal-overrides'`.
+3. Whether the resize nudge above heals it.
+4. Whether the drift appeared while output was still streaming or only once everything was idle.
+5. Terminal emulator, `TERM`, and any wrapper in the pane (`ssh`, `script`, `asciinema`, nested multiplexer).


### PR DESCRIPTION
Closes nothing on its own — this lands the reproducible triage for #3609 so users hitting the drift get an answer and a recovery step instead of a dead end.

## What
`docs/troubleshooting.md` gains a **"The prompt input line drifts into the middle of the pane"** section with:
- the negative repro matrix (every OMX-side pane mutation, idle and mid-stream)
- the recovery command (`tmux resize-pane -D 1 && tmux resize-pane -U 1`)
- the exact fields to attach when reporting a persistent drift

## Evidence
Executed against a live Codex TUI — `codex-cli 0.152.1`, `tmux 3.2a`, base `dev` @ `e4fdaa1c`, pane 100x30/100x40. Mid-stream cases were driven with a local OpenAI-compatible Responses-API SSE server so a turn streams ~400 lines under real repaint pressure.

Mutations exercised: HUD `split-window -v -f -l 6`, `kill-pane`, window shrink/grow (30→12→40→30), `clear-history` (detached prune hook), `detach-client` → `clear-history` → reattach, nudge transport `C-u`/text/`Tab`/`Enter` with queued follow-ups, and all of the above with `alternate-screen off` + `aggressive-resize on`. Composer stayed bottom-anchored in every case.

That negative result is why this PR is docs-only: shipping a repaint nudge into the team nudge path would add churn to every workflow without a reproduced failure to justify it. #3609 stays open with the owner lane attached, waiting on reporter environment detail (`codex --version`, tmux options, heal-on-resize).

Docs-only change; no runtime code touched.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*