### PR TITLE
Measure maintenance growth without adding runtime machinery

### DIFF
--- a/docs/debloat-metrics.md
+++ b/docs/debloat-metrics.md
@@ -1,0 +1,74 @@
+# Measuring OMX's maintenance surface
+
+Use the existing inventory; do not infer quality from a LOC target:
+
+```sh
+npm run build
+node dist/scripts/prompt-inventory.js --json > /tmp/omx-inventory.json
+git rev-parse HEAD
+node --test dist/scripts/__tests__/prompt-inventory.test.js
+node dist/scripts/prompt-inventory.js --check
+```
+
+Run from a clean worktree for revision-to-revision comparisons and record its commit
+and dirty status alongside the report. `--root <path>` measures that filesystem,
+including untracked files in the selected canonical source directories; it does not
+silently claim to be a Git snapshot. The command reads files and writes only stdout.
+
+## Schema and categories
+
+The additive `repositorySize` object has `schemaVersion: 1`, `groups`, and the ten
+`largestNonTestFiles`, ordered by descending physical lines then by path.
+Each group contains `files`, `physicalLines`, and raw `bytes`:
+
+| Group | Definition |
+| --- | --- |
+| `nonTestSource` | `src/**/*.{ts,js,mjs,sh}`, excluding test classification below; includes maintenance/build/smoke scripts, not just shipped runtime |
+| `testSource` | Same extensions under `__tests__`, or filenames containing `.test.` / `.spec.` |
+| `rustSourceIncludingTests` | `crates/**/*.rs`; includes inline and separate Rust tests |
+| `skillCards` | Canonical `skills/<name>/SKILL.md`, including sunset cards; not an active-skill count |
+| `agentPrompts` | Canonical `prompts/*.md`, including non-installable prompt assets |
+| `agentTemplate` | `templates/AGENTS.md`; not the local installed/generated root file |
+
+Physical lines include comments/blanks, count CRLF as one newline, and do not count
+a trailing newline as an extra empty line. Empty files contribute zero lines.
+Nested hidden directories, `generated`, `node_modules`, `dist`, `target`, and
+symlink entries are excluded. Plugin mirrors, local `.codex`/`.agents` installations,
+and runtime artifacts are not canonical source. No filename-based heuristic can
+identify every generated file; these are explicit path-based categories.
+
+Existing `totals` and `surfaces` retain their historical prompt-inventory semantics.
+They include docs and embedded source surfaces and count trailing empty lines.
+`approximateTokens` is a lexical word/punctuation estimate, **not a tokenizer count,
+actual injected context, or the total tokens consumed by a task**. Do not compare
+these legacy line totals directly with the new physical-line totals.
+
+## Interpreting a cleanup
+
+Compare category deltas and changed hotspots, then run the affected routing/skill
+contracts. The ordinary-task routing corpus (delivered in the companion hook-cleanup
+PR) tests classification and actual workflow-state effects with ordinary prompts,
+quoted mentions, and explicit workflow requests. It is not a model-quality benchmark.
+
+Record test passes, failures, unnecessary workflow activation, and instruction-size
+deltas together. Do not fail CI merely because source or tests grew. This inventory
+adds no model calls, runtime instrumentation, dependencies, or flaky latency budgets.
+Actual task success, injected tokens, and hook latency require a separate controlled
+end-to-end run with a recorded model, environment, corpus, and repeated measurements.
+
+## Initial reference snapshot
+
+Measured from a clean archive of `dev` commit
+`5190a9dcea2cf7e5f1b2b6be8daa891215596e82` (2026-09-09), using schema 1:
+
+| Category | Files | Physical lines |
+| --- | ---: | ---: |
+| Non-test source | 400 | 199,310 |
+| Test source | 444 | 247,047 |
+| Rust, including tests | 37 | 15,964 |
+| Skill cards | 29 | 2,657 |
+| Agent prompts | 32 | 2,189 |
+| Agent template | 1 | 229 |
+
+The native-hook hotspot was 23,077 lines. These are a dated reference, not frozen
+CI limits. Compare future reports against the same categories and source revision.

