### PR TITLE
fix(team): make startup checks side-effect free and errors actionable

### DIFF
--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -3263,6 +3263,58 @@ exit 1
     }
   });
 
+  for (const command of ['status-json', 'status-text', 'shutdown'] as const) {
+    it(`reports the selected state path for ${command} without searching another root`, async () => {
+      const wd = await mkdtemp(join(tmpdir(), 'omx-team-selected-root-'));
+      const previousCwd = process.cwd();
+      const envKeys = ['OMX_ROOT', 'OMX_STATE_ROOT', 'OMX_TEAM_STATE_ROOT', 'OMX_SESSION_ID'] as const;
+      const previousEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+      const originalLog = console.log;
+      const logs: string[] = [];
+      const teamName = 'selected-root-team';
+      const intendedRoot = join(wd, '.omx', 'state');
+      const selectedRoot = join(wd, 'inherited-root', '.omx', 'state');
+      const selectedPath = join(selectedRoot, 'team', teamName);
+      try {
+        process.chdir(wd);
+        delete process.env.OMX_ROOT;
+        delete process.env.OMX_STATE_ROOT;
+        delete process.env.OMX_SESSION_ID;
+        process.env.OMX_TEAM_STATE_ROOT = intendedRoot;
+        await initTeamState(teamName, 'selected root diagnostics', 'executor', 1, wd);
+        const configPath = join(intendedRoot, 'team', teamName, 'config.json');
+        const originalConfig = await readFile(configPath, 'utf8');
+        delete process.env.OMX_TEAM_STATE_ROOT;
+        process.env.OMX_STATE_ROOT = join(wd, 'inherited-root');
+        console.log = (message?: unknown) => { logs.push(String(message ?? '')); };
+
+        await teamCommand(command === 'shutdown'
+          ? ['shutdown', teamName, '--force']
+          : ['status', teamName, ...(command === 'status-json' ? ['--json'] : [])]);
+
+        assert.equal(await readFile(configPath, 'utf8'), originalConfig);
+        if (command === 'status-json') {
+          const payload = JSON.parse(logs[0]) as Record<string, unknown>;
+          assert.equal(payload.status, 'missing');
+          assert.equal(payload.state_root, selectedRoot);
+          assert.equal(payload.state_path, selectedPath);
+        } else {
+          assert.ok(logs.some((line) => line.includes(selectedPath)), logs.join('\n'));
+          assert.ok(logs.some((line) => line.includes('No team state found')), logs.join('\n'));
+          assert.ok(!logs.some((line) => line.includes('Team shutdown complete')));
+        }
+      } finally {
+        console.log = originalLog;
+        process.chdir(previousCwd);
+        for (const key of envKeys) {
+          if (previousEnv[key] === undefined) delete process.env[key];
+          else process.env[key] = previousEnv[key];
+        }
+        await rm(wd, { recursive: true, force: true });
+      }
+    });
+  }
+
   it('records leader runtime activity when team status is read', async () => {
     const wd = await mkdtemp(join(tmpdir(), 'omx-team-status-activity-'));
     const previousCwd = process.cwd();

--- a/src/cli/__tests__/team.test.ts
+++ b/src/cli/__tests__/team.test.ts
@@ -3264,7 +3264,7 @@ exit 1
   });
 
   for (const command of ['status-json', 'status-text', 'shutdown'] as const) {
-    it(`reports the selected state path for ${command} without searching another root`, async () => {
+    it(`reports the selected state path for ${command} and ignores aliases from unselected roots`, async () => {
       const wd = await mkdtemp(join(tmpdir(), 'omx-team-selected-root-'));
       const previousCwd = process.cwd();
       const envKeys = ['OMX_ROOT', 'OMX_STATE_ROOT', 'OMX_TEAM_STATE_ROOT', 'OMX_SESSION_ID'] as const;
@@ -3286,6 +3286,15 @@ exit 1
         const originalConfig = await readFile(configPath, 'utf8');
         delete process.env.OMX_TEAM_STATE_ROOT;
         process.env.OMX_STATE_ROOT = join(wd, 'inherited-root');
+        // An alias team in the unselected cwd root must not rename or mask the
+        // team addressed through the selected canonical state root.
+        const decoyDir = join(wd, '.omx', 'state', 'team', 'alias-team');
+        await mkdir(decoyDir, { recursive: true });
+        await writeFile(join(decoyDir, 'manifest.v2.json'), JSON.stringify({
+          leader: {},
+          requested_name: 'selected-root-team',
+          display_name: 'selected-root-team',
+        }));
         console.log = (message?: unknown) => { logs.push(String(message ?? '')); };
 
         await teamCommand(command === 'shutdown'

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -30,6 +30,7 @@ import {
 } from '../team/api-interop.js';
 import { teamReadConfig as readTeamConfig, teamReadPhase as readTeamPhase } from '../team/team-ops.js';
 import { resolveTeamNameForCurrentContext } from '../team/team-identity.js';
+import { resolveCanonicalTeamStateRoot } from '../team/state-root.js';
 import { recordLeaderRuntimeActivity } from '../team/leader-activity.js';
 import { readTeamPaneStatus } from '../team/pane-status.js';
 import {
@@ -1486,16 +1487,20 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
     await recordLeaderRuntimeActivity(cwd, 'team_status', resolvedName);
     const snapshot = await monitorTeam(resolvedName, cwd);
     if (!snapshot) {
+      const stateRoot = resolveCanonicalTeamStateRoot(cwd);
+      const statePath = join(stateRoot, 'team', resolvedName);
       if (wantsJson) {
         console.log(JSON.stringify({
           ...buildJsonBase(),
           command: 'omx team status',
           team_name: name,
           status: 'missing',
+          state_root: stateRoot,
+          state_path: statePath,
         }));
         return;
       }
-      console.log(`No team state found for ${name}`);
+      console.log(`No team state found for ${name} (searched: ${statePath})`);
       return;
     }
     const tailLines = parseStatusTailLines(teamArgs.slice(2));
@@ -1724,7 +1729,12 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
         error: error instanceof Error ? error.message : String(error),
       });
     });
-    console.log(`Team shutdown complete: ${name}`);
+    if (configBeforeShutdown) {
+      console.log(`Team shutdown complete: ${name}`);
+    } else {
+      const statePath = join(resolveCanonicalTeamStateRoot(cwd), 'team', resolvedName);
+      console.log(`No team state found for ${name} (searched: ${statePath}); cleanup of selected scope completed.`);
+    }
     if (summary.commitHygieneArtifacts) {
       console.log(`commit_hygiene_context_json: ${summary.commitHygieneArtifacts.jsonPath}`);
       console.log(`commit_hygiene_context_md: ${summary.commitHygieneArtifacts.markdownPath}`);

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1729,7 +1729,7 @@ export async function teamCommand(args: string[], _options: TeamCliOptions = {})
         error: error instanceof Error ? error.message : String(error),
       });
     });
