### PR TITLE
fix(setup): preserve user-owned root model_reasoning_effort across setup/update

### DIFF
--- a/src/cli/__tests__/setup-reasoning-preserve.test.ts
+++ b/src/cli/__tests__/setup-reasoning-preserve.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { after, describe, it } from "node:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import TOML from "@iarna/toml";
+import { buildMergedConfig } from "../../config/generator.js";
+import { setup } from "../setup.js";
+import { upsertTopLevelTomlString } from "../../utils/toml.js";
+
+/**
+ * Regression coverage for issue #3630:
+ * `omx setup` must preserve an existing root `model_reasoning_effort`
+ * (explicit user edit or `omx reasoning <mode>`) while still seeding the
+ * `medium` default when the key is absent.
+ */
+
+interface IsolatedHome {
+	wd: string;
+	home: string;
+	codexHome: string;
+	configPath: string;
+	restore: () => void;
+}
+
+
+async function createIsolatedHome(prefix: string): Promise<IsolatedHome> {
+	const wd = await mkdtemp(join(tmpdir(), `${prefix}-`));
+	const home = join(wd, "home");
+	const codexHome = join(home, ".codex");
+	await mkdirRecursive(codexHome);
+	const previous = {
+		HOME: process.env.HOME,
+		CODEX_HOME: process.env.CODEX_HOME,
+		XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+	};
+	process.env.HOME = home;
+	process.env.CODEX_HOME = codexHome;
+	process.env.XDG_CONFIG_HOME = join(home, ".config");
+	return {
+		wd,
+		home,
+		codexHome,
+		configPath: join(codexHome, "config.toml"),
+		restore: () => {
+			if (previous.HOME !== undefined) process.env.HOME = previous.HOME;
+			else delete process.env.HOME;
+			if (previous.CODEX_HOME !== undefined) {
+				process.env.CODEX_HOME = previous.CODEX_HOME;
+			} else {
+				delete process.env.CODEX_HOME;
+			}
+			if (previous.XDG_CONFIG_HOME !== undefined) {
+				process.env.XDG_CONFIG_HOME = previous.XDG_CONFIG_HOME;
+			} else {
+				delete process.env.XDG_CONFIG_HOME;
+			}
+		},
+	};
+}
+
+async function mkdirRecursive(dir: string): Promise<void> {
+	const { mkdir } = await import("node:fs/promises");
+	await mkdir(dir, { recursive: true });
+}
+
+const MANAGED_EFFORT_DEFAULT = "medium";
+
+describe("buildMergedConfig reasoning effort ownership (issue #3630)", () => {
+	it("does not preserve by default (legacy callers keep the managed default)", () => {
+		const existing = [
+			"model_reasoning_effort = \"high\"",
+			"",
+			"[features]",
+			"hooks = true",
+			"",
+		].join("\n");
+		const merged = buildMergedConfig(existing, "/tmp/omx-test-root", {
+			includeTui: false,
+		});
+		const parsed = TOML.parse(merged) as { model_reasoning_effort?: string };
+		assert.equal(parsed.model_reasoning_effort, MANAGED_EFFORT_DEFAULT);
+	});
+
+	it("preserves an existing non-default root effort when asked", () => {
+		const existing = [
+			"model_reasoning_effort = \"xhigh\"",
+			"",
+			"[features]",
+			"hooks = true",
+			"",
+		].join("\n");
+		const merged = buildMergedConfig(existing, "/tmp/omx-test-root", {
+			includeTui: false,
+			preserveReasoningEffort: true,
+		});
+		const parsed = TOML.parse(merged) as { model_reasoning_effort?: string };
+		assert.equal(parsed.model_reasoning_effort, "xhigh");
+	});
+
+	it("preserves the exact raw TOML value, including invalid values (honest hand-off)", () => {
+		const existing = [
+			"model_reasoning_effort = 'low'",
+			"",
+			"[features]",
+			"hooks = true",
+			"",
+		].join("\n");
+		const merged = buildMergedConfig(existing, "/tmp/omx-test-root", {
+			includeTui: false,
+			preserveReasoningEffort: true,
+		});
+		assert.match(
+			merged,
+			/^model_reasoning_effort = 'low'$/m,
+			"raw user-owned spelling must survive verbatim",
+		);
+	});
+
+	it("seeds the managed default when the key is absent even with preserve enabled", () => {
+		const existing = [
+			"model = \"gpt-5.6-sol\"",
+			"",
+			"[features]",
+			"hooks = true",
+			"",
+		].join("\n");
+		const merged = buildMergedConfig(existing, "/tmp/omx-test-root", {
+			includeTui: false,
+			preserveReasoningEffort: true,
+		});
+		const parsed = TOML.parse(merged) as { model_reasoning_effort?: string };
+		assert.equal(parsed.model_reasoning_effort, MANAGED_EFFORT_DEFAULT);
+	});
+
+	it("keeps [profiles.*] reasoning values intact while preserving the root key", () => {
+		const existing = [
+			"model_reasoning_effort = \"high\"",
+			"",
+			"[profiles.research]",
+			"model = \"gpt-5.6-terra\"",
+			"model_reasoning_effort = \"low\"",
+			"",
+			"[features]",
+			"hooks = true",
+			"",
+		].join("\n");
+		const merged = buildMergedConfig(existing, "/tmp/omx-test-root", {
+			includeTui: false,
+			preserveReasoningEffort: true,
+		});
+		const parsed = TOML.parse(merged) as {
+			model_reasoning_effort?: string;
+			profiles?: Record<string, { model_reasoning_effort?: string }>;
+		};
+		assert.equal(parsed.model_reasoning_effort, "high");
+		assert.equal(parsed.profiles?.research?.model_reasoning_effort, "low");
+	});
+
+	it("produces exactly one root effort key after a refresh", () => {
+		const existing = [
+			"# oh-my-codex top-level settings (must be before any [table])",
+			"notify = false",
+			"model_reasoning_effort = \"high\"",
+			"developer_instructions = \"custom\"",
+			"",
+			"[features]",
+			"hooks = true",
+			"",
+		].join("\n");
+		const merged = buildMergedConfig(existing, "/tmp/omx-test-root", {
+			includeTui: false,
+			preserveReasoningEffort: true,
+		});
+		const rootMatches = merged.match(/^model_reasoning_effort\s*=/gm) ?? [];
+		assert.equal(rootMatches.length, 1);
+	});
+});
+
+describe("omx setup preserves user reasoning effort (issue #3630)", () => {
+	const homes: IsolatedHome[] = [];
+
+	after(async () => {
+		for (const home of homes.splice(0)) {
+			home.restore();
+			await rm(home.wd, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+		}
+	});
+
+	it("keeps a non-default value across repeated setup runs", async () => {
+		const home = await createIsolatedHome("omx3630-nondefault-");
+		homes.push(home);
+		try {
+			await setup({ scope: "user", mergeAgents: true, installMode: "legacy" });
+			let content = await readFile(home.configPath, "utf-8");
+			content = upsertTopLevelTomlString(
+				content,
+				"model_reasoning_effort",
+				"high",
+			);
+			await writeFile(home.configPath, content);
+
+			await setup({ scope: "user", mergeAgents: true, installMode: "legacy" });
+			await setup({ scope: "user", mergeAgents: true, installMode: "legacy" });
+
+			const parsed = TOML.parse(
+				await readFile(home.configPath, "utf-8"),
+			) as { model_reasoning_effort?: string };
+			assert.equal(
+				parsed.model_reasoning_effort,
+				"high",
+				"`omx reasoning high` must survive repeated setup/update",
+			);
+		} finally {
+			// cleanup happens in `after`
+		}
+	});
+
+	it("seeds the managed default on fresh setups (missing default)", async () => {
+		const home = await createIsolatedHome("omx3630-fresh-");
+		homes.push(home);
+		await setup({ scope: "user", mergeAgents: true, installMode: "legacy" });
+		assert.ok(existsSync(home.configPath), "fresh setup must create config.toml");
+		const parsed = TOML.parse(
+			await readFile(home.configPath, "utf-8"),
+		) as { model_reasoning_effort?: string };
+		assert.equal(parsed.model_reasoning_effort, MANAGED_EFFORT_DEFAULT);
+	});
+
+	it("preserves a directly hand-edited non-default value through setup", async () => {
+		const home = await createIsolatedHome("omx3630-handedit-");
+		homes.push(home);
+		await writeFile(
+			home.configPath,
+			[
+				"model = \"gpt-5.6-sol\"",
+				"model_reasoning_effort = \"low\"",
+				"",
+			].join("\n"),
+		);
+		await setup({ scope: "user", mergeAgents: true, installMode: "legacy" });
+		const parsed = TOML.parse(
+			await readFile(home.configPath, "utf-8"),
+		) as { model_reasoning_effort?: string };
+		assert.equal(parsed.model_reasoning_effort, "low");
+	});
+});

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -6379,6 +6379,7 @@ async function planManagedConfig(
 		notifyCommand: notifyPlan.notifyCommand,
 		includeFirstPartyMcp: mcpMode === "compat",
 		preserveExistingFirstPartyMcp,
+		preserveReasoningEffort: true,
 	});
 	return {
 		finalConfig,

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -62,6 +62,12 @@ interface MergeOptions {
   notifyCommand?: string[] | false;
   includeFirstPartyMcp?: boolean;
   preserveExistingFirstPartyMcp?: boolean;
+  /**
+   * Preserve an existing root `model_reasoning_effort` instead of rewriting it
+   * to the managed default. Setup passes true so an explicit user choice
+   * (direct edit or `omx reasoning <mode>`) survives setup/update (issue #3630).
+   */
+  preserveReasoningEffort?: boolean;
 }
 
 function escapeTomlString(value: string): string {
@@ -573,15 +579,21 @@ function getOmxTopLevelLines(
   existingConfig = "",
   modelOverride?: string,
   notifyCommand: string[] | false = getDefaultNotifyCommand(pkgRoot),
+  preservedReasoningEffort?: string,
 ): string[] {
   const rootValues = parseRootKeyValues(existingConfig);
+
+  const reasoningEffortLine =
+    preservedReasoningEffort !== undefined
+      ? `model_reasoning_effort = ${preservedReasoningEffort}`
+      : 'model_reasoning_effort = "medium"';
 
   const lines = [
     "# oh-my-codex top-level settings (must be before any [table])",
     ...(notifyCommand === false
       ? []
       : [`notify = ${formatTomlStringArray(notifyCommand)}`]),
-    'model_reasoning_effort = "medium"',
+    reasoningEffortLine,
     `developer_instructions = "${escapeTomlString(OMX_DEVELOPER_INSTRUCTIONS)}"`,
   ];
 
@@ -4159,9 +4171,16 @@ export function buildMergedConfig(
     !isOmxManagedNotifyCommand(getRootTomlArray(existing, "notify"), pkgRoot)
       ? getRootTomlArray(existing, "notify")
       : null;
+  const userReasoningEffortToPreserve =
+    options.preserveReasoningEffort === true
+      ? parseRootKeyValues(existing).get("model_reasoning_effort")
+      : undefined;
   existing = stripOmxTopLevelKeys(existing).trimStart();
   if (userNotifyToPreserve) {
     existing = `${`notify = ${formatTomlStringArray(userNotifyToPreserve)}`}\n${existing.trimStart()}`;
+  }
+  if (userReasoningEffortToPreserve !== undefined) {
+    existing = stripRootLevelKeys(existing, ["model_reasoning_effort"]);
   }
   existing = stripOrphanedManagedNotify(existing, pkgRoot).trimStart();
   const hookTrustStrip = stripManagedCodexHookTrustStateForRefresh(
@@ -4196,6 +4215,9 @@ export function buildMergedConfig(
     options.notifyCommand === undefined
       ? getDefaultNotifyCommand(pkgRoot)
       : options.notifyCommand,
+    options.preserveReasoningEffort === true
+      ? userReasoningEffortToPreserve
+      : undefined,
   );
   const tablesBlock = getOmxTablesBlock(
     pkgRoot,


### PR DESCRIPTION
## Summary

`omx setup` rewrote the root `model_reasoning_effort` in `config.toml` to the
managed default `"medium"` on every legacy-scope config refresh, silently
discarding values set through direct edits or the documented
`omx reasoning <mode>` command. Because `omx update` runs setup, no
non-default root reasoning effort could survive an upgrade.

Fixes #3630.

## Root cause

In `buildMergedConfig` (`src/config/generator.ts`), the managed refresh
unconditionally strips the OMX top-level keys (`notify`,
`model_reasoning_effort`, `developer_instructions`) and re-emits
`model_reasoning_effort = "medium"` in `getOmxTopLevelLines`. `notify` had a
preserve path; this key did not.

## Fix

- `MergeOptions` gains `preserveReasoningEffort`. When set, an existing root
  `model_reasoning_effort` is captured before the managed block is stripped
  and re-emitted verbatim (byte-for-byte, including the raw TOML spelling).
- When the key is absent, the managed `"medium"` default is still seeded, so
  fresh installs keep the intended default.
- Setup passes `preserveReasoningEffort: true` in `planManagedConfig`
  (legacy managed path). Plugin mode never wrote this key and is unchanged.
- Invalid values are passed through unvalidated and remain user-owned;
  setup already refuses to write a config that fails TOML parsing
  (`Refusing to write invalid planned config.toml`). This keeps honest
  invalid-value handling: setup neither silently "fixes" the value nor
  crashes on it beyond existing parse validation.

The existing Astra default agent-level reasoning overrides (#3622) are
untouched: this change only covers the root key in `config.toml`.

## Verification

All in isolated temp `HOME` / `XDG_CONFIG_HOME` / `CODEX_HOME`, no host
config touched:

- Reproduced on current dev (`c81edfa5`): `omx reasoning high` → `omx setup`
  → reverted to `"medium"` with `config: updated=1` (silent). Same after
  `omx doctor`/normal use left it untouched.
- After the fix: `omx reasoning xhigh` survives repeated setup; direct
  hand-edit to `"low"` survives setup; `omx doctor` preserves; fresh setup
  still seeds `"medium"`; project-scope setup leaves the user config alone;
  `omx reasoning` (status) still reports the preserved value.
- `[profiles.*].model_reasoning_effort` values remain intact (no root-level
  key leakage into tables; exactly one root key after refresh).
- New tests: `src/cli/__tests__/setup-reasoning-preserve.test.ts` (9 tests)
  pass; generator suites, native-config, setup-install-mode,
  setup-prompts-overwrite, uninstall, index/exec/launch-fallback suites pass;
  the only failing tests in the full local run (tmux/team lifecycle) fail
  identically on pristine `dev` in this environment and are untouched by
  this change.

Document-refresh: not-needed | no documented setup behavior contract changed; `omx reasoning` semantics preserved and extended to survive updates.

*Signed-off-by: Yeachan-Heo <Yeachan-Heo@users.noreply.github.com>*
