### PR TITLE
feat(models): default all OMX agents to Astra, preserving effort and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ These are operator/support surfaces:
   - `omx uninstall` removes OMX-managed wrappers from `.codex/hooks.json` but keeps the file when user hooks remain
 - `omx update` checks npm immediately, installs the newest global OMX build, then reruns the same interactive setup refresh path
 - launch-time update checks are throttled and prompt by default; use `OMX_AUTO_UPDATE=0` to disable them or `OMX_AUTO_UPDATE=defer` to schedule deferred updates without a prompt
-- fresh OMX-managed `gpt-5.6-sol` config seeding now recommends `model_context_window = 250000` and `model_auto_compact_token_limit = 200000`, but only when those keys are missing
+- fresh OMX setup defaults to `gpt-6-astra` across frontier, standard, and spark/fast agents, with the same role reasoning defaults; existing user model configuration and explicit overrides are preserved
 - `.omx-config.json` model/env routing is documented in [the model/env routing reference](./docs/reference/omx-config-schema-routing.md); only edit keys supported by your installed OMX version
 - `omx doctor` verifies the install when something seems wrong; it does not prove that the active Codex profile can make an authenticated model call
 - `omx hud --watch` is a monitoring/status surface, not the primary user workflow
@@ -413,6 +413,7 @@ If `Shift+Enter` still submits instead of inserting a newline inside an OMX-mana
 
 - `omx sparkshell <command>` is for shell-native inspection and bounded verification
 - for read-only repository lookups, use normal Codex repository inspection tools/subagents (the deprecated `omx explore` command has been removed)
+- primary and fallback Sparkshell summary models both default to `gpt-6-astra`; set `OMX_SPARKSHELL_FALLBACK_MODEL` to a different model to enable a distinct fallback
 - sparkshell env overrides are intentionally narrow: `OMX_SPARKSHELL_BIN` selects a native sidecar path, `OMX_SPARKSHELL_MODEL` selects the primary summary model, `OMX_SPARKSHELL_FALLBACK_MODEL` selects the retry model, `OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE` selects summary instructions, and `OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS` controls the local API summary timeout
 
 Examples:

--- a/crates/omx-sparkshell/src/codex_bridge.rs
+++ b/crates/omx-sparkshell/src/codex_bridge.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 
 pub const DEFAULT_SUMMARY_TIMEOUT_MS: u64 = 60_000;
 pub const DEFAULT_API_BASE_URL: &str = "http://127.0.0.1:14510";
-pub const DEFAULT_SPARK_MODEL: &str = "gpt-5.6-luna";
-pub const DEFAULT_STANDARD_MODEL: &str = "gpt-5.6-terra";
+pub const DEFAULT_SPARK_MODEL: &str = "gpt-6-astra";
+pub const DEFAULT_STANDARD_MODEL: &str = "gpt-6-astra";
 
 pub fn resolve_model() -> String {
     env::var("OMX_SPARKSHELL_MODEL")

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -133,41 +133,48 @@ fn raw_mode_preserves_stdout_and_stderr() {
 }
 
 #[test]
-fn summary_mode_uses_local_api_and_model_override() {
-    let request_log = Arc::new(Mutex::new(String::new()));
-    let request_log_for_server = Arc::clone(&request_log);
-    let (base_url, server) = start_api_server(1, move |request| {
-        *request_log_for_server.lock().expect("request log") = request;
-        (
-            200,
-            response_json("- summary: command produced long output\n- warnings: stderr was empty"),
-        )
-    });
+fn summary_mode_defaults_to_astra_and_preserves_model_overrides() {
+    for (model_override, expected_model) in [("", "gpt-6-astra"), ("gpt-5.6-luna", "gpt-5.6-luna")]
+    {
+        let request_log = Arc::new(Mutex::new(String::new()));
+        let request_log_for_server = Arc::clone(&request_log);
+        let (base_url, server) = start_api_server(1, move |request| {
+            *request_log_for_server.lock().expect("request log") = request;
+            (
+                200,
+                response_json(
+                    "- summary: command produced long output\n- warnings: stderr was empty",
+                ),
+            )
+        });
 
-    let output = Command::new(sparkshell_bin())
-        .env("OMX_API_BASE_URL", base_url)
-        .env("OMX_SPARKSHELL_LINES", "1")
-        .env("OMX_SPARKSHELL_MODEL", "spark-test-model")
-        .arg("sh")
-        .arg("-c")
-        .arg("printf 'one\ntwo\n'")
-        .output()
-        .expect("run sparkshell");
-    server.join().expect("api server");
+        let output = Command::new(sparkshell_bin())
+            .env("OMX_API_BASE_URL", base_url)
+            .env("OMX_SPARKSHELL_LINES", "1")
+            .env("OMX_SPARKSHELL_MODEL", model_override)
+            .env_remove("OMX_DEFAULT_SPARK_MODEL")
+            .env_remove("OMX_SPARK_MODEL")
+            .arg("sh")
+            .arg("-c")
+            .arg("printf 'one\ntwo\n'")
+            .output()
+            .expect("run sparkshell");
+        server.join().expect("api server");
 
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("- summary: command produced long output"));
-    assert!(stdout.contains("- warnings: stderr was empty"));
-    assert!(String::from_utf8_lossy(&output.stderr).is_empty());
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("- summary: command produced long output"));
+        assert!(stdout.contains("- warnings: stderr was empty"));
+        assert!(String::from_utf8_lossy(&output.stderr).is_empty());
 
-    let request = request_log.lock().expect("request log");
-    assert!(request.starts_with("POST /v1/responses HTTP/1.1"));
-    assert!(request.contains("\"model\":\"spark-test-model\""));
-    assert!(request.contains("\"reasoning\":{\"effort\":\"low\"}"));
-    assert!(request.contains("Command family: generic-shell"));
-    assert!(request.contains("<<<STDOUT"));
-    assert!(request.contains("one\\ntwo"));
+        let request = request_log.lock().expect("request log");
+        assert!(request.starts_with("POST /v1/responses HTTP/1.1"));
+        assert!(request.contains(&format!("\"model\":\"{expected_model}\"")));
+        assert!(request.contains("\"reasoning\":{\"effort\":\"low\"}"));
+        assert!(request.contains("Command family: generic-shell"));
+        assert!(request.contains("<<<STDOUT"));
+        assert!(request.contains("one\\ntwo"));
+    }
 }
 
 #[test]

--- a/crates/omx-sparkshell/tests/execution.rs
+++ b/crates/omx-sparkshell/tests/execution.rs
@@ -977,7 +977,13 @@ printf '\xff\xfe\n'
         .output()
         .expect("run sparkshell");
 
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "raw command failed: status={}, stdout={:?}, stderr={}",
+        output.status,
+        output.stdout,
+        String::from_utf8_lossy(&output.stderr),
+    );
     assert_eq!(output.stdout, vec![0xff, 0xfe, b'\n']);
     let _ = fs::remove_dir_all(temp);
 }

--- a/docs/reference/omx-config-schema-routing.md
+++ b/docs/reference/omx-config-schema-routing.md
@@ -57,24 +57,24 @@ The model-routing reader supports `env`, `models`, and the per-role override map
 ```json
 {
   "agentModels": {
-    "planner": "gpt-5.6-sol",
-    "architect": "gpt-5.6-sol",
-    "researcher": "gpt-5.6-terra",
-    "explore": "gpt-5.6-luna"
+    "planner": "gpt-6-astra",
+    "architect": "gpt-6-astra",
+    "researcher": "gpt-6-astra",
+    "explore": "gpt-6-astra"
   },
   "agentReasoning": {
     "architect": "xhigh",
     "critic": "xhigh"
   },
   "env": {
-    "OMX_DEFAULT_FRONTIER_MODEL": "gpt-5.6-sol",
-    "OMX_DEFAULT_STANDARD_MODEL": "gpt-5.6-terra",
-    "OMX_DEFAULT_SPARK_MODEL": "gpt-5.6-luna"
+    "OMX_DEFAULT_FRONTIER_MODEL": "gpt-6-astra",
+    "OMX_DEFAULT_STANDARD_MODEL": "gpt-6-astra",
+    "OMX_DEFAULT_SPARK_MODEL": "gpt-6-astra"
   },
   "models": {
-    "default": "gpt-5.6-sol",
-    "team": "gpt-5.6-sol",
-    "team_low_complexity": "gpt-5.6-luna"
+    "default": "gpt-6-astra",
+    "team": "gpt-6-astra",
+    "team_low_complexity": "gpt-6-astra"
   }
 }
 ```
@@ -89,7 +89,7 @@ Supported model-related keys:
 | --- | --- |
 | `OMX_DEFAULT_FRONTIER_MODEL` | Main/frontier default used by leaders and frontier-class roles when no stronger config wins. |
 | `OMX_DEFAULT_STANDARD_MODEL` | Optional standard-lane override. If omitted, standard agents inherit the main/frontier default. |
