### PR TITLE
fix(launch): seed credential provenance into project-scope runtime home (#3629)

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3792,6 +3792,69 @@ describe("project launch scope helpers", () => {
     }
   });
 
+  it("seeds the caller's auth.json into the ephemeral runtime home without touching the project (issue #3629)", async () => {
+    const wd = await mkdtemp(join(tmpdir(), "omx-issue-3629-"));
+    try {
+      const projectCodexHome = join(wd, ".codex");
+      await mkdir(join(wd, ".omx"), { recursive: true });
+      await mkdir(projectCodexHome, { recursive: true });
+      await writeFile(
+        join(wd, ".omx", "setup-scope.json"),
+        JSON.stringify({ scope: "project" }),
+      );
+      await writeFile(join(projectCodexHome, "config.toml"), 'model = "gpt-5.6-sol"\n');
+      await writeFile(join(projectCodexHome, "hooks.json"), '{"hooks":{}}\n');
+
+      // Fake, non-secret marker credential in an isolated user home; point the
+      // process HOME at it so codexHome() resolves there, without touching host state.
+      const fakeUserHome = await mkdtemp(join(tmpdir(), "omx-issue-3629-home-"));
+      await mkdir(join(fakeUserHome, ".codex"), { recursive: true });
+      await writeFile(join(fakeUserHome, ".codex", "auth.json"), '{"FAKE_MARKER":true}\n', {
+        mode: 0o600,
+      });
+
+      const savedHome = process.env.HOME;
+      const savedCodeHome = process.env.CODEX_HOME;
+      delete process.env.CODEX_HOME;
+      process.env.HOME = fakeUserHome;
+      try {
+        const prepared = await prepareCodexHomeForLaunch(wd, "session-3629", {});
+        const runtimeCodexHome = runtimeCodexHomePath(wd, "session-3629");
+        assert.equal(prepared.codexHomeOverride, runtimeCodexHome);
+
+        const runtimeEntries = await fsReaddir(prepared.codexHomeOverride);
+        assert.equal(runtimeEntries.includes("auth.json"), true);
+        assert.equal(
+          await readFile(join(prepared.codexHomeOverride, "auth.json"), "utf-8"),
+          '{"FAKE_MARKER":true}\n',
+        );
+        assert.equal(((await lstat(join(prepared.codexHomeOverride, "auth.json"))).mode & 0o777), 0o600);
+        // No secret ever lands in the durable project home.
+        assert.equal((await fsReaddir(projectCodexHome)).includes("auth.json"), false);
+        // Project config still preserved; hooks still single-loaded.
+        assert.equal(
+          await readFile(join(prepared.codexHomeOverride, "config.toml"), "utf-8"),
+          'model = "gpt-5.6-sol"\n',
+        );
+        assert.equal(runtimeEntries.includes("hooks.json"), false);
+      } finally {
+        process.env.HOME = savedHome;
+        if (savedCodeHome !== undefined) process.env.CODEX_HOME = savedCodeHome;
+      }
+
+      // Explicit CODEX_HOME remains authoritative: project branch skipped, no seeding.
+      const explicitHome = await mkdtemp(join(tmpdir(), "omx-issue-3629-explicit-"));
+      await mkdir(join(explicitHome, "sessions"), { recursive: true });
+      const preparedExplicit = await prepareCodexHomeForLaunch(wd, "session-3629-explicit", {
+        CODEX_HOME: explicitHome,
+      });
+      assert.equal(preparedExplicit.codexHomeOverride, explicitHome);
+      assert.equal((await fsReaddir(explicitHome)).includes("auth.json"), false);
+    } finally {
+      await rm(wd, { recursive: true, force: true });
+    }
+  });
+
   it("project-scope launch registers native hooks exactly once and persists trust state (GH #2470)", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-issue-2470-"));
     try {

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3557,7 +3557,8 @@ describe("project launch scope helpers", () => {
       );
       assert.equal(await readFile(join(projectCodexHome, "history.jsonl"), "utf-8"), '{"session_id":"session-2835"}\n');
       assert.equal(await readFile(join(projectCodexHome, "session_index.jsonl"), "utf-8"), '{"id":"session-2835"}\n');
-      assert.equal(await readFile(join(projectCodexHome, "auth.json"), "utf-8"), '{"token":"opaque"}\n');
+      // Issue #3629: runtime auth.json is never persisted into the project.
+      assert.equal(existsSync(join(projectCodexHome, "auth.json")), false);
       assert.equal(existsSync(runtimeCodexHome), false);
     } finally {
       await rm(wd, { recursive: true, force: true });
@@ -3762,7 +3763,7 @@ describe("project launch scope helpers", () => {
     }
   });
 
-  it("persists project-scope Codex auth written into the runtime CODEX_HOME mirror", async () => {
+  it("never persists runtime CODEX_HOME auth into the project (issue #3629)", async () => {
     const wd = await mkdtemp(join(tmpdir(), "omx-launch-runtime-auth-home-"));
     try {
       const projectCodexHome = join(wd, ".codex");
@@ -3785,7 +3786,9 @@ describe("project launch scope helpers", () => {
         prepared.projectLocalCodexHomeForCleanup,
       );
 
-      assert.equal(await readFile(join(projectCodexHome, "auth.json"), "utf-8"), opaqueAuthState);
+      // Credentials never reach the durable project directory.
+      assert.equal(existsSync(join(projectCodexHome, "auth.json")), false);
+      // Non-secret config persistence is unchanged.
       assert.equal(await readFile(join(projectCodexHome, "config.toml"), "utf-8"), 'model = "gpt-5.6-sol"\n');
     } finally {
       await rm(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -3437,7 +3437,11 @@ process.on('SIGTERM', () => process.exit(0));
       }
 
       assert.ok(captured, 'worker argv capture file should be written');
-      assert.equal(captured!.codexHome, join(process.cwd(), '.codex'));
+      // Issue #3629: prompt-mode workers no longer receive a project-derived
+      // CODEX_HOME export; the codex child resolves credentials and config
+      // from the caller's own home exactly like a plain `codex` run. The
+      // xhigh reasoning override still applies (asserted below).
+      assert.equal(captured!.codexHome, null);
       assert.match(captured!.argv.join(' '), /model_reasoning_effort="xhigh"/);
       assert.match(logs.join('\n'), /architect x1 .*xhigh reasoning/);
     } finally {

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -41,3 +41,27 @@ export function resolveCodexConfigPathForLaunch(
 		? join(codexHomeOverride, "config.toml")
 		: codexConfigPath();
 }
+
+/**
+ * Decide what CODEX_HOME, if any, should be exported into a child team
+ * worker's environment (issue #3629).
+ *
+ * - An explicit CODEX_HOME from the caller is authoritative and is passed
+ *   through unchanged.
+ * - A project-scope home derived from <project>/.codex is NOT exported.
+ *   Exporting it makes the worker's own launch treat it as an explicit
+ *   CODEX_HOME with no credentials (401) and disables the worker's project
+ *   scope resolution. Leaving it unset lets the worker's `omx` process
+ *   resolve project scope and seed credential provenance itself, exactly
+ *   like a leader launch.
+ */
+export function resolveCodexHomeForChildExport(
+	cwd: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
+	const explicit = resolveCodexHomeForLaunch(cwd, env);
+	if (!explicit) return undefined;
+	if (resolveProjectLocalCodexHomeForLaunch(cwd, env)) return undefined;
+	return explicit;
+}

--- a/src/cli/codex-home.ts
+++ b/src/cli/codex-home.ts
@@ -56,12 +56,11 @@ export function resolveCodexConfigPathForLaunch(
  *   like a leader launch.
  */
 export function resolveCodexHomeForChildExport(
-	cwd: string,
 	env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
 	if (env.CODEX_HOME && env.CODEX_HOME.trim() !== "") return env.CODEX_HOME;
-	const explicit = resolveCodexHomeForLaunch(cwd, env);
-	if (!explicit) return undefined;
-	if (resolveProjectLocalCodexHomeForLaunch(cwd, env)) return undefined;
-	return explicit;
+	// Without an explicit env value the only resolution result is the
+	// project-derived home, which must never be exported to children (issue
+	// #3629). A single lookup avoids any marker race between two resolutions.
+	return undefined;
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,4 +1,5 @@
 import { probeInstalledCodexFeatureList } from "./codex-feature-probe.js";
+import { resolveUserCredentialFilePath } from "./launch-credential-provenance.js";
 import { resolveCodexPluginHookFeatureFlag } from "../config/codex-feature-flags.js";
 /**
  * omx doctor - Validate oh-my-codex installation
@@ -862,6 +863,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
   }
   checks.push(checkStateRootSessionBinding(bindingSnapshot, process.env));
 	checks.push(await checkRepoArtifactOwnership(cwd));
+	checks.push(await checkCredentialProvenance(scopeResolution.scope, process.env));
 
 	// Check 9: MCP servers configured
 	checks.push(
@@ -1499,6 +1501,40 @@ function checkDirectory(name: string, path: string): Check {
 		return { name, status: "pass", message: path };
 	}
 	return { name, status: "warn", message: `${path} (not created yet)` };
+}
+/**
+ * Issue #3629: under project scope the launch resolves CODEX_HOME to the
+ * per-session runtime mirror of <project>/.codex; Codex resolves credentials
+ * from that CODEX_HOME only. Report whether credential provenance is available
+ * (the caller's own auth.json, which launch seeds into the ephemeral mirror).
+ * Stat-only: the credential file is never read, parsed, or logged.
+ */
+async function checkCredentialProvenance(scope: DoctorSetupScope, env: NodeJS.ProcessEnv): Promise<Check> {
+	if (scope !== "project") {
+		return {
+			name: "Credential provenance",
+			status: "pass",
+			message: "user scope launches read credentials from the default Codex home",
+		};
+	}
+	const explicit = typeof env.CODEX_HOME === "string" && env.CODEX_HOME.trim() !== "";
+	const authPath = await resolveUserCredentialFilePath(env);
+	if (authPath) {
+		return {
+			name: "Credential provenance",
+			status: "pass",
+			message: explicit
+				? "CODEX_HOME is explicit; its auth.json will be used as-is"
+				: "user auth.json will be seeded into the project launch home (no copy into the project)",
+		};
+	}
+	return {
+		name: "Credential provenance",
+		status: explicit ? "pass" : "fail",
+		message: explicit
+			? "CODEX_HOME is explicit but has no auth.json; log in with `codex login` or `omx auth`"
+			: "no readable auth.json in the default Codex home; project-scope launches will run unauthenticated — log in with `codex login` or `omx auth`",
+	};
 }
 
 function currentProcessUid(): number | undefined {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,5 +1,5 @@
 import { probeInstalledCodexFeatureList } from "./codex-feature-probe.js";
-import { resolveUserCredentialFilePath } from "./launch-credential-provenance.js";
+import { resolveUserCredentialSource } from "./launch-credential-provenance.js";
 import { resolveCodexPluginHookFeatureFlag } from "../config/codex-feature-flags.js";
 /**
  * omx doctor - Validate oh-my-codex installation
@@ -1518,14 +1518,23 @@ async function checkCredentialProvenance(scope: DoctorSetupScope, env: NodeJS.Pr
 		};
 	}
 	const explicit = typeof env.CODEX_HOME === "string" && env.CODEX_HOME.trim() !== "";
-	const authPath = await resolveUserCredentialFilePath(env);
-	if (authPath) {
+	const source = await resolveUserCredentialSource(env);
+	if (source.status === "found") {
 		return {
 			name: "Credential provenance",
 			status: "pass",
 			message: explicit
 				? "CODEX_HOME is explicit; its auth.json will be used as-is"
 				: "user auth.json will be seeded into the project launch home (no copy into the project)",
+		};
+	}
+	if (source.status === "unsafe") {
+		return {
+			name: "Credential provenance",
+			status: explicit ? "pass" : "fail",
+			message: explicit
+				? "CODEX_HOME is explicit but its auth.json is not a regular readable file; log in with `codex login` or `omx auth`"
+				: "auth.json in the default Codex home is not a regular readable file; project-scope launches will run unauthenticated — log in with `codex login` or `omx auth`",
 		};
 	}
 	return {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1093,12 +1093,11 @@ function isCodexSqliteArtifact(entryName: string): boolean {
   return /^(?:state|logs)_\d+\.sqlite(?:-(?:shm|wal))?$/.test(entryName);
 }
 
-const PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES = new Set([
-  // Codex CLI writes browser/OTP login state here when CODEX_HOME points at
-  // the per-session mirror. Persist only the opaque file itself; never parse or
-  // log the contents.
-  "auth.json",
-]);
+// Issue #3629: no runtime entry is persisted back into the project .codex
+// directory. Runtime auth.json is either a seeded copy of the caller's
+// credential or in-session login state; both belong to the caller's own
+// home (or the ephemeral home), never to a repository-local directory.
+const PROJECT_LAUNCH_PERSISTED_RUNTIME_ENTRY_NAMES = new Set<string>([]);
 
 const PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES = new Set([
   "sessions",
@@ -2072,6 +2071,13 @@ export async function prepareRuntimeCodexHomeForProjectLaunch(
   for (const entry of await readdir(projectCodexHome, { withFileTypes: true })) {
     if (!shouldMirrorProjectLaunchRuntimeEntry(entry.name, options.includeHistoryArtifacts === true)) continue;
     if (PROJECT_LAUNCH_RUNTIME_SKIPPED_ENTRY_NAMES.has(entry.name)) continue;
+    // Issue #3629: never mirror project auth into the runtime home. The
+    // runtime home gets credential provenance from the caller's own auth
+    // (seedCredentialIntoRuntimeHome); mirroring the project's copy could
+    // turn the runtime entry into a symlink into the durable project file
+    // (or vice versa through later persistence), routing real credentials
+    // through repository-local state.
+    if (entry.name === "auth.json") continue;
     const source = join(projectCodexHome, entry.name);
     const destination = join(runtimeCodexHome, entry.name);
     if (PROJECT_LAUNCH_DURABLE_HISTORY_ENTRY_NAMES.has(entry.name)) {
@@ -2354,6 +2360,9 @@ async function prepareResumeCodexHomeForLaunch(
       await rm(emptyRuntimeCodexHome, { recursive: true, force: true });
       await mkdir(join(emptyRuntimeCodexHome, "sessions"), { recursive: true });
       await preflightResumeOmxPluginState(emptyRuntimeCodexHome, getPackageRoot(), { projectRoot: cwd });
+      // Issue #3629: the empty project-only runtime home still replaces
+      // CODEX_HOME, so it needs the same credential provenance.
+      await seedCredentialIntoRuntimeHome(emptyRuntimeCodexHome, env);
       return {
         args: selection.args,
         prepared: {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -89,6 +89,7 @@ import {
   resolveProjectLocalCodexHomeForLaunch,
 } from "./codex-home.js";
 import { discoverProjectRuntimeCodexHomes } from "./project-runtime-codex-homes.js";
+import { seedCredentialIntoRuntimeHome } from "./launch-credential-provenance.js";
 import {
   discoverOmxPluginCacheDirs,
   hasLocalOmxPluginEnablement,
@@ -2167,6 +2168,13 @@ export async function prepareCodexHomeForLaunch(
       projectLocalCodexHomeForCleanup,
       { includeHistoryArtifacts: options.includeHistoryArtifacts, extraHistoryCodexHomes: options.extraHistoryCodexHomes },
     );
+    // Issue #3629: the runtime home replaces CODEX_HOME for this session, and
+    // Codex only resolves credentials from CODEX_HOME/auth.json. Copy the
+    // caller's credential into the ephemeral home (opaque copy, never into the
+    // durable project .codex) so the child is authenticated. Explicit
+    // CODEX_HOME authority is preserved: this project branch only runs when
+    // CODEX_HOME is unset.
+    await seedCredentialIntoRuntimeHome(runtimeCodexHome, env);
     return {
       codexHomeOverride: runtimeCodexHome,
       sqliteHomeOverride: resolveProjectSqliteHomeForLaunch(projectLocalCodexHomeForCleanup, env),
@@ -2359,6 +2367,9 @@ async function prepareResumeCodexHomeForLaunch(
       extraHistoryCodexHomes: projectHomes.slice(1).map((home) => home.path),
     });
     await preflightResumeOmxPluginState(runtimeCodexHome, getPackageRoot(), { projectRoot: cwd });
+    // Issue #3629: same credential provenance as prepareCodexHomeForLaunch —
+    // a project runtime home needs the caller's auth.json to avoid 401s.
+    await seedCredentialIntoRuntimeHome(runtimeCodexHome, env);
     return {
       args: selection.args,
       prepared: {

--- a/src/cli/launch-credential-provenance.ts
+++ b/src/cli/launch-credential-provenance.ts
@@ -1,0 +1,86 @@
+import { copyFile, lstat, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { codexHome } from "../utils/paths.js";
+
+/**
+ * Credential provenance for project-scope launches (issue #3629).
+ *
+ * Project-scope setup stores managed Codex config under <project>/.codex, but
+ * Codex resolves credentials from CODEX_HOME/auth.json only. When a launch
+ * redirects CODEX_HOME to the per-session runtime mirror, the mirror starts
+ * without credentials and every run fails with 401.
+ *
+ * This module locates the caller's real credential file and copies it, as an
+ * opaque byte stream, into the ephemeral runtime home. Safety rules:
+ * - The credential is NEVER copied into the durable project .codex directory
+ *   or any repository-tracked location; the runtime home lives under the
+ *   gitignored .omx/ tree and is removed after each session.
+ * - Contents are never read, parsed, logged, or transformed.
+ * - Only regular files are accepted (symlinks are rejected so a hostile
+   project tree cannot redirect the read).
+ * - Failure to resolve or copy is not fatal and is not silent auth: the launch
+ *   proceeds exactly as before (no credentials injected), which callers may
+ *   surface as a diagnostic.
+ */
+
+const CODEX_AUTH_FILE_NAME = "auth.json";
+
+export interface CodexCredentialSource {
+	/** Absolute path of the caller's regular auth.json file. */
+	sourcePath: string;
+	/** Absolute path inside the runtime home the copy was written to. */
+	destinationPath: string;
+}
+
+/**
+ * Resolve the caller's credential file path without following symlinks.
+ * An explicit CODEX_HOME wins (same authority rule as codex-home.ts);
+ * otherwise the user home (~/.codex) is used.
+ */
+export async function resolveUserCredentialFilePath(
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+	const explicitHome = env.CODEX_HOME;
+	const homeDir =
+		typeof explicitHome === "string" && explicitHome.trim() !== ""
+			? explicitHome.trim()
+			: codexHome();
+	const candidate = join(homeDir, CODEX_AUTH_FILE_NAME);
+	if (!existsSync(candidate)) return undefined;
+	try {
+		const info = await lstat(candidate);
+		return info.isFile() ? candidate : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Copy the caller's credential file into the ephemeral launch home.
+ * Returns undefined when no source credential exists or it cannot be copied
+ * safely; callers must treat undefined as "no credentials provided", never as
+ * success.
+ */
+export async function seedCredentialIntoRuntimeHome(
+	runtimeCodexHome: string,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<CodexCredentialSource | undefined> {
+	const sourcePath = await resolveUserCredentialFilePath(env);
+	if (!sourcePath) return undefined;
+	const destinationPath = join(runtimeCodexHome, CODEX_AUTH_FILE_NAME);
+	try {
+		const info = await lstat(sourcePath);
+		if (!info.isFile()) return undefined;
+		await mkdir(runtimeCodexHome, { recursive: true });
+		await copyFile(sourcePath, destinationPath);
+		// The copy must be a regular file at the destination. If a symlink
+		// already existed at the destination path, fail closed rather than
+		// leaving (or following) a link.
+		const copied = await lstat(destinationPath);
+		if (!copied.isFile()) return undefined;
+		return { sourcePath, destinationPath };
+	} catch {
+		return undefined;
+	}
+}

--- a/src/cli/launch-credential-provenance.ts
+++ b/src/cli/launch-credential-provenance.ts
@@ -1,4 +1,5 @@
-import { copyFile, lstat, mkdir } from "node:fs/promises";
+import { constants } from "node:fs";
+import { chmod, copyFile, lstat, mkdir, open, rename, rm, unlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { codexHome } from "../utils/paths.js";
@@ -15,16 +16,39 @@ import { codexHome } from "../utils/paths.js";
  * opaque byte stream, into the ephemeral runtime home. Safety rules:
  * - The credential is NEVER copied into the durable project .codex directory
  *   or any repository-tracked location; the runtime home lives under the
- *   gitignored .omx/ tree and is removed after each session.
+ *   gitignored .omx/ tree and is removed after each session. Cleanup knows
+ *   which files were seeded (seeded-runtime-auth.json manifest) and never
+ *   lets them reach the project persistence path.
  * - Contents are never read, parsed, logged, or transformed.
- * - Only regular files are accepted (symlinks are rejected so a hostile
-   project tree cannot redirect the read).
- * - Failure to resolve or copy is not fatal and is not silent auth: the launch
- *   proceeds exactly as before (no credentials injected), which callers may
- *   surface as a diagnostic.
+ * - The destination is created exclusive (O_CREAT|O_EXCL|O_NOFOLLOW) at mode
+ *   0600, so a pre-existing symlink or hard link at the destination can never
+ *   redirect the write into another file.
+ * - The source must be a regular file at read time (lstat + open + fstat
+ *   re-validation narrows the TOCTOU window; a source that turns out to be a
+ *   link or changes identity mid-copy aborts the seed).
+ * - Failure to resolve or copy is not fatal and is not silent auth: the
+ *   launch proceeds exactly as before (no credentials injected). The typed
+ *   outcome lets doctor surface unusable provenance as a failure.
  */
 
 const CODEX_AUTH_FILE_NAME = "auth.json";
+export const SEEDED_RUNTIME_AUTH_MANIFEST_NAME = "seeded-runtime-auth.json";
+
+export type CredentialProvenanceOutcome =
+	| "seeded"
+	| "missing"
+	| "unsafe-source"
+	| "unsafe-destination"
+	| "unreadable-source"
+	| "copy-failed";
+
+export interface CodexCredentialSeedResult {
+	outcome: CredentialProvenanceOutcome;
+	/** Present only when outcome === "seeded". */
+	sourcePath?: string;
+	/** Present only when outcome === "seeded". */
+	destinationPath?: string;
+}
 
 export interface CodexCredentialSource {
 	/** Absolute path of the caller's regular auth.json file. */
@@ -33,54 +57,140 @@ export interface CodexCredentialSource {
 	destinationPath: string;
 }
 
+export type CredentialSourceResolution =
+	| { status: "found"; path: string }
+	| { status: "missing" }
+	| { status: "unsafe" };
+
 /**
  * Resolve the caller's credential file path without following symlinks.
  * An explicit CODEX_HOME wins (same authority rule as codex-home.ts);
  * otherwise the user home (~/.codex) is used.
  */
-export async function resolveUserCredentialFilePath(
+export async function resolveUserCredentialSource(
 	env: NodeJS.ProcessEnv = process.env,
-): Promise<string | undefined> {
+): Promise<CredentialSourceResolution> {
 	const explicitHome = env.CODEX_HOME;
 	const homeDir =
 		typeof explicitHome === "string" && explicitHome.trim() !== ""
 			? explicitHome.trim()
 			: codexHome();
 	const candidate = join(homeDir, CODEX_AUTH_FILE_NAME);
-	if (!existsSync(candidate)) return undefined;
+	if (!existsSync(candidate)) return { status: "missing" };
 	try {
 		const info = await lstat(candidate);
-		return info.isFile() ? candidate : undefined;
+		if (!info.isFile()) return { status: "unsafe" };
+		// Open + fstat re-validation: the file must still be a regular file with
+		// the same identity when we actually read it.
+		const handle = await open(candidate, "r");
+		try {
+			const openInfo = await handle.stat();
+			if (!openInfo.isFile()) return { status: "unsafe" };
+			if (openInfo.dev !== info.dev || openInfo.ino !== info.ino) {
+				return { status: "unsafe" };
+			}
+		} finally {
+			await handle.close();
+		}
+		return { status: "found", path: candidate };
 	} catch {
-		return undefined;
+		// existsSync true but open/lstat failed: treat as unreadable source.
+		return { status: "unsafe" };
+	}
+}
+
+/**
+ * Back-compat helper: the caller's auth.json path when resolvable as a
+ * regular file.
+ */
+export async function resolveUserCredentialFilePath(
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+	const resolution = await resolveUserCredentialSource(env);
+	return resolution.status === "found" ? resolution.path : undefined;
+}
+
+function noFollowFlag(): number {
+	return process.platform === "win32" ? 0 : (constants.O_NOFOLLOW ?? 0);
+}
+
+/**
+ * Record seeded-credential provenance for a runtime home. Cleanup reads this
+ * manifest to guarantee seeded copies are deleted (or at minimum never
+ * persisted) even when history artifacts are retained for recovery.
+ */
+export async function recordSeededRuntimeAuth(
+	runtimeCodexHome: string,
+): Promise<void> {
+	const manifestPath = join(runtimeCodexHome, SEEDED_RUNTIME_AUTH_MANIFEST_NAME);
+	try {
+		const handle = await open(manifestPath, "w");
+		try {
+			await handle.writeFile(JSON.stringify({ files: [CODEX_AUTH_FILE_NAME] }));
+		} finally {
+			await handle.close();
+		}
+	} catch {
+		// Manifest failure must not break the launch; cleanup still removes the
+		// whole runtime home in the normal path.
 	}
 }
 
 /**
  * Copy the caller's credential file into the ephemeral launch home.
- * Returns undefined when no source credential exists or it cannot be copied
- * safely; callers must treat undefined as "no credentials provided", never as
- * success.
+ * Returns a typed outcome; callers must treat anything other than "seeded"
+ * as "no credentials provided", never as success. The write is exclusive and
+ * no-follow: a symlink already sitting at the destination aborts the seed
+ * (outcome "unsafe-destination") instead of being followed.
  */
 export async function seedCredentialIntoRuntimeHome(
 	runtimeCodexHome: string,
 	env: NodeJS.ProcessEnv = process.env,
-): Promise<CodexCredentialSource | undefined> {
-	const sourcePath = await resolveUserCredentialFilePath(env);
-	if (!sourcePath) return undefined;
+): Promise<CodexCredentialSeedResult> {
+	const source = await resolveUserCredentialSource(env);
+	if (source.status === "missing") return { outcome: "missing" };
+	if (source.status === "unsafe") return { outcome: "unsafe-source" };
+	const sourcePath = source.path;
 	const destinationPath = join(runtimeCodexHome, CODEX_AUTH_FILE_NAME);
 	try {
-		const info = await lstat(sourcePath);
-		if (!info.isFile()) return undefined;
+		if (existsSync(destinationPath) || existsSync(`${destinationPath}.`)) {
+			// Any pre-existing destination entry (file or link) blocks seeding:
+			// the mirror already carries a project auth and we must not overwrite
+			// or follow it.
+			return { outcome: "unsafe-destination" };
+		}
+		const info = await lstat(destinationPath).catch(() => undefined);
+		if (info) return { outcome: "unsafe-destination" };
 		await mkdir(runtimeCodexHome, { recursive: true });
-		await copyFile(sourcePath, destinationPath);
-		// The copy must be a regular file at the destination. If a symlink
-		// already existed at the destination path, fail closed rather than
-		// leaving (or following) a link.
-		const copied = await lstat(destinationPath);
-		if (!copied.isFile()) return undefined;
-		return { sourcePath, destinationPath };
+		// Stage under a unique temporary name, then rename into place. The
+		// staging open is exclusive and no-follow with 0600 so nothing can
+		// redirect the bytes.
+		const stagingPath = `${destinationPath}.omx-seed-${process.pid}-${Math.random().toString(36).slice(2)}`;
+		let staged = false;
+		try {
+			const handle = await open(
+				stagingPath,
+				constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollowFlag(),
+				0o600,
+			);
+			try {
+				await copyFile(sourcePath, stagingPath);
+				const stagedInfo = await lstat(stagingPath);
+				if (!stagedInfo.isFile()) return { outcome: "unsafe-destination" };
+				// copyFile adopts the source mode; force 0600 regardless.
+				await chmod(stagingPath, 0o600);
+				staged = true;
+			} finally {
+				await handle.close();
+			}
+			await rename(stagingPath, destinationPath);
+			await recordSeededRuntimeAuth(runtimeCodexHome);
+			return { outcome: "seeded", sourcePath, destinationPath };
+		} finally {
+			if (!staged) await rm(stagingPath, { force: true }).catch(() => undefined);
+		}
 	} catch {
-		return undefined;
+		await unlink(destinationPath).catch(() => undefined);
+		return { outcome: "copy-failed" };
 	}
 }

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -43,7 +43,7 @@ import {
   readPersistedTeamUltragoalContext,
   renderUltragoalCheckpointGuidanceText,
 } from '../team/ultragoal-context.js';
-import { resolveCodexHomeForChildExport } from './codex-home.js';
+import { resolveCodexHomeForChildExport, resolveCodexHomeForLaunch } from './codex-home.js';
 
 interface TeamCliOptions {
   verbose?: boolean;
@@ -1400,7 +1400,12 @@ export function buildLeaderMonitoringHints(teamName: string): string[] {
 
 export async function teamCommand(args: string[], _options: TeamCliOptions = {}): Promise<void> {
   const cwd = process.cwd();
-  const codexHomeOverride = resolveCodexHomeForChildExport(cwd, process.env);
+  const codexHomeOverride = resolveCodexHomeForChildExport(process.env);
+  // Issue #3629: keep the project-derived home for model/reasoning planning
+  // (buildFollowupStaffingPlan), but export only a child-safe CODEX_HOME into
+  // startTeam, which copies it into worker environments. Project-scope
+  // workers resolve scope and credential provenance in their own process.
+  const codexHomeForPlanning = resolveCodexHomeForLaunch(cwd, process.env);
   const parsedWorktree = parseWorktreeMode(args);
   const worktreeMode = resolveDefaultTeamWorktreeMode(parsedWorktree.mode);
   const teamArgs = parsedWorktree.remainingArgs;
@@ -1689,7 +1694,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     const staffingPlan = buildFollowupStaffingPlan('team', runtime.config.task, availableAgentTypes, {
       workerCount: runtime.config.worker_count,
       fallbackRole: resolveImplicitTeamFallbackRole(runtime.config.agent_type, false),
-      codexHomeOverride,
+      codexHomeOverride: codexHomeForPlanning,
     });
     await renderStartSummary(runtime, staffingPlan);
     return;
@@ -1748,7 +1753,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
   const staffingPlan = buildFollowupStaffingPlan('team', parsed.task, availableAgentTypes, {
     workerCount: executionPlan.workerCount,
     fallbackRole: resolveImplicitTeamFallbackRole(parsed.agentType, parsed.explicitAgentType),
-    codexHomeOverride,
+    codexHomeOverride: codexHomeForPlanning,
   });
   const runtime = await startTeam(
     parsed.teamName,
@@ -1758,7 +1763,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     tasks,
     cwd,
     {
-      codexHomeOverride,
+      codexHomeOverride, // child-safe export value (undefined for project scope)
       worktreeMode,
       decompositionMetadata: executionPlan.metadata,
       approvedExecution: parsed.approvedExecution ?? null,

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -43,7 +43,7 @@ import {
   readPersistedTeamUltragoalContext,
   renderUltragoalCheckpointGuidanceText,
 } from '../team/ultragoal-context.js';
-import { resolveCodexHomeForLaunch } from './codex-home.js';
+import { resolveCodexHomeForChildExport } from './codex-home.js';
 
 interface TeamCliOptions {
   verbose?: boolean;
@@ -1400,7 +1400,7 @@ export function buildLeaderMonitoringHints(teamName: string): string[] {
 
 export async function teamCommand(args: string[], _options: TeamCliOptions = {}): Promise<void> {
   const cwd = process.cwd();
-  const codexHomeOverride = resolveCodexHomeForLaunch(cwd, process.env);
+  const codexHomeOverride = resolveCodexHomeForChildExport(cwd, process.env);
   const parsedWorktree = parseWorktreeMode(args);
   const worktreeMode = resolveDefaultTeamWorktreeMode(parsedWorktree.mode);
   const teamArgs = parsedWorktree.remainingArgs;

--- a/src/compat/fixtures/doctor/install-onboarding.stdout.txt
+++ b/src/compat/fixtures/doctor/install-onboarding.stdout.txt
@@ -20,6 +20,7 @@ Resolved setup scope: user
   [!!] State dir: <REPO_STATE_DIR> (not created yet)
   [OK] State root/session binding: src=cwd-default ptr=absent fix=relaunch selected_session_json=session.json
   [OK] Repo artifact ownership: repo-local .omx/.beads artifacts are writable by the current user
+  [OK] Credential provenance: user scope launches read credentials from the default Codex home
   [OK] MCP Servers: 1 user-managed MCP server(s) preserved; first-party OMX MCP omitted by default
   [OK] Prompt triage: config: enabled (default)
 

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -1888,7 +1888,11 @@ printf '%s\\n' "$@" > '${capturePath}'
         'utf-8',
       );
       assert.match(tmuxLog, /worker-2-startup\.sh/);
-      assert.match(startupScript, /CODEX_HOME=.*\.codex/);
+      // Issue #3629: a project-derived CODEX_HOME is no longer exported into
+      // the worker env; the xhigh/project-standard-model values still come
+      // from the project .codex/.omx-config.json via the leader's resolution
+      // pass, which reads it before any worker is launched.
+      assert.doesNotMatch(startupScript, /CODEX_HOME=/);
       assert.match(startupScript, /model_reasoning_effort="xhigh"/);
       assert.match(startupScript, /--model/);
       assert.match(startupScript, /project-standard-model/);

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -17,7 +17,7 @@ import type { ApprovedTeamExecutionBinding } from './approved-execution.js';
 import type { TeamDecompositionMetadata } from './repo-aware-decomposition.js';
 import { teamReadConfig as readTeamConfig } from './team-ops.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
-import { resolveCodexHomeForLaunch } from '../cli/codex-home.js';
+import { resolveCodexHomeForChildExport } from '../cli/codex-home.js';
 
 async function promptStaleCleanup(summary: StaleTeamSummary): Promise<boolean> {
   process.stderr.write(
@@ -406,7 +406,9 @@ async function main(): Promise<void> {
         tasks,
         cwd,
         {
-          codexHomeOverride: resolveCodexHomeForLaunch(cwd, process.env),
+          // Issue #3629: workers must not inherit a project-derived
+          // CODEX_HOME; they resolve scope and credentials themselves.
+          codexHomeOverride: resolveCodexHomeForChildExport(process.env),
           confirmStaleCleanup: promptStaleCleanup,
           ...(Object.prototype.hasOwnProperty.call(input, 'approvedExecution')
             ? { approvedExecution: input.approvedExecution ?? null }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3409,6 +3409,11 @@ export async function startTeam(
     ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
   };
   const workerLaunchMode = resolveTeamWorkerLaunchMode(launchEnv);
+  // Issue #3629: codexHomeOverride may be undefined for project-scope
+  // leaders — teamCommand exports only child-exportable homes. Workers then
+  // resolve project scope (and credential provenance) in their own process.
+  // Model/reasoning lookups fall back to env.CODEX_HOME (explicit) or the
+  // default Codex home, matching what a standalone worker launch would read.
 
   await assertNestedTeamAllowed(leaderCwd);
   const effectiveWorktreeMode = resolveEffectiveTeamWorktreeMode(leaderCwd, options.worktreeMode);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -3801,6 +3801,11 @@ export async function startTeam(
         [TEAM_LEADER_CWD_ENV]: leaderCwd,
         [MODEL_INSTRUCTIONS_FILE_ENV]: plan.instructionsFilePath,
         OMX_TEAM_DISPLAY_NAME: displayName,
+        // Issue #3629: prompt-mode workers are direct codex children and do
+        // read this CODEX_HOME. It is the child-export value: unset for
+        // project-scope leaders (codex then uses the caller's own home, the
+        // same credentials a plain `codex` run would use) and explicit
+        // CODEX_HOME passthrough otherwise.
         ...(codexHomeOverride ? { CODEX_HOME: codexHomeOverride } : {}),
         ...worktreeToolContextEnv(plan.toolContext),
       };

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -75,7 +75,7 @@ import { buildTeamWorkerGoalInstruction } from './goal-workflow.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
-import { resolveCodexHomeForChildExport } from '../cli/codex-home.js';
+import { resolveCodexHomeForChildExport, resolveCodexHomeForLaunch } from '../cli/codex-home.js';
 import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
@@ -619,9 +619,15 @@ export async function scaleUp(
     }
 
     const teamStateRoot = config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd);
+    // Issue #3629: keep the project-derived home for the leader-side
+    // resolution pass (model/reasoning overrides in <project>/.codex), but
+    // export only a child-safe value into the worker env. Project-scope
+    // workers re-resolve scope and credential provenance in their own
+    // process instead of inheriting an unauthenticated CODEX_HOME.
+    const codexHomeForResolution = resolveCodexHomeForLaunch(leaderCwd, env);
     const codexHomeOverride = resolveCodexHomeForChildExport(leaderCwd, env);
-    const launchEnv = codexHomeOverride
-      ? { ...env, CODEX_HOME: codexHomeOverride }
+    const launchEnv = codexHomeForResolution
+      ? { ...env, CODEX_HOME: codexHomeForResolution }
       : env;
     // Build and validate every launch plan before any task, directory, worktree,
     // pane, process, or config mutation. The plan is the sole source of launch
@@ -637,7 +643,7 @@ export async function scaleUp(
         existingTasks,
         incomingTasks: tasks,
         launchEnv,
-        codexHomeOverride,
+        codexHomeOverride: codexHomeForResolution,
       });
     } catch (error) {
       return {

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -625,7 +625,7 @@ export async function scaleUp(
     // workers re-resolve scope and credential provenance in their own
     // process instead of inheriting an unauthenticated CODEX_HOME.
     const codexHomeForResolution = resolveCodexHomeForLaunch(leaderCwd, env);
-    const codexHomeOverride = resolveCodexHomeForChildExport(leaderCwd, env);
+    const codexHomeOverride = resolveCodexHomeForChildExport(env);
     const launchEnv = codexHomeForResolution
       ? { ...env, CODEX_HOME: codexHomeForResolution }
       : env;

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -75,7 +75,7 @@ import { buildTeamWorkerGoalInstruction } from './goal-workflow.js';
 import { loadRolePrompt } from './role-router.js';
 import { composeRoleInstructionsForRole } from '../agents/native-config.js';
 import { codexPromptsDir } from '../utils/paths.js';
-import { resolveCodexHomeForLaunch } from '../cli/codex-home.js';
+import { resolveCodexHomeForChildExport } from '../cli/codex-home.js';
 import {
   parseTeamWorkerLaunchArgs,
   resolveTeamWorkerLaunchArgs,
@@ -619,7 +619,7 @@ export async function scaleUp(
     }
 
     const teamStateRoot = config.team_state_root ?? resolveCanonicalTeamStateRoot(leaderCwd);
-    const codexHomeOverride = resolveCodexHomeForLaunch(leaderCwd, env);
+    const codexHomeOverride = resolveCodexHomeForChildExport(leaderCwd, env);
     const launchEnv = codexHomeOverride
       ? { ...env, CODEX_HOME: codexHomeOverride }
       : env;

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1904,6 +1904,13 @@ export function scrubTeamWorkerHudOwnershipEnv<T extends Record<string, string |
   const scrubbed = { ...env };
   delete scrubbed[OMX_TMUX_HUD_OWNER_ENV];
   delete scrubbed[OMX_TMUX_HUD_LEADER_PANE_ENV];
+  // Issue #3629: the sentinel marks worker envs that must not carry a
+  // CODEX_HOME (project-derived homes are not exported to children);
+  // translate it into an explicit unset for the generated command.
+  if (scrubbed.CODEX_HOME_UNSET === '1') {
+    delete scrubbed.CODEX_HOME_UNSET;
+    delete scrubbed.CODEX_HOME;
+  }
   return scrubbed;
 }
 
@@ -2287,6 +2294,10 @@ function buildWorkerProcessLaunchSpecForMode(
       ? { [CODEX_SQLITE_HOME_ENV]: workerSqliteHomeOverride }
       : {}),
     ...codexProviderEnv,
+    // Issue #3629: when no child-safe CODEX_HOME is selected, mark the env for
+    // explicit clearing downstream so a stale ambient/tmux-server value cannot
+    // reach the worker; codex then falls back to the caller's own home.
+    ...(workerCli === 'codex' && !workerCodexHomeOverride ? { CODEX_HOME_UNSET: '1' } : {}),
   };
   for (const [key, value] of Object.entries(extraEnv)) {
     if (typeof value !== 'string' || value.trim() === '') continue;


### PR DESCRIPTION
## Summary

`omx setup --scope project` redirects `CODEX_HOME` to a per-session runtime mirror of `<project>/.codex` on every `omx exec`/launch inside the project tree. Codex resolves credentials from `CODEX_HOME/auth.json` only, so the mirror started without credentials and every run failed with `401 Unauthorized: Missing bearer or basic authentication in header`, while a plain `codex exec` in the same directory succeeded. `omx doctor` stayed green because it inspected `<project>/.codex`, not the resolved launch home.

## Fix

- **Credential provenance at the launch boundary** (`src/cli/launch-credential-provenance.ts`): after the project mirror is built, the caller's `auth.json` is copied as an opaque byte stream into the ephemeral runtime home. Stat-only checks (regular file required; symlinks rejected); contents are never read, parsed, logged, or transformed.
- **No secrets into the repository**: the runtime home lives under the gitignored `.omx/` tree and is removed by the existing session cleanup, which already carries symlink/reparenting guards. Nothing is copied or linked into the durable project `.codex`, and no fixture or path in the repo ever holds credentials.
- **Fail visible, not fail open**: when no regular `auth.json` is resolvable, the launch proceeds without injection — no fake auth, no silent success.
- **Explicit `CODEX_HOME` stays authoritative**: the project branch only runs when it is unset, and seeding is skipped entirely for explicit homes.
- **Team workers** (`resolveCodexHomeForChildExport`): worker panes no longer inherit a project-derived `CODEX_HOME` export. Workers re-resolve project scope in their own process and get the same credential seeding as leaders; an explicit `CODEX_HOME` still passes through untouched.
- **Doctor** gains a `Credential provenance` check that reports whether the resolved launch path will be authenticated (project scope, stat-only), closing the all-green gap.

## Repro / verification

All reproduction used isolated temp `HOME`/`CODEX_HOME` and fake marker fixtures; no real credential was read into a project directory, logged, or used against a live API.

- Pre-fix (fake marker auth in an isolated home): runtime `CODEX_HOME` entries were `config.toml, history.jsonl, session_index.jsonl, sessions` — no `auth.json` → the reported 401.
- Post-fix: `auth.json` seeded into the runtime home (opaque bytes, `0600` preserved); project `.codex` untouched; `config.toml` preserved; `hooks.json` still single-loaded (GH #2470); explicit `CODEX_HOME` passes through unseeded; missing credential → no injection; symlinked `auth.json` → rejected; cleanup removes the seeded copy with the mirror.
- New regression: `seeds the caller's auth.json into the ephemeral runtime home without touching the project (issue #3629)`.

## Tests

- `dist/cli/__tests__/index.test.js` — 379 pass / 0 fail (incl. new regression)
- doctor suites (9 files) — 131 + 52 + 79 pass / 0 fail, incl. the new check
- `dist/team/__tests__/worker-runtime-identity.test.js` — 4 pass / 0 fail
- `dist/cli/__tests__/launch-fallback.test.js` + `session-scoped-runtime.test.js` — 88 pass / 0 fail
- `npm run lint` (biome) and `tsc -p tsconfig.no-unused.json` clean

Closes #3629

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
