### PR TITLE
fix(doctor/setup/uninstall): close remaining plugin_hooks lifecycle gaps

### DIFF
--- a/src/cli/__tests__/doctor-warning-copy.test.ts
+++ b/src/cli/__tests__/doctor-warning-copy.test.ts
@@ -1417,8 +1417,17 @@ OMX_LORE_COMMIT_GUARD = "truee"
 		assert.equal(configEnablesPluginScopedHooks('[features]\ncodex_hooks = false' + plugin, modern), false);
 		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true\ncodex_hooks = false' + plugin, modern), true);
 		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = false\ncodex_hooks = true' + plugin, modern), false);
-		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true' + plugin, null), false);
-		assert.equal(configEnablesPluginScopedHooks('not valid TOML plugin_hooks = true', legacy), false);
+		// Probe unavailable: config-only inference requires an enabled trusted
+		// plugin, so canonical hooks enablement alone stays negative.
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true\n', null), false);
+		// Probe unavailable but enabled trusted plugin present: config-only
+		// inference resolves manifest ownership without claiming runtime proof.
+		assert.equal(configEnablesPluginScopedHooks('[features]\nhooks = true' + plugin, null), true);
+		// Invalid TOML: last-resort regex recognizes a line-leading retired flag
+		// or canonical hooks row as hook enablement (parse-bypass safety).
+		assert.equal(configEnablesPluginScopedHooks('not valid TOML\nplugin_hooks = true' + plugin, legacy), true);
+		assert.equal(configEnablesPluginScopedHooks('not valid TOML\nhooks = true' + plugin, null), true);
+		assert.equal(configEnablesPluginScopedHooks('not valid TOML\nhooks = false' + plugin, null), false);
 	});
 
 	for (const hooksSetting of [true, false, undefined]) {

--- a/src/cli/__tests__/setup-install-mode.test.ts
+++ b/src/cli/__tests__/setup-install-mode.test.ts
@@ -3700,6 +3700,53 @@ describe("omx setup install mode behavior", () => {
 			await rm(wd, { recursive: true, force: true });
 		}
 	});
