### PR TITLE
chore: bump dev base version to 0.21.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "0.21.3"
+version = "0.21.4"
 
 edition = "2021"
 rust-version = "1.73"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-codex",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-codex",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/oh-my-codex/.codex-plugin/plugin.json
+++ b/plugins/oh-my-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-codex",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "Multi-agent orchestration layer for OpenAI Codex CLI",
   "author": {
     "name": "Yeachan Heo",


### PR DESCRIPTION
Post-publish step 7 of the release protocol: after publishing v0.21.3, dev moves to the next development base version so dev installs display as `v0.21.4-dev-<revision>` instead of sharing the just-published stable base.

Carriers bumped: package.json, package-lock.json (root + self), Cargo.toml [workspace.package], plugins/oh-my-codex/.codex-plugin/plugin.json.

Base dev @ 2da36489 (shipped v0.21.3 commit).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*