### PR TITLE
fix: correct Codex hook capability and session diagnostics

### DIFF
--- a/src/cli/__tests__/doctor-state-root-binding.test.ts
+++ b/src/cli/__tests__/doctor-state-root-binding.test.ts
@@ -29,6 +29,54 @@ function syntheticSnapshot(
 }
 
 describe('doctor state-root/session binding diagnostics', () => {
+  it('reports unavailable runtime binding for only an ambient Codex session in an uninitialized workspace', () => {
+    const check = checkStateRootSessionBinding(
+      syntheticSnapshot('absent', { rootSource: 'cwd-default' }),
+      { CODEX_SESSION_ID: 'codex-session' },
+    );
+    assert.equal(check.status, 'warn');
+    assert.match(check.message, /runtime binding unavailable/);
+    assert.doesNotMatch(check.message, /bad_selectors|clear|relaunch/);
+  });
+
+  it('leaves a fresh workspace untouched when inspecting an ambient Codex session', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-doctor-ambient-session-'));
+    try {
+      const env = { CODEX_SESSION_ID: 'codex-session' };
+      const snapshot = await readCanonicalSessionBindingSnapshot(cwd, env);
+      assert.equal(snapshot.status, 'absent');
+      assert.equal(snapshot.rootSource, 'cwd-default');
+      assert.equal(checkStateRootSessionBinding(snapshot, env).status, 'warn');
+      assert.deepEqual(await readdir(cwd), []);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps explicit runtime selectors and unsafe pointers fail-closed', () => {
+    for (const env of [
+      { CODEX_SESSION_ID: 'codex-session', OMX_SESSION_ID: 'omx-session' },
+      { CODEX_SESSION_ID: 'codex-session', SESSION_ID: 'session' },
+      { CODEX_SESSION_ID: 'codex-session', OMX_ROOT: '/explicit' },
+      { CODEX_SESSION_ID: 'codex-session', OMX_STATE_ROOT: '/explicit' },
+      { CODEX_SESSION_ID: 'codex-session', OMX_TEAM_STATE_ROOT: '/explicit' },
+      { CODEX_SESSION_ID: 'invalid/session' },
+    ]) {
+      assert.equal(checkStateRootSessionBinding(
+        syntheticSnapshot('absent', { rootSource: 'cwd-default' }), env,
+      ).status, 'fail');
+    }
+    for (const status of ['foreign-cwd', 'malformed', 'identity-indeterminate', 'usable'] as const) {
+      assert.equal(checkStateRootSessionBinding(
+        syntheticSnapshot(status, { rootSource: 'cwd-default' }),
+        { CODEX_SESSION_ID: 'unverified-codex' },
+      ).status, 'fail');
+    }
+    assert.equal(checkStateRootSessionBinding(
+      syntheticSnapshot('absent'), { CODEX_SESSION_ID: 'codex-session' },
+    ).status, 'fail');
+  });
+
   it('prefers the winning env root over OMX_SESSION_ID during resolution failure', async () => {
     const env = {
       OMX_ROOT: '/winning-root',

--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -12,8 +12,8 @@ import {
 	symlink,
 	writeFile,
 } from "node:fs/promises";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join, dirname, delimiter } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -29,6 +29,7 @@ import {
 	checkNativeHookDistSmoke,
 	checkNativePostCompactHookRuntime,
 	checkNativeHooks,
+	configEnablesPluginScopedHooks,
 	classifyPostCompactHookStdout,
 	doctor,
 	setDoctorClaimJournalDurabilityForTest,
@@ -58,11 +59,24 @@ function runOmx(
 	cwd: string,
 	argv: string[],
 	envOverrides: Record<string, string> = {},
+	featuresListOutput = "hooks stable true\nplugin_hooks experimental true",
 ): { status: number | null; stdout: string; stderr: string; error?: string } {
 	const testDir = dirname(fileURLToPath(import.meta.url));
 	const repoRoot = join(testDir, "..", "..", "..");
 	const omxBin = join(repoRoot, "dist", "cli", "omx.js");
 	const mergedEnv = { ...process.env, ...envOverrides };
+	if (envOverrides.PATH === undefined) {
+		const fakeBin = join(cwd, "doctor-codex-fixture");
+		mkdirSync(fakeBin, { recursive: true });
+		const fixture = process.platform === "win32" ? "codex.cmd" : "codex";
+		const content = process.platform === "win32"
+			? `@echo off\n${featuresListOutput.split("\n").map((line) => `echo ${line}`).join("\n")}\n`
+			: `#!/bin/sh\nprintf '%s\\n' '${featuresListOutput}'\n`;
+		writeFileSync(join(fakeBin, fixture), content);
+		chmodSync(join(fakeBin, fixture), 0o755);
+		mergedEnv.PATH = `${fakeBin}${delimiter}${mergedEnv.PATH ?? ""}`;
+	}
+
 	if (
 		typeof envOverrides.HOME === "string" &&
 		typeof envOverrides.USERPROFILE !== "string"
@@ -1390,6 +1404,95 @@ OMX_LORE_COMMIT_GUARD = "truee"
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+
+	it("uses only the effective hook flag for the installed Codex capability", () => {
+		const plugin = '\n[plugins."oh-my-codex@oh-my-codex-local"]\nenabled = true\n';
+		const modern = "hooks stable true\nplugin_hooks removed false";
+		const legacy = "hooks stable true\nplugin_hooks experimental false";
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true\nplugin_hooks = false' + plugin, legacy), false);
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = false\nplugin_hooks = true' + plugin, modern), false);
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true\nplugin_hooks = false' + plugin, modern), true);
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true\n', modern), false);
+		assert.equal(configEnablesPluginScopedHooks(plugin, modern), true);
+		assert.equal(configEnablesPluginScopedHooks('[features]\ncodex_hooks = false' + plugin, modern), false);
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true\ncodex_hooks = false' + plugin, modern), true);
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = false\ncodex_hooks = true' + plugin, modern), false);
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true' + plugin, null), false);
+		assert.equal(configEnablesPluginScopedHooks('not valid TOML plugin_hooks = true', legacy), false);
+	});
+
+	for (const hooksSetting of [true, false, undefined]) {
+		it(`infers plugin mode with canonical hooks ${String(hooksSetting)} and no removed flag`, async () => {
+			const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-config-compat-"));
+			try {
+				const home = join(wd, "home");
+				const codexDir = join(home, ".codex");
+				await mkdir(codexDir, { recursive: true });
+				await installPluginCacheFixture(codexDir);
+				await writeFile(
+					join(codexDir, "config.toml"),
+					[
+						"[features]",
+						...(hooksSetting === undefined ? [] : [`hooks = ${hooksSetting}`]),
+						"goals = true",
+						"",
+						"[marketplaces.oh-my-codex-local]",
+						'source_type = "local"',
+						`source = ${JSON.stringify(repoRoot())}`,
+						"",
+						'[plugins."oh-my-codex@oh-my-codex-local"]',
+						"enabled = true",
+						"",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_state]',
+						"enabled = true",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_memory]',
+						"enabled = true",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_code_intel]',
+						"enabled = true",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_trace]',
+						"enabled = true",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_wiki]',
+						"enabled = true",
+						'[plugins."oh-my-codex@oh-my-codex-local".mcp_servers.omx_hermes]',
+						"enabled = true",
+						"",
+					].join("\n"),
+				);
+
+				assert.equal(existsSync(join(wd, ".omx", "setup-scope.json")), false);
+
+				const res = runOmx(wd, ["doctor"], {
+					HOME: home,
+					CODEX_HOME: codexDir,
+				}, "hooks stable true\nplugin_hooks removed false");
+				if (shouldSkipForSpawnPermissions(res.error)) return;
+				assert.equal(res.status, 0, res.stderr || res.stdout);
+				assert.match(
+					res.stdout,
+					/Resolved setup MCP mode: compat \(inferred from Codex plugin config\)/,
+				);
+				assert.match(
+					res.stdout,
+					/MCP Servers: plugin MCP compatibility enabled by setup MCP mode compat \(6\/6 first-party servers enabled\)/,
+				);
+				assert.doesNotMatch(
+					res.stdout,
+					/plugin MCP compatibility overrides are incomplete or mixed/,
+				);
+				if (hooksSetting !== false) {
+					assert.match(res.stdout, /\[OK\] Native hooks: plugin-scoped hooks are enabled/);
+					assert.doesNotMatch(res.stdout, /expected setup-owned hooks.json is missing/);
+				} else {
+					assert.doesNotMatch(res.stdout, /Native hooks: plugin-scoped hooks are enabled/);
+				}
+				assert.doesNotMatch(res.stdout, /Prompts: prompts directory not found|Skills:.*expected/);
+
+			} finally {
+				await rm(wd, { recursive: true, force: true });
+			}
+		});
+
+	}
 
 	it("does not infer plugin mode from a foreign local marketplace source", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-doctor-plugin-config-foreign-"));
@@ -2866,6 +2969,7 @@ command = "node"
 			const check = await checkNativeHooks(hooksPath, configPath, {
 				codexHomeDir: codexDir,
 				installMode: "plugin",
+				codexFeaturesListOutput: "plugin_hooks experimental true",
 			});
 
 			assert.equal(check.status, "fail");
@@ -2899,6 +3003,7 @@ command = "node"
 			const check = await checkNativeHooks(hooksPath, configPath, {
 				codexHomeDir: codexDir,
 				installMode: "plugin",
+				codexFeaturesListOutput: "plugin_hooks experimental true",
 				platform: "win32",
 			});
 

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -2071,6 +2071,48 @@ describe("omx setup install mode behavior", () => {
 		}
 	});
 
+	it("uses unified hooks when Codex reports plugin_hooks removed", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					await setup({ scope: "user", installMode: "plugin", codexFeaturesProbe: () => "hooks stable true\nplugin_hooks removed false\n", codexVersionProbe: () => "codex-cli 0.140.0" });
+					await setup({ scope: "user", installMode: "plugin", codexFeaturesProbe: () => "hooks stable true\nplugin_hooks removed false\n", codexVersionProbe: () => "codex-cli 0.140.0" });
+
+					assert.equal(existsSync(join(codexHomeDir, "hooks.json")), false);
+					const config = await readFile(
+						join(codexHomeDir, "config.toml"),
+						"utf-8",
+					);
+					assert.doesNotMatch(config, /^plugin_hooks\s*=/m);
+					assert.equal((config.match(/^hooks = true$/gm) ?? []).length, 1);
+					assert.doesNotMatch(config, /^codex_hooks = true$/m);
+					assert.match(config, /^goals = true$/m);
+					assert.doesNotMatch(config, /\[hooks\.state\./);
+					assert.doesNotMatch(
+						config,
+						/developer_instructions|notify-hook/g,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "skills", "ask", "SKILL.md")),
+						false,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "agents", "planner.toml")),
+						true,
+					);
+					assert.equal(
+						existsSync(join(codexHomeDir, "prompts", "executor.md")),
+						false,
+					);
+					assert.equal(existsSync(join(codexHomeDir, "AGENTS.md")), true);
+				});
+			});
+		} finally {
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
+
 	it("can opt into plugin AGENTS.md and developer_instructions defaults", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-install-mode-"));
 		try {

--- a/src/cli/codex-feature-probe.ts
+++ b/src/cli/codex-feature-probe.ts
@@ -2,7 +2,8 @@ import { spawnSync } from "child_process";
 import {
   DEFAULT_CODEX_HOOK_FEATURE_FLAG,
   resolveCodexHookFeatureFlag,
-  supportsCodexPluginScopedHooks,
+  resolveCodexPluginHookFeatureFlag,
+  type CodexPluginHookFeatureFlag,
   type CodexHookFeatureFlag,
 } from "../config/codex-feature-flags.js";
 
@@ -112,6 +113,7 @@ export function probeInstalledCodexVersion(
 export interface CodexHookFeatureSupport {
   hookFeatureFlag: CodexHookFeatureFlag;
   pluginScopedHooks: boolean;
+  pluginHookFeatureFlag: CodexPluginHookFeatureFlag | null;
 }
 
 export function resolveCodexHookFeatureSupportForCli(
@@ -120,13 +122,15 @@ export function resolveCodexHookFeatureSupportForCli(
   const featuresListOutput =
     options.codexFeaturesProbe?.() ?? probeInstalledCodexFeatureList();
   const versionOutput = options.codexVersionProbe?.() ?? probeInstalledCodexVersion();
+  const pluginHookFeatureFlag = resolveCodexPluginHookFeatureFlag({ featuresListOutput });
   return {
     hookFeatureFlag: resolveCodexHookFeatureFlag({
       featuresListOutput,
       versionOutput,
       fallback: DEFAULT_CODEX_HOOK_FEATURE_FLAG,
     }),
-    pluginScopedHooks: supportsCodexPluginScopedHooks({ featuresListOutput }),
+    pluginScopedHooks: pluginHookFeatureFlag !== null,
+    pluginHookFeatureFlag,
   };
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,3 +1,5 @@
+import { probeInstalledCodexFeatureList } from "./codex-feature-probe.js";
+import { resolveCodexPluginHookFeatureFlag } from "../config/codex-feature-flags.js";
 /**
  * omx doctor - Validate oh-my-codex installation
  */
@@ -248,8 +250,6 @@ async function inferPluginInstallModeFromConfigForScope(
 
 	try {
 		const configContent = await readFile(configPath, "utf-8");
-		if (!configEnablesPluginScopedHooks(configContent)) return null;
-
 		const { marketplace, plugin } = getParsedPluginMarketplaceConfig(configContent);
 		if (!marketplace || marketplace.source_type !== "local") return null;
 		if (!(await isTrustedOmxPluginMarketplaceSource(marketplace.source))) return null;
@@ -556,6 +556,21 @@ export function checkStateRootSessionBinding(
   env: NodeJS.ProcessEnv = process.env,
 ): Check {
   const evaluation = selectorEvaluation(snapshot, env);
+  // Codex also supplies a session ID outside OMX-managed sessions. Its presence
+  // alone cannot establish a broken binding in an uninitialized workspace.
+  // Keep explicit runtime roots/selectors and existing pointers fail-closed.
+  if (
+    snapshot.status === "absent" && snapshot.rootSource === "cwd-default" &&
+    !bindingEnvironmentRootSelector(env) &&
+    evaluation.nonblank.length === 1 && evaluation.nonblank[0] === "CODEX_SESSION_ID" &&
+    normalizeSessionId(env.CODEX_SESSION_ID) !== undefined
+  ) {
+    return {
+      name: "State root/session binding",
+      status: "warn",
+      message: "src=cwd-default ptr=absent; runtime binding unavailable: inherited CODEX_SESSION_ID has no OMX session pointer; no runtime authority verified",
+    };
+  }
   let status: Check["status"] = "fail";
   if (snapshot.status === "absent" && evaluation.bad.length === 0) status = "pass";
   else if (snapshot.status === "stale-dead" && evaluation.bad.length === 0) status = "warn";
@@ -2112,6 +2127,7 @@ export async function checkExternalCodexProcessGuards(
 }
 
 export interface NativeHookCheckContext {
+	codexFeaturesListOutput?: string;
 	codexHomeDir: string;
 	installMode?: SetupInstallMode;
 	platform?: NodeJS.Platform;
@@ -2126,15 +2142,24 @@ function configHasOmxEntries(configContent: string): boolean {
 	return configContent.includes("omx_") || configContent.includes("oh-my-codex");
 }
 
-function configEnablesPluginScopedHooks(configContent: string): boolean {
+export function configEnablesPluginScopedHooks(
+	configContent: string,
+	featuresListOutput = probeInstalledCodexFeatureList(),
+): boolean {
+	const featureFlag = resolveCodexPluginHookFeatureFlag({ featuresListOutput });
+	if (!featureFlag) return false;
 	try {
 		const parsed = parseToml(configContent) as {
 			plugin_hooks?: unknown;
 			features?: Record<string, unknown>;
 		};
-		return isEnabledTomlValue(parsed.plugin_hooks) || isEnabledTomlValue(parsed.features?.plugin_hooks);
+		const { plugin } = getParsedPluginMarketplaceConfig(configContent);
+		const nativeHooks = parsed.features?.hooks ?? parsed.features?.codex_hooks;
+		return featureFlag === "plugin_hooks"
+			? isEnabledTomlValue(parsed.plugin_hooks) || isEnabledTomlValue(parsed.features?.plugin_hooks)
+			: plugin?.enabled === true && (nativeHooks === undefined || isEnabledTomlValue(nativeHooks));
 	} catch {
-		return /^\s*plugin_hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
+		return false;
 	}
 }
 
@@ -2711,7 +2736,7 @@ export async function checkNativeHooks(
 	if (existsSync(configPath) && context.installMode === "plugin") {
 		try {
 			const configContent = await readFile(configPath, "utf-8");
-			if (configEnablesPluginScopedHooks(configContent)) {
+			if (configEnablesPluginScopedHooks(configContent, context.codexFeaturesListOutput)) {
 				const globalCheck = existsSync(hooksPath)
 					? await checkExistingNativeHooks(hooksPath, context)
 					: null;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -78,7 +78,7 @@ import {
 	extractFirstPartyOmxMcpSections,
 	stripFirstPartyOmxMcpSections,
 } from "../config/generator.js";
-import type { CodexHookFeatureFlag } from "../config/codex-feature-flags.js";
+import type { CodexHookFeatureFlag, CodexPluginHookFeatureFlag } from "../config/codex-feature-flags.js";
 import {
 	buildManagedCodexNativeHookWindowsShimContent,
 	buildManagedCodexNativeHookWindowsShimPath,
@@ -3369,6 +3369,7 @@ function buildPluginModeHooksConfigPlan(
 	options: {
 		codexHookFeatureFlag: CodexHookFeatureFlag;
 		pluginScopedHooks: boolean;
+		pluginHookFeatureFlag?: CodexPluginHookFeatureFlag;
 		preserveFirstPartyMcp?: boolean;
 		developerInstructionsDecision: PluginDeveloperInstructionsDecision;
 		platform: NodeJS.Platform;
@@ -3422,6 +3423,7 @@ function buildPluginModeHooksConfigPlan(
 		options.codexHookFeatureFlag,
 		{
 			pluginScopedHooks: options.pluginScopedHooks,
+			pluginHookFeatureFlag: options.pluginHookFeatureFlag,
 			preserveNativeHooks:
 				options.pluginScopedHooks && managedHooksPlan?.hasForeignHooks === true,
 		},
@@ -3536,6 +3538,7 @@ interface PlanNativeHookSetupTransactionOptions {
 	platform: NodeJS.Platform;
 	isPluginInstallMode: boolean;
 	pluginScopedHooks: boolean;
+	pluginHookFeatureFlag?: CodexPluginHookFeatureFlag;
 	codexHookFeatureFlag: CodexHookFeatureFlag;
 	preserveFirstPartyMcp: boolean;
 	removeFirstPartyMcp: boolean;
@@ -3784,6 +3787,7 @@ async function planNativeHookSetupTransaction(
 			{
 				codexHookFeatureFlag: options.codexHookFeatureFlag,
 				pluginScopedHooks: options.pluginScopedHooks,
+				pluginHookFeatureFlag: options.pluginHookFeatureFlag,
 				preserveFirstPartyMcp: options.preserveFirstPartyMcp,
 				developerInstructionsDecision:
 					options.pluginDeveloperInstructionsDecision,
@@ -4300,6 +4304,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
 		isPluginInstallMode,
 		pluginScopedHooks: pluginScopedHooksSupported,
+		pluginHookFeatureFlag: codexHookFeatureSupport.pluginHookFeatureFlag ?? undefined,
 		codexHookFeatureFlag,
 		preserveFirstPartyMcp:
 			shouldOfferFirstPartyMcpRemoval && !removeFirstPartyMcpRegistrations,
@@ -4703,7 +4708,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 		}
 		console.log(
 			pluginScopedHooksSupported
-				? "  Plugin-scoped Codex hooks and runtime feature flags refresh complete (plugin_hooks, goals).\n"
+				? `  Plugin-scoped Codex hooks and runtime feature flags refresh complete (${codexHookFeatureSupport.pluginHookFeatureFlag}, goals).\n`
 				: `  Native Codex hooks fallback and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
 		);
 		if (pluginDeveloperInstructionsDecision.action !== "preserve") {

--- a/src/config/__tests__/codex-feature-flags.test.ts
+++ b/src/config/__tests__/codex-feature-flags.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   parseCodexFeatureNames,
   resolveCodexHookFeatureFlag,
+  resolveCodexPluginHookFeatureFlag,
   supportsCodexPluginScopedHooks,
 } from "../codex-feature-flags.js";
 
@@ -41,6 +42,16 @@ describe("Codex feature flag resolution", () => {
 
     assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: output }), true);
     assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: "hooks stable true" }), false);
+  });
+
+  it("selects canonical hooks when the separate plugin flag is removed", () => {
+    const output = "hooks stable true\nplugin_hooks removed false\n";
+    assert.equal(resolveCodexPluginHookFeatureFlag({ featuresListOutput: output }), "hooks");
+    assert.equal(supportsCodexPluginScopedHooks({ featuresListOutput: output }), true);
+    assert.equal(resolveCodexPluginHookFeatureFlag({ featuresListOutput: "plugin_hooks removed true" }), null);
+    assert.equal(resolveCodexPluginHookFeatureFlag({ featuresListOutput: "hooks removed false\nplugin_hooks removed true" }), null);
+    assert.equal(resolveCodexPluginHookFeatureFlag({ featuresListOutput: "plugin_hooks experimental false" }), "plugin_hooks");
+    assert.equal(resolveCodexPluginHookFeatureFlag(), null);
   });
 
   it("uses version fallback for current Codex releases when feature listing is unavailable", () => {

--- a/src/config/__tests__/generator-notify.test.ts
+++ b/src/config/__tests__/generator-notify.test.ts
@@ -447,6 +447,16 @@ describe('config generator', () => {
     }
   });
 
+  it('migrates removed plugin_hooks to unified hooks without duplicate native flags', () => {
+    for (const config of ['', '[features]\nplugin_hooks = true\nhooks = false\ncodex_hooks = true\n']) {
+      const options = { pluginScopedHooks: true, pluginHookFeatureFlag: 'hooks' as const, preserveNativeHooks: true };
+      const result = upsertPluginModeRuntimeFeatureFlags(config, 'hooks', options);
+      assert.equal((result.match(/^hooks = true$/gm) ?? []).length, 1);
+      assert.doesNotMatch(result, /^(?:plugin_hooks|codex_hooks)\s*=/m);
+      assert.equal(upsertPluginModeRuntimeFeatureFlags(result, 'hooks', options), result);
+    }
+  });
+
   it('normalizes plugin-mode runtime flags to the current hooks flag by default', () => {
     const original = [
       '[features]',

--- a/src/config/codex-feature-flags.ts
+++ b/src/config/codex-feature-flags.ts
@@ -55,12 +55,30 @@ export function isCodexCliVersionAtLeast(
   return true;
 }
 
+export type CodexPluginHookFeatureFlag = "hooks" | "plugin_hooks";
+
+export function resolveCodexPluginHookFeatureFlag(options: {
+  featuresListOutput?: string | null;
+} = {}): CodexPluginHookFeatureFlag | null {
+  const stages = new Map<string, string>();
+  for (const line of (options.featuresListOutput ?? "").split(/\r?\n/)) {
+    const match = line.trim().match(/^(\w+)\s+(.+?)\s+(?:true|false)$/);
+    if (match) stages.set(match[1], match[2]);
+  }
+  const pluginStage = stages.get(CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG);
+  // Removed flags remain in `features list`, but cannot enable a capability.
+  // Codex consolidated plugin hooks into the canonical hooks feature.
+  if (pluginStage === "removed") {
+    const hooksStage = stages.get("hooks");
+    return hooksStage && hooksStage !== "removed" ? "hooks" : null;
+  }
+  return pluginStage ? CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG : null;
+}
+
 export function supportsCodexPluginScopedHooks(options: {
   featuresListOutput?: string | null;
 } = {}): boolean {
-  return parseCodexFeatureNames(options.featuresListOutput).has(
-    CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
-  );
+  return resolveCodexPluginHookFeatureFlag(options) !== null;
 }
 
 export function resolveCodexHookFeatureFlag(options: {

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -23,6 +23,7 @@ import {
   formatCodexHookFeatureFlagLine,
   normalizeCodexHookFeatureFlag,
   type CodexHookFeatureFlag,
+  type CodexPluginHookFeatureFlag,
 } from "./codex-feature-flags.js";
 import {
   OMX_FIRST_PARTY_MCP_SERVER_NAMES,
@@ -874,12 +875,13 @@ function upsertPluginScopedHookFeatureFlagInSection(
   lines: string[],
   featuresStart: number,
   sectionEnd: number,
+  featureFlag: CodexPluginHookFeatureFlag,
 ): { sectionEnd: number; featureFlagIndex: number } {
   return upsertFeatureFlagLineInSection(
     lines,
     featuresStart,
     sectionEnd,
-    CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG,
+    featureFlag,
     isAnyPluginModeHookFeatureFlagLine,
   );
 }
@@ -2888,14 +2890,20 @@ export function upsertManagedCodexHookTrustState(
 export function upsertPluginModeRuntimeFeatureFlags(
   config: string,
   codexHookFeatureFlag: CodexHookFeatureFlag = DEFAULT_CODEX_HOOK_FEATURE_FLAG,
-  options: { pluginScopedHooks?: boolean; preserveNativeHooks?: boolean } = {},
+  options: {
+    pluginScopedHooks?: boolean;
+    pluginHookFeatureFlag?: CodexPluginHookFeatureFlag;
+    preserveNativeHooks?: boolean;
+  } = {},
 ): string {
   const lines = config.split(/\r?\n/);
   const featuresStart = lines.findIndex((line) =>
     /^\s*\[features\]\s*$/.test(line),
   );
+  const pluginHookFeatureFlag = options.pluginHookFeatureFlag ?? CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG;
+  const preserveNativeHooks = options.preserveNativeHooks && pluginHookFeatureFlag !== codexHookFeatureFlag;
   const hookFeatureFlagLine = options.pluginScopedHooks
-    ? `${CODEX_PLUGIN_SCOPED_HOOKS_FEATURE_FLAG} = true`
+    ? `${pluginHookFeatureFlag} = true`
     : formatCodexHookFeatureFlagLine(codexHookFeatureFlag);
 
   if (featuresStart < 0) {
@@ -2903,7 +2911,7 @@ export function upsertPluginModeRuntimeFeatureFlags(
     const featureBlock = [
       "[features]",
       hookFeatureFlagLine,
-      ...(options.pluginScopedHooks && options.preserveNativeHooks
+      ...(options.pluginScopedHooks && preserveNativeHooks
         ? [formatCodexHookFeatureFlagLine(codexHookFeatureFlag)]
         : []),
       "goals = true",
@@ -2937,8 +2945,9 @@ export function upsertPluginModeRuntimeFeatureFlags(
       lines,
       featuresStart,
       sectionEnd,
+      pluginHookFeatureFlag,
     ));
-    if (options.preserveNativeHooks) {
+    if (preserveNativeHooks) {
       ({ sectionEnd } = upsertCodexHookFeatureFlagInSection(
         lines,
         featuresStart,


### PR DESCRIPTION
## Summary

Current Codex consolidates plugin hooks under `hooks`, but OMX still checks and generates the removed `plugin_hooks` flag. This causes missing-hooks/prompts/skills warnings for an installed plugin. Doctor also reports a failure when an ordinary Codex session has no OMX session pointer.

## Changes

- Select the effective plugin-hook flag from Codex capabilities; preserve older supported flags, explicit disablement, and canonical/alias precedence.
- Infer plugin installation from trusted enabled plugin registration and generate canonical hook configuration on current Codex.
- Report unavailable runtime binding as a warning only for an absent default-workspace pointer with a lone valid `CODEX_SESSION_ID`. Explicit OMX selectors and unsafe/conflicting pointers still fail.

## Validation

- [x] `npm run build`
- [x] `npm run lint` and `npm run check:no-unused`
- [x] 363 tests passed across the affected doctor, setup, feature-probe, and configuration suites; no skips
- [ ] Full `npm test` suite (not run)
- [x] Installed the packed build and ran user-scoped plugin setup with `--merge-agents --mcp none`
- [x] Installed `omx doctor`: 20 passed, 2 warnings, 0 failures. Remaining warnings are the fresh workspace's absent state directory and explicitly unavailable runtime binding.
- [x] Fresh `omx exec` returned `OMX-EXEC-OK`; SessionStart and UserPromptSubmit hooks completed

Validated on macOS arm64 with Codex CLI 0.153.4. Existing `hooks = true` and intentional Stop-hook disablement were preserved. The local launcher’s separate Node provenance mismatch was resolved by refreshing the plugin under the workspace’s Node executable.

## Checklist

- [x] Changes are limited to hook compatibility and session diagnostics, with regression coverage
- [x] Backward compatibility and explicit disablement considered
- [x] Independent source review completed

Closes #3623