-    if (configBeforeShutdown) {
+    if (summary.configExisted) {
       console.log(`Team shutdown complete: ${name}`);
     } else {
       const statePath = join(resolveCanonicalTeamStateRoot(cwd), 'team', resolvedName);

--- a/src/team/__tests__/runtime.test.ts
+++ b/src/team/__tests__/runtime.test.ts
@@ -39,6 +39,7 @@ import {
   sendWorkerMessage,
   applyCreatedInteractiveSessionToConfig,
   reconcileStartupCleanupPanes,
+  rethrowStartupRollbackProofDebt,
   resolveWorkerLaunchArgsFromEnv,
   resolveTeamWorkerCliForResolvedLaunchArgs,
   shouldPrekillInteractiveShutdownProcessTrees,
@@ -13687,5 +13688,25 @@ exit 0
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('rethrowStartupRollbackProofDebt keeps the original startup failure as cause', () => {
+    const original = new Error('tmux_test_startup_failure');
+    assert.throws(
+      () => rethrowStartupRollbackProofDebt('startup_rollback', original, [
+        { paneId: '%2', reason: 'pane_proof_lost_during_process_teardown' },
+      ]),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          /^startup_rollback_pane_proof_unavailable:%2:pane_proof_lost_during_process_teardown \(during startup_rollback of: tmux_test_startup_failure\)$/,
+        );
+        assert.equal(error.cause, original);
+        return true;
+      },
+    );
+    // Without proof debt the helper must not throw at all.
+    assert.doesNotThrow(() => rethrowStartupRollbackProofDebt('startup_rollback', original, []));
   });
 });

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2923,6 +2923,28 @@ describe('team worker CLI helpers', () => {
     ));
   });
 