-| `OMX_DEFAULT_SPARK_MODEL` | Spark/fast-lane default for low-cost exploration and low-complexity workers. |
+| `OMX_DEFAULT_SPARK_MODEL` | Spark/fast-lane default for exploration and low-complexity workers. |
 | `OMX_SPARK_MODEL` | Legacy spark fallback; prefer `OMX_DEFAULT_SPARK_MODEL` for new config. |
 | `OMX_TEAM_CHILD_MODEL` | Default child model for specific team-child paths that read this setting directly. |
 
@@ -105,12 +105,15 @@ For `omx sparkshell`, the documented helper-specific environment keys are:
 | `OMX_SPARKSHELL_MODEL_INSTRUCTIONS_FILE` | Override the packaged lightweight summary instructions file. |
 | `OMX_SPARKSHELL_SUMMARY_TIMEOUT_MS` | Override the local API summary timeout in milliseconds. |
 
+Both Sparkshell summary model defaults are `gpt-6-astra`. To retry with a distinct model when the primary is unavailable, explicitly set `OMX_SPARKSHELL_FALLBACK_MODEL` to a different model.
+
 ### `models`
 
 `models` maps mode names to explicit model overrides. Values must be non-empty strings.
 
-The built-in defaults are `gpt-5.6-sol` (frontier), `gpt-5.6-terra` (standard), and `gpt-5.6-luna` (spark); the known-alias list contains exactly these three GPT-5.6 models. Legacy prior-generation names (for example `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`) are not aliases and carry no special routing meaning; like any provider-specific model name, they pass through only as opaque override strings. The known-alias list is used for display and contract tests, not as a closed allow-list.
+The built-in frontier, standard, and spark defaults are all `gpt-6-astra`, including fast agents and low-complexity workers. Existing role reasoning defaults are unchanged. The known-alias list contains `gpt-6-astra` plus the configurable GPT-5.6 alternatives `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. Legacy prior-generation names (for example `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`) are not aliases and carry no special routing meaning; like any provider-specific model name, they pass through only as opaque override strings. The known-alias list is used for display and contract tests, not as a closed allow-list.
 
+Setup seeds Astra when no root model exists; it preserves an existing user model unless an explicit model change is requested. Explicit launch arguments, environment values, and model configuration retain their documented precedence.
 
 Supported model-routing keys:
 
@@ -128,6 +131,8 @@ Do not invent per-role maps such as `models.executor`, `models.architect`, or `m
 
 `agentModels` is the supported per-agent model override map. Keys are normalized OMX agent names using the same normalization as `agentReasoning`: case-insensitive agent names containing letters, numbers, underscores, and hyphens. Values must be non-empty strings. Malformed agent names, empty values, and non-string values are ignored rather than fatal.
 