--- a/src/scripts/__tests__/prompt-inventory.test.ts
+++ b/src/scripts/__tests__/prompt-inventory.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import {
   buildPromptInventory,
+  buildRepositorySizeInventory,
   checkPromptInvariantDuplicates,
   listPromptSurfacePaths,
   renderPromptInventoryMarkdown,
@@ -119,6 +120,88 @@ describe('prompt inventory', () => {
       assert.equal(runPromptInventoryCli(['--check', '--root'], root), 1);
     } finally {
       console.log = originalLog;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+
+describe('repository size inventory', () => {
+  it('separates canonical instructions, source, tests and Rust without counting mirrors', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-size-inventory-'));
+    try {
+      const files: Record<string, string> = {
+        'src/a.ts': 'a\r\n\r\nb\r\n',
+        'src/empty.ts': '',
+        'src/b.mjs': 'b',
+        'src/scripts/run.sh': 'run\n',
+        'src/a.test.ts': 'test\nassert\n',
+        'src/b.spec.ts': 'spec',
+        'src/__tests__/helper.ts': 'helper\n',
+        'crates/example/src/lib.rs': 'fn main() {}\n// test\n',
+        'skills/one/SKILL.md': '# Skill\nDo it.\n',
+        'skills/one/references/notes.md': 'not a canonical card\n',
+        'prompts/executor.md': '# Executor\n',
+        'templates/AGENTS.md': '# Contract\nRules.\n',
+        'src/generated/example.ts': 'generated\n',
+        'src/node_modules/example/index.ts': 'dependency\n',
+        'crates/example/target/generated.rs': 'build output\n',
+        'crates/example/.omx/state/fixture.rs': 'runtime artifact\n',
+        'plugins/oh-my-codex/skills/one/SKILL.md': 'mirror\n',
+        '.codex/skills/external/SKILL.md': 'third party\n',
+        'dist/index.js': 'compiled\n',
+      };
+      for (const [path, content] of Object.entries(files)) {
+        const fullPath = join(root, path);
+        await mkdir(join(fullPath, '..'), { recursive: true });
+        await writeFile(fullPath, content);
+      }
+      const report = buildRepositorySizeInventory(root);
+      assert.equal(report.schemaVersion, 1);
+      assert.deepEqual(Object.fromEntries(Object.entries(report.groups).map(([name, group]) => [name, [group.files, group.physicalLines]])), {
+        nonTestSource: [4, 5],
+        testSource: [3, 4],
+        rustSourceIncludingTests: [1, 2],
+        skillCards: [1, 2],
+        agentPrompts: [1, 1],
+        agentTemplate: [1, 2],
+      });
+      assert.equal(report.groups.nonTestSource.bytes, Buffer.byteLength('a\r\n\r\nb\r\n' + 'b' + 'run\n'));
+      assert.equal(report.largestNonTestFiles[0]?.path, 'src/a.ts');
+      assert.deepEqual(report, buildRepositorySizeInventory(root));
+      assert.deepEqual(buildPromptInventory(root, 'fixed').repositorySize, report);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not follow nested symlinks and orders equal-size hotspots by path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-size-links-'));
+    try {
+      await mkdir(join(root, 'src'));
+      await mkdir(join(root, 'external'));
+      await writeFile(join(root, 'src/z.ts'), 'z\n');
+      await writeFile(join(root, 'src/a.ts'), 'a\n');
+      await writeFile(join(root, 'external/foreign.ts'), 'foreign\n');
+      await symlink(join(root, 'external'), join(root, 'src/dependency'), 'junction');
+      await mkdir(join(root, 'templates'));
+      await symlink(join(root, 'src/a.ts'), join(root, 'templates/AGENTS.md'));
+      const report = buildRepositorySizeInventory(root);
+      assert.equal(report.groups.agentTemplate.files, 0);
+      assert.equal(report.groups.nonTestSource.files, 2);
+      assert.deepEqual(report.largestNonTestFiles.map((file) => file.path), ['src/a.ts', 'src/z.ts']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports empty groups for an empty root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-size-empty-'));
+    try {
+      const report = buildRepositorySizeInventory(root);
+      assert.ok(Object.values(report.groups).every((group) => group.files === 0 && group.physicalLines === 0 && group.bytes === 0));
+      assert.deepEqual(report.largestNonTestFiles, []);
+    } finally {
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/src/scripts/prompt-inventory.ts
+++ b/src/scripts/prompt-inventory.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 export interface PromptSurfaceInventory {
@@ -37,7 +37,20 @@ export interface PromptInvariantCheckReport {
   ok: boolean;
 }
 
+export interface SizeTotals {
+  files: number;
+  physicalLines: number;
+  bytes: number;
+}
+
+export interface RepositorySizeInventory {
+  schemaVersion: 1;
+  groups: Record<'nonTestSource' | 'testSource' | 'rustSourceIncludingTests' | 'skillCards' | 'agentPrompts' | 'agentTemplate', SizeTotals>;
+  largestNonTestFiles: Array<{ path: string; physicalLines: number; bytes: number }>;
+}
+
 export interface PromptInventoryReport {
+  repositorySize: RepositorySizeInventory;
   generatedAt: string;
   root: string;
   totals: {
@@ -115,21 +128,58 @@ export const INVARIANT_PHRASE_RULES: readonly PromptInvariantPhraseRule[] = [
   },
 ];
 
-function walkFiles(root: string, dir: string, out: string[]): void {
+const EXCLUDED_INVENTORY_DIRS = new Set(['node_modules', 'dist', 'target', 'generated']);
+
+function walkFiles(root: string, dir: string, out: string[], extensions = /\.(md|ts)$/): void {
   const absoluteDir = join(root, dir);
-  if (!existsSync(absoluteDir)) return;
-  for (const entry of readdirSync(absoluteDir)) {
-    const rel = join(dir, entry);
-    const absolute = join(root, rel);
-    const stats = statSync(absolute);
-    if (stats.isDirectory()) {
-      walkFiles(root, rel, out);
-      continue;
-    }
-    if (stats.isFile() && /\.(md|ts)$/.test(entry)) {
+  if (!existsSync(absoluteDir) || !lstatSync(absoluteDir).isDirectory()) return;
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const rel = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!entry.name.startsWith('.') && !EXCLUDED_INVENTORY_DIRS.has(entry.name)) {
+        walkFiles(root, rel, out, extensions);
+      }
+    } else if (entry.isFile() && extensions.test(entry.name)) {
+      // Do not follow symlinks into external installations or back into this tree.
       out.push(rel);
     }
   }
+}
+
+/** Filesystem snapshot: use a clean worktree when comparing Git revisions. */
+export function buildRepositorySizeInventory(root = process.cwd()): RepositorySizeInventory {
+  const empty = (): SizeTotals => ({ files: 0, physicalLines: 0, bytes: 0 });
+  const groups: RepositorySizeInventory['groups'] = {
+    nonTestSource: empty(), testSource: empty(), rustSourceIncludingTests: empty(),
+    skillCards: empty(), agentPrompts: empty(), agentTemplate: empty(),
+  };
+  const paths: string[] = [];
+  walkFiles(root, 'src', paths, /\.(ts|js|mjs|sh)$/);
+  walkFiles(root, 'crates', paths, /\.rs$/);
+  walkFiles(root, 'skills', paths, /^SKILL\.md$/);
+  walkFiles(root, 'prompts', paths, /\.md$/);
+  if (existsSync(join(root, 'templates/AGENTS.md')) && lstatSync(join(root, 'templates/AGENTS.md')).isFile()) paths.push('templates/AGENTS.md');
+  const largestNonTestFiles: RepositorySizeInventory['largestNonTestFiles'] = [];
+  for (const path of paths.map((entry) => entry.replaceAll('\\', '/')).sort()) {
+    let group: keyof typeof groups;
+    if (path.startsWith('src/')) {
+      group = /(?:\/__tests__\/|\.(?:test|spec)\.)/.test(path) ? 'testSource' : 'nonTestSource';
+    } else if (path.startsWith('crates/')) group = 'rustSourceIncludingTests';
+    else if (/^skills\/[^/]+\/SKILL\.md$/.test(path)) group = 'skillCards';
+    else if (/^prompts\/[^/]+\.md$/.test(path)) group = 'agentPrompts';
+    else if (path === 'templates/AGENTS.md') group = 'agentTemplate';
+    else continue;
+    const content = readFileSync(join(root, path));
+    const text = content.toString('utf-8');
+    const physicalLines = text.length === 0 ? 0 : text.split(/\r\n|\r|\n/).length - (/[\r\n]$/.test(text) ? 1 : 0);
+    const bytes = content.byteLength;
+    groups[group].files += 1;
+    groups[group].physicalLines += physicalLines;
+    groups[group].bytes += bytes;
+    if (group === 'nonTestSource') largestNonTestFiles.push({ path, physicalLines, bytes });
+  }
+  largestNonTestFiles.sort((a, b) => b.physicalLines - a.physicalLines || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return { schemaVersion: 1, groups, largestNonTestFiles: largestNonTestFiles.slice(0, 10) };
 }
 
 export function listPromptSurfacePaths(root = process.cwd()): string[] {
@@ -271,6 +321,7 @@ export function buildPromptInventory(root = process.cwd(), generatedAt = new Dat
   return {
     generatedAt,
     root: resolvedRoot,
+    repositorySize: buildRepositorySizeInventory(resolvedRoot),
     totals: {
       files: surfaces.length,
       lines: surfaces.reduce((sum, surface) => sum + surface.lines, 0),
@@ -309,6 +360,14 @@ export function renderPromptInventoryMarkdown(report: PromptInventoryReport): st
     `- Lines: ${report.totals.lines}`,
     `- Approximate tokens: ${report.totals.approximateTokens}`,
     `- Absolute directive lines: ${report.totals.absoluteDirectiveCount}`,
+    '',
+    '## Repository size (physical lines; not a quality score)',
+    '',
+    '| Category | Files | Physical lines | Bytes |',
+    '| --- | ---: | ---: | ---: |',
+    ...Object.entries(report.repositorySize.groups).map(([name, group]) => `| ${name} | ${group.files} | ${group.physicalLines} | ${group.bytes} |`),
+    '',
+    'Token counts are lexical estimates, not actual model tokens or injected context. See docs/debloat-metrics.md for category definitions.',
     '',
     '## Surfaces',
     '',


### PR DESCRIPTION
## Why
Quantify OMX's maintenance surface without adding another runtime/monitoring framework. This is the measurement slice of the requested debloat series; it targets `dev` independently.

## Changes
- Extend existing `prompt-inventory --json` with schema-versioned physical line/file/byte categories and top non-test hotspots.
- Separate tests, Rust (including tests), canonical skill cards, prompts, and AGENTS template; exclude mirrors/build/runtime directories and symlinks.
- Preserve historical inventory totals and explicitly distinguish lexical token estimates from actual injected/model tokens.
- Document a reproducible baseline from `5190a9dc`: 199,310 non-test source lines; 247,047 test lines; 2,657 skill-card lines.

## Validation
- `npm run build`
- Inventory tests: **6 passed** (red before implementation; new grouping, line endings, empty files, exclusions, symlinks, deterministic ordering).
- `npm run lint`, `npm run check:no-unused`
- `npm run verify:generated`, `npm run verify:native-agents`
- `git diff --check`
- Independent architectural review reproduced baseline counts; its symlink edge finding was fixed and tested.

## Limits
No LOC quality gate, dependency, model call, latency budget, or claim of task-quality improvement. This is a filesystem snapshot (use a clean worktree to compare revisions), not a Git object reader. Full application suite and real model/latency benchmarks were not run for this tooling-only slice.