+  it('assertTeamWorkerCliBinaryAvailable treats empty PATH components as the current directory without executing', { skip: process.platform === 'win32' }, async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-cli-cwd-probe-'));
+    const marker = join(dir, 'executed');
+    const previousPath = process.env.PATH;
+    const previousCwd = process.cwd();
+    try {
+      await writeFile(join(dir, 'codex'), `#!/bin/sh\nprintf invoked > '${marker}'\n`);
+      await chmod(join(dir, 'codex'), 0o755);
+      process.chdir(dir);
+      for (const pathValue of ['', ':', `:${join(dir, 'no-such-segment')}`, `${join(dir, 'no-such-segment')}:`]) {
+        process.env.PATH = pathValue;
+        assertTeamWorkerCliBinaryAvailable('codex');
+        assert.equal(fs.existsSync(marker), false, 'discovery must not execute cwd-resolved wrappers');
+      }
+    } finally {
+      process.chdir(previousCwd);
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('CreateTeamSessionPartialError exposes the original startup failure and cleanup debt', () => {
     const original = new Error('tmux_test_startup_failure');
     const partial = {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -2899,6 +2899,45 @@ describe('team worker CLI helpers', () => {
     );
   });
 
+  it('assertTeamWorkerCliBinaryAvailable does not execute a CLI wrapper during discovery', { skip: process.platform === 'win32' }, async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'omx-cli-probe-'));
+    const marker = join(dir, 'executed');
+    const previousPath = process.env.PATH;
+    try {
+      await writeFile(join(dir, 'codex'), `#!/bin/sh\nprintf invoked > '${marker}'\n`);
+      await chmod(join(dir, 'codex'), 0o755);
+      process.env.PATH = dir;
+      assertTeamWorkerCliBinaryAvailable('codex');
+      assert.equal(fs.existsSync(marker), false, 'availability checks must not launch CLI wrappers');
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('assertTeamWorkerCliBinaryAvailable detects a missing CLI without an injected probe', () => {
+    withEmptyPath(() => assert.throws(
+      () => assertTeamWorkerCliBinaryAvailable('codex'),
+      /not available on PATH/,
+    ));
+  });
+
+  it('CreateTeamSessionPartialError exposes the original startup failure and cleanup debt', () => {
+    const original = new Error('tmux_test_startup_failure');
+    const partial = {
+      name: 'isolated:1', workerCount: 1, cwd: '/tmp', workerPaneIds: ['%2'],
+      leaderPaneId: '%1', hudPaneId: null, resizeHookName: null, resizeHookTarget: null,
+      teamPaneOwnerId: 'team:test',
+    };
+    const error = new CreateTeamSessionPartialError(partial, [], original, ['worker_cleanup_failed:%2']);
+    assert.match(error.message, /^create_team_session_cleanup_incomplete/);
+    assert.match(error.message, /tmux_test_startup_failure/);
+    assert.match(error.message, /worker_cleanup_failed:%2/);
+    assert.equal(error.cause, original);
+    assert.equal(error.partialSession, partial);
+  });
+
   it('resolveTeamWorkerCliPlan supports mixed per-worker CLI map', () => {
     const plan = resolveTeamWorkerCliPlan(
       4,

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -490,6 +490,8 @@ interface ShutdownOptions {
 
 export interface TeamShutdownSummary {
   commitHygieneArtifacts: TeamCommitHygieneArtifactPaths | null;
+  /** Whether shutdown acted on a canonical team config that existed when the operation began. */
+  configExisted: boolean;
 }
 let terminalEpochStartedHookForTest: ((teamName: string, cwd: string, phase: TeamPhaseState) => Promise<void>) | null = null;
 
@@ -915,6 +917,19 @@ function assertPaneTeardownProofsAvailable(
     .map((proof) => `${proof.paneId}:${proof.reason}${proof.detail ? `:${proof.detail}` : ''}`)
     .join(',');
   throw new Error(`${operation}_pane_proof_unavailable:${detail}`);
+}
+
+export function rethrowStartupRollbackProofDebt(
+  operation: string,
+  error: Error,
+  unavailableProofs: readonly UnavailablePaneProof[],
+): void {
+  try {
+    assertPaneTeardownProofsAvailable(operation, unavailableProofs);
+  } catch (proofError) {
+    const proofMessage = proofError instanceof Error ? proofError.message : String(proofError);
+    throw new Error(`${proofMessage} (during ${operation} of: ${error.message})`, { cause: error });
+  }
 }
 
 export async function cleanupTeamWorkerLaunchOrphanedMcpProcesses(
@@ -4235,7 +4250,9 @@ export async function startTeam(
       // proven-gone state. Preserve its config, hook registration, state and
       // worktrees exactly as saved above for a later retry; generic rollback
       // would otherwise destroy the retry evidence.
-      assertPaneTeardownProofsAvailable('startup_rollback', error.proofUnavailable);
+      // Surface the proof debt without hiding the actionable original startup
+      // failure carried by CreateTeamSessionPartialError.
+      rethrowStartupRollbackProofDebt('startup_rollback', error, error.proofUnavailable);
       throw error;
     }
     if (config && error instanceof Error && error.message.startsWith('startup_worker_pane_identity_changed:')) {
@@ -4876,7 +4893,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     await cleanupTeamState(sanitized, cwd);
     await syncTeamModeStateOnShutdown(sanitized, cwd);
     restoreTeamModelInstructionsFile(sanitized);
-    return { commitHygieneArtifacts: null };
+    return { commitHygieneArtifacts: null, configExisted: false };
   }
   // Reconcile accepted detached-session destruction before any other shutdown
   // effect. A receipt is the only durable authority across the kill/query crash
@@ -5653,7 +5670,7 @@ export async function shutdownTeam(teamName: string, cwd: string, options: Shutd
     throw new Error(cleanupErrors.join(' | '));
   }
 
-  return { commitHygieneArtifacts }
+  return { commitHygieneArtifacts, configExisted: true };
 }
 
 /**

--- a/src/team/team-identity.ts
+++ b/src/team/team-identity.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'crypto';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { TEAM_NAME_SAFE_PATTERN } from './contracts.js';
+import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
 export interface TeamIdentityScope {
   sessionId: string;
@@ -123,18 +124,12 @@ function candidateFromDir(root: string, teamName: string): TeamLookupCandidate |
 }
 
 function teamLookupRoots(cwd: string, env: NodeJS.ProcessEnv = process.env): string[] {
-  const roots: string[] = [];
-  const addStateRoot = (stateRoot: string): void => {
-    const trimmed = stateRoot.trim();
-    if (!trimmed) return;
-    const root = join(resolve(cwd, trimmed), 'team');
-    if (!roots.includes(root)) roots.push(root);
-  };
-
-  const explicit = typeof env.OMX_TEAM_STATE_ROOT === 'string' ? env.OMX_TEAM_STATE_ROOT : '';
-  addStateRoot(explicit);
-  addStateRoot(join(resolve(cwd), '.omx', 'state'));
-  return roots;
+  // Identity lookup follows the canonical state root only. Enumerating
+  // cwd/.omx/state alongside an explicitly selected root lets an alias in the
+  // unselected root rename or mask teams addressed through the selected root
+  // and makes the reported state path unreliable.
+  const canonical = resolveCanonicalTeamStateRoot(cwd, env);
+  return [join(canonical, 'team')];
 }
 
 export function listTeamLookupCandidates(cwd: string, env: NodeJS.ProcessEnv = process.env): TeamLookupCandidate[] {

--- a/src/team/team-identity.ts
+++ b/src/team/team-identity.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'crypto';
 import { existsSync, readdirSync, readFileSync } from 'fs';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { TEAM_NAME_SAFE_PATTERN } from './contracts.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -34,7 +34,6 @@ import {
 import { sleep, sleepSync } from '../utils/sleep.js';
 import {
   buildPlatformCommandSpec,
-  classifySpawnError,
   resolveCommandPathForPlatform,
   spawnPlatformCommandSync,
 } from '../utils/platform-command.js';
@@ -110,7 +109,11 @@ export class CreateTeamSessionPartialError extends Error {
     /** Cleanup commands that failed after resources were created and must be retried. */
     readonly cleanupErrors: string[] = [],
   ) {
-    super('create_team_session_cleanup_incomplete');
+    super(
+      `create_team_session_cleanup_incomplete: ${originalError instanceof Error ? originalError.message : String(originalError)}`
+        + (cleanupErrors.length > 0 ? `; cleanup: ${cleanupErrors.join('; ')}` : ''),
+      { cause: originalError },
+    );
     this.name = 'CreateTeamSessionPartialError';
   }
 }
@@ -1825,11 +1828,8 @@ export function translateWorkerLaunchArgsForCli(
 }
 
 function commandExists(binary: string): boolean {
-  const { result } = spawnPlatformCommandSync(binary, ['--version'], { encoding: 'utf-8' });
-  if (result.error) {
-    return classifySpawnError(result.error as NodeJS.ErrnoException) !== 'missing';
-  }
-  return true;
+  // Launch wrappers may bootstrap profiles even for --version. Discovery must not execute them.
+  return resolveCommandPathForPlatform(binary) !== null;
 }
 
 export function trustWorkerMiseConfigIfAvailable(workerCwd: string): boolean {

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -161,13 +161,15 @@ function resolvePosixCommandPath(
     return existsImpl(candidate) ? candidate : null;
   }
 
+  // Empty PATH components resolve to the current directory under execvp
+  // semantics, so discovery must consider them to stay consistent with how a
+  // later bare-binary spawn actually resolves the command.
   const pathEntries = String(env.PATH ?? env.Path ?? '')
     .split(delimiter)
-    .map((value) => value.trim())
-    .filter(Boolean);
+    .map((value) => value.trim());
 
   for (const entry of pathEntries) {
-    const candidate = resolve(entry, trimmed);
+    const candidate = resolve(entry === '' ? '.' : entry, trimmed);
     if (existsImpl(candidate)) return candidate;
   }
 


### PR DESCRIPTION
## Summary

Team startup diagnostics could trigger a CLI wrapper just to discover whether it was installed, hide the original startup failure behind a cleanup error, or report successful shutdown when the selected state root contained no team configuration.

## Changes

- Resolve CLI executables without running `--version`, using the existing platform-aware resolver.
- Preserve the original startup exception as `Error.cause` and include startup and cleanup details while retaining the existing error prefix.
- Include the selected state root/path in missing-team status output (including JSON).
- Distinguish missing team configuration from successful team shutdown, without searching or mutating another state root.
- Add six regression cases covering wrapper side effects, missing executables, error details, and scoped status/shutdown output.

## Validation

- Rebased onto upstream `dev` at `1ab5926975192541614a586926af907e9a51a22b`; all checks below were rerun successfully: **398 focused tests passed, 0 failed, 0 skipped**.
- TypeScript: `./node_modules/.bin/tsc`
- Biome lint: all four touched files.
- Focused tests: `node dist/scripts/run-test-files.js dist/team/__tests__/tmux-session.test.js dist/cli/__tests__/team.test.js dist/team/__tests__/state-root.test.js dist/team/__tests__/tmux-source-authority-realtmux.test.js`
- `git diff --check`
- Earlier isolated real-tmux smoke: three Codex workers started and acknowledged; all three fixture tasks completed. This was an assisted smoke, not proof of unattended startup: the hook-review modal required closing without granting trust. Shutdown also reported merge warnings because it was invoked from the wrong working directory; no product code changed. No claim of a clean unattended 15-worker run.
- Full `npm test` / full build pipeline / cross-platform CI were not run locally.

## Compatibility and scope

- Pane ownership checks, state-root precedence, and cleanup authority are unchanged.
- Missing-state JSON gains additive fields; missing-state text becomes more explicit. The startup cleanup error prefix remains unchanged.
- No application, deployment, authentication, provider configuration, or control-plane files are included.

## Checklist

- [x] Focused on Team startup and state diagnostics.
- [x] Regression coverage added.
- [x] Backward-compatibility impact considered.
- [ ] Full CI validation.