+For example, explicitly select GPT-5.6 alternatives instead of the Astra defaults:
+
 ```json
 {
   "agentModels": {
@@ -144,7 +149,7 @@ These overrides do not change built-in defaults in source. They are user/project
 For a named role, effective model precedence is:
 
 1. `.omx-config.json` `agentModels[role]`
-2. Built-in `exactModel` pins, such as planner/architect `gpt-5.6-sol` or researcher `gpt-5.6-terra`
+2. Built-in `exactModel` pins, such as planner/architect/researcher `gpt-6-astra`
 3. Special role logic, such as `executor` using the main/frontier lane
 4. `modelClass` routing: `fast` uses spark/low-complexity, `frontier` uses main/frontier, and `standard` uses the standard lane
 
@@ -178,7 +183,7 @@ The main default resolves in this order:
 1. Shell `OMX_DEFAULT_FRONTIER_MODEL`
 2. `.omx-config.json` `env.OMX_DEFAULT_FRONTIER_MODEL`
 3. Active Codex `config.toml` root `model`
-4. Built-in default: `gpt-5.6-sol`
+4. Built-in default: `gpt-6-astra`
 
 ### Mode-specific model lookup
 
@@ -209,7 +214,7 @@ Spark/fast defaults resolve in this order:
 3. `.omx-config.json` `env.OMX_DEFAULT_SPARK_MODEL`
 4. `.omx-config.json` legacy `env.OMX_SPARK_MODEL`
 5. `.omx-config.json` `models.team_low_complexity`, `models.team-low-complexity`, or `models.teamLowComplexity`
-6. Built-in default: `gpt-5.6-luna`
+6. Built-in default: `gpt-6-astra`
 
 For team low-complexity helpers, the exact order depends on the call path: `getSparkDefaultModel()` checks spark env/config values before low-complexity aliases, while `getTeamLowComplexityModel()` checks low-complexity aliases before falling back to the spark default.
 
@@ -221,7 +226,7 @@ Examples:
 
 | Role/category | Examples | Model class behavior |
 | --- | --- | --- |
-| Exact planning/research pins | `planner`, `architect`, `researcher` | Uses the built-in `exactModel` pin before model-class routing unless `agentModels[role]` is set; planner uses exact `gpt-5.6-sol` with medium reasoning, architect uses exact `gpt-5.6-sol` with xhigh reasoning, and researcher stays on exact `gpt-5.6-terra`. Ralplan's `critic` remains frontier-routed for the consensus gate. In Autopilot, `planning_routing.owner` switches the initial ralplan Planner draft/decomposition to this dedicated `planner` role when `[main]` is cheap/mini or when `agentModels.planner` is configured. |
+| Exact planning/research pins | `planner`, `architect`, `researcher` | Uses the built-in `exactModel` pin before model-class routing unless `agentModels[role]` is set; planner uses exact `gpt-6-astra` with medium reasoning, architect uses exact `gpt-6-astra` with xhigh reasoning, and researcher uses exact `gpt-6-astra` with high reasoning. Ralplan's `critic` remains frontier-routed for the consensus gate. In Autopilot, `planning_routing.owner` switches the initial ralplan Planner draft/decomposition to this dedicated `planner` role when `[main]` is cheap/mini or when `agentModels.planner` is configured. |
 | Frontier orchestration | `critic`, `code-reviewer`, `security-reviewer`, `team-executor`, `vision` | Native-agent generation uses active `config.toml` root `model` first, then the main/frontier default fallback. |
 | Standard worker/review | `debugger`, `quality-reviewer`, `api-reviewer`, `performance-reviewer`, `dependency-expert`, `writer` | Uses the standard-lane default, which inherits main/frontier unless `OMX_DEFAULT_STANDARD_MODEL` is set. |
 | Fast/low-complexity | `explore`, `style-reviewer` | Uses the spark/low-complexity default. |
@@ -258,7 +263,7 @@ JSON does not allow comments, so copy only the JSON blocks.
 
 ### Cost-saving starter
 
-This keeps orchestration on the frontier default, routes standard workers to a cheaper standard model, and uses the spark lane for exploration/low-complexity work.
+This opts into GPT-5.6 alternatives: Sol for orchestration, Terra for standard workers, and Luna for exploration/low-complexity work. Exact-pinned planner, architect, and researcher roles remain on Astra unless `agentModels` overrides them, as shown above.
 
 ```json
 {
@@ -275,38 +280,28 @@ This keeps orchestration on the frontier default, routes standard workers to a c
 }
 ```
 
-### Max-quality starter
+### Astra default starter
 
-This keeps standard agents inheriting the frontier model by omitting `OMX_DEFAULT_STANDARD_MODEL`, keeps a fast spark lane for default low-complexity routing, and explicitly promotes selected exact-pinned/generated roles to a max-quality model with matching reasoning overrides.
+This explicitly selects Astra across lanes and modes. Omitting `agentReasoning` preserves the existing role reasoning defaults, including low reasoning for `explore`, medium for `planner`, xhigh for `architect`, and high for `researcher`. Remove or update conflicting per-agent overrides if you want an existing installation to use these defaults.
 
 ```json
 {
-  "agentModels": {
-    "planner": "gpt-5.6-sol",
-    "architect": "gpt-5.6-sol",
-    "researcher": "gpt-5.6-terra",
-    "explore": "gpt-5.6-luna"
-  },
-  "agentReasoning": {
-    "planner": "medium",
-    "architect": "xhigh",
-    "researcher": "high",
-    "explore": "medium",
-    "critic": "xhigh"
-  },
   "env": {
-    "OMX_DEFAULT_FRONTIER_MODEL": "gpt-5.6-sol",
-    "OMX_DEFAULT_SPARK_MODEL": "gpt-5.6-luna"
+    "OMX_DEFAULT_FRONTIER_MODEL": "gpt-6-astra",
+    "OMX_DEFAULT_STANDARD_MODEL": "gpt-6-astra",
+    "OMX_DEFAULT_SPARK_MODEL": "gpt-6-astra"
   },
   "models": {
-    "default": "gpt-5.6-sol",
-    "team": "gpt-5.6-sol",
-    "autopilot": "gpt-5.6-sol",
-    "ralph": "gpt-5.6-sol",
-    "team_low_complexity": "gpt-5.6-luna"
+    "default": "gpt-6-astra",
+    "team": "gpt-6-astra",
+    "autopilot": "gpt-6-astra",
+    "ralph": "gpt-6-astra",
+    "team_low_complexity": "gpt-6-astra"
   }
 }
 ```
+
+For generated frontier agents and the executor special case, an existing root `config.toml` model still wins over lane defaults. Set that root model to `gpt-6-astra` too when intentionally migrating an existing configuration.
 
 ## Verifying the effective config
 

--- a/docs/shared/agent-tiers.md
+++ b/docs/shared/agent-tiers.md
@@ -12,7 +12,7 @@ OMX now separates three concepts:
 - `exactModel`: optional role pin that bypasses tier defaults when a role needs a
   specific model contract.
 
-Use role to choose responsibility, tier to choose depth, and posture to choose operating style.
+Use role to choose responsibility, tier to choose depth, and posture to choose operating style. All model lanes default to `gpt-6-astra`, including fast agents; role reasoning defaults and explicit model overrides remain unchanged.
 
 ## Tiers
 
@@ -47,8 +47,8 @@ Use role to choose responsibility, tier to choose depth, and posture to choose o
   - Prioritizes intent classification, delegation, verification, and architectural judgment.
   - Typical roles: `planner`, `analyst`, `architect`, `critic`, `code-reviewer`.
   - Ralplan keeps `planner` and `architect` in this posture; `planner`
-    uses exact `gpt-5.6-sol` with medium reasoning, `architect` uses exact
-    `gpt-5.6-sol` with xhigh reasoning, and the `critic` consensus gate stays
+    uses exact `gpt-6-astra` with medium reasoning, `architect` uses exact
+    `gpt-6-astra` with xhigh reasoning, and the `critic` consensus gate stays
     on the frontier lane.
 
 - `deep-worker`:
@@ -57,6 +57,6 @@ Use role to choose responsibility, tier to choose depth, and posture to choose o
   - Typical roles: `executor`, `debugger`, `test-engineer`, `build-fixer`.
 
 - `fast-lane`:
-  - Best for cheap/fast models used for triage, search, and narrow synthesis.
+  - Best for triage, search, and narrow synthesis. It defaults to Astra like the other lanes; configure a spark model override for a cheaper model.
   - Prioritizes quick routing, concise search, and escalation over deep autonomous work.
   - Typical roles: `explore`, `writer`, and lightweight research/search specialists.

--- a/src/agents/__tests__/definitions.test.ts
+++ b/src/agents/__tests__/definitions.test.ts
@@ -165,14 +165,17 @@ describe('agents/definitions', () => {
     }
   });
 
-  it('pins ralplan thesis and antithesis to exact gpt-5.6-sol with role-specific reasoning', () => {
-    assert.equal(AGENT_DEFINITIONS.planner.exactModel, 'gpt-5.6-sol');
+  it('pins ralplan thesis and antithesis to exact gpt-6-astra with role-specific reasoning', () => {
+    assert.equal(AGENT_DEFINITIONS.planner.exactModel, 'gpt-6-astra');
     assert.equal(AGENT_DEFINITIONS.planner.reasoningEffort, 'medium');
     assert.equal(AGENT_DEFINITIONS.planner.modelClass, 'frontier');
 
-    assert.equal(AGENT_DEFINITIONS.architect.exactModel, 'gpt-5.6-sol');
+    assert.equal(AGENT_DEFINITIONS.architect.exactModel, 'gpt-6-astra');
     assert.equal(AGENT_DEFINITIONS.architect.reasoningEffort, 'xhigh');
     assert.equal(AGENT_DEFINITIONS.architect.modelClass, 'frontier');
+
+    assert.equal(AGENT_DEFINITIONS.researcher.exactModel, 'gpt-6-astra');
+    assert.equal(AGENT_DEFINITIONS.researcher.reasoningEffort, 'high');
 
     assert.equal(AGENT_DEFINITIONS.critic.exactModel, undefined);
     assert.equal(AGENT_DEFINITIONS.critic.reasoningEffort, 'high');

--- a/src/agents/__tests__/native-config.test.ts
+++ b/src/agents/__tests__/native-config.test.ts
@@ -76,6 +76,64 @@ afterEach(() => {
 });
 
 describe("agents/native-config", () => {
+  it("defaults every role to Astra with its existing reasoning effort", () => {
+    delete process.env.OMX_DEFAULT_STANDARD_MODEL;
+    const expectedEfforts = {
+      "executor": "medium",
+      "team-executor": "medium",
+      "explore": "low",
+      "analyst": "medium",
+      "planner": "medium",
+      "architect": "xhigh",
+      "debugger": "high",
+      "verifier": "high",
+      "style-reviewer": "low",
+      "quality-reviewer": "medium",
+      "api-reviewer": "medium",
+      "security-reviewer": "medium",
+      "performance-reviewer": "medium",
+      "code-reviewer": "high",
+      "dependency-expert": "high",
+      "test-engineer": "medium",
+      "quality-strategist": "medium",
+      "build-fixer": "high",
+      "designer": "high",
+      "writer": "high",
+      "qa-tester": "low",
+      "git-master": "high",
+      "code-simplifier": "high",
+      "researcher": "high",
+      "product-manager": "medium",
+      "ux-researcher": "medium",
+      "information-architect": "low",
+      "product-analyst": "low",
+      "critic": "high",
+      "vision": "low",
+    };
+    assert.deepEqual(Object.keys(AGENT_DEFINITIONS).sort(), Object.keys(expectedEfforts).sort());
+    for (const [role, effort] of Object.entries(expectedEfforts)) {
+      const toml = parseToml(generateAgentToml(AGENT_DEFINITIONS[role], `${role} prompt`));
+      assert.equal(toml.model, "gpt-6-astra", role);
+      assert.equal(toml.model_reasoning_effort, effort, role);
+      assert.doesNotMatch(String(toml.developer_instructions), /exact gpt-5\.6-terra model/, role);
+    }
+  });
+
+  it("preserves older per-role model choices across every model class", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-legacy-models-"));
+    try {
+      const agentModels = { planner: "gpt-5.6-sol", researcher: "gpt-5.6-terra", explore: "gpt-5.6-luna" };
+      await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({ agentModels }));
+      for (const [role, model] of Object.entries(agentModels)) {
+        const toml = parseToml(generateAgentToml(AGENT_DEFINITIONS[role], `${role} prompt`, { codexHomeOverride: codexHome }));
+        assert.equal(toml.model, model, role);
+        assert.equal(toml.model_reasoning_effort, AGENT_DEFINITIONS[role].reasoningEffort, role);
+      }
+    } finally {
+      await rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
   it("generates TOML with stripped frontmatter and escaped triple quotes", () => {
     const agent: AgentDefinition = {
       name: "executor",
@@ -92,7 +150,7 @@ describe("agents/native-config", () => {
     const toml = generateAgentToml(agent, prompt);
 
     assert.match(toml, /# oh-my-codex agent: executor/);
-    assert.match(toml, /model = "gpt-5\.6-sol"/);
+    assert.match(toml, /model = "gpt-6-astra"/);
     assert.match(toml, /model_reasoning_effort = "medium"/);
     assert.ok(!toml.includes("title: demo"));
     assert.ok(toml.includes("Instruction line"));
@@ -190,7 +248,7 @@ describe("agents/native-config", () => {
     }
   });
 
-  it("applies Terra guidance when agentModels resolves exact-Sol roles to gpt-5.6-terra", async () => {
+  it("applies Terra guidance when agentModels resolves exact-Astra roles to gpt-5.6-terra", async () => {
     const codexHome = await mkdtemp(join(tmpdir(), "omx-native-config-terra-override-"));
     try {
       await writeFile(join(codexHome, ".omx-config.json"), JSON.stringify({
@@ -222,16 +280,16 @@ describe("agents/native-config", () => {
   });
 
 
-  it("pins planner and architect to exact gpt-5.6-sol while keeping researcher on exact Terra", () => {
+  it("pins planner, architect, and researcher to Astra while retaining effort defaults", () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = "gpt-5.6-sol";
     process.env.OMX_DEFAULT_STANDARD_MODEL = "gpt-5.6-sol";
 
-    for (const role of ["planner", "architect"] as const) {
+    for (const role of ["planner", "architect", "researcher"] as const) {
       const toml = generateAgentToml(AGENT_DEFINITIONS[role], `${role} prompt`);
-      assert.match(toml, /model = "gpt-5\.6-sol"/, `${role} should use exact gpt-5.6-sol`);
-      assert.match(toml, /exact gpt-5\.6-sol model/, `${role} should receive exact-gpt-5.6-sol guidance`);
+      assert.match(toml, /model = "gpt-6-astra"/, `${role} should use exact gpt-6-astra`);
+      assert.match(toml, /exact gpt-6-astra model/, `${role} should receive exact-gpt-6-astra guidance`);
       assert.match(toml, /strict execution order: inspect -> plan -> act -> verify/, `${role} should receive the exact-model guardrail`);
-      assert.match(toml, /resolved_model: gpt-5\.6-sol/, `${role} should record exact gpt-5.6-sol metadata`);
+      assert.match(toml, /resolved_model: gpt-6-astra/, `${role} should record exact gpt-6-astra metadata`);
     }
 
     const plannerToml = generateAgentToml(AGENT_DEFINITIONS.planner, "planner prompt");
@@ -241,9 +299,9 @@ describe("agents/native-config", () => {
     assert.match(architectToml, /model_reasoning_effort = "xhigh"/);
 
     const researcherToml = generateAgentToml(AGENT_DEFINITIONS.researcher, "researcher prompt");
-    assert.match(researcherToml, /model = "gpt-5\.6-terra"/, "researcher should keep exact Terra");
-    assert.match(researcherToml, /exact gpt-5\.6-terra model/, "researcher should receive exact-Terra guidance");
-    assert.match(researcherToml, /resolved_model: gpt-5.6-terra/, "researcher should record exact Terra metadata");
+    assert.match(researcherToml, /model = "gpt-6-astra"/, "researcher should keep exact Astra");
+    assert.match(researcherToml, /exact gpt-6-astra model/, "researcher should receive exact-Astra guidance");
+    assert.match(researcherToml, /resolved_model: gpt-6-astra/, "researcher should record exact Astra metadata");
     assert.match(researcherToml, /model_reasoning_effort = "high"/);
 
     for (const role of [
@@ -396,7 +454,7 @@ describe("agents/native-config", () => {
         join(outDir, "executor.toml"),
         "utf8",
       );
-      assert.match(executorToml, /model = "gpt-5\.6-sol"/);
+      assert.match(executorToml, /model = "gpt-6-astra"/);
       assert.match(executorToml, /model_reasoning_effort = "medium"/);
 
       const skipped = await installNativeAgentConfigs(root, {

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -9,7 +9,7 @@ export interface AgentDefinition {
   description: string;
   reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh';
   /** Optional exact model pin for roles that should bypass tier defaults. */
-  exactModel?: 'gpt-5.6-terra' | 'gpt-5.6-sol';
+  exactModel?: 'gpt-6-astra' | 'gpt-5.6-terra' | 'gpt-5.6-sol';
   posture: 'frontier-orchestrator' | 'deep-worker' | 'fast-lane';
   modelClass: 'frontier' | 'standard' | 'fast';
   routingRole: 'leader' | 'specialist' | 'executor';
@@ -75,7 +75,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
     name: 'planner',
     description: 'Task sequencing, execution plans, risk flags',
     reasoningEffort: 'medium',
-    exactModel: 'gpt-5.6-sol',
+    exactModel: 'gpt-6-astra',
     posture: 'frontier-orchestrator',
     modelClass: 'frontier',
     routingRole: 'leader',
@@ -86,7 +86,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
     name: 'architect',
     description: 'System design, boundaries, interfaces, long-horizon tradeoffs',
     reasoningEffort: 'xhigh',
-    exactModel: 'gpt-5.6-sol',
+    exactModel: 'gpt-6-astra',
     posture: 'frontier-orchestrator',
     modelClass: 'frontier',
     routingRole: 'leader',
@@ -273,7 +273,7 @@ export const AGENT_DEFINITIONS: Record<string, AgentDefinition> = {
     name: 'researcher',
     description: 'External documentation and reference research',
     reasoningEffort: 'high',
-    exactModel: 'gpt-5.6-terra',
+    exactModel: 'gpt-6-astra',
     posture: 'fast-lane',
     modelClass: 'standard',
     routingRole: 'specialist',

--- a/src/agents/native-config.ts
+++ b/src/agents/native-config.ts
@@ -24,7 +24,7 @@ import { getRootModelName } from "../config/generator.js";
 import { codexAgentsDir } from "../utils/paths.js";
 
 export const EXACT_GPT_5_6_TERRA_MODEL = "gpt-5.6-terra";
-export const EXACT_RESEARCHER_MODEL = EXACT_GPT_5_6_TERRA_MODEL;
+export const EXACT_RESEARCHER_MODEL = "gpt-6-astra";
 
 const POSTURE_OVERLAYS: Record<AgentDefinition["posture"], string> = {
   "frontier-orchestrator": [

--- a/src/autopilot/__tests__/planner-routing.test.ts
+++ b/src/autopilot/__tests__/planner-routing.test.ts
@@ -38,9 +38,20 @@ describe('autopilot planner routing', () => {
     assert.equal(isCheapOrMiniModelName('gpt-5.6-terra'), true);
     assert.equal(isCheapOrMiniModelName('gpt-5.6-luna'), true);
     assert.equal(isCheapOrMiniModelName('gpt-5.6-sol'), false);
+    assert.equal(isCheapOrMiniModelName('gpt-6-astra'), false);
     assert.equal(isCheapOrMiniModelName('o4-mini'), true);
     assert.equal(isCheapOrMiniModelName('vendor/cheap-router'), true);
     assert.equal(isCheapOrMiniModelName('dominican-router'), false);
+  });
+
+  it('keeps default Astra planning on main', () => {
+    assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
+      owner: 'main',
+      mainModel: 'gpt-6-astra',
+      plannerModel: 'gpt-6-astra',
+      reason: 'main_not_cheap_or_mini',
+      explicitPlannerOverride: false,
+    });
   });
 
   it('keeps planning on main when autopilot main is not cheap and no planner override exists', async () => {
@@ -49,7 +60,7 @@ describe('autopilot planner routing', () => {
     assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
       owner: 'main',
       mainModel: 'gpt-5.6-sol',
-      plannerModel: 'gpt-5.6-sol',
+      plannerModel: 'gpt-6-astra',
       reason: 'main_not_cheap_or_mini',
       explicitPlannerOverride: false,
     });
@@ -61,7 +72,7 @@ describe('autopilot planner routing', () => {
     assert.deepEqual(resolveAutopilotPlannerRouting(tempDir), {
       owner: 'planner',
       mainModel: 'o4-mini',
-      plannerModel: 'gpt-5.6-sol',
+      plannerModel: 'gpt-6-astra',
       reason: 'main_is_cheap_or_mini',
       explicitPlannerOverride: false,
     });

--- a/src/autopilot/planner-routing.ts
+++ b/src/autopilot/planner-routing.ts
@@ -1,7 +1,5 @@
 import { AGENT_DEFINITIONS } from '../agents/definitions.js';
 import {
-  DEFAULT_SPARK_MODEL,
-  DEFAULT_STANDARD_MODEL,
   getAgentModelOverride,
   getMainDefaultModel,
   getModelForMode,
@@ -26,7 +24,7 @@ function normalizeModelName(value: string): string {
 export function isCheapOrMiniModelName(model: string): boolean {
   const normalized = normalizeModelName(model);
   if (!normalized) return false;
-  if (normalized === DEFAULT_STANDARD_MODEL || normalized === DEFAULT_SPARK_MODEL) return true;
+  if (normalized === 'gpt-5.6-terra' || normalized === 'gpt-5.6-luna') return true;
   return CHEAP_OR_MINI_MODEL_PATTERN.test(normalized);
 }
 

--- a/src/cli/__tests__/agents.test.ts
+++ b/src/cli/__tests__/agents.test.ts
@@ -86,7 +86,7 @@ describe('omx agents', () => {
       assert.match(content, /^name = "my-helper"$/m);
       assert.match(content, /^description = "TODO: describe this agent's purpose"$/m);
       assert.match(content, /^developer_instructions = """$/m);
-      assert.match(content, /^# model = "gpt-5\.6-sol"$/m);
+      assert.match(content, /^# model = "gpt-6-astra"$/m);
       assert.match(content, /^# model_reasoning_effort = "medium"$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/auth.test.ts
+++ b/src/cli/__tests__/auth.test.ts
@@ -124,7 +124,7 @@ exit 2
       await writeFakeCodex(bin, `#!/bin/sh\nif [ "$1" = "login" ]; then mkdir -p "$CODEX_HOME"; printf '{"access_token":"sentinel-secret"}\\n' > "$CODEX_HOME/auth.json"; exit 0; fi\necho unexpected "$@" >&2\nexit 2\n`);
       const add = runOmx(wd, ["auth", "add", "work"], { HOME: home, CODEX_HOME: codexHome, PATH: `${bin}:/usr/bin:/bin` });
       assert.equal(add.status, 0, add.stderr);
