### PR TITLE
fix(config): respect TOML array-of-tables boundaries

### DIFF
--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -6907,6 +6907,14 @@ describe("readTopLevelTomlString", () => {
     );
     assert.equal(value, null);
   });
+
+  it("ignores array-of-tables values", () => {
+    const value = readTopLevelTomlString(
+      '[[entries]] # array of tables\nmodel_reasoning_effort = "low"\n',
+      "model_reasoning_effort",
+    );
+    assert.equal(value, null);
+  });
 });
 
 describe("injectModelInstructionsBypassArgs", () => {
@@ -7019,6 +7027,25 @@ describe("upsertTopLevelTomlString", () => {
       updated,
       'model_reasoning_effort = "xhigh"\n[tui]\nstatus_line = []\n',
     );
+  });
+
+  it("preserves array-of-tables values when inserting a top-level key", () => {
+    const content = '[[entries]] # array of tables\nmodel_reasoning_effort = "low"\n';
+    const updated = upsertTopLevelTomlString(content, "model_reasoning_effort", "high");
+    assert.equal(updated, `model_reasoning_effort = "high"\n${content}`);
+  });
+
+  it("inserts before an array of tables that precedes an ordinary table", () => {
+    const content = [
+      "[[skills.config]]",
+      'path = "/tmp/skill/SKILL.md"',
+      "enabled = false",
+      "[tui]",
+      "status_line = []",
+      "",
+    ].join("\r\n");
+    const updated = upsertTopLevelTomlString(content, "model_reasoning_effort", "high");
+    assert.equal(updated, `model_reasoning_effort = "high"\r\n${content}`);
   });
 });
 

--- a/src/utils/toml.ts
+++ b/src/utils/toml.ts
@@ -1,3 +1,5 @@
+const TABLE_HEADER = /^(?:\[[^[\]]+\]|\[\[[^[\]]+\]\])\s*(#.*)?$/;
+
 export function readTopLevelTomlString(
   content: string,
   key: string,
@@ -7,7 +9,7 @@ export function readTopLevelTomlString(
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
-    if (/^\[[^[\]]+\]\s*(#.*)?$/.test(trimmed)) {
+    if (TABLE_HEADER.test(trimmed)) {
       inTopLevel = false;
       continue;
     }
@@ -39,7 +41,7 @@ export function upsertTopLevelTomlString(
     const line = lines[i];
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
-    if (/^\[[^[\]]+\]\s*(#.*)?$/.test(trimmed)) {
+    if (TABLE_HEADER.test(trimmed)) {
       inTopLevel = false;
       continue;
     }
@@ -54,7 +56,7 @@ export function upsertTopLevelTomlString(
 
   if (!replaced) {
     const firstTableIndex = lines.findIndex((line) =>
-      /^\s*\[[^[\]]+\]\s*(#.*)?$/.test(line.trim()),
+      TABLE_HEADER.test(line.trim()),
     );
     if (firstTableIndex >= 0) {
       lines.splice(firstTableIndex, 0, assignment);


### PR DESCRIPTION
## Summary

When `config.toml` starts with an array of tables such as `[[skills.config]]`, `omx reasoning high` inserts `model_reasoning_effort` inside the array entry instead of at the root. The helpers only recognize ordinary `[table]` headers, so reads can also return an array-local value and updates can overwrite it.

## Changes

Recognize both table-header forms when reading, replacing, and locating the insertion point for root strings. Add three regression tests covering array-local values, commented headers, and insertion before an array followed by an ordinary table with CRLF line endings.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `node --test --test-name-pattern='^(readTopLevelTomlString|upsertTopLevelTomlString)' dist/cli/__tests__/index.test.js` — 7 passed; all 3 new cases failed before the fix.
- [x] `node --test dist/cli/__tests__/setup-reasoning-preserve.test.js dist/cli/__tests__/auth.test.js` — 19 passed.
- [x] `git diff --check`
- [ ] Full `npm test` suite was not run; validation was scoped to the affected helpers and their setup/auth consumers.

## Checklist

- [x] PR is focused and avoids unrelated changes
- [x] Backward-compatibility impact considered: ordinary table and root-key behavior is preserved.

Document-refresh: not-needed | Restores existing top-level config semantics without adding options or changing the documented workflow.