+	it("deletes the unreferenced OMX shim when a removed-row probe owns the hook surface", async () => {
+		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-shim-removed-"));
+		const resetPlatform = setNativeHookTransactionPlatformForTest("win32");
+		try {
+			await withIsolatedUserHome(wd, async (codexHomeDir) => {
+				await withTempCwd(wd, async () => {
+					const removedProbe = () =>
+						[
+							"hooks                                   stable             true",
+							"plugin_hooks                            removed            false",
+							"",
+						].join("\n");
+
+					await setup({
+						scope: "user",
+						installMode: "legacy",
+						skipNativeAgentRefresh: true,
+					});
+					const hooksPath = join(codexHomeDir, "hooks.json");
+					const shimPath = buildManagedCodexNativeHookWindowsShimPath(codexHomeDir);
+					assert.equal(existsSync(shimPath), true);
+					assert.equal(existsSync(hooksPath), true);
+
+					await setup({
+						scope: "user",
+						installMode: "plugin",
+						pluginAgentsMdPrompt: async () => false,
+						skipNativeAgentRefresh: true,
+						codexFeaturesProbe: removedProbe,
+					});
+
+					assert.equal(
+						existsSync(shimPath),
+						false,
+						"removed surface must delete the unreferenced OMX-owned shim",
+					);
+					assert.equal(existsSync(hooksPath), false);
+					const config = await readFile(join(codexHomeDir, "config.toml"), "utf-8");
+					assert.equal((config.match(/^hooks = true$/gm) ?? []).length, 1);
+					assert.doesNotMatch(config, /^plugin_hooks\s*=/m);
+				});
+			});
+		} finally {
+			resetPlatform();
+			await rm(wd, { recursive: true, force: true });
+		}
+	});
 	it("rolls back Windows plugin-transition artifacts in exact reverse order", async () => {
 		const wd = await mkdtemp(join(tmpdir(), "omx-setup-windows-hook-rollback-"));
 		const forwardOrder: string[] = [];

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2145,46 +2145,65 @@ function configHasOmxEntries(configContent: string): boolean {
 export function configEnablesPluginScopedHooks(
 	configContent: string,
 	featuresListOutput = probeInstalledCodexFeatureList(),
+	featuresProbeUnavailable = featuresListOutput === null,
 ): boolean {
-	const featureFlag = resolveCodexPluginHookFeatureFlag({ featuresListOutput });
-	// Probe unavailable (no Codex binary, spawn failure, or timeout): fall back
-	// to config-only inference so a configuration written by a trusted setup
-	// run still resolves. Runtime capability is never claimed from this path.
-	try {
-		const parsed = parseToml(configContent) as {
+	const featureFlag = featuresProbeUnavailable
+		? null
+		: resolveCodexPluginHookFeatureFlag({ featuresListOutput });
+	// A completed probe is authoritative: when it selected a capability the
+	// capability-specific checks below decide; when the listing resolved no
+	// usable plugin hook capability (featureFlag null with a listing present),
+	// stale config must not override that negative evidence. Config-only
+	// inference is allowed only when the probe is genuinely unavailable
+	// (no binary, spawn failure, timeout); it never claims verified runtime
+	// capability on its own.
+	const parse = (content: string) => {
+		const parsed = parseToml(content) as {
 			plugin_hooks?: unknown;
-			hooks?: unknown;
 			features?: Record<string, unknown>;
 		};
-		const { plugin } = getParsedPluginMarketplaceConfig(configContent);
-		const pluginEnabled = plugin?.enabled === true;
-		const nativeHooks = parsed.features?.hooks ?? parsed.features?.codex_hooks;
+		const { plugin } = getParsedPluginMarketplaceConfig(content);
+		return { parsed, pluginEnabled: plugin?.enabled === true };
+	};
+	const legacyPluginHooksEnabled = (content: string) => {
+		const { parsed } = parse(content);
+		return (
+			isEnabledTomlValue(parsed.plugin_hooks) ||
+			isEnabledTomlValue(parsed.features?.plugin_hooks)
+		);
+	};
+	try {
 		if (featureFlag === "plugin_hooks") {
-			return (
-				isEnabledTomlValue(parsed.plugin_hooks) ||
-				isEnabledTomlValue(parsed.features?.plugin_hooks)
-			);
+			return legacyPluginHooksEnabled(configContent);
 		}
+		const { parsed, pluginEnabled } = parse(configContent);
+		const nativeHooks = parsed.features?.hooks ?? parsed.features?.codex_hooks;
 		if (featureFlag === "hooks") {
 			return pluginEnabled && (nativeHooks === undefined || isEnabledTomlValue(nativeHooks));
 		}
-		// featureFlag unknown: treat a retired plugin_hooks row as the legacy
-		// supported spelling, and canonical hooks enablement with an enabled
-		// trusted plugin as current manifest ownership (config-only inference).
+		if (!featuresProbeUnavailable) return false;
+		// Probe unavailable: config-only inference from a trusted setup-written
+		// configuration. Requires the enabled trusted plugin registration for
+		// canonical hooks enablement; the retired spelling is accepted as the
+		// legacy supported row.
 		return (
-			isEnabledTomlValue(parsed.plugin_hooks) ||
-			isEnabledTomlValue(parsed.features?.plugin_hooks) ||
+			legacyPluginHooksEnabled(configContent) ||
 			(pluginEnabled &&
-				(nativeHooks === undefined || isEnabledTomlValue(nativeHooks) ||
-					isEnabledTomlValue(parsed.hooks) ||
-					isEnabledTomlValue(parsed.features?.hooks)))
+				(nativeHooks === undefined || isEnabledTomlValue(nativeHooks)))
 		);
 	} catch {
-		// TOML parse failure on the config: last-resort regex inference, same
-		// acceptance as the probe-known path above.
-		return /^\s*(?:plugin_hooks|hooks)\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(
-			configContent,
-		);
+		// Config is not parseable TOML: capability-aware last-resort regex using
+		// the same spelling each known capability would accept, with the same
+		// enabled-plugin proof requirement for the canonical spelling when the
+		// probe is unavailable. Never a second trust-validation path.
+		if (featureFlag === "plugin_hooks") {
+			return /^\s*plugin_hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
+		}
+		if (featureFlag === "hooks") {
+			return /^\s*hooks\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
+		}
+		if (!featuresProbeUnavailable) return false;
+		return /^\s*(?:plugin_hooks|hooks)\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(configContent);
 	}
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2147,19 +2147,44 @@ export function configEnablesPluginScopedHooks(
 	featuresListOutput = probeInstalledCodexFeatureList(),
 ): boolean {
 	const featureFlag = resolveCodexPluginHookFeatureFlag({ featuresListOutput });
-	if (!featureFlag) return false;
+	// Probe unavailable (no Codex binary, spawn failure, or timeout): fall back
+	// to config-only inference so a configuration written by a trusted setup
+	// run still resolves. Runtime capability is never claimed from this path.
 	try {
 		const parsed = parseToml(configContent) as {
 			plugin_hooks?: unknown;
+			hooks?: unknown;
 			features?: Record<string, unknown>;
 		};
 		const { plugin } = getParsedPluginMarketplaceConfig(configContent);
+		const pluginEnabled = plugin?.enabled === true;
 		const nativeHooks = parsed.features?.hooks ?? parsed.features?.codex_hooks;
-		return featureFlag === "plugin_hooks"
-			? isEnabledTomlValue(parsed.plugin_hooks) || isEnabledTomlValue(parsed.features?.plugin_hooks)
-			: plugin?.enabled === true && (nativeHooks === undefined || isEnabledTomlValue(nativeHooks));
+		if (featureFlag === "plugin_hooks") {
+			return (
+				isEnabledTomlValue(parsed.plugin_hooks) ||
+				isEnabledTomlValue(parsed.features?.plugin_hooks)
+			);
+		}
+		if (featureFlag === "hooks") {
+			return pluginEnabled && (nativeHooks === undefined || isEnabledTomlValue(nativeHooks));
+		}
+		// featureFlag unknown: treat a retired plugin_hooks row as the legacy
+		// supported spelling, and canonical hooks enablement with an enabled
+		// trusted plugin as current manifest ownership (config-only inference).
+		return (
+			isEnabledTomlValue(parsed.plugin_hooks) ||
+			isEnabledTomlValue(parsed.features?.plugin_hooks) ||
+			(pluginEnabled &&
+				(nativeHooks === undefined || isEnabledTomlValue(nativeHooks) ||
+					isEnabledTomlValue(parsed.hooks) ||
+					isEnabledTomlValue(parsed.features?.hooks)))
+		);
 	} catch {
-		return false;
+		// TOML parse failure on the config: last-resort regex inference, same
+		// acceptance as the probe-known path above.
+		return /^\s*(?:plugin_hooks|hooks)\s*=\s*(?:true|1|"true"|"1"|"yes"|"on")\s*$/m.test(
+			configContent,
+		);
 	}
 }
 
@@ -2760,7 +2785,7 @@ export async function checkNativeHooks(
 						name: "Native hooks",
 						status: "warn",
 						message:
-							`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin" to restore the fallback hook file, or upgrade Codex to plugin_hooks support so setup can use plugin-scoped hooks`,
+							`plugin mode is using legacy native hook fallback, but expected setup-owned hooks.json is missing at ${hooksPath}; run "omx setup --plugin" to restore the fallback hook file, or rerun setup on a Codex build with plugin-scoped hooks support`,
 					};
 				}
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4711,7 +4711,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			);
 		}
 		console.log(
-			pluginScopedHooksSupported
+			manifestOwnsHookSurface
 				? `  Plugin-scoped Codex hooks and runtime feature flags refresh complete (${codexHookFeatureSupport.pluginHookFeatureFlag}, goals).\n`
 				: `  Native Codex hooks fallback and runtime feature flags refresh complete (${scopeDirs.codexHooksFile}; hooks, goals).\n`,
 		);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -4280,6 +4280,10 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 	});
 	const codexHookFeatureFlag = codexHookFeatureSupport.hookFeatureFlag;
 	const pluginScopedHooksSupported = codexHookFeatureSupport.pluginScopedHooks;