-      assert.match(await readFile(join(codexHome, "config.toml"), "utf-8"), /^model = "gpt-5-codex"\n+model_provider = "openai-chatgpt"\n$/);
+      assert.match(await readFile(join(codexHome, "config.toml"), "utf-8"), /^model = "gpt-6-astra"\n+model_provider = "openai-chatgpt"\n$/);
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/doctor-spark-routing.test.ts
+++ b/src/cli/__tests__/doctor-spark-routing.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 
 import { checkSparkRouting } from '../doctor.js';
 
-const SPARK_DEFAULT = 'gpt-5.6-luna';
+const SPARK_DEFAULT = 'gpt-6-astra';
 
 const SPARK_ENV_KEYS = [
   'OMX_DEFAULT_SPARK_MODEL',

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -967,6 +967,73 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	for (const fixture of [
+		{ name: "fresh config", config: "", model: "gpt-6-astra" },
+		{
+			name: "multiline developer instructions with bracket headings",
+			config: [
+				'developer_instructions = """',
+				"Preserve these custom instructions.",
+				"",
+				"[review]",
+				"Inspect the diff before editing.",
+				"",
+				"[verification]",
+				"Run focused checks.",
+				'"""',
+				"",
+			].join("\n"),
+			model: "gpt-6-astra",
+		},
+		{
+			name: "explicit root and profile settings",
+			config: [
+				'"model" = "gpt-5.6-sol"',
+				'model_provider = "custom"',
+				'model_reasoning_effort = "high"',
+				'profile = "research"',
+				'[profiles.research]',
+				'model = "gpt-5.6-terra"',
+				'model_provider = "profile-custom"',
+				'model_reasoning_effort = "xhigh"',
+				"",
+			].join("\n"),
+			model: "gpt-5.6-sol",
+		},
+		{
+			name: "profile settings without a root model",
+			config: [
+				'model_provider = "custom"',
+				'model_reasoning_effort = "high"',
+				'profile = "research"',
+				'[profiles.research]',
+				'model = "gpt-5.6-luna"',
+				'model_reasoning_effort = "low"',
+				"",
+			].join("\n"),
+			model: "gpt-6-astra",
+		},
+	]) {
+		it(`seeds only a missing plugin root model for ${fixture.name}`, async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-plugin-root-model-"));
+			try {
+				await withIsolatedUserHome(wd, async (codexHomeDir) => {
+					const configPath = join(codexHomeDir, "config.toml");
+					if (fixture.config) await writeFile(configPath, fixture.config);
+					const original = parseToml(fixture.config);
+					await runSetupWithCapturedLogs(wd, { scope: "user", installMode: "plugin" });
+					const config = parseToml(await readFile(configPath, "utf-8"));
+					assert.equal(config.model, fixture.model);
+					for (const key of ["model_provider", "model_reasoning_effort", "profile", "profiles", "developer_instructions"]) {
+						assert.deepEqual(config[key], original[key], key);
+					}
+				});
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+	}
+
 	it("installs native agent TOML files in plugin mode so agent_type roles are available", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/__tests__/setup-refresh.test.ts
+++ b/src/cli/__tests__/setup-refresh.test.ts
@@ -16,6 +16,7 @@ import { setup } from "../setup.js";
 import TOML from "@iarna/toml";
 
 const TEST_CODEX_PROBES = {
+  installMode: "legacy",
   codexFeaturesProbe: () => null,
   codexVersionProbe: () => null,
 } satisfies Parameters<typeof setup>[0];
@@ -408,7 +409,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("offers an upgrade from gpt-5.3-codex to gpt-5.6-sol when accepted", async () => {
+  it("offers an upgrade from gpt-5.3-codex to gpt-6-astra when accepted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
@@ -431,14 +432,14 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         modelUpgradePrompt: async (currentModel, targetModel) => {
           promptCalls += 1;
           assert.equal(currentModel, "gpt-5.3-codex");
-          assert.equal(targetModel, "gpt-5.6-sol");
+          assert.equal(targetModel, "gpt-6-astra");
           return true;
         },
       });
 
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
       assert.equal(promptCalls, 1);
-      assert.match(config, /^model = "gpt-5\.6-sol"$/m);
+      assert.match(config, /^model = "gpt-6-astra"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.3-codex"$/m);
       assert.doesNotMatch(config, /^model_context_window = 250000$/m);
       assert.doesNotMatch(config, /^model_auto_compact_token_limit = 200000$/m);
@@ -448,7 +449,7 @@ describe("omx setup refresh summary and dry-run behavior", () => {
     }
   });
 
-  it("offers an upgrade from gpt-5.5 to gpt-5.6-sol when accepted", async () => {
+  it("offers an upgrade from gpt-5.5 to gpt-6-astra when accepted", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-setup-refresh-"));
     try {
       await mkdir(join(wd, ".omx", "state"), { recursive: true });
@@ -459,13 +460,13 @@ describe("omx setup refresh summary and dry-run behavior", () => {
         scope: "project",
         modelUpgradePrompt: async (currentModel, targetModel) => {
           assert.equal(currentModel, "gpt-5.5");
-          assert.equal(targetModel, "gpt-5.6-sol");
+          assert.equal(targetModel, "gpt-6-astra");
           return true;
         },
       });
 
       const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-      assert.match(config, /^model = "gpt-5\.6-sol"$/m);
+      assert.match(config, /^model = "gpt-6-astra"$/m);
       assert.doesNotMatch(config, /^model = "gpt-5\.5"$/m);
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -5,10 +5,11 @@ import { spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline/promises';
 import { basename, join } from 'node:path';
 import TOML from '@iarna/toml';
+import { DEFAULT_FRONTIER_MODEL } from '../config/models.js';
 import { codexAgentsDir, projectCodexAgentsDir } from '../utils/paths.js';
 
 export const RESERVED_NATIVE_AGENT_NAMES = new Set(['default', 'worker', 'explorer']);
-const DEFAULT_AGENT_MODEL = 'gpt-5.6-sol';
+const DEFAULT_AGENT_MODEL = DEFAULT_FRONTIER_MODEL;
 const AGENTS_USAGE = [
   'Usage:',
   '  omx agents list [--scope user|project]',

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "path";
 import { homedir } from "os";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { spawnPlatformCommandSync, classifySpawnError } from "../utils/platform-command.js";
+import { DEFAULT_FRONTIER_MODEL } from "../config/models.js";
 import { readAuthConfig } from "../auth/config.js";
 import { resolveLiveAuthPath } from "../auth/paths.js";
 import { redactAuthSecrets } from "../auth/redact.js";
@@ -23,7 +24,7 @@ Auth slots are stored under ~/.omx/auth/<slot>.json with owner-only permissions.
 function wantsJson(args: string[]): boolean {
   return args.includes("--json");
 }
-const DEFAULT_SUBSCRIPTION_MODEL = "gpt-5-codex";
+const DEFAULT_SUBSCRIPTION_MODEL = DEFAULT_FRONTIER_MODEL;
 const DEFAULT_SUBSCRIPTION_MODEL_PROVIDER = "openai-chatgpt";
 
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -324,7 +324,7 @@ Options:
                 (shorthand for: -c model_reasoning_effort="xhigh")
   --madmax      DANGEROUS: bypass Codex approvals and sandbox
                 (alias for --dangerously-bypass-approvals-and-sandbox)
-  --spark       Use the Codex spark model (~1.3x faster) for team workers only
+  --spark       Use the configured spark-lane model for team workers only
                 Workers get the configured low-complexity team model; leader model unchanged
   --madmax-spark  spark model for workers + bypass approvals for leader and workers
                 (shorthand for: --spark --madmax)

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3411,8 +3411,14 @@ function buildPluginModeHooksConfigPlan(
 		},
 	);
 
+	const configWithDefaultModel = Object.prototype.hasOwnProperty.call(
+		TOML.parse(configAfterLegacyCleanup),
+		"model",
+	)
+		? configAfterLegacyCleanup
+		: `model = ${JSON.stringify(DEFAULT_FRONTIER_MODEL)}\n${configAfterLegacyCleanup}`;
 	const configWithRuntimeFeatures = upsertPluginModeRuntimeFeatureFlags(
-		configAfterLegacyCleanup,
+		configWithDefaultModel,
 		options.codexHookFeatureFlag,
 		{
 			pluginScopedHooks: options.pluginScopedHooks,

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -14,7 +14,7 @@ Resolved setup scope: user
   [OK] Lore commit guard: disabled by default
   [!!] Prompts: prompts directory not found
   [!!] Skills: skills directory not found
-  [!!] Spark routing: lanes: frontier=`gpt-5.6-sol`, standard=`gpt-5.6-sol`, spark=`gpt-5.6-luna` (source: built-in default); Spark lane issue(s): explore.toml is missing under <CODEX_HOME>/agents (run `omx setup --force`)
+  [!!] Spark routing: lanes: frontier=`gpt-6-astra`, standard=`gpt-6-astra`, spark=`gpt-6-astra` (source: built-in default); Spark lane issue(s): explore.toml is missing under <CODEX_HOME>/agents (run `omx setup --force`)
   [OK] Legacy skill roots: no ~/.agents/skills overlap detected
   [!!] AGENTS.md: not found in <CODEX_HOME>/AGENTS.md (run omx setup --scope user)
   [!!] State dir: <REPO_STATE_DIR> (not created yet)

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -17,7 +17,7 @@ describe('config generator', () => {
       const notifyIdx = toml.indexOf('notify =');
       const reasoningIdx = toml.indexOf('model_reasoning_effort =');
       const devInstrIdx = toml.indexOf('developer_instructions =');
-      const modelIdx = toml.indexOf('model = "gpt-5.6-sol"');
+      const modelIdx = toml.indexOf('model = "gpt-6-astra"');
       const featuresIdx = toml.indexOf('[features]');
 
       assert.ok(notifyIdx >= 0, 'notify not found');
@@ -49,14 +49,15 @@ describe('config generator', () => {
     }
   });
 
-  it('does not seed context defaults for fresh configs', async () => {
+  it('defaults fresh configs to Astra with unchanged medium reasoning and no context overrides', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-config-gen-'));
     try {
       const configPath = join(wd, 'config.toml');
       await mergeConfig(configPath, wd);
       const toml = await readFile(configPath, 'utf-8');
 
-      assert.match(toml, /^model = "gpt-5\.6-sol"$/m);
+      assert.match(toml, /^model = "gpt-6-astra"$/m);
+      assert.match(toml, /^model_reasoning_effort = "medium"$/m);
       assert.doesNotMatch(toml, /seeded behavioral defaults/);
       assert.doesNotMatch(toml, /^model_context_window\s*=/m);
       assert.doesNotMatch(toml, /^model_auto_compact_token_limit\s*=/m);

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -8,6 +8,7 @@ import {
   CANONICAL_REASONING_EFFORTS,
   DEFAULT_FRONTIER_MODEL,
   DEFAULT_SPARK_MODEL,
+  DEFAULT_STANDARD_MODEL,
   DEFAULT_TEAM_CHILD_MODEL,
   GPT_5_6_MODEL_ALIASES,
   KNOWN_CODEX_MODEL_ALIASES,
@@ -205,8 +206,8 @@ describe('getModelForMode', () => {
 
   it('defaults team child model to the standard lane independent of frontier defaults', () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = 'frontier-expensive';
-    assert.equal(DEFAULT_TEAM_CHILD_MODEL, 'gpt-5.6-terra');
-    assert.equal(getTeamChildModel(), 'gpt-5.6-terra');
+    assert.equal(DEFAULT_TEAM_CHILD_MODEL, 'gpt-6-astra');
+    assert.equal(getTeamChildModel(), 'gpt-6-astra');
   });
 
   it('uses OMX_TEAM_CHILD_MODEL shell override for team child model', () => {
@@ -390,6 +391,13 @@ describe('getModelForMode', () => {
     assert.equal(getAgentModelOverride('ARCHITECT'), 'gpt-5.6-sol');
     assert.equal(getAgentModelOverride('executor'), undefined);
     assert.equal(getAgentModelOverride('bad role'), undefined);
+  });
+
+  it('defaults every model tier to Astra', () => {
+    for (const model of [DEFAULT_FRONTIER_MODEL, DEFAULT_STANDARD_MODEL, DEFAULT_SPARK_MODEL, getMainDefaultModel(), getStandardDefaultModel(), getSparkDefaultModel(), getTeamChildModel(), getTeamLowComplexityModel()]) {
+      assert.equal(model, 'gpt-6-astra');
+    }
+    assert.equal(isKnownCodexModelAlias('gpt-6-astra'), true);
   });
 
   it('lists GPT-5.6 Terra/Luna/Sol as known Codex model aliases', () => {

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -110,11 +110,11 @@ function readModelsBlock(codexHomeOverride?: string): ModelsConfig | null {
   return null;
 }
 
-export const DEFAULT_FRONTIER_MODEL = 'gpt-5.6-sol';
-export const DEFAULT_STANDARD_MODEL = 'gpt-5.6-terra';
-export const DEFAULT_SPARK_MODEL = 'gpt-5.6-luna';
-export const GPT_5_6_MODEL_ALIASES = [DEFAULT_STANDARD_MODEL, DEFAULT_SPARK_MODEL, DEFAULT_FRONTIER_MODEL] as const;
-export const KNOWN_CODEX_MODEL_ALIASES = GPT_5_6_MODEL_ALIASES;
+export const DEFAULT_FRONTIER_MODEL = 'gpt-6-astra';
+export const DEFAULT_STANDARD_MODEL = 'gpt-6-astra';
+export const DEFAULT_SPARK_MODEL = 'gpt-6-astra';
+export const GPT_5_6_MODEL_ALIASES = ['gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.6-sol'] as const;
+export const KNOWN_CODEX_MODEL_ALIASES = ['gpt-6-astra', ...GPT_5_6_MODEL_ALIASES] as const;
 export type KnownCodexModelAlias = (typeof KNOWN_CODEX_MODEL_ALIASES)[number];
 
 export function isKnownCodexModelAlias(model: string): model is KnownCodexModelAlias {

--- a/src/hooks/__tests__/keyword-detector.test.ts
+++ b/src/hooks/__tests__/keyword-detector.test.ts
@@ -2219,8 +2219,8 @@ describe('keyword detector skill-active-state lifecycle', () => {
       assert.equal(modeState.state.return_to_ralplan_reason, null);
       assert.deepEqual(modeState.state.planning_routing, {
         owner: 'main',
-        mainModel: 'gpt-5.6-sol',
-        plannerModel: 'gpt-5.6-sol',
+        mainModel: 'gpt-6-astra',
+        plannerModel: 'gpt-6-astra',
         reason: 'main_not_cheap_or_mini',
         explicitPlannerOverride: false,
       });

--- a/src/team/__tests__/delegation-policy.test.ts
+++ b/src/team/__tests__/delegation-policy.test.ts
@@ -32,7 +32,7 @@ describe('synthesizeDelegationPlan', () => {
     else delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
   });
 
-  it('auto-delegates broad investigation tasks to gpt-5.6-terra child agents', () => {
+  it('auto-delegates broad investigation tasks to gpt-6-astra child agents', () => {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = 'frontier-expensive';
     const plan = synthesizeDelegationPlan(task({
       subject: 'Investigate flaky runtime behavior',
@@ -45,7 +45,7 @@ describe('synthesizeDelegationPlan', () => {
     assert.equal(plan.required_parallel_probe, true);
     assert.equal(plan.spawn_before_serial_search_threshold, 3);
     assert.equal(plan.child_model_policy, 'standard');
-    assert.equal(plan.child_model, 'gpt-5.6-terra');
+    assert.equal(plan.child_model, 'gpt-6-astra');
     assert.equal(plan.child_report_format, 'bullets');
     assert.equal(plan.skip_allowed_reason_required, true);
     assert.ok((plan.subtask_candidates ?? []).some((candidate) => /debug|root-cause/i.test(candidate)));

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -253,9 +253,9 @@ describe('team model contract', () => {
   it('maps worker roles to configured default model lanes', () => {
     withIsolatedDefaultModelEnv(() => {
       assert.equal(resolveAgentDefaultModel('explore'), expectedLowComplexityModel());
-      assert.equal(resolveAgentDefaultModel('writer'), 'gpt-5.6-sol');
-      assert.equal(resolveAgentDefaultModel('executor'), 'gpt-5.6-sol');
-      assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.6-sol');
+      assert.equal(resolveAgentDefaultModel('writer'), 'gpt-6-astra');
+      assert.equal(resolveAgentDefaultModel('executor'), 'gpt-6-astra');
+      assert.equal(resolveAgentDefaultModel('architect'), 'gpt-6-astra');
       assert.equal(resolveAgentDefaultModel('does-not-exist'), undefined);
     });
   });
@@ -263,9 +263,9 @@ describe('team model contract', () => {
     withIsolatedDefaultModelEnv(() => {
       process.env.OMX_DEFAULT_FRONTIER_MODEL = 'gpt-5.2-frontier';
 
-      assert.equal(resolveAgentDefaultModel('planner'), 'gpt-5.6-sol');
-      assert.equal(resolveAgentDefaultModel('architect'), 'gpt-5.6-sol');
-      assert.equal(resolveAgentDefaultModel('researcher'), 'gpt-5.6-terra');
+      assert.equal(resolveAgentDefaultModel('planner'), 'gpt-6-astra');
+      assert.equal(resolveAgentDefaultModel('architect'), 'gpt-6-astra');
+      assert.equal(resolveAgentDefaultModel('researcher'), 'gpt-6-astra');
       assert.equal(resolveAgentDefaultModel('critic'), 'gpt-5.2-frontier');
     });
   });
@@ -310,7 +310,7 @@ describe('team model contract', () => {
           '-c',
           'model_reasoning_effort="high"',
           '--model',
-          'gpt-5.6-sol',
+          'gpt-6-astra',
         ],
       );
     });
@@ -378,14 +378,14 @@ describe('team model contract', () => {
         }),
         {
           requestedAgentType: 'architect',
-          requestedDefaultModel: 'gpt-5.6-sol',
+          requestedDefaultModel: 'gpt-6-astra',
           requestedDefaultReasoning: 'xhigh',
-          actualModel: 'gpt-5.6-sol',
+          actualModel: 'gpt-6-astra',
           actualReasoning: 'xhigh',
           modelSource: 'fallback',
           reasoningSource: 'role-default',
           inheritedParentModel: false,
-          actualLaunchArgs: ['-c', 'model_reasoning_effort="xhigh"', '--model', 'gpt-5.6-sol'],
+          actualLaunchArgs: ['-c', 'model_reasoning_effort="xhigh"', '--model', 'gpt-6-astra'],
         },
       );
     });

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -1014,7 +1014,7 @@ process.on('SIGTERM', () => process.exit(0));`,
       assert.deepEqual(workerArgs, [
         '--sandbox', 'workspace-write',
         '-c', 'model_reasoning_effort="medium"',
-        '--model', 'gpt-5.6-sol',
+        '--model', 'gpt-6-astra',
         '--', 'C:\\workspace\\nested\\', '', '--sandbox=read-only', '--madmax',
       ]);
       const startedRuntime = runtime as TeamRuntime | null;
@@ -1405,7 +1405,7 @@ require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slic
         { OMX_TEAM_WORKER_LAUNCH_ARGS: '--no-alt-screen' },
         'executor',
       );
-      assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-5.6-sol']);
+      assert.deepEqual(args, ['--no-alt-screen', '--model', 'gpt-6-astra']);
     });
   });
 
@@ -1418,11 +1418,11 @@ require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slic
         resolveAgentReasoningEffort('executor'),
         'codex',
       );
-      assert.deepEqual(args, ['--no-alt-screen', '-c', 'model_reasoning_effort="medium"', '--model', 'gpt-5.6-sol']);
+      assert.deepEqual(args, ['--no-alt-screen', '-c', 'model_reasoning_effort="medium"', '--model', 'gpt-6-astra']);
     });
   });
 
-  it('resolveWorkerLaunchArgsFromEnv keeps planner on exact gpt-5.6-sol medium when inherited leader is mini', () => {
+  it('resolveWorkerLaunchArgsFromEnv keeps planner on exact gpt-6-astra medium when inherited leader is mini', () => {
     withIsolatedDefaultModelEnv(() => {
       const args = resolveWorkerLaunchArgsFromEnv(
         {
@@ -1439,7 +1439,7 @@ require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slic
         '-c',
         'model_reasoning_effort="medium"',
         '--model',
-        'gpt-5.6-sol',
+        'gpt-6-astra',
       ]);
     });
   });
@@ -1482,7 +1482,7 @@ require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slic
         '-c',
         'model_reasoning_effort="medium"',
         '--model',
-        'gpt-5.6-sol',
+        'gpt-6-astra',
       ]);
     });
   });
@@ -1564,8 +1564,8 @@ require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slic
           'high',
           'codex',
         );
-        assert.deepEqual(lowArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'gpt-5.6-sol']);
-        assert.deepEqual(highArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.6-sol']);
+        assert.deepEqual(lowArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'gpt-6-astra']);
+        assert.deepEqual(highArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-6-astra']);
       });
     } finally {
       console.log = originalLog;
@@ -1690,7 +1690,7 @@ require('fs').writeFileSync(process.env.OMX_NON_CODEX_CAPTURE, process.argv.slic
         'low',
         'gemini',
       );
-      assert.deepEqual(codexArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-5.6-sol']);
+      assert.deepEqual(codexArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="high"', '--model', 'gpt-6-astra']);
       assert.deepEqual(claudeArgs, ['--no-alt-screen', '-c', 'model_reasoning_effort="low"', '--model', 'claude-3-7-sonnet']);
       assert.deepEqual(geminiArgs, ['-c', 'model_reasoning_effort="low"', '--model', 'gemini-2.0-pro']);
     } finally {
@@ -5732,7 +5732,7 @@ process.on('SIGTERM', () => process.exit(0));
       assert.match(worker2Instructions, /You are operating as the \*\*writer\*\* role/);
       assert.match(worker2Instructions, /You are Writer\./);
       assert.doesNotMatch(worker2Instructions, /exact gpt-5\.6-terra model/);
-      assert.match(worker2Instructions, /resolved_model: gpt-5\.6-sol/);
+      assert.match(worker2Instructions, /resolved_model: gpt-6-astra/);
 
       let worker1Args: string[] | null = null;
       let worker2Args: string[] | null = null;
@@ -5753,10 +5753,10 @@ process.on('SIGTERM', () => process.exit(0));
       const worker2Joined = worker2Args!.join(' ');
       assert.match(worker1Joined, /model_reasoning_effort="medium"/);
       assert.match(worker1Joined, /model_instructions_file=.*worker-1\/AGENTS\.md/);
-      assert.match(worker1Joined, /--model gpt-5\.6-sol/);
+      assert.match(worker1Joined, /--model gpt-6-astra/);
       assert.match(worker2Joined, /model_reasoning_effort="xhigh"/);
       assert.match(worker2Joined, /model_instructions_file=.*worker-2\/AGENTS\.md/);
-      assert.match(worker2Joined, /--model gpt-5\.6-sol/);
+      assert.match(worker2Joined, /--model gpt-6-astra/);
 
       await shutdownTeam(runtime.teamName, cwd, { force: true });
       runtime = null;
@@ -12414,7 +12414,7 @@ esac
 
       const task = await readTask(runtime.teamName, '1', cwd);
       assert.equal(task?.delegation?.mode, 'auto');
-      assert.equal(task?.delegation?.child_model, 'gpt-5.6-terra');
+      assert.equal(task?.delegation?.child_model, 'gpt-6-astra');
       assert.equal(task?.delegation?.required_parallel_probe, true);
       assert.equal(task?.coordination?.mode, 'coordinated');
       assert.ok(task?.coordination?.activation_reasons.includes('cross_boundary_or_handoff_language'));
@@ -13080,7 +13080,7 @@ esac
 
       const reread = await readTask('team-assign-delegation', task.id, cwd);
       assert.equal(reread?.delegation?.mode, 'auto');
-      assert.equal(reread?.delegation?.child_model, 'gpt-5.6-terra');
+      assert.equal(reread?.delegation?.child_model, 'gpt-6-astra');
       assert.equal(reread?.coordination?.mode, 'coordinated');
       assert.ok(reread?.coordination?.activation_reasons.includes('shared_file_scope'));
       assert.equal(reread?.coordination?.activation_reasons.includes('stale_snapshot_before_assignment'), false);

--- a/src/team/__tests__/worker-runtime-identity.test.ts
+++ b/src/team/__tests__/worker-runtime-identity.test.ts
@@ -219,9 +219,9 @@ process.on('SIGTERM', () => process.exit(0));
       const worker1Joined = worker1Args!.join(' ');
       const worker2Joined = worker2Args!.join(' ');
       assert.match(worker1Joined, /model_reasoning_effort="low"/);
-      assert.match(worker1Joined, /--model gpt-5\.6-luna/);
+      assert.match(worker1Joined, /--model gpt-6-astra/);
       assert.match(worker2Joined, /model_reasoning_effort="low"/);
-      assert.match(worker2Joined, /--model gpt-5\.6-luna/);
+      assert.match(worker2Joined, /--model gpt-6-astra/);
 
       await shutdownTeam(runtime.teamName, cwd, { force: true });
       runtime = null;
@@ -326,7 +326,7 @@ process.on('SIGTERM', () => process.exit(0));
         join(cwd, '.omx', 'state', 'team', 'low-role-scale', 'runtime', 'worker-2-startup.sh'),
         'utf-8',
       );
-      assert.match(startupScript, /gpt-5\.6-luna/);
+      assert.match(startupScript, /gpt-6-astra/);
       execFileSync('sh', ['-n', join(cwd, '.omx', 'state', 'team', 'low-role-scale', 'runtime', 'worker-2-startup.sh')]);
       assert.match(startupScript, /model_reasoning_effort.*low/);
     } finally {

--- a/src/utils/__tests__/agents-model-table.test.ts
+++ b/src/utils/__tests__/agents-model-table.test.ts
@@ -15,15 +15,18 @@ const originalFrontierEnv = process.env.OMX_DEFAULT_FRONTIER_MODEL;
 const originalStandardEnv = process.env.OMX_DEFAULT_STANDARD_MODEL;
 const originalSparkEnv = process.env.OMX_DEFAULT_SPARK_MODEL;
 const originalLegacySparkEnv = process.env.OMX_SPARK_MODEL;
+let isolatedCodexHome: string;
 
-beforeEach(() => {
+beforeEach(async () => {
+  isolatedCodexHome = await mkdtemp(join(tmpdir(), 'omx-model-table-defaults-'));
   delete process.env.OMX_DEFAULT_FRONTIER_MODEL;
   delete process.env.OMX_DEFAULT_STANDARD_MODEL;
   delete process.env.OMX_DEFAULT_SPARK_MODEL;
   delete process.env.OMX_SPARK_MODEL;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await rm(isolatedCodexHome, { recursive: true, force: true });
   if (typeof originalFrontierEnv === 'string') {
     process.env.OMX_DEFAULT_FRONTIER_MODEL = originalFrontierEnv;
   } else {
@@ -52,7 +55,7 @@ describe('agents model table', () => {
     process.env.OMX_DEFAULT_STANDARD_MODEL = 'standard-env';
     process.env.OMX_DEFAULT_SPARK_MODEL = 'spark-env';
 
-    const context = resolveAgentsModelTableContext('model = "frontier-config"\n');
+    const context = resolveAgentsModelTableContext('model = "frontier-config"\n', { codexHomeOverride: isolatedCodexHome });
 
     assert.deepEqual(context, {
       frontierModel: 'frontier-config',
@@ -62,11 +65,11 @@ describe('agents model table', () => {
   });
 
   it('uses the configured frontier model as the standard subagent default when no standard override exists', () => {
-    const context = resolveAgentsModelTableContext('model = "frontier-config"\n');
+    const context = resolveAgentsModelTableContext('model = "frontier-config"\n', { codexHomeOverride: isolatedCodexHome });
 
     assert.deepEqual(context, {
       frontierModel: 'frontier-config',
-      sparkModel: 'gpt-5.6-luna',
+      sparkModel: 'gpt-6-astra',
       subagentDefaultModel: 'frontier-config',
     });
   });
@@ -76,14 +79,14 @@ describe('agents model table', () => {
       frontierModel: 'gpt-frontier',
       sparkModel: 'gpt-spark',
       subagentDefaultModel: 'gpt-standard',
-    });
+    }, undefined, { codexHomeOverride: isolatedCodexHome });
 
     assert.match(table, /\| Frontier \(leader\) \| `gpt-frontier` \| high \|/);
     assert.match(table, /\| Spark \(explorer\/fast\) \| `gpt-spark` \| low \|/);
     assert.match(table, /\| Standard \(subagent default\) \| `gpt-standard` \| high \|/);
     assert.match(table, /\| `explore` \| `gpt-spark` \| low \| Fast codebase search and file\/symbol mapping \(fast-lane, fast\) \|/);
-    assert.match(table, /\| `planner` \| `gpt-5\.6-sol` \| medium \| Task sequencing, execution plans, risk flags \(frontier-orchestrator, frontier\) \|/);
-    assert.match(table, /\| `architect` \| `gpt-5\.6-sol` \| xhigh \| System design, boundaries, interfaces, long-horizon tradeoffs \(frontier-orchestrator, frontier\) \|/);
+    assert.match(table, /\| `planner` \| `gpt-6-astra` \| medium \| Task sequencing, execution plans, risk flags \(frontier-orchestrator, frontier\) \|/);
+    assert.match(table, /\| `architect` \| `gpt-6-astra` \| xhigh \| System design, boundaries, interfaces, long-horizon tradeoffs \(frontier-orchestrator, frontier\) \|/);
     assert.doesNotMatch(table, /\| `security-reviewer` \|/);
     assert.doesNotMatch(table, /\| `build-fixer` \|/);
     assert.match(table, /\| `code-reviewer` \| `gpt-frontier` \| high \| Comprehensive review across all concerns \(frontier-orchestrator, frontier\) \|/);
@@ -133,7 +136,7 @@ describe('agents model table', () => {
       OMX_MODELS_END_MARKER,
       'after',
     ].join('\n');
-    const replaced = upsertAgentsModelTable(withMarkers, context);
+    const replaced = upsertAgentsModelTable(withMarkers, context, undefined, { codexHomeOverride: isolatedCodexHome });
     assert.match(replaced, /## Model Capability Table/);
     assert.doesNotMatch(replaced, /stale/);
 
@@ -146,7 +149,7 @@ describe('agents model table', () => {
       '',
       '<verification>',
     ].join('\n');
-    const inserted = upsertAgentsModelTable(withoutMarkers, context);
+    const inserted = upsertAgentsModelTable(withoutMarkers, context, undefined, { codexHomeOverride: isolatedCodexHome });
     assert.match(
       inserted,
       /<\/team_model_resolution>\n\n<!-- OMX:MODELS:START -->[\s\S]*<!-- OMX:MODELS:END -->\n\n---/,


### PR DESCRIPTION
## Summary

Default OMX leaders, specialists, fast agents, low-complexity workers, and Sparkshell summaries to `gpt-6-astra`. Preserve existing reasoning-effort defaults and explicit model configuration, profiles, per-agent overrides, and CLI/environment choices.

Normal contribution targeting `dev`, per the repository contribution guide.

## Changes

- Set frontier, standard, spark, team-child, exact planning/research, new-agent, and subscription model defaults to Astra. Keep GPT-5.6 alternatives recognized and preserve opaque provider-specific overrides.
- Seed a missing root model during plugin setup, as legacy setup already does. Preserve existing model/profile/provider values and custom multiline instructions; keep reasoning-effort behavior unchanged.
- Keep cheap-model planner detection tied to Terra/Luna rather than default-model constants, so Astra is not classified as a cheap model.
- Default Sparkshell primary/fallback models to Astra while preserving low reasoning effort and configurable alternatives. A distinct fallback remains opt-in.
- Update routing documentation and regressions for all 30 built-in roles, effort defaults, overrides, plugin setup, and worker identity. Include captured status/output in raw-byte test failures without weakening assertions.

## Default behavior changes and rationale

This intentionally changes OMX's default model policy while preserving its orchestration structure, role responsibilities, reasoning-effort defaults, and explicit model overrides.

| Behavior | Before | After |
| --- | --- | --- |
| Frontier / standard / fast model defaults | Sol / Terra / Luna | Astra / Astra / Astra, including fast agents and low-complexity workers |
| Sparkshell primary / fallback | Luna / Terra | Astra / Astra; an alternate-model fallback requires explicit configuration |
| Plugin setup with no root `model` | Leaves the root model unset | Seeds `gpt-6-astra`; existing model and profile choices retain precedence |

**Why choose these defaults?** Astra across roles makes the default model selection consistent and gives delegated work access to the same model family as the leader. [OpenAI's model guidance](https://learn.chatgpt.com/docs/models) positions Astra for demanding workflows involving sustained reasoning, multiple steps, and tools. That supports Astra as a reasonable starting point when output quality is the priority. Seeding a missing plugin root model also makes fresh setup reproduce the declared OMX default instead of depending on the client's recommended model.

**What is the tradeoff?** The former defaults assigned different models to different lanes to balance capability, latency, and cost. Astra everywhere removes that balance from the defaults; lightweight work may be better served by a faster or cheaper model. Preserving reasoning-effort settings does not guarantee unchanged latency, cost, or quality across models. Pinning the root model also means fresh plugin configurations do not automatically follow future changes to the client's recommended model. Other models remain configurable.

**Fallback behavior is a deliberate availability tradeoff.** Sparkshell only tries an alternate model when its fallback differs from its primary. With both defaults set to Astra, eligible quota, access, or capacity errors no longer trigger a different-model attempt by default. This keeps the default on Astra; it is not a reliability improvement. Configure `OMX_SPARKSHELL_FALLBACK_MODEL` to restore an alternate-model attempt where desired.

**Comparative superiority is unverified.** This PR does not include OMX task benchmarks comparing Astra with Sol, Terra, or Luna. CI verifies routing and compatibility behavior, not better model output, speed, or cost. [OpenAI's model-selection guidance](https://developers.openai.com/api/docs/guides/model-selection) recommends evaluating accuracy, latency, and cost on representative tasks. The supported claim here is a consistent Astra-first default policy with preserved customization; any quality advantage for a particular role needs task-level evaluation.

## Validation

- [x] [Full GitHub CI matrix](https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/33919827830) passed on `5a1a7c5f862271a79b438e9b6f2b41aa3c54d13c`, including all grouped TypeScript lanes, team coverage, Rust tests/coverage/format/Clippy, builds, and platform checks.
- [x] Local `npm run build`, `npm run lint`, `npm run check:no-unused`, generated-file/native-agent/prompt checks, and `git diff --check`.
- [x] 519 focused TypeScript tests: 161 routing, 169 setup, 4 isolated team model/inheritance regressions, and 185 hook/delegation/worker-identity tests.
- [x] `cargo test -p omx-sparkshell`: 78 tests passed; `cargo fmt --all -- --check` and a focused raw-byte regression also passed.
- [x] Compiled `omx doctor`: 18 passed, 4 installation/provenance warnings, 0 failures because the development checkout differs from the installed plugin. Installed OMX doctor passed all 22 checks; live Astra/high execution returned `OMX-EXEC-OK`.
- [x] Independent static review found no remaining issues.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Docs updated when needed
- [x] Backward compatibility considered: explicit choices retain precedence; unconfigured defaults now use Astra
