### PR TITLE
fix(doctor/setup): stop relying on removed Codex plugin_hooks flag

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1886,6 +1886,109 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("infers plugin mode from canonical [features].hooks enablement when plugin_hooks is removed", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-canonical-hooks-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			const cacheDir = await installPluginCacheFixture(codexDir);
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"goals = true",
+					"",
+					"[features]",
+					"hooks = true",
+					"",
+					"[marketplaces.oh-my-codex-local]",
+					'source_type = "local"',
+					`source = ${JSON.stringify(repoRoot())}`,
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const setupOwnedHooksPath = join(codexDir, "hooks.json");
+			assert.equal(existsSync(setupOwnedHooksPath), false);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.match(res.stdout, /Resolved setup install mode: plugin/);
+			assert.match(
+				res.stdout,
+				new RegExp(
+					`\\[OK\\] Native hooks: plugin-scoped hooks are enabled; setup-owned hooks\\.json is intentionally absent at .*\\.codex[\\/]+hooks\\.json, and plugin cache native hook coverage smoke passed via ${join(cacheDir, "hooks", "hooks.json").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+				),
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/plugin mode is using legacy native hook fallback/,
+			);
+			assert.doesNotMatch(
+				res.stdout,
+				/expected setup-owned hooks\.json is missing/,
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps disabled hook enablement out of plugin-mode hook inference", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-hooks-disabled-"));
+		try {
+			const home = join(wd, "home");
+			const codexDir = join(home, ".codex");
+			await mkdir(join(wd, ".omx"), { recursive: true });
+			await mkdir(codexDir, { recursive: true });
+			await writeFile(
+				join(wd, ".omx", "setup-scope.json"),
+				`${JSON.stringify({ scope: "user", installMode: "plugin", mcpMode: "none" }, null, 2)}\n`,
+			);
+			await writeFile(
+				join(codexDir, "config.toml"),
+				[
+					"goals = true",
+					"",
+					"[features]",
+					"hooks = false",
+					"",
+					'[plugins."oh-my-codex@oh-my-codex-local"]',
+					"enabled = true",
+					"",
+				].join("\n"),
+			);
+
+			const res = runOmx(wd, ["doctor"], {
+				HOME: home,
+				CODEX_HOME: codexDir,
+			});
+			if (shouldSkipForSpawnPermissions(res.error)) return;
+			assert.equal(res.status, 0, res.stderr || res.stdout);
+			assert.doesNotMatch(
+				res.stdout,
+				/Native hooks: plugin-scoped hooks are enabled/,
+			);
+			assert.match(
+				res.stdout,
+				/Native hooks: plugin mode is using legacy native hook fallback, but expected setup-owned hooks\.json is missing/,
+				"disabled hooks configuration must still surface the missing fallback hooks.json diagnostic",
+			);
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
 	it("warns when hooks.json is missing OMX-managed native hook coverage", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-hooks-coverage-"));

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -550,8 +550,8 @@ approval_policy = "on-failure"
 async function assertProjectPluginModeArtifacts(wd: string): Promise<void> {
 	assert.equal(existsSync(join(wd, ".codex", "hooks.json")), false);
 	const config = await readFile(join(wd, ".codex", "config.toml"), "utf-8");
-	assert.match(config, /^plugin_hooks = true$/m);
-	assert.doesNotMatch(config, /^hooks = true$/m);
+	assert.match(config, /^hooks = true$/m);
+	assert.doesNotMatch(config, /^plugin_hooks = true$/m);
 	assert.match(config, /^goals = true$/m);
 	assert.doesNotMatch(config, /developer_instructions|notify-hook/g);
 	assert.equal(
@@ -1804,8 +1804,8 @@ describe("omx setup install mode behavior", () => {
 						existsSync(join(cacheDir, "skills", "ask", "SKILL.md")),
 						true,
 					);
-					assert.match(config, /^plugin_hooks = true$/m);
-					assert.doesNotMatch(config, /^hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /^plugin_hooks = true$/m);
 					assert.doesNotMatch(config, /^codex_hooks = true$/m);
 					assert.doesNotMatch(config, /\[mcp_servers\./);
 					assert.equal(
@@ -2042,8 +2042,8 @@ describe("omx setup install mode behavior", () => {
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
-					assert.match(config, /^plugin_hooks = true$/m);
-					assert.doesNotMatch(config, /^hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /^plugin_hooks = true$/m);
 					assert.doesNotMatch(config, /^codex_hooks = true$/m);
 					assert.match(config, /^goals = true$/m);
 					assert.doesNotMatch(config, /\[hooks\.state\./);
@@ -2126,7 +2126,7 @@ describe("omx setup install mode behavior", () => {
 					assert.doesNotMatch(config, /before Ralplan planning, state, HUD, runtime, or delegation work, run `omx ralplan preflight --json`/i);
 					assert.doesNotMatch(config, /Native subagents live in \.codex\/agents/);
 					assert.doesNotMatch(config, /Treat installed prompts as narrower execution surfaces/);
-					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /notify-hook/);
 					assert.doesNotMatch(config, /^\s*\[mcp_servers[.\]]/m);
 					assert.doesNotMatch(config, /mcp_servers\.omx_state/);
@@ -2219,7 +2219,7 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(promptCount, 0);
 					const config = await readFile(configPath, "utf-8");
 					assert.match(config, /^developer_instructions = "custom"$/m);
-					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.equal(
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
@@ -2525,7 +2525,7 @@ describe("omx setup install mode behavior", () => {
 						(config.match(/^developer_instructions\s*=/gm) ?? []).length,
 						1,
 					);
-					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(config, /\[hooks\.state\./);
 				});
 			});
@@ -2548,7 +2548,7 @@ describe("omx setup install mode behavior", () => {
 
 					const config = await readFile(configPath, "utf-8");
 					assert.doesNotMatch(config, /^developer_instructions\s*=/m);
-					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 				});
 			});
 		} finally {
@@ -2574,7 +2574,7 @@ describe("omx setup install mode behavior", () => {
 						"utf-8",
 					);
 					assert.match(config, /^codex_hooks = true$/m);
-					assert.doesNotMatch(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /^plugin_hooks = true$/m);
 				});
 			});
 		} finally {
@@ -2613,8 +2613,8 @@ describe("omx setup install mode behavior", () => {
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
-					assert.match(config, /^plugin_hooks = true$/m);
-					assert.doesNotMatch(config, /^hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /^plugin_hooks = true$/m);
 					assert.doesNotMatch(config, /\[hooks\.state\./);
 				});
 			});
@@ -3760,8 +3760,8 @@ describe("omx setup install mode behavior", () => {
 					const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
 					assert.match(finalHooksContent, /foreign-hook\.py/);
 					assert.doesNotMatch(finalHooksContent, /codex-native-hook\.js/);
-					assert.match(config, /^plugin_hooks = true$/m);
 					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(config, /^plugin_hooks = true$/m);
 				});
 			});
 		} finally {
@@ -3803,11 +3803,11 @@ describe("omx setup install mode behavior", () => {
 						join(codexHomeDir, "config.toml"),
 						"utf-8",
 					);
-					assert.match(config, /^plugin_hooks = true$/m);
-					assert.match(
+					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(
 						config,
-						/^hooks = true$/m,
-						"plugin-scoped setup must keep native hooks enabled for foreign hooks",
+						/^plugin_hooks = true$/m,
+						"plugin-scoped setup must not emit the removed plugin_hooks flag",
 					);
 				});
 			});
@@ -3899,7 +3899,7 @@ describe("omx setup install mode behavior", () => {
 					await setup({ scope: "user", installMode: "plugin" });
 
 					const config = await readFile(configPath, "utf-8");
-					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.match(config, /^trusted_hash = "sha256:user"$/m);
 					assert.match(config, /^enabled = false$/m);
 					assert.equal(
@@ -4125,7 +4125,7 @@ describe("omx setup install mode behavior", () => {
 					assert.match(pluginOutput, /Using setup install mode: plugin/);
 					assert.match(
 						pluginOutput,
-						/Plugin-scoped Codex hooks and runtime feature flags refresh complete .*plugin_hooks, goals/,
+						/Plugin-scoped Codex hooks and runtime feature flags refresh complete .*hooks, goals/,
 					);
 					assert.doesNotMatch(pluginOutput, /user-scope skill delivery mode/);
 					assert.doesNotMatch(
@@ -4220,7 +4220,7 @@ describe("omx setup install mode behavior", () => {
 					assert.equal(existsSync(hooksPath), false);
 					assert.equal(existsSync(agentsMdPath), true);
 					const config = await readFile(configPath, "utf-8");
-					assert.match(config, /^plugin_hooks = true$/m);
+					assert.match(config, /^hooks = true$/m);
 					assert.doesNotMatch(
 						config,
 						/^\s*(?:notify)\s*=|^\s*\[mcp_servers[.\]]/m,
@@ -5671,7 +5671,7 @@ describe("omx setup install mode behavior", () => {
 					assert.deepEqual(await readFile(driftedStagedPath), foreignStagedCopy);
 					assert.equal(existsSync(shimPath), false);
 					assert.equal(existsSync(hooksPath), false);
-					assert.match(await readFile(configPath, "utf-8"), /^plugin_hooks = true$/m);
+					assert.match(await readFile(configPath, "utf-8"), /^hooks = true$/m);
 				});
 			});
 		} finally {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3815,6 +3815,45 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("generates canonical hooks flag instead of removed plugin_hooks on current Codex", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const logs = await runSetupWithCapturedLogs(wd, {
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						codexFeaturesProbe: () =>
+							[
+								"goals                                   stable             true",
+								"hooks                                   stable             true",
+								"plugin_hooks                            removed            false",
+								"",
+							].join("\n"),
+					});
+
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.match(config, /^\[features\]\s*$/m);
+					assert.match(config, /^hooks = true$/m);
+					assert.doesNotMatch(
+						config,
+						/^plugin_hooks\s*=/m,
+						"setup must not emit the removed plugin_hooks feature flag",
+					);
+					assert.match(
+						logs,
+						/Native Codex hooks fallback and runtime feature flags refresh complete \(.*hooks\.json; hooks, goals\)/,
+					);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
 	it("preserves same-key user hook trust state in plugin-scoped setup", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3859,6 +3859,54 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("leaves no global wrappers or stale flags when the removed-flag config pre-exists", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const configPath = join(codexHomeDir, "config.toml");
+					await writeFile(
+						configPath,
+						"[features]\nplugin_hooks = true\nhooks = false\n",
+					);
+
+					const removedProbe = () =>
+						[
+							"hooks                                   stable             true",
+							"plugin_hooks                            removed            false",
+							"",
+						].join("\n");
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						codexFeaturesProbe: removedProbe,
+					});
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						codexFeaturesProbe: removedProbe,
+					});
+
+					assert.equal(
+						existsSync(hooksPath),
+						false,
+						"rerun must keep the plugin manifest as the single hook surface",
+					);
+					const config = await readFile(configPath, "utf-8");
+					assert.doesNotMatch(config, /^plugin_hooks\s*=/m);
+					assert.doesNotMatch(config, /^codex_hooks\s*=/m);
+					assert.equal((config.match(/^hooks = true$/gm) ?? []).length, 1);
+					assert.doesNotMatch(config, /\[hooks\.state\./);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 
 	it("preserves same-key user hook trust state in plugin-scoped setup", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3838,15 +3838,20 @@ describe("omx setup install mode behavior", () => {
 						"utf-8",
 					);
 					assert.match(config, /^\[features\]\s*$/m);
-					assert.match(config, /^hooks = true$/m);
+					assert.equal((config.match(/^hooks = true$/gm) ?? []).length, 1);
 					assert.doesNotMatch(
 						config,
 						/^plugin_hooks\s*=/m,
 						"setup must not emit the removed plugin_hooks feature flag",
 					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "hooks.json")),
+						false,
+						"removed-flag Codex keeps manifest-owned hooks; no global wrapper fallback",
+					);
 					assert.match(
 						logs,
-						/Native Codex hooks fallback and runtime feature flags refresh complete \(.*hooks\.json; hooks, goals\)/,
+						/Plugin-scoped Codex hooks and runtime feature flags refresh complete \(hooks, goals\)/,
 					);
 				});
 			});

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3908,6 +3908,58 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("removes the Windows shim for the removed surface without orphaning or failing setup", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const removedProbe = () =>
+						[
+							"hooks                                   stable             true",
+							"plugin_hooks                            removed            false",
+							"",
+						].join("\n");
+
+					// Seed a legacy install so an OMX-owned shim and global
+					// wrappers exist, then transition to plugin mode on a
+					// removed-flag Codex.
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					assert.equal(existsSync(shimPath), true);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), true);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: removedProbe,
+					});
+
+					assert.equal(
+						existsSync(shimPath),
+						false,
+						"removed surface must delete the unreferenced OMX-owned shim",
+					);
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.equal((config.match(/^hooks = true$/gm) ?? []).length, 1);
+					assert.doesNotMatch(config, /^plugin_hooks\s*=/m);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 	it("preserves same-key user hook trust state in plugin-scoped setup", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/codex-feature-probe.ts
+++ b/src/cli/codex-feature-probe.ts
@@ -2,8 +2,10 @@ import { spawnSync } from "child_process";
 import {
   DEFAULT_CODEX_HOOK_FEATURE_FLAG,
   resolveCodexHookFeatureFlag,
+  resolveCodexPluginHookSurface,
   supportsCodexPluginScopedHooks,
   type CodexHookFeatureFlag,
+  type CodexPluginHookSurface,
 } from "../config/codex-feature-flags.js";
 
 export interface CodexFeatureProbeOptions {
@@ -112,6 +114,7 @@ export function probeInstalledCodexVersion(
 export interface CodexHookFeatureSupport {
   hookFeatureFlag: CodexHookFeatureFlag;
   pluginScopedHooks: boolean;
+  pluginHookSurface: CodexPluginHookSurface;
 }
 
 export function resolveCodexHookFeatureSupportForCli(
@@ -127,6 +130,7 @@ export function resolveCodexHookFeatureSupportForCli(
       fallback: DEFAULT_CODEX_HOOK_FEATURE_FLAG,
     }),
     pluginScopedHooks: supportsCodexPluginScopedHooks({ featuresListOutput }),
+    pluginHookSurface: resolveCodexPluginHookSurface({ featuresListOutput }),
   };
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2130,11 +2130,21 @@ function configEnablesPluginScopedHooks(configContent: string): boolean {
 	try {
 		const parsed = parseToml(configContent) as {
 			plugin_hooks?: unknown;
+			hooks?: unknown;
 			features?: Record<string, unknown>;
 		};
-		return isEnabledTomlValue(parsed.plugin_hooks) || isEnabledTomlValue(parsed.features?.plugin_hooks);
+		return (
+			isEnabledTomlValue(parsed.plugin_hooks) ||
+			isEnabledTomlValue(parsed.features?.plugin_hooks) ||
+			// Canonical current hook enablement; `plugin_hooks` was removed from
+			// Codex, so `[features].hooks = true` also proves plugin hooks work.
+			isEnabledTomlValue(parsed.hooks) ||
+			isEnabledTomlValue(parsed.features?.hooks)
+		);
 	} catch {
-		return /^\s*plugin_hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
+		return /^\s*(?:plugin_hooks|hooks)\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(
+			configContent,
+		);
 	}
 }
 
@@ -2735,7 +2745,7 @@ export async function checkNativeHooks(
 						name: "Native hooks",
 						status: "warn",
 						message:
-							`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin" to restore the fallback hook file, or upgrade Codex to plugin_hooks support so setup can use plugin-scoped hooks`,
+							`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin" to restore the fallback hook file, or rerun setup on a Codex build with plugin-scoped hooks support`,
 					};
 				}
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -78,7 +78,7 @@ import {
 	extractFirstPartyOmxMcpSections,
 	stripFirstPartyOmxMcpSections,
 } from "../config/generator.js";
-import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
+import type { CodexHookFeatureFlag, CodexPluginHookSurface } from "../config/codex-feature-flags.js";
 import {
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
@@ -3369,6 +3369,7 @@ function buildPluginModeHooksConfigPlan(
 	options: {
 		codexHookFeatureFlag: CodexHookFeatureFlag;
 		pluginScopedHooks: boolean;
+		pluginHookSurface?: CodexPluginHookSurface;
 		preserveFirstPartyMcp?: boolean;
 		developerInstructionsDecision: PluginDeveloperInstructionsDecision;
 		platform: NodeJS.Platform;
@@ -3378,7 +3379,13 @@ function buildPluginModeHooksConfigPlan(
 		platform: options.platform,
 		codexHomeDir,
 	} as const;
-	const managedHooksPlan = options.pluginScopedHooks
+	// Current Codex removed the `plugin_hooks` feature but still loads
+	// manifest-driven plugin hooks, so a removed row selects the plugin-scoped
+	// surface (global OMX wrappers are removed) rather than the legacy
+	// fallback that would double-register the same hooks (issue #3623).
+	const manifestOwnsHooks = options.pluginScopedHooks
+		|| options.pluginHookSurface === "removed";
+	const managedHooksPlan = manifestOwnsHooks
 		? existingHooksContent === null
 			? null
 			: planManagedCodexHooksRemoval(
@@ -3515,6 +3522,7 @@ interface NativeHookSetupTransactionPlan {
 	finalConfig: string;
 	hooksRemovedCount: number;
 	pluginScopedHooks: boolean;
+	pluginHookSurface?: CodexPluginHookSurface;
 	cleanedLegacyConfig: boolean;
 	pluginMarketplaceResult: "updated" | "unchanged" | "unavailable";
 	pluginDeveloperInstructionsResult: "updated" | "exists" | "skipped";
@@ -3531,6 +3539,7 @@ interface PlanNativeHookSetupTransactionOptions {
 	platform: NodeJS.Platform;
 	isPluginInstallMode: boolean;
 	pluginScopedHooks: boolean;
+	pluginHookSurface?: CodexPluginHookSurface;
 	codexHookFeatureFlag: CodexHookFeatureFlag;
 	preserveFirstPartyMcp: boolean;
 	removeFirstPartyMcp: boolean;
@@ -3780,6 +3789,7 @@ async function planNativeHookSetupTransaction(
 				codexHookFeatureFlag: options.codexHookFeatureFlag,
 				pluginScopedHooks: options.pluginScopedHooks,
 				preserveFirstPartyMcp: options.preserveFirstPartyMcp,
+				pluginHookSurface: options.pluginHookSurface,
 				developerInstructionsDecision:
 					options.pluginDeveloperInstructionsDecision,
 				platform: options.platform,
@@ -4010,6 +4020,7 @@ async function planNativeHookSetupTransaction(
 		finalConfig,
 		hooksRemovedCount,
 		pluginScopedHooks: options.pluginScopedHooks,
+		pluginHookSurface: options.pluginHookSurface,
 		cleanedLegacyConfig,
 		pluginMarketplaceResult,
 		pluginDeveloperInstructionsResult,
@@ -4271,6 +4282,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	});
 	const codexHookFeatureFlag = codexHookFeatureSupport.hookFeatureFlag;
 	const pluginScopedHooksSupported = codexHookFeatureSupport.pluginScopedHooks;
+	// The plugin manifest owns the hook surface both when Codex reports the
+	// dedicated plugin flag and when that flag is removed-but-listed on a
+	// current build (issue #3623).
+	const manifestOwnsHookSurface = pluginScopedHooksSupported
+		|| codexHookFeatureSupport.pluginHookSurface === "removed";
 	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
 	const registryCandidates = getUnifiedMcpRegistryCandidates();
 	const defaultRegistryCandidates = registryCandidates.slice(0, 1);
@@ -4295,6 +4311,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
 		isPluginInstallMode,
 		pluginScopedHooks: pluginScopedHooksSupported,
+		pluginHookSurface: codexHookFeatureSupport.pluginHookSurface,
 		codexHookFeatureFlag,
 		preserveFirstPartyMcp:
 			shouldOfferFirstPartyMcpRemoval && !removeFirstPartyMcpRegistrations,
@@ -4619,17 +4636,17 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	const changedConfigArtifact = nativeHookSetupTransaction.artifacts.some(
 		(artifact) => artifact.kind === "config",
 	);
+	const transactionManifestOwnsHooks = isPluginInstallMode && (
+		nativeHookSetupTransaction.pluginScopedHooks
+			|| nativeHookSetupTransaction.pluginHookSurface === "removed"
+	);
 	if (changedHookArtifact) {
-		if (
-			isPluginInstallMode &&
-			nativeHookSetupTransaction.pluginScopedHooks &&
-			nativeHookSetupTransaction.hooksRemovedCount > 0
-		) {
+		if (transactionManifestOwnsHooks && nativeHookSetupTransaction.hooksRemovedCount > 0) {
 			summary.config.removed += nativeHookSetupTransaction.hooksRemovedCount;
 		} else {
 			summary.config.updated += 1;
 		}
-	} else if (!isPluginInstallMode || !nativeHookSetupTransaction.pluginScopedHooks) {
+	} else if (!transactionManifestOwnsHooks) {
 		summary.config.unchanged += 1;
 	}
 	if (changedShimArtifact) summary.config.updated += 1;
@@ -4697,7 +4714,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 		}
 		console.log(
-			pluginScopedHooksSupported
+			manifestOwnsHookSurface
 				? "  Plugin-scoped Codex hooks and runtime feature flags refresh complete (hooks, goals).\n"
 				: `  Native Codex hooks fallback and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
 		);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4288,8 +4288,10 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	// The plugin manifest owns the hook surface both when Codex reports the
 	// dedicated plugin flag and when that flag is removed-but-listed on a
 	// current build (issue #3623).
-	const manifestOwnsHookSurface = pluginScopedHooksSupported
-		|| codexHookFeatureSupport.pluginHookSurface === "removed";
+	const manifestOwnsHookSurface = isPluginInstallMode && (
+		pluginScopedHooksSupported
+		|| codexHookFeatureSupport.pluginHookSurface === "removed"
+	);
 	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
 	const registryCandidates = getUnifiedMcpRegistryCandidates();
 	const defaultRegistryCandidates = registryCandidates.slice(0, 1);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3420,11 +3420,6 @@ function buildPluginModeHooksConfigPlan(
 	const configWithRuntimeFeatures = upsertPluginModeRuntimeFeatureFlags(
 		configWithDefaultModel,
 		options.codexHookFeatureFlag,
-		{
-			pluginScopedHooks: options.pluginScopedHooks,
-			preserveNativeHooks:
-				options.pluginScopedHooks && managedHooksPlan?.hasForeignHooks === true,
-		},
 	);
 	return {
 		finalConfig: upsertManagedCodexHookTrustState(
@@ -4703,7 +4698,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		}
 		console.log(
 			pluginScopedHooksSupported
-				? "  Plugin-scoped Codex hooks and runtime feature flags refresh complete (plugin_hooks, goals).\n"
+				? "  Plugin-scoped Codex hooks and runtime feature flags refresh complete (hooks, goals).\n"
 				: `  Native Codex hooks fallback and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
 		);
 		if (pluginDeveloperInstructionsDecision.action !== "preserve") {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3955,9 +3955,12 @@ async function planNativeHookSetupTransaction(
 			finalHooksContent,
 			shimPath,
 		);
+		const manifestOwnsHookSurface = options.isPluginInstallMode && (
+			options.pluginScopedHooks || options.pluginHookSurface === "removed"
+		);
 		const shouldDeleteShim =
 			shimReference === "not_referenced" &&
-			(options.disableHooks || (options.isPluginInstallMode && options.pluginScopedHooks));
+			(options.disableHooks || manifestOwnsHookSurface);
 		shimArtifact = nativeHookTransactionArtifact(
 			"shim",
 			shimPath,
@@ -4602,7 +4605,13 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			`  Native Codex hook feature flag: [features].${codexHookFeatureFlag}`,
 		);
 		console.log(
-			`  Plugin-scoped Codex hooks: ${pluginScopedHooksSupported ? "supported" : "not reported; using legacy setup fallback"}`,
+			`  Plugin-scoped Codex hooks: ${
+				manifestOwnsHookSurface
+					? pluginScopedHooksSupported
+						? "supported"
+						: "removed feature row; plugin manifest owns hooks"
+					: "not reported; using legacy setup fallback"
+			}`,
 		);
 	}
 	if (

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -213,7 +213,7 @@ function hasNativeHooksFeatureFlag(config: string): boolean {
 
   return lines
     .slice(featuresStart + 1, sectionEnd)
-    .some((line) => /^\s*(?:hooks|codex_hooks)\s*=\s*true/.test(line));
+    .some((line) => /^\s*(?:hooks|codex_hooks|plugin_hooks)\s*=\s*true/.test(line));
 }
 
 type FileIdentityScalar = number | bigint;

--- a/src/config/__tests__/codex-feature-flags.test.ts
+++ b/src/config/__tests__/codex-feature-flags.test.ts
@@ -43,6 +43,32 @@ describe("Codex feature flag resolution", () => {
     assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: "hooks stable true" }), false);
   });
 
+  it("does not treat a removed plugin_hooks row as plugin-scoped hook support", () => {
+    const output = [
+      "goals                                   stable             true",
+      "hooks                                   stable             true",
+      "plugin_hooks                            removed            false",
+      "",
+    ].join("\n");
+
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: output }), false);
+    assert.equal(
+      supportsCodexPluginScopedHooks({
+        featuresListOutput: "plugin_hooks removed true",
+      }),
+      false,
+      "even a removed=true row no longer names a supported feature",
+    );
+    assert.equal(
+      supportsCodexPluginScopedHooks({
+        featuresListOutput: "plugin_hooks experimental true",
+      }),
+      true,
+      "non-removed lifecycle rows still report plugin-scoped hook support",
+    );
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: null }), false);
+  });
+
   it("uses version fallback for current Codex releases when feature listing is unavailable", () => {
     assert.equal(
       resolveCodexHookFeatureFlag({ versionOutput: "codex-cli 0.130.0" }),

--- a/src/config/__tests__/codex-feature-flags.test.ts
+++ b/src/config/__tests__/codex-feature-flags.test.ts
@@ -4,6 +4,7 @@ import {
   parseCodexFeatureNames,
   resolveCodexHookFeatureFlag,
   supportsCodexPluginScopedHooks,
+  resolveCodexPluginHookSurface,
 } from "../codex-feature-flags.js";
 
 describe("Codex feature flag resolution", () => {
@@ -41,6 +42,17 @@ describe("Codex feature flag resolution", () => {
 
     assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: output }), true);
     assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: "hooks stable true" }), false);
+  });
+
+  it("classifies removed plugin_hooks rows with canonical hooks as manifest-owned", () => {
+    const modern = "hooks stable true\nplugin_hooks removed false";
+    const legacyOnly = "codex_hooks experimental true";
+    assert.equal(resolveCodexPluginHookSurface({ featuresListOutput: modern }), "removed");
+    assert.equal(resolveCodexPluginHookSurface({ featuresListOutput: legacyOnly }), "legacy");
+    assert.equal(resolveCodexPluginHookSurface({ featuresListOutput: null }), "legacy");
+    assert.equal(resolveCodexPluginHookSurface({ featuresListOutput: "plugin_hooks experimental true" }), "supported");
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: modern }), false);
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: "plugin_hooks experimental true" }), true);
   });
 
   it("does not treat a removed plugin_hooks row as plugin-scoped hook support", () => {

--- a/src/config/codex-feature-flags.ts
+++ b/src/config/codex-feature-flags.ts
@@ -55,18 +55,36 @@ export function isCodexCliVersionAtLeast(
   return true;
 }
 
-export function supportsCodexPluginScopedHooks(options: {
+export type CodexPluginHookSurface = "supported" | "removed" | "legacy";
+
+export function resolveCodexPluginHookSurface(options: {
   featuresListOutput?: string | null;
-} = {}): boolean {
-  // `codex features list` keeps listing removed features by name. Treat the
-  // feature as supported only when its row reports a non-removed lifecycle;
-  // a removed name alone must not count as support.
-  const pluginScopedHookRow = (options.featuresListOutput ?? "")
+} = {}): CodexPluginHookSurface {
+  // `codex features list` keeps listing removed features by name. A removed
+  // lifecycle never counts as support; when the canonical `hooks` feature is
+  // also reported, that row proves a current Codex build whose plugin hooks
+  // are manifest-driven (see issue #3623).
+  const pluginHookRow = (options.featuresListOutput ?? "")
     .split(/\r?\n/)
     .map((rawLine) => rawLine.trim())
     .find((line) => /^plugin_hooks\s/.test(line));
-  if (!pluginScopedHookRow) return false;
-  return !/^plugin_hooks\s+removed\s+(?:true|false)$/.test(pluginScopedHookRow);
+  if (pluginHookRow) {
+    if (/^plugin_hooks\s+removed\s+(?:true|false)$/.test(pluginHookRow)) {
+      const hooksRow = (options.featuresListOutput ?? "")
+        .split(/\r?\n/)
+        .map((rawLine) => rawLine.trim())
+        .find((line) => /^hooks\s/.test(line));
+      return hooksRow ? "removed" : "legacy";
+    }
+    return "supported";
+  }
+  return "legacy";
+}
+
+export function supportsCodexPluginScopedHooks(options: {
+  featuresListOutput?: string | null;
+} = {}): boolean {
+  return resolveCodexPluginHookSurface(options) === "supported";
 }
 
 export function resolveCodexHookFeatureFlag(options: {

--- a/src/config/codex-feature-flags.ts
+++ b/src/config/codex-feature-flags.ts
@@ -58,9 +58,15 @@ export function isCodexCliVersionAtLeast(
 export function supportsCodexPluginScopedHooks(options: {
   featuresListOutput?: string | null;
 } = {}): boolean {
-  return parseCodexFeatureNames(options.featuresListOutput).has(
-    CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
-  );
+  // `codex features list` keeps listing removed features by name. Treat the
+  // feature as supported only when its row reports a non-removed lifecycle;
+  // a removed name alone must not count as support.
+  const pluginScopedHookRow = (options.featuresListOutput ?? "")
+    .split(/\r?\n/)
+    .map((rawLine) => rawLine.trim())
+    .find((line) => /^plugin_hooks\s/.test(line));
+  if (!pluginScopedHookRow) return false;
+  return !/^plugin_hooks\s+removed\s+(?:true|false)$/.test(pluginScopedHookRow);
 }
 
 export function resolveCodexHookFeatureFlag(options: {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -18,6 +18,7 @@ import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import {
   DEFAULT_CODEX_HOOK_FEATURE_FLAG,
+  CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
   CODEX_HOOK_FEATURE_FLAGS,
   formatCodexHookFeatureFlagLine,
   normalizeCodexHookFeatureFlag,
@@ -804,7 +805,12 @@ function isFeatureFlagLine(line: string, featureFlag: string): boolean {
 }
 
 function isAnyCodexHookFeatureFlagLine(line: string): boolean {
-  return CODEX_HOOK_FEATURE_FLAGS.some((flag) => isFeatureFlagLine(line, flag));
+  // The retired `plugin_hooks` spelling is a migration-only alias: upserts
+  // may replace it, but it is never emitted (issue #3623).
+  return (
+    CODEX_HOOK_FEATURE_FLAGS.some((flag) => isFeatureFlagLine(line, flag))
+    || isFeatureFlagLine(line, CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG)
+  );
 }
 
 
@@ -3143,6 +3149,7 @@ export function stripOmxFeatureFlags(
     "child_agents_md",
     "hooks",
     "codex_hooks",
+    "plugin_hooks",
     "goals",
     "goal",
     "collab",

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -19,7 +19,6 @@ import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import {
   DEFAULT_CODEX_HOOK_FEATURE_FLAG,
   CODEX_HOOK_FEATURE_FLAGS,
-  CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
   formatCodexHookFeatureFlagLine,
   normalizeCodexHookFeatureFlag,
   type CodexHookFeatureFlag,
@@ -808,10 +807,6 @@ function isAnyCodexHookFeatureFlagLine(line: string): boolean {
   return CODEX_HOOK_FEATURE_FLAGS.some((flag) => isFeatureFlagLine(line, flag));
 }
 
-function isAnyPluginModeHookFeatureFlagLine(line: string): boolean {
-  return isAnyCodexHookFeatureFlagLine(line)
-    || isFeatureFlagLine(line, CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG);
-}
 
 function upsertFeatureFlagLineInSection(
   lines: string[],
@@ -870,19 +865,6 @@ function upsertCodexHookFeatureFlagInSection(
   );
 }
 
-function upsertPluginScopedHookFeatureFlagInSection(
-  lines: string[],
-  featuresStart: number,
-  sectionEnd: number,
-): { sectionEnd: number; featureFlagIndex: number } {
-  return upsertFeatureFlagLineInSection(
-    lines,
-    featuresStart,
-    sectionEnd,
-    CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
-    isAnyPluginModeHookFeatureFlagLine,
-  );
-}
 
 function upsertFeatureFlags(
   config: string,
@@ -2888,24 +2870,21 @@ export function upsertManagedCodexHookTrustState(
 export function upsertPluginModeRuntimeFeatureFlags(
   config: string,
   codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
-  options: { pluginScopedHooks?: boolean; preserveNativeHooks?: boolean } = {},
 ): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
   );
-  const hookFeatureFlagLine = options.pluginScopedHooks
-    ? `${CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG} = true`
-    : formatCodexHookFeatureFlagLine(codexHookFeatureFlag);
+  // Codex retired `plugin_hooks`; manifest-driven plugin hooks no longer
+  // depend on it, so setup always emits the installed-Codex canonical flag
+  // (see issue #3623) and never regenerates the obsolete name.
+  const hookFeatureFlagLine = formatCodexHookFeatureFlagLine(codexHookFeatureFlag);
 
   if (featuresStart < 0) {
     const base = config.trimEnd();
     const featureBlock = [
       "[features]",
       hookFeatureFlagLine,
-      ...(options.pluginScopedHooks && options.preserveNativeHooks
-        ? [formatCodexHookFeatureFlagLine(codexHookFeatureFlag)]
-        : []),
       "goals = true",
       "",
     ].join("\n");
@@ -2932,28 +2911,14 @@ export function upsertPluginModeRuntimeFeatureFlags(
     }
   }
 
-  if (options.pluginScopedHooks) {
-    ({ sectionEnd } = upsertPluginScopedHookFeatureFlagInSection(
-      lines,
-      featuresStart,
-      sectionEnd,
-    ));
-    if (options.preserveNativeHooks) {
-      ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
-        lines,
-        featuresStart,
-        sectionEnd,
-        codexHookFeatureFlag,
-      ));
-    }
-  } else {
-    ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
-      lines,
-      featuresStart,
-      sectionEnd,
-      codexHookFeatureFlag,
-    ));
-  }
+  // The canonical flag replaces both hook feature spellings, including a
+  // stale removed `plugin_hooks` row, in one upsert pass.
+  ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
+    lines,
+    featuresStart,
+    sectionEnd,
+    codexHookFeatureFlag,
+  ));
 
   let goalsIdx = -1;
   for (let i = featuresStart + 1; i < sectionEnd; i++) {


### PR DESCRIPTION
## Summary

OMX 0.21.3+ probes Codex plugin-scoped hook support by feature name only. Codex CLI 0.153.x still lists `plugin_hooks` in `codex features list` but marks it `removed false`, so:

- `supportsCodexPluginScopedHooks` treated the retired feature as supported,
- plugin-mode setup replaced canonical `[features].hooks = true` with obsolete `plugin_hooks = true` (which Codex reports as removed/false even when explicitly enabled),
- `omx doctor` only recognized `plugin_hooks` in config, so plugin mode was not inferred and plugin-hook diagnostics did not run under canonical `hooks` configuration — producing false "missing global hooks" / "legacy native hook fallback" warnings (issue #3623).

## Fix

- `src/config/codex-feature-flags.ts` — `supportsCodexPluginScopedHooks` now evaluates the full feature row: a `removed` lifecycle never counts as support; any non-removed lifecycle does; absent row means unsupported. No speculative compatibility layers.
- `src/cli/doctor.ts` — `configEnablesPluginScopedHooks` additionally accepts canonical `hooks = true` (root or `[features]`), so plugin mode is inferred and plugin-scoped hook checks run without the removed flag; stale "upgrade Codex to plugin_hooks support" copy replaced.
- Setup on current Codex now keeps the native `hooks.json` fallback contract instead of generating the removed flag. Explicit user configuration and disabled/missing-hook diagnostics are preserved (covered by new tests).

## Testing

- `npm run build`
- `node --test dist/config/__tests__/codex-feature-flags.test.js` (6/6, incl. new removed-flag matrix)
- `node --test dist/cli/__tests__/doctor-warning-copy.test.js` (77/77, incl. new canonical-hooks inference + disabled-hook regression)
- `node --test dist/cli/__tests__/setup-install-mode.test.js` (131/131, incl. new setup flag-generation regression)
- `node --test dist/cli/__tests__/setup-hooks-trust-e2e.test.js`, `plugin-launcher-provenance-3558.test.js`, `dist/config/__tests__/codex-hooks.test.js`, `generator-idempotent/notify` — all green
- End-to-end with isolated temp `HOME`/`CODEX_HOME`: `omx setup --plugin` generates `[features].hooks = true` with zero `plugin_hooks` lines, and `omx doctor` reports plugin-scoped hooks OK (21 passed / 0 warnings / 0 failed) on the issue's configuration shape; local Codex 0.148.0-alpha.5 reproduces the `plugin_hooks removed false` row.

All reproductions and tests ran against isolated temporary user dirs; no host configuration was touched.

Fixes #3623