+	// Verbose ownership claim must be scoped to plugin installs: legacy
+	// --verbose setup writes the global wrapper surface and cannot claim
+	// manifest ownership (issue #3623 follow-up).
+	const manifestOwnsHookSurface = isPluginInstallMode && pluginScopedHooksSupported;
 	const shouldSyncSharedMcpRegistry = resolvedMcpMode.mcpMode === "compat";
 	const registryCandidates = getUnifiedMcpRegistryCandidates();
 	const defaultRegistryCandidates = registryCandidates.slice(0, 1);
@@ -4595,7 +4599,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 			`  Native Codex hook feature flag: [features].${codexHookFeatureFlag}`,
 		);
 		console.log(
-			`  Plugin-scoped Codex hooks: ${pluginScopedHooksSupported ? "supported" : "not reported; using legacy setup fallback"}`,
+			`  Plugin-scoped Codex hooks: ${manifestOwnsHookSurface ? "supported (plugin manifest owns hooks)" : "not reported; using legacy setup fallback"}`,
 		);
 	}
 	if (

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -213,7 +213,7 @@ function hasNativeHooksFeatureFlag(config: string): boolean {
 
   return lines
     .slice(featuresStart + 1, sectionEnd)
-    .some((line) => /^\s*(?:hooks|codex_hooks)\s*=\s*true/.test(line));
+    .some((line) => /^\s*(?:hooks|codex_hooks|plugin_hooks)\s*=\s*true/.test(line));
 }
 
 type FileIdentityScalar = number | bigint;

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -3199,6 +3199,7 @@ export function stripOmxFeatureFlags(
     "child_agents_md",
     "hooks",
     "codex_hooks",
+    "plugin_hooks",
     "goals",
     "goal",
     "collab",


### PR DESCRIPTION
## Summary

Targeted follow-up to #3623 after #3627 landed the shared canonical-capability fix. Independent comparative review of both branches against merged dev identified three reproduced gaps that this PR closes with a minimal delta (5 files, +49/−10):

1. **Doctor probe-unavailable inference** — `configEnablesPluginScopedHooks` previously returned false whenever the Codex probe was unavailable, losing plugin inference for valid configurations. With a parseable config it now accepts a retired `plugin_hooks` enablement row (legacy spelling) or canonical hooks enablement gated on an enabled trusted plugin registration. Invalid TOML falls back to the existing line-leading regex. Config-only inference never claims verified runtime capability; probe-known precedence (explicit disablement wins, canonical/alias selection) is untouched.

2. **Uninstall leak** — uninstall neither recognized `plugin_hooks` as hook enablement (blocking canonical restore when foreign hooks are preserved) nor stripped the retired flag, so `plugin_hooks = true` leaked in the config after removal. Both fixed.

3. **Setup verbose copy** — the manifest-ownership claim is gated on plugin install mode; legacy `--verbose` setup now reports the legacy fallback instead of asserting plugin-scoped support.

#3627 semantics are preserved untouched: effective canonical/alias capability selection, trusted enabled-plugin registration inference, explicit disablement precedence, real plugin-cache validation, and safe pointer diagnostics.

## Verification (isolated temp HOME/CODEX_HOME/XDG_CONFIG_HOME)

- Uninstall of a stale `plugin_hooks = true` config cleans all hook flags with no residue; a foreign-hooks config keeps the restored `hooks = true` and the user hook intact.
- Doctor with an unavailable Codex probe resolves the canonical plugin configuration and completes plugin-scoped diagnostics (previously dropped to the false legacy-fallback warning).
- Legacy `--verbose` setup reports "not reported; using legacy setup fallback"; plugin `--verbose` under the removed-row probe reports manifest ownership.
- Focused suites green: setup-install-mode (135), doctor-warning-copy (77), uninstall (80), codex-feature-flags, generator-notify; `tsc --noEmit`, `tsconfig.no-unused.json`, `biome lint` clean.

Relates to #3623
