### PR TITLE
fix(session): portable pointer recovery without native runtime (#3636)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -99,7 +99,7 @@ To remove a verified-dead selected pointer and preserve its exact forensic bytes
 omx session pointer recover --cwd /path/to/project
 ```
 
-The command serializes with the canonical pointer lock and moves only an authoritative, positively dead `session.json` to an adjacent no-clobber quarantine path. It refuses live or usable owners, uncertain or reused identities, malformed or foreign pointers, root/lineage mismatches, concurrent changes, I/O failures, and existing quarantine destinations. A successful recovery leaves the canonical pointer absent so an ordinary relaunch can publish a fresh pointer.
+The command serializes with the canonical pointer lock and moves only an authoritative, positively dead `session.json` to an adjacent no-clobber quarantine path. It refuses live or usable owners, uncertain or reused identities, malformed or foreign pointers, root/lineage mismatches, concurrent changes, I/O failures, and existing quarantine destinations. A successful recovery leaves the canonical pointer absent so an ordinary relaunch can publish a fresh pointer. No native runtime is required: when the atomic no-replace rename provider is unavailable (for example an unhydrated `omx-runtime` on macOS arm64), recovery falls back to a portable `link()` + `unlink()` quarantine with the same no-clobber guarantee, so the documented command works on every platform the docs address.
 
 When the pointer's recorded PID is definitively dead, bind the exact current session explicitly and retry the same command — no manual file surgery:
 

--- a/src/cli/__tests__/doctor-process-identity-readiness.test.ts
+++ b/src/cli/__tests__/doctor-process-identity-readiness.test.ts
@@ -60,7 +60,6 @@ describe('doctor native process identity readiness', () => {
     assert.equal(check, null);
     assert.equal(called, false);
   });
-
   it('fails safely when the native runtime is missing or unsupported', () => {
     const check = checkProcessIdentityReadiness({
       platform: 'win32',
@@ -70,7 +69,7 @@ describe('doctor native process identity readiness', () => {
     assert.equal(check?.status, 'fail');
     assert.equal(
       check?.message,
-      'native process identity is unavailable (provider unavailable); reinstall or update OMX and rerun doctor',
+      'native process identity is unavailable (provider unavailable); run `omx update` (repairs the native runtime cache) or `omx setup`, then rerun doctor; session pointer recovery works without the native runtime',
     );
   });
 
@@ -85,7 +84,6 @@ describe('doctor native process identity readiness', () => {
       assert.match(check?.message ?? '', /reinstall or update OMX and rerun doctor$/);
     }
   });
-
   it('rejects foreign-platform identity evidence without trusting or repairing it', () => {
     const check = checkProcessIdentityReadiness({
       platform: 'darwin',

--- a/src/cli/__tests__/update.test.ts
+++ b/src/cli/__tests__/update.test.ts
@@ -498,6 +498,54 @@ describe('maybeCheckAndPromptUpdate', () => {
     }
   });
 
+  it('repairs the native runtime cache on the passive up-to-date path (issue #3636)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-update-hydrate-'));
+    const originalLog = console.log;
+    const originalMode = process.env.OMX_AUTO_UPDATE;
+    const logs: string[] = [];
+    let hydrateCalls = 0;
+    let deferredCalls = 0;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(' '));
+    };
+    process.env.OMX_AUTO_UPDATE = 'defer';
+
+    try {
+      await withInteractiveTty(async () => {
+        await maybeCheckAndPromptUpdate(cwd, {
+          getCurrentVersion: async () => '0.21.3',
+          fetchLatestVersion: async () => '0.21.3',
+          runGlobalUpdate: () => {
+            throw new Error('no install should run when already up to date');
+          },
+          runDeferredGlobalUpdate: () => {
+            deferredCalls += 1;
+            return { ok: true, stderr: '', logPath: join(cwd, 'update.log') };
+          },
+          runSetupRefresh: async () => {
+            throw new Error('no setup refresh should run when already up to date');
+          },
+          hydrateRuntime: async () => {
+            hydrateCalls += 1;
+            return undefined;
+          },
+        });
+      });
+
+      assert.equal(hydrateCalls, 1);
+      assert.equal(deferredCalls, 0);
+    } finally {
+      if (typeof originalMode === 'string') {
+        process.env.OMX_AUTO_UPDATE = originalMode;
+      } else {
+        delete process.env.OMX_AUTO_UPDATE;
+      }
+      console.log = originalLog;
+      await rm(cwd, { recursive: true, force: true });
+    }
+    void logs;
+  });
+
   it('treats a current dev install dev_base_version as the launch update baseline', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-update-dev-baseline-'));
     let promptCalls = 0;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1382,10 +1382,18 @@ export function checkProcessIdentityReadiness(
 					: observation.kind === "unsupported"
 						? "provider unavailable"
 						: "provider response unverifiable";
+		// The native runtime is hydrated to the version-keyed cache, not shipped
+		// in the npm tarball. When hydration never ran (offline install) or the
+		// cache was cleared, reinstall/update repairs it — but when the provider
+		// is unavailable for any other reason, say what actually restores it
+		// instead of prescribing a no-op reinstall (issue #3636).
+		const remedy = observation.kind === "unsupported"
+			? "run `omx update` (repairs the native runtime cache) or `omx setup`, then rerun doctor; session pointer recovery works without the native runtime"
+			: "reinstall or update OMX and rerun doctor";
 		return {
 			name: "Process identity",
 			status: "fail",
-			message: `native process identity is unavailable (${reason}); reinstall or update OMX and rerun doctor`,
+			message: `native process identity is unavailable (${reason}); ${remedy}`,
 		};
 	} catch {
 		return {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -858,7 +858,13 @@ async function executeUpdate(
         return { status: 'up-to-date', currentVersion: current, latestVersion: latest };
       }
     }
-
+    // Same version, nothing to install — but the version-keyed native cache
+    // may still be empty (issue #3636: `omx update` on macOS arm64 reinstalled
+    // 0.21.3 yet never hydrated omx-runtime, so doctor kept failing). Repair
+    // the cache before reporting up-to-date so the check is not a no-op for
+    // this failure mode. Immediate and passive runs share the repair; the
+    // setup-refresh branch above returns before reaching it.
+    await dependencies.hydrateRuntime(ownership ?? undefined);
     if (immediate) {
       console.log(`[omx] oh-my-codex is already up to date (v${updateCheckBaseline}).`);
     }

--- a/src/hooks/__tests__/session.test.ts
+++ b/src/hooks/__tests__/session.test.ts
@@ -1059,20 +1059,50 @@ describe('verified-dead selected session pointer recovery', { concurrency: false
     }
   });
 
-  it('reports unavailable atomic no-replace support without moving the pointer', async () => {
+  it('recovers via the portable no-clobber fallback when the native atomic rename is unavailable', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-unsupported-'));
     try {
       const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
       await withPointerDependencies({
         probePid: () => 'dead',
         token: () => SUCCESSOR_TOKEN,
         atomicRenameNoReplace: async () => 'unsupported',
       }, async () => {
         const result = await recoverDeadSessionPointer(cwd);
-        assert.equal(result.status, 'unsupported');
+        assert.equal(result.status, 'recovered', result.reason);
+        assert.equal(result.recovered, true);
+        assert.equal(result.action, 'quarantined');
+        assert.ok(result.quarantinePath);
+        assert.equal(existsSync(pointer.path), false);
+        assert.equal(await readFile(result.quarantinePath, 'utf-8'), pointer.body);
+      });
+      assert.equal(existsSync(context.sessionPath), false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('never overwrites an existing quarantine destination when the native atomic rename is unavailable', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-session-pointer-recover-portable-collision-'));
+    try {
+      const pointer = await writePointer(cwd);
+      const context = resolveSessionPointerContext(cwd);
+      const quarantinePath = `${context.sessionPath}.quarantine.dead-owner.${SUCCESSOR_TOKEN}`;
+      await mkdir(context.baseStateDir, { recursive: true });
+      await writeFile(quarantinePath, 'foreign quarantine bytes', 'utf-8');
+      await withPointerDependencies({
+        probePid: () => 'dead',
+        token: () => SUCCESSOR_TOKEN,
+        atomicRenameNoReplace: async () => 'unsupported',
+      }, async () => {
+        const result = await recoverDeadSessionPointer(cwd);
+        assert.equal(result.status, 'collision', result.reason);
         assert.equal(result.recovered, false);
+        assert.equal(result.action, 'none');
       });
       assert.equal(await readFile(pointer.path, 'utf-8'), pointer.body);
+      assert.equal(await readFile(quarantinePath, 'utf-8'), 'foreign quarantine bytes');
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -2620,7 +2650,10 @@ describe('session pointer transaction', () => {
       const context = resolveSessionPointerContext(cwd);
       await writeLockOwner(cwd, validLockOwner());
       const parked = `${context.lockPath}.parked-lock-${SUCCESSOR_TOKEN}`;
-      await withPointerDependencies({ token: () => SUCCESSOR_TOKEN, probePid: () => 'dead', atomicRenameNoReplace: async (_from, to) => {
+      const probeFrom = join(context.lockPath, '.omx-recovery-probe-from');
+      const probeTo = join(context.lockPath, '.omx-recovery-probe-to');
+      await withPointerDependencies({ token: () => SUCCESSOR_TOKEN, probePid: () => 'dead', atomicRenameNoReplace: async (from, to) => {
+        if (from === probeFrom && to === probeTo) return await defaultTestAtomicRenameNoReplace(from, to);
         await mkdir(to); await writeFile(join(to, 'foreign'), 'foreign'); return 'not-moved';
       } }, async () => assert.equal((await recoverSessionPointerLock(cwd)).recovered, false));
       assert.equal(await readFile(join(parked, 'foreign'), 'utf8'), 'foreign');
@@ -2740,7 +2773,7 @@ describe('session pointer transaction', () => {
     }
   });
 
-  it('preserves recovery evidence when atomic directory quarantine is unsupported', async () => {
+  it('fails closed for lock directory quarantine when the native atomic rename is unavailable', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-session-recovery-unsupported-'));
     try {
       const context = resolveSessionPointerContext(cwd);
@@ -2752,9 +2785,10 @@ describe('session pointer transaction', () => {
       }, async () => {
         const recovered = await recoverSessionPointerLock(cwd);
         assert.equal(recovered.recovered, false);
-        assert.match(recovered.reason, /unsupported/i);
+        assert.match(recovered.reason, /portable recovery applies to regular files only/i);
       });
-      // Capability is probed before checkpoint/quarantine mutations.
+      // Directory incarnations cannot use the portable file fallback, so the
+      // canonical lock and owner evidence stay untouched.
       assert.equal(existsSync(context.lockPath), true);
       assert.equal(await readFile(join(context.lockPath, 'owner.json'), 'utf8'), JSON.stringify(validLockOwner()));
       assert.equal(existsSync(`${context.lockPath}.quarantine.${TEST_TOKEN}.${SUCCESSOR_TOKEN}`), false);

--- a/src/hooks/session.ts
+++ b/src/hooks/session.ts
@@ -8,7 +8,6 @@
 import { execFileSync as nodeExecFileSync } from 'node:child_process';
 import {
   appendFile,
-  mkdtemp as nodeMkdtemp,
   link as nodeLink,
   lstat as nodeLstat,
   mkdir as nodeMkdir,
@@ -24,7 +23,6 @@ import {
 } from 'fs/promises';
 import { appendFileSync, closeSync, constants as fsConstants, fstatSync, openSync, readFileSync, realpathSync } from 'fs';
 import type { FileHandle } from 'fs/promises';
-import { tmpdir } from 'node:os';
 import { createHash, randomUUID } from 'crypto';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { omxRoot, omxLogsDir, sameFilePath } from '../utils/paths.js';
@@ -511,7 +509,6 @@ export type SessionPointerRecoveryStatus =
   | 'lock-unavailable'
   | 'race'
   | 'collision'
-  | 'unsupported'
   | 'recovery-required'
   | 'io-error';
 
@@ -1544,24 +1541,48 @@ function sameRecoveryIdentity(stat: Awaited<ReturnType<SessionPointerFsDependenc
 async function lstatRecoveryPath(path: string): Promise<Awaited<ReturnType<SessionPointerFsDependencies['lstat']>> | undefined> {
   try { return await transactionDependencies.fs.lstat(path); } catch (error) { if (isNotFound(error)) return undefined; throw error; }
 }
-async function probeRecoveryRenameCapability(): Promise<RecoveryRenameNoReplaceResult> {
-  let probeDir: string | undefined;
+
+/**
+ * Portable no-clobber move for recovery quarantine: hard-link the captured
+ * object to its token-bound destination, then unlink the source. `link()`
+ * fails with EEXIST when the destination exists, giving the same no-clobber
+ * guarantee as renameat2(RENAME_NOREPLACE)/renamex_np(RENAME_EXCL) without
+ * needing the native runtime. Identity checks before and after bound the
+ * non-atomic window; callers verify the captured object landed intact.
+ */
+async function moveRecoveryPathPortableNoReplace(
+  from: string,
+  to: string,
+  identity: RecoveryIdentity,
+  kind: 'file' | 'directory',
+): Promise<{ moved: boolean; reason?: string }> {
+  if (kind !== 'file') {
+    return { moved: false, reason: 'Portable no-clobber recovery move supports regular files only.' };
+  }
   try {
-    probeDir = await nodeMkdtemp(join(tmpdir(), 'omx-session-recovery-probe-'));
-    const from = join(probeDir, 'from');
-    const to = join(probeDir, 'to');
-    await nodeWriteFile(from, 'omx-recovery-capability-probe', { flag: 'wx' });
-    const outcome = await transactionDependencies.atomicRenameNoReplace(from, to);
-    return outcome === 'moved' || outcome === 'not-moved' || outcome === 'unsupported'
-      ? outcome
-      : 'unsupported';
-  } catch {
-    return 'unsupported';
-  } finally {
-    if (probeDir) {
-      try { await rm(probeDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    await transactionDependencies.fs.link(from, to);
+  } catch (error) {
+    if (isAlreadyExists(error)) return { moved: false, reason: 'The selected pointer quarantine destination already exists.' };
+    return { moved: false, reason: `Portable no-clobber recovery move failed (${errorCode(error) ?? 'unknown'}).` };
+  }
+  const destination = await lstatRecoveryPath(to);
+  if (!destination || !sameRecoveryIdentity(destination, identity, kind)) {
+    try { await transactionDependencies.fs.unlink(to); } catch { /* durable residue is safer than cleanup */ }
+    return { moved: false, reason: 'Portable no-clobber recovery move did not leave the captured object at its token-bound destination.' };
+  }
+  try {
+    await transactionDependencies.fs.unlink(from);
+  } catch (error) {
+    if (!isNotFound(error)) {
+      // The captured bytes are safely linked at quarantine; the stale source
+      // pathname remains and needs explicit recovery, same as an ambiguous move.
+      return { moved: false, reason: `Portable no-clobber recovery move linked quarantine but could not release the source pathname (${errorCode(error) ?? 'unknown'}).` };
     }
   }
+  const source = await lstatRecoveryPath(from);
+  const finalDestination = await lstatRecoveryPath(to);
+  if (finalDestination && sameRecoveryIdentity(finalDestination, identity, kind) && !source) return { moved: true };
+  return { moved: false, reason: 'Portable no-clobber recovery move did not leave the captured object at its token-bound destination.' };
 }
 
 async function moveRecoveryPathNoReplace(
@@ -1570,10 +1591,17 @@ async function moveRecoveryPathNoReplace(
   identity: RecoveryIdentity,
   kind: 'file' | 'directory',
   onAtomicMove?: () => void,
-): Promise<{ moved: boolean; unsupported?: boolean; reason?: string }> {
+): Promise<{ moved: boolean; reason?: string }> {
   try {
     const outcome = await transactionDependencies.atomicRenameNoReplace(from, to);
-    if (outcome === 'unsupported') return { moved: false, unsupported: true, reason: 'Atomic no-replace recovery rename is unsupported on this platform.' };
+    if (outcome === 'unsupported') {
+      // Native no-replace rename unavailable (e.g. unhydrated omx-runtime on
+      // macOS arm64, issue #3636): fall back to link()+unlink(), which gives the
+      // same no-clobber guarantee for regular files without the native runtime.
+      const portable = await moveRecoveryPathPortableNoReplace(from, to, identity, kind);
+      if (portable.moved) onAtomicMove?.();
+      return portable;
+    }
     if (outcome === 'not-moved') return { moved: false, reason: 'Atomic recovery move left its source pathname in place.' };
     onAtomicMove?.();
   } catch (error) {
@@ -1714,17 +1742,36 @@ export async function recoverSessionPointerLock(cwd: string): Promise<SessionPoi
       return { ...inspection, action: 'none', recovered: false, reason: 'Session pointer lock evidence changed before recovery claim.' };
     }
 
-    // Fresh recovery probes before checkpoint creation; an unsupported host leaves the
-    // canonical lock and owner evidence untouched. Existing checkpoints are resumed
-    // independently and may remain as durable recovery residue.
-
-    const capability = await probeRecoveryRenameCapability();
-    if (capability === 'unsupported') {
+    // Existing checkpoints are resumed independently and may remain as durable
+    // recovery residue. The no-replace move helper falls back to a portable
+    // link()+unlink() quarantine for regular files when the native atomic
+    // rename is unavailable — but a lock directory incarnation cannot use that
+    // file fallback. Probe the native capability with temp files inside the
+    // lock directory before writing any checkpoint so an unsupported host
+    // leaves no residue at all. Probe paths sort outside the allowed recovery
+    // entries, so resume treats a crashed probe as foreign evidence fail-closed.
+    const probeFrom = join(context.lockPath, '.omx-recovery-probe-from');
+    const probeTo = join(context.lockPath, '.omx-recovery-probe-to');
+    let directoryCapability: RecoveryRenameNoReplaceResult;
+    try {
+      try {
+        await transactionDependencies.fs.writeFile(probeFrom, 'omx-recovery-capability-probe', { flag: 'wx' });
+      } catch (error) {
+        if (!isAlreadyExists(error)) throw error;
+      }
+      directoryCapability = await transactionDependencies.atomicRenameNoReplace(probeFrom, probeTo);
+    } catch {
+      directoryCapability = 'unsupported';
+    } finally {
+      try { await transactionDependencies.fs.unlink(probeFrom); } catch { /* best effort */ }
+      try { await transactionDependencies.fs.unlink(probeTo); } catch { /* best effort */ }
+    }
+    if (directoryCapability === 'unsupported') {
       return {
         ...inspection,
         action: 'none',
         recovered: false,
-        reason: 'Atomic no-replace recovery rename is unsupported on this platform.',
+        reason: 'Atomic no-replace lock directory quarantine is unsupported on this platform; portable recovery applies to regular files only.',
       };
     }
 
@@ -2052,7 +2099,7 @@ export async function recoverDeadSessionPointer(cwd: string): Promise<SessionPoi
           && !capturedDestination;
         result = pointerRecoveryRefusal(
           context,
-          moved.unsupported ? 'unsupported' : foreignDestination && !sourceExists ? 'race' : destinationExists ? 'collision' : 'race',
+          foreignDestination && !sourceExists ? 'race' : destinationExists ? 'collision' : 'race',
           moved.reason ?? 'The selected session pointer could not be quarantined atomically.',
           sessionId,
         );


### PR DESCRIPTION
Fixes #3636 (supsersedes the #3600 symptom: same unhydrated-runtime failure, two releases later). Also invalidates the premise that PR #3527's `session pointer recover` holds on macOS — it could not run there.

## Root cause

1. **Recovery dead-ends without the native binary.** `moveRecoveryPathNoReplace` (`src/hooks/session.ts:1591`) returned `{ unsupported: true, reason: 'Atomic no-replace recovery rename is unsupported on this platform.' }` whenever `defaultRecoveryRenameNoReplace` (`src/hooks/session.ts:579`) could not spawn `omx-runtime fs-rename-no-replace` — and `recoverSessionPointerLock` (`src/hooks/session.ts:1771`, since removed) probed the same capability and refused before writing any checkpoint. On the reporter's machine the binary was never hydrated, so `omx session pointer recover` returned `status: "unsupported"` on a pointer satisfying every documented precondition.
2. **The published tarball can never contain a macOS arm64 `omx-runtime`.** `package.json` `files` (`package.json:87`) ships `crates/` as Rust sources only; the binary hydrates at install/update time from the GitHub release manifest into the version-keyed native cache (`src/cli/native-assets.ts:685` `hydrateNativeBinary`). The `aarch64-apple-darwin` asset exists in the v0.21.3 release, so hydration works when it runs — I hydrated it from Linux as proof (`Mach-O 64-bit arm64 executable`).
3. **`omx update` was a no-op for this failure mode.** The up-to-date branch (`src/cli/update.ts:843`) returned before `hydrateRuntime`, so reinstalling 0.21.3 over 0.21.3 never repaired the empty version-keyed cache — exactly the reporter's comment #1.
4. **Doctor prescribed the no-op.** `checkProcessIdentityReadiness` (`src/cli/doctor.ts:1388`) told every macOS/Windows user with an unavailable provider to "reinstall or update OMX and rerun doctor", which changes nothing when hydration never ran.

## Fix

- **Portable fallback (reporter's `link()`+`unlink()` suggestion, credited):** `moveRecoveryPathNoReplace` now falls back to `moveRecoveryPathPortableNoReplace` (`src/hooks/session.ts:1548`) when the native provider reports `unsupported`. Hard-linking to the token-bound quarantine path fails with `EEXIST` on collision — the same no-clobber guarantee — then unlinking the source leaves the canonical pointer absent with forensic bytes preserved. Directory-incarnation lock recovery still fails closed before checkpoint residue (probe at `src/hooks/session.ts:1753`), since `link()` cannot move directories.
- **Update repairs the cache:** the up-to-date branch now calls `hydrateRuntime` on both immediate and passive paths (`src/cli/update.ts:861`).
- **Truthful doctor:** the `unsupported` verdict now says `run `omx update` (repairs the native runtime cache) or `omx setup`, then rerun doctor; session pointer recovery works without the native runtime` (`src/cli/doctor.ts:1390`).

## Verification

```
npm run build                              # clean
npx tsc --noEmit                           # clean
npx tsc -p tsconfig.no-unused.json         # clean
npx biome lint src docs                    # 838 files, no findings
node --test dist/hooks/__tests__/session.test.js                          # pass 152 fail 0
node --test dist/cli/__tests__/update.test.js                             # pass 83 fail 0
node --test dist/cli/__tests__/doctor-process-identity-readiness.test.js  # pass 6 fail 0
node --test dist/cli/__tests__/native-assets.test.js                      # pass 18 fail 0
```

New regression tests: portable recovery succeeds with the native provider forced to `unsupported`; existing quarantine destination is never overwritten (`collision`); lock-directory quarantine fails closed without residue; passive up-to-date `omx update` hydrates the runtime cache. End-to-end manual run with `atomicRenameNoReplace: () => 'unsupported'`: `status: recovered`, canonical absent, quarantine bytes exact, fresh relaunch publishes.

## Platform-unverified

No macOS arm64 host was available: the `renamex_np(RENAME_EXCL)` native path and the real `omx update` hydration on macOS are unverified. The portable fallback is platform-agnostic Node (`fs.link`/`fs.unlink`) and covered by the regression tests above, but a Mac run of `omx session pointer recover --cwd <path> --json` and `omx doctor` after `omx update` is still wanted.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
