### PR TITLE
Stop active workflows handing off to retired skills

### DIFF
--- a/docs/workflow-retirement.md
+++ b/docs/workflow-retirement.md
@@ -1,0 +1,40 @@
+# Workflow retirement boundary
+
+## Canonical policy
+
+`src/catalog/manifest.json` owns installability/lifecycle status; `src/hooks/sunset-stub.ts`
+owns the implemented removed-token diagnostics and supported replacements; on-disk
+sunset cards also carry migration messages. The diagnostic map is not an exhaustive
+lifecycle inventory. `templates/AGENTS.md` owns
+ordinary-mode selection. Skill cards own only their task-specific process; plugin copies
+are generated with `npm run sync:plugin`.
+
+Ordinary scoped coding is direct execution. Explicit Autopilot retains its full
+Deep Interview → Ralplan → Ultragoal contract. New execution handoffs use supported
+skills, not `$ralph`, `$ultrawork`, `$pipeline`, or `$autoresearch-goal`.
+
+## Compatibility is not a second recommended workflow
+
+Retiring a prompt token does not retire its similarly named CLI, existing on-disk
+state, HUD projection, cancellation cleanup, or previously produced artifacts.
+In particular, the `omx ralph` CLI and persistence runtime remain supported by the
+current sunset contract. Do not delete their identity, ownership, stop, or cancel
+checks as part of prompt cleanup.
+
+Active cards may mention retired tokens only as explicitly labeled migration or
+historical-artifact input, not as an executable fallback. HUD examples must label
+legacy compatibility rather than encourage starting retired skills.
+
+## Removal conditions
+
+- **Prompt stubs:** remove only in a release that explicitly ends their advertised
+  grace period, after catalog/install cleanup, replacement diagnostics, generated
+  mirrors, and active-card handoff tests agree. Do not infer removal from a name alone.
+- **Runtime compatibility:** requires a separate reviewed migration with tests for
+  supported saved-state resume, exact-session cancellation, and stale/foreign-owner
+  rejection. Prompt retirement alone is insufficient evidence to remove it.
+- **Historical artifacts:** remain readable without granting activation or write
+  authority. Any future removal must document a migration path and affected format.
+
+Check active handoffs with the sunset-routing contract tests; regenerate mirrors,
+then run `npm run verify:generated` and the affected skill contracts.

--- a/omx-capabilities.lock.json
+++ b/omx-capabilities.lock.json
@@ -1417,10 +1417,10 @@
       ]
     },
     "skills": {
-      "digest": "d57210c04d430afd3acff8acba455de25799873107ece17d781b3ef4155dd1ac",
+      "digest": "b6528f0708575602fff89f1a840e2f552c3b1b383a15a58894150766542a13e8",
       "files": [
         {
-          "digest": "227c02cb4304603fae65200878acb9708bc31523d0d851ea148861a8c6f72055",
+          "digest": "d81095f3480b4d15dc8607d85c9dd5c872fe0786e29561a3d101a117f104e77b",
           "path": "skills/ai-slop-cleaner/SKILL.md"
         },
         {
@@ -1444,7 +1444,7 @@
           "path": "skills/autoresearch/SKILL.md"
         },
         {
-          "digest": "3d5904298db7125184742e86d075eb331954586e45d2647c09249a3dac38e010",
+          "digest": "6f0525b364f03ea4ec991ceb1b77a5bf0674efc605bed5db5cb98ebfc09e7c5e",
           "path": "skills/best-practice-research/SKILL.md"
         },
         {
@@ -1452,7 +1452,7 @@
           "path": "skills/cancel/SKILL.md"
         },
         {
-          "digest": "be16f9bb2bc567b38eb5e302a360b248f46e2686ee6de5bd4aa233f0db3485e8",
+          "digest": "0ee041726093d160f42f7568b0581ca9b98ac95a687d764af4b3b0470d490b19",
           "path": "skills/code-review/SKILL.md"
         },
         {
@@ -1460,11 +1460,11 @@
           "path": "skills/configure-notifications/SKILL.md"
         },
         {
-          "digest": "7094e29dc0d00d1c3fadf5fad111330b23056ed2cdc6aa2116618c2dfe2becbe",
+          "digest": "383f8d66c6e882520e8338331b78af5d8cbcef59cf66f3138cca3ca226411bb1",
           "path": "skills/deep-interview/SKILL.md"
         },
         {
-          "digest": "3f1bddf79820c83433f3ba97cc3e41a61cb72b009acbd08ba3f9dcc5e5ead67a",
+          "digest": "51f13a8616043a18fdeb099a3d1725394cbfb576e6ff54b19bf77a3c399b5d0a",
           "path": "skills/design/SKILL.md"
         },
         {
@@ -1476,7 +1476,7 @@
           "path": "skills/git-master/SKILL.md"
         },
         {
-          "digest": "d5c30b632149f1fc06e9945872e3eb02a5efeb93ba66bf512ecae558d1e3b4ea",
+          "digest": "a7d365daef2795f7b31ae748aa0991924e9cccfd8b1d4478a477b069e32d7294",
           "path": "skills/hud/SKILL.md"
         },
         {
@@ -1492,7 +1492,7 @@
           "path": "skills/pipeline/SKILL.md"
         },
         {
-          "digest": "31badb8a5a61fda71a56c5aa7412ce43b4056bd0a8eeae1455c8a887bf933ebe",
+          "digest": "4a2312fee52f4780338eccc217a9340300e03c8a3e8b0f8e8dde0a8239afd0b7",
           "path": "skills/plan/SKILL.md"
         },
         {
@@ -1500,7 +1500,7 @@
           "path": "skills/ralph/SKILL.md"
         },
         {
-          "digest": "c5bbe67859e1bb8d5d4b766336a56d488e1c1ee7a3db10d14b8ccdf264efbd42",
+          "digest": "1d17d7d478ad83946520f22e0b8bacdbdb214342edde58742fad9fba0e9227d5",
           "path": "skills/ralplan/SKILL.md"
         },
         {
@@ -1524,7 +1524,7 @@
           "path": "skills/ultrawork/SKILL.md"
         },
         {
-          "digest": "d2da6f86a297f8e053d7e740f5352b3fc88706afbb8b3ccb82023066d410d473",
+          "digest": "f18a5a68667877e50d752782aba270aa776eef107971aaea270d5c9b6da2e1bd",
           "path": "skills/visual-ralph/SKILL.md"
         },
         {

--- a/plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md
+++ b/plugins/oh-my-codex/skills/ai-slop-cleaner/SKILL.md
@@ -15,8 +15,7 @@ Use when working code is bloated, noisy, repetitive, over-abstracted, or AI-gene
 the user requests cleanup/refactor/deslop; or a follow-up left duplicate/dead code,
 weak boundaries, missing tests, fallback-like paths, or wrappers. Inputs are the requested
 feature/files and behavior to preserve. A file list scope is valid; keep the pass bounded
-to it. In the Ralph workflow, run this skill on Ralph's changed files only, standard mode
-unless explicitly requested otherwise.
+to it. Limit the pass to the calling task's changed files unless broader cleanup was requested.
 
 ## Before editing
 
@@ -24,7 +23,7 @@ unless explicitly requested otherwise.
 2. **Create a cleanup plan before code**: list scope and smells, include fallback findings/classifications/escalation, and order safest/highest-signal fixes first.
 3. **Inventory fallback-like code** in scope: quick hacks, temporary workaround, temporary fallback, just bypass, just skip, fallback if it fails, swallowed errors, silent defaults, broad compatibility shims, and duplicate alternate execution paths.
 4. Classify each fallback: **Masking fallback slop** hides evidence, bypasses the contract, suppresses validation, swallows failures, silently defaults, or adds untested paths; **Grounded compatibility/fail-safe fallback** is narrow at an external/version/fail-safe boundary, documents rationale, preserves failure evidence, and tests primary plus fallback.
-5. Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior. For broad/ambiguous/cross-layer/architectural findings, invoke `$ralplan` for consensus resolution; when already inside ralplan, ralph, team, or another OMX workflow, do not spawn a nested `$ralplan`—attach the finding to the active handoff.
+5. Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior. For broad/ambiguous/cross-layer/architectural findings, invoke `$ralplan` for consensus resolution; when already inside ralplan, ultragoal, team, or another OMX workflow, do not spawn a nested `$ralplan`—attach the finding to the active handoff.
 
 ## Smell taxonomy and passes
 

--- a/plugins/oh-my-codex/skills/best-practice-research/SKILL.md
+++ b/plugins/oh-my-codex/skills/best-practice-research/SKILL.md
@@ -26,7 +26,7 @@ This skill is terminal and read-only by default. It gathers evidence and produce
 
 - The answer is fully repo-local; use `explore` for codebase facts.
 - The main question is whether to adopt, replace, upgrade, or compare dependencies; use `dependency-expert`.
-- The user only needs implementation against already-grounded requirements; use `executor`, `$ralph`, or `$team` as appropriate.
+- The user only needs implementation against already-grounded requirements; execute directly, or use `$team` when coordinated parallel work is warranted.
 - The task can be answered from stable local project conventions without current external lookup.
 
 ## Specialist Routing

--- a/plugins/oh-my-codex/skills/code-review/SKILL.md
+++ b/plugins/oh-my-codex/skills/code-review/SKILL.md
@@ -87,7 +87,7 @@ Combine the `code-reviewer` recommendation and architect status. Approval requir
 
 Approval criteria: **APPROVE** only when `code-reviewer` returns APPROVE, architect status is `CLEAR`, and both independent lanes returned evidence. **REQUEST CHANGES** for a blocker, unresolved high/critical finding, or unavailable lane. **COMMENT** may record non-blocking findings.
 
-Do not self-review as a fallback. If the `code-reviewer` or `architect` path is missing, unavailable, skipped, or fails, block approval until independent lane evidence exists. On the explicit Ralph path, findings may trigger automatic fix follow-up without another permission prompt; plain `code-review` itself remains read-only and does **not** promise auto-fix.
+Do not self-review as a fallback. If the `code-reviewer` or `architect` path is missing, unavailable, skipped, or fails, block approval until independent lane evidence exists. On the supported `omx ralph` CLI compatibility path, findings may trigger automatic fix follow-up without another permission prompt; plain `code-review` itself remains read-only and does **not** promise auto-fix.
 
 ## Evidence/output contract
 

--- a/plugins/oh-my-codex/skills/deep-interview/SKILL.md
+++ b/plugins/oh-my-codex/skills/deep-interview/SKILL.md
@@ -12,7 +12,7 @@ Deep Interview is an intent-first Socratic clarification loop before planning or
 - The request is broad, ambiguous, or missing concrete acceptance criteria
 - The user says "deep interview", "interview me", "ask me everything", "don't assume", or "ouroboros"
 - The user wants to avoid misaligned implementation from underspecified requirements
-- You need a requirements artifact before handing off to `ralplan`, `autopilot`, `ralph`, or `team`
+- You need a requirements artifact before handing off to `ralplan`, `autopilot`, `ultragoal`, or `team`
 </Use_When>
 
 <Do_Not_Use_When>
@@ -149,7 +149,7 @@ If no flag is provided, use **Standard**.
 Repeat until ambiguity `<= threshold`, the pressure pass is complete, the readiness gates are explicit, the user exits with warning, or max rounds are reached. This is a stop condition: below threshold, do not open a new ordinary interview branch.
 
 ### 2a) Generate next question
-If the initial context is oversized and no prompt-safe summary has been recorded yet, the next question must be only a summary request. Do not score ambiguity, do not run readiness gates, and do not hand off to `$ultragoal`, `$ralplan`, `$autopilot`, `$ralph`, or `$team` until that summary answer is captured.
+If the initial context is oversized and no prompt-safe summary has been recorded yet, the next question must be only a summary request. Do not score ambiguity, do not run readiness gates, and do not hand off to `$ultragoal`, `$ralplan`, `$autopilot`, or `$team` until that summary answer is captured.
 
 Use:
 - Original idea
@@ -429,13 +429,13 @@ Only set `execution_contract_required:true` when the selected downstream workflo
 
 ### Goal-mode follow-ups
 
-Include these product-facing suggestions when they fit the clarified spec, without removing the existing `$ultragoal`, `$ralplan`, `$autopilot`, `$ralph`, and `$team` handoff options:
+Include these product-facing suggestions when they fit the clarified spec, without removing the existing `$ultragoal`, `$ralplan`, `$autopilot`, and `$team` handoff options:
 
 - **`$ultragoal`** — default goal-mode follow-up for implementation or general goal-oriented follow-up specs that should be converted into durable Codex/OMX goals with sequential completion tracking.
-- **`$autoresearch-goal`** — use when the clarified context is a research project: a research question, reference/literature gathering, evaluator-backed analysis, or professor/critic-style deliverable.
+- **`$autoresearch`** — use when the clarified context is a research project: a research question, reference/literature gathering, evaluator-backed analysis, or professor/critic-style deliverable.
 - **`$performance-goal`** — use when the clarified context is an optimization or performance project with measurable speed, latency, throughput, memory, benchmark, or evaluator criteria.
 
-Recommend `$ultragoal` as the default durable goal-mode follow-up because it supersedes Ralph for goal tracking. Preserve `$team` for coordinated parallel implementation and keep `$ralph` only as an explicit fallback for persistent single-owner execution/verification when the user specifically selects it.
+Recommend `$ultragoal` as the default durable goal-mode follow-up because it supersedes Ralph for goal tracking. Preserve `$team` for coordinated parallel implementation.
 
 ### 1. **`$ultragoal` (Default durable execution follow-up)**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md` (optionally accompanied by the transcript/context snapshot for traceability)
@@ -444,7 +444,7 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - **Skipped / Already-Satisfied Stages:** Requirement interview, ambiguity clarification, doc/context preflight, and early intent-boundary elicitation
 - **Expected Output:** `.omx/ultragoal/brief.md`, `.omx/ultragoal/goals.json`, `.omx/ultragoal/ledger.jsonl`, implementation evidence, verification evidence, and final cleanup/review-gate evidence
 - **Best When:** The clarified spec is execution-ready or the user explicitly wants durable goal tracking as the next step
-- **Next Recommended Step:** Run the Ultragoal completion loop; launch `$team` only inside an active Ultragoal story when parallel lanes are warranted, and use `$ralph` only as an explicit fallback when the user asks for that legacy persistence mode
+- **Next Recommended Step:** Run the Ultragoal completion loop; launch `$team` only inside an active Ultragoal story when parallel lanes are warranted
 
 ### 2. **`$ralplan` (Recommended when architecture/test-shape review is still needed)**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md` (optionally accompanied by the transcript/context snapshot for traceability)
@@ -453,7 +453,7 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - **Skipped / Already-Satisfied Stages:** Requirements discovery, ambiguity clarification, and early intent-boundary elicitation
 - **Expected Output:** Canonical planning artifacts under `.omx/plans/`, especially `prd-*.md` and `test-spec-*.md`
 - **Best When:** Requirements are clear enough to stop interviewing, but architectural validation / consensus planning is still desirable
-- **Next Recommended Step:** Use the approved planning artifacts with `$ultragoal` as the default durable goal-mode follow-up (optionally with `$team` for parallel lanes); choose `$autoresearch-goal` for research validation or `$performance-goal` for measurable optimization, and use `$ralph` only as an explicit fallback when a narrow single-owner persistence loop is requested
+- **Next Recommended Step:** Use the approved planning artifacts with `$ultragoal` as the default durable goal-mode follow-up (optionally with `$team` for parallel lanes); choose `$autoresearch` for research validation or `$performance-goal` for measurable optimization
 
 ### 3. **`$autopilot`**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md`
@@ -462,27 +462,18 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - **Skipped / Already-Satisfied Stages:** Initial requirement discovery and ambiguity reduction
 - **Expected Output:** Planning/execution progress, QA evidence, and validation artifacts produced by autopilot
 - **Best When:** The clarified spec is already strong enough for direct planning + execution without an additional consensus gate
-- **Next Recommended Step:** Continue through autopilot's execution/QA/validation flow; if coordination-heavy execution emerges, prefer `$team` under a leader-owned `$ultragoal` ledger, using `$ralph` only as an explicit fallback when a narrow single-owner persistence loop is requested
+- **Next Recommended Step:** Continue through autopilot's execution/QA/validation flow; if coordination-heavy execution emerges, prefer `$team` under a leader-owned `$ultragoal` ledger
 
-### 4. **`$ralph` (Explicit fallback only)**
-- **Input Artifact:** `.omx/specs/deep-interview-{slug}.md`
-- **Invocation:** `$ralph <spec-path>`
-- **Consumer Behavior:** Use the spec's acceptance criteria and boundary constraints as the persistence target. Do not reopen requirements discovery unless the user explicitly asks to refine further.
-- **Skipped / Already-Satisfied Stages:** Requirement interview, ambiguity clarification, and initial scope-definition work
-- **Expected Output:** Iterative execution progress and verification evidence tracked against the clarified criteria
-- **Best When:** The user explicitly asks for Ralph's persistent sequential completion pressure; otherwise use `$ultragoal` for durable goal tracking and completion checkpoints
-- **Next Recommended Step:** If this explicit fallback is selected, continue Ralph's persistence loop; if work expands into coordination-heavy lanes, hand off to `$team` under `$ultragoal` checkpointing rather than promoting Ralph as the next default
-
-### 5. **`$team`**
+### 4. **`$team`**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md`
 - **Invocation:** `$team <spec-path>`
 - **Consumer Behavior:** Treat the spec as shared execution context for coordinated parallel work. Preserve the clarified intent, non-goals, decision boundaries, and acceptance criteria as common lane constraints.
 - **Skipped / Already-Satisfied Stages:** Requirement clarification and early ambiguity reduction
-- **Expected Output:** Coordinated multi-agent execution against the shared spec, with evidence that can later feed Ultragoal checkpoints by default, or an explicit Ralph verification pass only when requested
+- **Expected Output:** Coordinated multi-agent execution against the shared spec, with final verification evidence and checkpoints in an already-active Ultragoal ledger when applicable
 - **Best When:** The task is large, multi-lane, or blocker-sensitive enough to justify coordinated parallel execution instead of a single persistent loop
-- **Next Recommended Step:** Follow the team verification path when the coordinated execution phase finishes; checkpoint completion through `$ultragoal` by default, escalating to a separate Ralph loop only when the user explicitly asks for that persistent verification/fix owner
+- **Next Recommended Step:** Follow the team verification path when the coordinated execution phase finishes; checkpoint an already-active `$ultragoal` ledger when applicable. Do not start another execution loop solely to verify.
 
-### 6. **Refine further**
+### 5. **Refine further**
 - **Input Artifact:** Existing transcript, context snapshot, and current spec draft
 - **Invocation:** Continue the interview loop
 - **Consumer Behavior:** Re-enter questioning to resolve the highest-leverage remaining uncertainty
@@ -534,7 +525,7 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - [ ] Fuzzy or conflicting terminology was challenged against repo language/current code behavior when applicable
 - [ ] Scenario-based edge-case grilling was used when boundary ambiguity would materially affect implementation
 - [ ] Durable docs/ADR/memory updates, if any, were explicitly opted into and public-safe
-- [ ] Handoff options provided (`$ultragoal`, `$ralplan`, `$autopilot`, `$ralph`, `$team`) plus context-sensitive goal-mode suggestions (`$autoresearch-goal`, `$performance-goal`) when applicable
+- [ ] Handoff options provided (`$ultragoal`, `$ralplan`, `$autopilot`, `$team`) plus context-sensitive goal-mode suggestions (`$autoresearch`, `$performance-goal`) when applicable
 - [ ] No direct implementation performed in this mode
 </Final_Checklist>
 

--- a/plugins/oh-my-codex/skills/design/SKILL.md
+++ b/plugins/oh-my-codex/skills/design/SKILL.md
@@ -12,7 +12,7 @@ Shared operating, delegation, state, hook, team, cancellation, and verification 
 ## Use when
 
 - Product, UX, frontend, or design-system decisions need a repo-local source of truth.
-- A feature needs a design brief before `$ralph`, a designer lane, or implementation.
+- A feature needs a design brief before a designer lane or implementation.
 - Existing UI, assets, screenshots, or constraints need an actionable design summary.
 
 Do not use it for visual-reference implementation matching (use `$visual-ralph`), screenshot comparison alone, or backend/infrastructure work without user-facing design impact.

--- a/plugins/oh-my-codex/skills/hud/SKILL.md
+++ b/plugins/oh-my-codex/skills/hud/SKILL.md
@@ -95,4 +95,4 @@ If the TUI statusline is not showing:
 
 If `omx hud` shows "No active modes":
 - This is expected when no workflows are running
-- Start a workflow (ralph, autopilot, etc.) and check again
+- Start an explicitly requested supported workflow (`$autopilot` or `$ultragoal`) and check again

--- a/plugins/oh-my-codex/skills/plan/SKILL.md
+++ b/plugins/oh-my-codex/skills/plan/SKILL.md
@@ -14,7 +14,7 @@ Plan creates concise, actionable work plans. Auto-detects interview vs direct, s
 </Use_When>
 
 <Do_Not_Use_When>
-- Want direct execution — use `ultragoal`/`team`/`ralph`
+- Want direct execution — execute the scoped task directly; use `ultragoal` only for durable goals or `team` for coordinated parallel work
 - Simple focused fix with obvious scope — skip planning
 </Do_Not_Use_When>
 

--- a/plugins/oh-my-codex/skills/ralplan/SKILL.md
+++ b/plugins/oh-my-codex/skills/ralplan/SKILL.md
@@ -92,7 +92,7 @@ Before any execution lane begins, ralplan must emit terminal planning state (com
 
 Ralplan is not complete, skippable, or ready for execution merely because `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist. Those files are planning artifacts, not consensus evidence.
 
-Before any Autopilot, Pipeline, Ultragoal, Team, Ralph, or implementation handoff, persist a durable handoff record that distinguishes:
+Before any Autopilot, Ultragoal, Team, or implementation handoff, persist a durable handoff record that distinguishes:
 
 - `planning_artifacts`: PRD/test-spec paths.
 - `ralplan_architect_review`: the completed Architect review with an approving verdict.
@@ -106,13 +106,13 @@ Follow the Plan skill's full documentation for consensus mode details.
 
 ## Goal-Mode Follow-up Suggestions
 
-When a bound `ralplan_execution_handoff` permits execution, include product-facing goal-mode suggestions alongside the existing Ralph and team options. Record the requested lane and persist the handoff without claiming host-issued authority.
+When a bound `ralplan_execution_handoff` permits execution, include product-facing goal-mode suggestions alongside coordinated Team execution. Record the requested lane and persist the handoff without claiming host-issued authority.
 
 - `$ultragoal` — **default goal-mode follow-up** for implementation or general goal-oriented follow-up plans that should become durable Codex/OMX goals with sequential completion tracking.
 - `$autoresearch` — research-project follow-up when the plan centers on a question, literature/reference gathering, evaluator-backed research, or a professor/critic-style research deliverable. (`$autoresearch-goal` was retired to a sunset stub in OMX 0.21.)
 - `$performance-goal` — optimization/performance follow-up when the plan centers on speed, latency, throughput, memory, benchmark, or other measurable performance work.
 
-Keep `$team` as a first-class execution option and keep `$ralph` available only as an explicit fallback where appropriate: use Ultragoal as the default durable goal-mode follow-up, Team for coordinated parallel implementation, and Ralph only for intentionally selected persistent single-owner completion/verification pressure. For parallelizable durable-goal delivery, recommend `$ultragoal` + `$team` together: Ultragoal remains the leader-owned `.omx/ultragoal` ledger/Codex-goal wrapper while Team runs parallel lanes and returns checkpoint-ready evidence. Do not present Ralph as the recommended follow-up when durable goal tracking is needed; present Ultragoal as the superseding default, with Team for parallel delivery and Ralph only as an explicit fallback when its narrow persistence loop is specifically desired.
+Use `$ultragoal` for durable goal tracking and `$team` for coordinated parallel implementation. When combined, Ultragoal owns the ledger and Team returns checkpoint-ready execution evidence.
 Use the available-agent-types roster to produce explicit role/staffing allocation, reasoning-by-lane guidance, concrete launch hints (including `omx team` when parallel delivery is justified), and team verification responsibilities for any future receipt-authorized execution path.
 
 ## Pre-context Intake
@@ -130,80 +130,15 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - likely codebase touchpoints
 4. If ambiguity remains high, gather brownfield facts first. `omx explore` is deprecated; use normal repository inspection tools/subagents for simple read-only repository lookups and `omx sparkshell` only for explicit shell-native read-only evidence. Then run `$deep-interview --quick <task>` before continuing.
 5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, use `$best-practice-research` as the bounded evidence wrapper and auto-delegate `researcher` for the official/upstream lookup before finalizing the planning handoff so execution does not start from repo-local recall alone.
-6. If a prior `$autoresearch` or `$autoresearch-goal` run exists, treat its approved artifact as evidence for the plan. Do not include Autoresearch as a final architecture or runtime component unless the user explicitly requested ongoing research automation; otherwise synthesize the evidence into the `$ralplan` ADR, risks, and verification steps.
+6. If a prior `$autoresearch` run exists, treat its approved artifact as evidence for the plan. Read historical artifacts from `$autoresearch-goal` only as compatibility input. Do not include Autoresearch as a final architecture or runtime component unless the user explicitly requested ongoing research automation; otherwise synthesize the evidence into the `$ralplan` ADR, risks, and verification steps.
 
 Do not hand off to execution modes until this intake is complete; if urgency forces progress, explicitly document the risk tradeoffs.
 
-## Pre-Execution Gate
+## Routing boundary
 
-### Why the Gate Exists
-
-Execution modes (ralph, autopilot, team, ultrawork) spin up heavy multi-agent orchestration. When launched on a vague request like "ralph improve the app", agents have no clear target — they waste cycles on scope discovery that should happen during planning, often delivering partial or misaligned work that requires rework.
-
-The ralplan-first gate intercepts underspecified execution requests and redirects them through the ralplan consensus planning workflow. This ensures:
-- **Explicit scope**: A PRD defines exactly what will be built
-- **Test specification**: Acceptance criteria are testable before code is written
-- **Consensus**: Planner, Architect, and Critic agree on the approach
-- **No wasted execution**: Agents start with a clear, bounded task
-
-### Good vs Bad Prompts
-
-**Passes the gate** (specific enough for direct execution):
-- `ralph fix the null check in src/hooks/bridge.ts:326`
-- `autopilot implement issue #42`
-- `team add validation to function processKeywordDetector`
-- `ralph do:\n1. Add input validation\n2. Write tests\n3. Update README`
-- `ultrawork add the user model in src/models/user.ts`
-
-**Gated — redirected to ralplan** (needs scoping first):
-- `ralph fix this`
-- `autopilot build the app`
-- `team improve performance`
-- `ralph add authentication`
-- `ultrawork make it better`
-
-**Bypass the gate** (when you know what you want):
-- `force: ralph refactor the auth module`
-- `! autopilot optimize everything`
-
-### When the Gate Does NOT Trigger
-
-The gate auto-passes when it detects **any** concrete signal. You do not need all of them — one is enough:
-
-| Signal Type | Example prompt | Why it passes |
-|---|---|---|
-| File path | `ralph fix src/hooks/bridge.ts` | References a specific file |
-| Issue/PR number | `ralph implement #42` | Has a concrete work item |
-| camelCase symbol | `ralph fix processKeywordDetector` | Names a specific function |
-| PascalCase symbol | `ralph update UserModel` | Names a specific class |
-| snake_case symbol | `team fix user_model` | Names a specific identifier |
-| Test runner | `ralph npm test && fix failures` | Has an explicit test target |
-| Numbered steps | `ralph do:\n1. Add X\n2. Test Y` | Structured deliverables |
-| Acceptance criteria | `ralph add login - acceptance criteria: ...` | Explicit success definition |
-| Error reference | `ralph fix TypeError in auth` | Specific error to address |
-| Code block | `ralph add: \`\`\`ts ... \`\`\`` | Concrete code provided |
-| Escape prefix | `force: ralph do it` or `! ralph do it` | Explicit user override |
-
-### End-to-End Flow Example
-
-1. User types: `ralph add user authentication`
-2. Gate detects: execution keyword (`ralph`) + underspecified prompt (no files, functions, or test spec)
-3. Gate redirects to **ralplan** with message explaining the redirect
-4. Ralplan consensus runs:
-   - **Planner** creates initial plan (which files, what auth method, what tests)
-   - **Architect** reviews for soundness
-   - **Critic** validates quality and testability
-5. Architect and Critic approval completes the planning lifecycle and persists `ralplan_consensus_gate.complete:true` as lifecycle evidence.
-6. Execution begins when the session-bound, review-cycle-bound `ralplan_execution_handoff` authorizes the selected lane. An active supervised Autopilot run authorizes its defining Ultragoal next stage; standalone Ralplan records the user's selected lane.
-
-### Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Gate fires on a well-specified prompt | Add a file reference, function name, or issue number to anchor the request |
-| Want to bypass the gate | Prefix with `force:` or `!` (e.g., `force: ralph fix it`) |
-| Gate does not fire on a vague prompt | The gate only catches prompts with <=15 effective words and no concrete anchors; add more detail or use `$ralplan` explicitly |
-| Redirected to ralplan but want to stop planning | Cancel or abandon through the workflow's administrative path. Advisory is cooperative and does not enforce host permissions; a real security gate would require an explicit host-issued, host-verified receipt. |
+Ordinary scoped tasks stay in the direct execution lane described by `templates/AGENTS.md`.
+Explicit workflow requests follow the keyword registry (`src/hooks/keyword-registry.ts`) and their owning skill contracts; this card does not define a second activation table.
+Once Ralplan is active, preserve the planning/execution and consensus handoff requirements above. A conversational “just do it” is not a substitute for the required review evidence.
 
 ## Scenario Examples
 

--- a/plugins/oh-my-codex/skills/visual-ralph/SKILL.md
+++ b/plugins/oh-my-codex/skills/visual-ralph/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: visual-ralph
-description: "Visual Ralph orchestration for frontend UI from generated references, static references, or live URL targets, using $ralph with built-in visual verdict and pixel-diff evidence until the implementation matches and leaves a reproducible design system."
+description: "Visual Ralph orchestration for frontend UI from generated references, static references, or live URL targets, using $ultragoal with built-in visual verdict and pixel-diff evidence until the implementation matches and leaves a reproducible design system."
 ---
 
 # Visual Ralph Skill
 
 Use `$visual-ralph` for measured frontend implementation from an approved generated reference, static image, or live-URL baseline. The loop is:
 
-`description / URL -> approved reference -> $ralph implementation -> Visual Ralph verdict + pixel diff -> reusable design system`.
+`description / URL -> approved reference -> $ultragoal implementation -> Visual Ralph verdict + pixel diff -> reusable design system`.
 
 For URL cloning, this skill owns the migrated `$web-clone` use case; preserve URL, viewport, fidelity, and interaction notes here. Do not invoke standalone `$web-clone`.
 
@@ -19,7 +19,7 @@ Shared operating, delegation, state, hook, team, cancellation, and verification 
 - A live URL or generated raster mockup needs measured implementation and pixel-level iteration.
 - The result must leave reusable repo-native tokens/components, not only a matching screenshot.
 
-Do not use it for a durable `DESIGN.md` brief (`$design`), non-visual backend work, comparison-only fixes that can go directly to `$ralph`, or deterministic SVG/code-native assets.
+Do not use it for a durable `DESIGN.md` brief (`$design`), non-visual backend work, comparison-only fixes that can be executed directly, or deterministic SVG/code-native assets.
 
 ## Workflow
 
@@ -41,11 +41,11 @@ Copy the approved reference into `.omx/artifacts/visual-ralph/<slug>/reference.p
 
 ### 3. Approval gate
 
-Stop after generation or URL capture and obtain approval of one reference image/state (or a targeted regeneration/capture adjustment). Before approval, do not implement or invoke `$ralph`. After approval, the image/baseline is the visual source of truth; major pivots require an explicit user request.
+Stop after generation or URL capture and obtain approval of one reference image/state (or a targeted regeneration/capture adjustment). Before approval, do not implement or invoke `$ultragoal`. After approval, the image/baseline is the visual source of truth; major pivots require an explicit user request.
 
-### 4. Hand off to `$ralph`
+### 4. Hand off to `$ultragoal`
 
-Pass the approved reference/baseline, URL and permission note when applicable, viewport/content state, interaction parity and exclusions, user description, detected frontend context, screenshot command/viewport, and the completion checklist. Ralph edits, runs, captures, and iterates after approval until matched or blocked.
+Pass the approved reference/baseline, URL and permission note when applicable, viewport/content state, interaction parity and exclusions, user description, detected frontend context, screenshot command/viewport, and the completion checklist. The active Ultragoal execution lane edits, runs, captures, and iterates after approval until matched or blocked.
 
 ### 5. Verdict before every edit
 
@@ -66,7 +66,7 @@ Do not declare done until the approved reference/baseline and reproduction comma
 ## Handoff template
 
 ```text
-$ralph "Implement the approved frontend reference.
+$ultragoal "Implement the approved frontend reference.
 Reference: <workspace reference or URL-derived artifact>
 Source URL and permission/scope: <when applicable>
 Viewport/content state: <viewport, route/state, seed/login assumptions>

--- a/skills/ai-slop-cleaner/SKILL.md
+++ b/skills/ai-slop-cleaner/SKILL.md
@@ -15,8 +15,7 @@ Use when working code is bloated, noisy, repetitive, over-abstracted, or AI-gene
 the user requests cleanup/refactor/deslop; or a follow-up left duplicate/dead code,
 weak boundaries, missing tests, fallback-like paths, or wrappers. Inputs are the requested
 feature/files and behavior to preserve. A file list scope is valid; keep the pass bounded
-to it. In the Ralph workflow, run this skill on Ralph's changed files only, standard mode
-unless explicitly requested otherwise.
+to it. Limit the pass to the calling task's changed files unless broader cleanup was requested.
 
 ## Before editing
 
@@ -24,7 +23,7 @@ unless explicitly requested otherwise.
 2. **Create a cleanup plan before code**: list scope and smells, include fallback findings/classifications/escalation, and order safest/highest-signal fixes first.
 3. **Inventory fallback-like code** in scope: quick hacks, temporary workaround, temporary fallback, just bypass, just skip, fallback if it fails, swallowed errors, silent defaults, broad compatibility shims, and duplicate alternate execution paths.
 4. Classify each fallback: **Masking fallback slop** hides evidence, bypasses the contract, suppresses validation, swallows failures, silently defaults, or adds untested paths; **Grounded compatibility/fail-safe fallback** is narrow at an external/version/fail-safe boundary, documents rationale, preserves failure evidence, and tests primary plus fallback.
-5. Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior. For broad/ambiguous/cross-layer/architectural findings, invoke `$ralplan` for consensus resolution; when already inside ralplan, ralph, team, or another OMX workflow, do not spawn a nested `$ralplan`—attach the finding to the active handoff.
+5. Prefer root-cause repair, deletion, boundary repair, or explicit failure behavior. For broad/ambiguous/cross-layer/architectural findings, invoke `$ralplan` for consensus resolution; when already inside ralplan, ultragoal, team, or another OMX workflow, do not spawn a nested `$ralplan`—attach the finding to the active handoff.
 
 ## Smell taxonomy and passes
 

--- a/skills/best-practice-research/SKILL.md
+++ b/skills/best-practice-research/SKILL.md
@@ -26,7 +26,7 @@ This skill is terminal and read-only by default. It gathers evidence and produce
 
 - The answer is fully repo-local; use `explore` for codebase facts.
 - The main question is whether to adopt, replace, upgrade, or compare dependencies; use `dependency-expert`.
-- The user only needs implementation against already-grounded requirements; use `executor`, `$ralph`, or `$team` as appropriate.
+- The user only needs implementation against already-grounded requirements; execute directly, or use `$team` when coordinated parallel work is warranted.
 - The task can be answered from stable local project conventions without current external lookup.
 
 ## Specialist Routing

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -87,7 +87,7 @@ Combine the `code-reviewer` recommendation and architect status. Approval requir
 
 Approval criteria: **APPROVE** only when `code-reviewer` returns APPROVE, architect status is `CLEAR`, and both independent lanes returned evidence. **REQUEST CHANGES** for a blocker, unresolved high/critical finding, or unavailable lane. **COMMENT** may record non-blocking findings.
 
-Do not self-review as a fallback. If the `code-reviewer` or `architect` path is missing, unavailable, skipped, or fails, block approval until independent lane evidence exists. On the explicit Ralph path, findings may trigger automatic fix follow-up without another permission prompt; plain `code-review` itself remains read-only and does **not** promise auto-fix.
+Do not self-review as a fallback. If the `code-reviewer` or `architect` path is missing, unavailable, skipped, or fails, block approval until independent lane evidence exists. On the supported `omx ralph` CLI compatibility path, findings may trigger automatic fix follow-up without another permission prompt; plain `code-review` itself remains read-only and does **not** promise auto-fix.
 
 ## Evidence/output contract
 

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -12,7 +12,7 @@ Deep Interview is an intent-first Socratic clarification loop before planning or
 - The request is broad, ambiguous, or missing concrete acceptance criteria
 - The user says "deep interview", "interview me", "ask me everything", "don't assume", or "ouroboros"
 - The user wants to avoid misaligned implementation from underspecified requirements
-- You need a requirements artifact before handing off to `ralplan`, `autopilot`, `ralph`, or `team`
+- You need a requirements artifact before handing off to `ralplan`, `autopilot`, `ultragoal`, or `team`
 </Use_When>
 
 <Do_Not_Use_When>
@@ -149,7 +149,7 @@ If no flag is provided, use **Standard**.
 Repeat until ambiguity `<= threshold`, the pressure pass is complete, the readiness gates are explicit, the user exits with warning, or max rounds are reached. This is a stop condition: below threshold, do not open a new ordinary interview branch.
 
 ### 2a) Generate next question
-If the initial context is oversized and no prompt-safe summary has been recorded yet, the next question must be only a summary request. Do not score ambiguity, do not run readiness gates, and do not hand off to `$ultragoal`, `$ralplan`, `$autopilot`, `$ralph`, or `$team` until that summary answer is captured.
+If the initial context is oversized and no prompt-safe summary has been recorded yet, the next question must be only a summary request. Do not score ambiguity, do not run readiness gates, and do not hand off to `$ultragoal`, `$ralplan`, `$autopilot`, or `$team` until that summary answer is captured.
 
 Use:
 - Original idea
@@ -429,13 +429,13 @@ Only set `execution_contract_required:true` when the selected downstream workflo
 
 ### Goal-mode follow-ups
 
-Include these product-facing suggestions when they fit the clarified spec, without removing the existing `$ultragoal`, `$ralplan`, `$autopilot`, `$ralph`, and `$team` handoff options:
+Include these product-facing suggestions when they fit the clarified spec, without removing the existing `$ultragoal`, `$ralplan`, `$autopilot`, and `$team` handoff options:
 
 - **`$ultragoal`** — default goal-mode follow-up for implementation or general goal-oriented follow-up specs that should be converted into durable Codex/OMX goals with sequential completion tracking.
-- **`$autoresearch-goal`** — use when the clarified context is a research project: a research question, reference/literature gathering, evaluator-backed analysis, or professor/critic-style deliverable.
+- **`$autoresearch`** — use when the clarified context is a research project: a research question, reference/literature gathering, evaluator-backed analysis, or professor/critic-style deliverable.
 - **`$performance-goal`** — use when the clarified context is an optimization or performance project with measurable speed, latency, throughput, memory, benchmark, or evaluator criteria.
 
-Recommend `$ultragoal` as the default durable goal-mode follow-up because it supersedes Ralph for goal tracking. Preserve `$team` for coordinated parallel implementation and keep `$ralph` only as an explicit fallback for persistent single-owner execution/verification when the user specifically selects it.
+Recommend `$ultragoal` as the default durable goal-mode follow-up because it supersedes Ralph for goal tracking. Preserve `$team` for coordinated parallel implementation.
 
 ### 1. **`$ultragoal` (Default durable execution follow-up)**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md` (optionally accompanied by the transcript/context snapshot for traceability)
@@ -444,7 +444,7 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - **Skipped / Already-Satisfied Stages:** Requirement interview, ambiguity clarification, doc/context preflight, and early intent-boundary elicitation
 - **Expected Output:** `.omx/ultragoal/brief.md`, `.omx/ultragoal/goals.json`, `.omx/ultragoal/ledger.jsonl`, implementation evidence, verification evidence, and final cleanup/review-gate evidence
 - **Best When:** The clarified spec is execution-ready or the user explicitly wants durable goal tracking as the next step
-- **Next Recommended Step:** Run the Ultragoal completion loop; launch `$team` only inside an active Ultragoal story when parallel lanes are warranted, and use `$ralph` only as an explicit fallback when the user asks for that legacy persistence mode
+- **Next Recommended Step:** Run the Ultragoal completion loop; launch `$team` only inside an active Ultragoal story when parallel lanes are warranted
 
 ### 2. **`$ralplan` (Recommended when architecture/test-shape review is still needed)**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md` (optionally accompanied by the transcript/context snapshot for traceability)
@@ -453,7 +453,7 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - **Skipped / Already-Satisfied Stages:** Requirements discovery, ambiguity clarification, and early intent-boundary elicitation
 - **Expected Output:** Canonical planning artifacts under `.omx/plans/`, especially `prd-*.md` and `test-spec-*.md`
 - **Best When:** Requirements are clear enough to stop interviewing, but architectural validation / consensus planning is still desirable
-- **Next Recommended Step:** Use the approved planning artifacts with `$ultragoal` as the default durable goal-mode follow-up (optionally with `$team` for parallel lanes); choose `$autoresearch-goal` for research validation or `$performance-goal` for measurable optimization, and use `$ralph` only as an explicit fallback when a narrow single-owner persistence loop is requested
+- **Next Recommended Step:** Use the approved planning artifacts with `$ultragoal` as the default durable goal-mode follow-up (optionally with `$team` for parallel lanes); choose `$autoresearch` for research validation or `$performance-goal` for measurable optimization
 
 ### 3. **`$autopilot`**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md`
@@ -462,27 +462,18 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - **Skipped / Already-Satisfied Stages:** Initial requirement discovery and ambiguity reduction
 - **Expected Output:** Planning/execution progress, QA evidence, and validation artifacts produced by autopilot
 - **Best When:** The clarified spec is already strong enough for direct planning + execution without an additional consensus gate
-- **Next Recommended Step:** Continue through autopilot's execution/QA/validation flow; if coordination-heavy execution emerges, prefer `$team` under a leader-owned `$ultragoal` ledger, using `$ralph` only as an explicit fallback when a narrow single-owner persistence loop is requested
+- **Next Recommended Step:** Continue through autopilot's execution/QA/validation flow; if coordination-heavy execution emerges, prefer `$team` under a leader-owned `$ultragoal` ledger
 
-### 4. **`$ralph` (Explicit fallback only)**
-- **Input Artifact:** `.omx/specs/deep-interview-{slug}.md`
-- **Invocation:** `$ralph <spec-path>`
-- **Consumer Behavior:** Use the spec's acceptance criteria and boundary constraints as the persistence target. Do not reopen requirements discovery unless the user explicitly asks to refine further.
-- **Skipped / Already-Satisfied Stages:** Requirement interview, ambiguity clarification, and initial scope-definition work
-- **Expected Output:** Iterative execution progress and verification evidence tracked against the clarified criteria
-- **Best When:** The user explicitly asks for Ralph's persistent sequential completion pressure; otherwise use `$ultragoal` for durable goal tracking and completion checkpoints
-- **Next Recommended Step:** If this explicit fallback is selected, continue Ralph's persistence loop; if work expands into coordination-heavy lanes, hand off to `$team` under `$ultragoal` checkpointing rather than promoting Ralph as the next default
-
-### 5. **`$team`**
+### 4. **`$team`**
 - **Input Artifact:** `.omx/specs/deep-interview-{slug}.md`
 - **Invocation:** `$team <spec-path>`
 - **Consumer Behavior:** Treat the spec as shared execution context for coordinated parallel work. Preserve the clarified intent, non-goals, decision boundaries, and acceptance criteria as common lane constraints.
 - **Skipped / Already-Satisfied Stages:** Requirement clarification and early ambiguity reduction
-- **Expected Output:** Coordinated multi-agent execution against the shared spec, with evidence that can later feed Ultragoal checkpoints by default, or an explicit Ralph verification pass only when requested
+- **Expected Output:** Coordinated multi-agent execution against the shared spec, with final verification evidence and checkpoints in an already-active Ultragoal ledger when applicable
 - **Best When:** The task is large, multi-lane, or blocker-sensitive enough to justify coordinated parallel execution instead of a single persistent loop
-- **Next Recommended Step:** Follow the team verification path when the coordinated execution phase finishes; checkpoint completion through `$ultragoal` by default, escalating to a separate Ralph loop only when the user explicitly asks for that persistent verification/fix owner
+- **Next Recommended Step:** Follow the team verification path when the coordinated execution phase finishes; checkpoint an already-active `$ultragoal` ledger when applicable. Do not start another execution loop solely to verify.
 
-### 6. **Refine further**
+### 5. **Refine further**
 - **Input Artifact:** Existing transcript, context snapshot, and current spec draft
 - **Invocation:** Continue the interview loop
 - **Consumer Behavior:** Re-enter questioning to resolve the highest-leverage remaining uncertainty
@@ -534,7 +525,7 @@ Recommend `$ultragoal` as the default durable goal-mode follow-up because it sup
 - [ ] Fuzzy or conflicting terminology was challenged against repo language/current code behavior when applicable
 - [ ] Scenario-based edge-case grilling was used when boundary ambiguity would materially affect implementation
 - [ ] Durable docs/ADR/memory updates, if any, were explicitly opted into and public-safe
-- [ ] Handoff options provided (`$ultragoal`, `$ralplan`, `$autopilot`, `$ralph`, `$team`) plus context-sensitive goal-mode suggestions (`$autoresearch-goal`, `$performance-goal`) when applicable
+- [ ] Handoff options provided (`$ultragoal`, `$ralplan`, `$autopilot`, `$team`) plus context-sensitive goal-mode suggestions (`$autoresearch`, `$performance-goal`) when applicable
 - [ ] No direct implementation performed in this mode
 </Final_Checklist>
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -12,7 +12,7 @@ Shared operating, delegation, state, hook, team, cancellation, and verification 
 ## Use when
 
 - Product, UX, frontend, or design-system decisions need a repo-local source of truth.
-- A feature needs a design brief before `$ralph`, a designer lane, or implementation.
+- A feature needs a design brief before a designer lane or implementation.
 - Existing UI, assets, screenshots, or constraints need an actionable design summary.
 
 Do not use it for visual-reference implementation matching (use `$visual-ralph`), screenshot comparison alone, or backend/infrastructure work without user-facing design impact.

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -95,4 +95,4 @@ If the TUI statusline is not showing:
 
 If `omx hud` shows "No active modes":
 - This is expected when no workflows are running
-- Start a workflow (ralph, autopilot, etc.) and check again
+- Start an explicitly requested supported workflow (`$autopilot` or `$ultragoal`) and check again

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -14,7 +14,7 @@ Plan creates concise, actionable work plans. Auto-detects interview vs direct, s
 </Use_When>
 
 <Do_Not_Use_When>
-- Want direct execution — use `ultragoal`/`team`/`ralph`
+- Want direct execution — execute the scoped task directly; use `ultragoal` only for durable goals or `team` for coordinated parallel work
 - Simple focused fix with obvious scope — skip planning
 </Do_Not_Use_When>
 

--- a/skills/ralplan/SKILL.md
+++ b/skills/ralplan/SKILL.md
@@ -92,7 +92,7 @@ Before any execution lane begins, ralplan must emit terminal planning state (com
 
 Ralplan is not complete, skippable, or ready for execution merely because `.omx/plans/prd-*.md` and `.omx/plans/test-spec-*.md` exist. Those files are planning artifacts, not consensus evidence.
 
-Before any Autopilot, Pipeline, Ultragoal, Team, Ralph, or implementation handoff, persist a durable handoff record that distinguishes:
+Before any Autopilot, Ultragoal, Team, or implementation handoff, persist a durable handoff record that distinguishes:
 
 - `planning_artifacts`: PRD/test-spec paths.
 - `ralplan_architect_review`: the completed Architect review with an approving verdict.
@@ -106,13 +106,13 @@ Follow the Plan skill's full documentation for consensus mode details.
 
 ## Goal-Mode Follow-up Suggestions
 
-When a bound `ralplan_execution_handoff` permits execution, include product-facing goal-mode suggestions alongside the existing Ralph and team options. Record the requested lane and persist the handoff without claiming host-issued authority.
+When a bound `ralplan_execution_handoff` permits execution, include product-facing goal-mode suggestions alongside coordinated Team execution. Record the requested lane and persist the handoff without claiming host-issued authority.
 
 - `$ultragoal` — **default goal-mode follow-up** for implementation or general goal-oriented follow-up plans that should become durable Codex/OMX goals with sequential completion tracking.
 - `$autoresearch` — research-project follow-up when the plan centers on a question, literature/reference gathering, evaluator-backed research, or a professor/critic-style research deliverable. (`$autoresearch-goal` was retired to a sunset stub in OMX 0.21.)
 - `$performance-goal` — optimization/performance follow-up when the plan centers on speed, latency, throughput, memory, benchmark, or other measurable performance work.
 
-Keep `$team` as a first-class execution option and keep `$ralph` available only as an explicit fallback where appropriate: use Ultragoal as the default durable goal-mode follow-up, Team for coordinated parallel implementation, and Ralph only for intentionally selected persistent single-owner completion/verification pressure. For parallelizable durable-goal delivery, recommend `$ultragoal` + `$team` together: Ultragoal remains the leader-owned `.omx/ultragoal` ledger/Codex-goal wrapper while Team runs parallel lanes and returns checkpoint-ready evidence. Do not present Ralph as the recommended follow-up when durable goal tracking is needed; present Ultragoal as the superseding default, with Team for parallel delivery and Ralph only as an explicit fallback when its narrow persistence loop is specifically desired.
+Use `$ultragoal` for durable goal tracking and `$team` for coordinated parallel implementation. When combined, Ultragoal owns the ledger and Team returns checkpoint-ready execution evidence.
 Use the available-agent-types roster to produce explicit role/staffing allocation, reasoning-by-lane guidance, concrete launch hints (including `omx team` when parallel delivery is justified), and team verification responsibilities for any future receipt-authorized execution path.
 
 ## Pre-context Intake
@@ -130,80 +130,15 @@ Before consensus planning or execution handoff, ensure a grounded context snapsh
    - likely codebase touchpoints
 4. If ambiguity remains high, gather brownfield facts first. `omx explore` is deprecated; use normal repository inspection tools/subagents for simple read-only repository lookups and `omx sparkshell` only for explicit shell-native read-only evidence. Then run `$deep-interview --quick <task>` before continuing.
 5. If the plan depends on official docs, version-aware framework guidance, best practices, or external dependency behavior, use `$best-practice-research` as the bounded evidence wrapper and auto-delegate `researcher` for the official/upstream lookup before finalizing the planning handoff so execution does not start from repo-local recall alone.
-6. If a prior `$autoresearch` or `$autoresearch-goal` run exists, treat its approved artifact as evidence for the plan. Do not include Autoresearch as a final architecture or runtime component unless the user explicitly requested ongoing research automation; otherwise synthesize the evidence into the `$ralplan` ADR, risks, and verification steps.
+6. If a prior `$autoresearch` run exists, treat its approved artifact as evidence for the plan. Read historical artifacts from `$autoresearch-goal` only as compatibility input. Do not include Autoresearch as a final architecture or runtime component unless the user explicitly requested ongoing research automation; otherwise synthesize the evidence into the `$ralplan` ADR, risks, and verification steps.
 
 Do not hand off to execution modes until this intake is complete; if urgency forces progress, explicitly document the risk tradeoffs.
 
-## Pre-Execution Gate
+## Routing boundary
 
-### Why the Gate Exists
-
-Execution modes (ralph, autopilot, team, ultrawork) spin up heavy multi-agent orchestration. When launched on a vague request like "ralph improve the app", agents have no clear target — they waste cycles on scope discovery that should happen during planning, often delivering partial or misaligned work that requires rework.
-
-The ralplan-first gate intercepts underspecified execution requests and redirects them through the ralplan consensus planning workflow. This ensures:
-- **Explicit scope**: A PRD defines exactly what will be built
-- **Test specification**: Acceptance criteria are testable before code is written
-- **Consensus**: Planner, Architect, and Critic agree on the approach
-- **No wasted execution**: Agents start with a clear, bounded task
-
-### Good vs Bad Prompts
-
-**Passes the gate** (specific enough for direct execution):
-- `ralph fix the null check in src/hooks/bridge.ts:326`
-- `autopilot implement issue #42`
-- `team add validation to function processKeywordDetector`
-- `ralph do:\n1. Add input validation\n2. Write tests\n3. Update README`
-- `ultrawork add the user model in src/models/user.ts`
-
-**Gated — redirected to ralplan** (needs scoping first):
-- `ralph fix this`
-- `autopilot build the app`
-- `team improve performance`
-- `ralph add authentication`
-- `ultrawork make it better`
-
-**Bypass the gate** (when you know what you want):
-- `force: ralph refactor the auth module`
-- `! autopilot optimize everything`
-
-### When the Gate Does NOT Trigger
-
-The gate auto-passes when it detects **any** concrete signal. You do not need all of them — one is enough:
-
-| Signal Type | Example prompt | Why it passes |
-|---|---|---|
-| File path | `ralph fix src/hooks/bridge.ts` | References a specific file |
-| Issue/PR number | `ralph implement #42` | Has a concrete work item |
-| camelCase symbol | `ralph fix processKeywordDetector` | Names a specific function |
-| PascalCase symbol | `ralph update UserModel` | Names a specific class |
-| snake_case symbol | `team fix user_model` | Names a specific identifier |
-| Test runner | `ralph npm test && fix failures` | Has an explicit test target |
-| Numbered steps | `ralph do:\n1. Add X\n2. Test Y` | Structured deliverables |
-| Acceptance criteria | `ralph add login - acceptance criteria: ...` | Explicit success definition |
-| Error reference | `ralph fix TypeError in auth` | Specific error to address |
-| Code block | `ralph add: \`\`\`ts ... \`\`\`` | Concrete code provided |
-| Escape prefix | `force: ralph do it` or `! ralph do it` | Explicit user override |
-
-### End-to-End Flow Example
-
-1. User types: `ralph add user authentication`
-2. Gate detects: execution keyword (`ralph`) + underspecified prompt (no files, functions, or test spec)
-3. Gate redirects to **ralplan** with message explaining the redirect
-4. Ralplan consensus runs:
-   - **Planner** creates initial plan (which files, what auth method, what tests)
-   - **Architect** reviews for soundness
-   - **Critic** validates quality and testability
-5. Architect and Critic approval completes the planning lifecycle and persists `ralplan_consensus_gate.complete:true` as lifecycle evidence.
-6. Execution begins when the session-bound, review-cycle-bound `ralplan_execution_handoff` authorizes the selected lane. An active supervised Autopilot run authorizes its defining Ultragoal next stage; standalone Ralplan records the user's selected lane.
-
-### Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Gate fires on a well-specified prompt | Add a file reference, function name, or issue number to anchor the request |
-| Want to bypass the gate | Prefix with `force:` or `!` (e.g., `force: ralph fix it`) |
-| Gate does not fire on a vague prompt | The gate only catches prompts with <=15 effective words and no concrete anchors; add more detail or use `$ralplan` explicitly |
-| Redirected to ralplan but want to stop planning | Cancel or abandon through the workflow's administrative path. Advisory is cooperative and does not enforce host permissions; a real security gate would require an explicit host-issued, host-verified receipt. |
+Ordinary scoped tasks stay in the direct execution lane described by `templates/AGENTS.md`.
+Explicit workflow requests follow the keyword registry (`src/hooks/keyword-registry.ts`) and their owning skill contracts; this card does not define a second activation table.
+Once Ralplan is active, preserve the planning/execution and consensus handoff requirements above. A conversational “just do it” is not a substitute for the required review evidence.
 
 ## Scenario Examples
 

--- a/skills/visual-ralph/SKILL.md
+++ b/skills/visual-ralph/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: visual-ralph
-description: "Visual Ralph orchestration for frontend UI from generated references, static references, or live URL targets, using $ralph with built-in visual verdict and pixel-diff evidence until the implementation matches and leaves a reproducible design system."
+description: "Visual Ralph orchestration for frontend UI from generated references, static references, or live URL targets, using $ultragoal with built-in visual verdict and pixel-diff evidence until the implementation matches and leaves a reproducible design system."
 ---
 
 # Visual Ralph Skill
 
 Use `$visual-ralph` for measured frontend implementation from an approved generated reference, static image, or live-URL baseline. The loop is:
 
-`description / URL -> approved reference -> $ralph implementation -> Visual Ralph verdict + pixel diff -> reusable design system`.
+`description / URL -> approved reference -> $ultragoal implementation -> Visual Ralph verdict + pixel diff -> reusable design system`.
 
 For URL cloning, this skill owns the migrated `$web-clone` use case; preserve URL, viewport, fidelity, and interaction notes here. Do not invoke standalone `$web-clone`.
 
@@ -19,7 +19,7 @@ Shared operating, delegation, state, hook, team, cancellation, and verification 
 - A live URL or generated raster mockup needs measured implementation and pixel-level iteration.
 - The result must leave reusable repo-native tokens/components, not only a matching screenshot.
 
-Do not use it for a durable `DESIGN.md` brief (`$design`), non-visual backend work, comparison-only fixes that can go directly to `$ralph`, or deterministic SVG/code-native assets.
+Do not use it for a durable `DESIGN.md` brief (`$design`), non-visual backend work, comparison-only fixes that can be executed directly, or deterministic SVG/code-native assets.
 
 ## Workflow
 
@@ -41,11 +41,11 @@ Copy the approved reference into `.omx/artifacts/visual-ralph/<slug>/reference.p
 
 ### 3. Approval gate
 
-Stop after generation or URL capture and obtain approval of one reference image/state (or a targeted regeneration/capture adjustment). Before approval, do not implement or invoke `$ralph`. After approval, the image/baseline is the visual source of truth; major pivots require an explicit user request.
+Stop after generation or URL capture and obtain approval of one reference image/state (or a targeted regeneration/capture adjustment). Before approval, do not implement or invoke `$ultragoal`. After approval, the image/baseline is the visual source of truth; major pivots require an explicit user request.
 
-### 4. Hand off to `$ralph`
+### 4. Hand off to `$ultragoal`
 
-Pass the approved reference/baseline, URL and permission note when applicable, viewport/content state, interaction parity and exclusions, user description, detected frontend context, screenshot command/viewport, and the completion checklist. Ralph edits, runs, captures, and iterates after approval until matched or blocked.
+Pass the approved reference/baseline, URL and permission note when applicable, viewport/content state, interaction parity and exclusions, user description, detected frontend context, screenshot command/viewport, and the completion checklist. The active Ultragoal execution lane edits, runs, captures, and iterates after approval until matched or blocked.
 
 ### 5. Verdict before every edit
 
@@ -66,7 +66,7 @@ Do not declare done until the approved reference/baseline and reproduction comma
 ## Handoff template
 
 ```text
-$ralph "Implement the approved frontend reference.
+$ultragoal "Implement the approved frontend reference.
 Reference: <workspace reference or URL-derived artifact>
 Source URL and permission/scope: <when applicable>
 Viewport/content state: <viewport, route/state, seed/login assumptions>

--- a/src/hooks/__tests__/anti-slop-workflow.test.ts
+++ b/src/hooks/__tests__/anti-slop-workflow.test.ts
@@ -24,13 +24,13 @@ function assertCanonicalPluginParity(path: string): void {
 }
 
 describe('anti-slop workflow surfaces', () => {
-  it('keeps the cleaner a bounded helper with file-list and Ralph scope rules', () => {
+  it('keeps the cleaner a bounded helper with file-list and calling-task scope rules', () => {
     const skill = read('skills/ai-slop-cleaner/SKILL.md');
     assertCanonicalPluginParity('skills/ai-slop-cleaner/SKILL.md');
     assert.ok(skill.trimEnd().split(/\r?\n/).length <= 120, 'task card must stay within the prompt size limit');
     assert.match(skill, /bounded helper.*not as a competing top-level\s+workflow/is);
     assert.match(skill, /A file list scope is valid; keep the pass bounded\s+to it/i);
-    assert.match(skill, /Ralph workflow.*changed files only, standard mode/i);
+    assert.match(skill, /Limit the pass to the calling task's changed files unless broader cleanup was requested/i);
     assert.match(skill, /requested\s+feature\/files and behavior to preserve/i);
   });
 

--- a/src/hooks/__tests__/code-review-skill-contract.test.ts
+++ b/src/hooks/__tests__/code-review-skill-contract.test.ts
@@ -60,10 +60,10 @@ describe('code-review skill contract', () => {
     assert.match(codeReviewSkill, /\*\*REQUEST CHANGES\*\* for a blocker, unresolved high\/critical finding, or unavailable lane/i);
   });
 
-  it('bounds auto-fix wording to the explicit ralph path only', () => {
-    assert.match(codeReviewSkill, /On the explicit Ralph path/i);
+  it('bounds auto-fix wording to the supported omx ralph compatibility path only', () => {
+    assert.match(codeReviewSkill, /On the supported `omx ralph` CLI compatibility path/i);
     assert.match(codeReviewSkill, /automatic fix follow-up without another permission prompt/i);
-    assert.match(codeReviewSkill, /Plain `code-review` itself remains read-only and does \*\*not\*\* promise auto-fix/i);
+    assert.match(codeReviewSkill, /plain `code-review` itself remains read-only and does \*\*not\*\* promise auto-fix/i);
   });
 
   it('keeps the sample output consistent with a WATCH and COMMENT outcome', () => {

--- a/src/hooks/__tests__/deep-interview-contract.test.ts
+++ b/src/hooks/__tests__/deep-interview-contract.test.ts
@@ -206,7 +206,7 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 		assert.match(
 			deepInterviewSkill,
-			/Do not score ambiguity, do not run readiness gates, and do not hand off to `\$ultragoal`, `\$ralplan`, `\$autopilot`, `\$ralph`, or `\$team` until that summary answer is captured/i,
+			/Do not score ambiguity, do not run readiness gates, and do not hand off to `\$ultragoal`, `\$ralplan`, `\$autopilot`, or `\$team` until that summary answer is captured/i,
 		);
 		assert.match(
 			deepInterviewSkill,
@@ -238,7 +238,6 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /\$ultragoal/i);
 		assert.match(deepInterviewSkill, /\$ralplan/i);
 		assert.match(deepInterviewSkill, /\$autopilot/i);
-		assert.match(deepInterviewSkill, /\$ralph/i);
 		assert.match(deepInterviewSkill, /\$team/i);
 		assert.match(deepInterviewSkill, /Input Artifact/i);
 		assert.match(deepInterviewSkill, /Invocation/i);
@@ -376,13 +375,13 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /team verification path/i);
 	});
 
-	it("suggests Ultragoal as the default durable follow-up with team and explicit Ralph fallback lanes", () => {
+	it("suggests Ultragoal as the default durable follow-up with supported Team and research lanes", () => {
 		assert.match(deepInterviewSkill, /Goal-mode follow-ups/i);
 		assert.match(deepInterviewSkill, /\$ultragoal[\s\S]*general goal-oriented follow-up/i);
-		assert.match(deepInterviewSkill, /\$autoresearch-goal[\s\S]*research project/i);
+		assert.match(deepInterviewSkill, /\$autoresearch[\s\S]*research project/i);
 		assert.match(deepInterviewSkill, /\$performance-goal[\s\S]*(optimization|performance) project/i);
 		assert.match(deepInterviewSkill, /Recommend `\$ultragoal`[\s\S]*default durable goal-mode follow-up/i);
-		assert.match(deepInterviewSkill, /keep `\$ralph` only as an explicit fallback/i);
+		assert.doesNotMatch(deepInterviewSkill, /\$ralph\b/i);
 		assert.match(deepInterviewSkill, /supersedes Ralph for goal tracking/i);
 		assert.match(deepInterviewSkill, /`\$ultragoal` \(Default durable execution follow-up\)/i);
 		assert.match(
@@ -399,7 +398,7 @@ describe("deep-interview Ouroboros contract", () => {
 		);
 		assert.match(
 			deepInterviewSkill,
-			/Handoff options provided \(`\$ultragoal`, `\$ralplan`, `\$autopilot`, `\$ralph`, `\$team`\)/i,
+			/Handoff options provided \(`\$ultragoal`, `\$ralplan`, `\$autopilot`, `\$team`\)/i,
 		);
 	});
 
@@ -414,7 +413,7 @@ describe("deep-interview Ouroboros contract", () => {
 		assert.match(deepInterviewSkill, /do not paste or forward the raw payload/i);
 		assert.match(deepInterviewSkill, /wait for the concise summary before ambiguity scoring, crystallizing artifacts, or any downstream execution handoff/i);
 		assert.match(deepInterviewSkill, /The oversized initial-context summary gate is blocking/i);
-		assert.match(deepInterviewSkill, /Do not score ambiguity, do not run readiness gates, and do not hand off to `\$ultragoal`, `\$ralplan`, `\$autopilot`, `\$ralph`, or `\$team` until that summary answer is captured/i);
+		assert.match(deepInterviewSkill, /Do not score ambiguity, do not run readiness gates, and do not hand off to `\$ultragoal`, `\$ralplan`, `\$autopilot`, or `\$team` until that summary answer is captured/i);
 		assert.match(deepInterviewSkill, /goals, constraints, success criteria, non-goals, decision boundaries/i);
 	});
 

--- a/src/hooks/__tests__/sunset-routing-contract.test.ts
+++ b/src/hooks/__tests__/sunset-routing-contract.test.ts
@@ -238,3 +238,30 @@ describe('sunset routing contract', () => {
     );
   });
 });
+
+
+describe('active workflow handoff hygiene', () => {
+  const retiredExecutionTokens = /\$(?:ralph|ultrawork|pipeline|autoresearch-goal)\b/;
+  const retiredProseHandoff = /\b(?:run|use|start|launch|invoke|hand off to|explicit|separate)\s+(?:a\s+|an\s+|the\s+)?(?:Ralph|Ultrawork|Pipeline|Autoresearch-goal)\b/i;
+  const migrationOnly = /(?:was|has been) (?:removed|retired)|(?:legacy|historical) (?:artifact|state)|compatibility (?:input|cleanup)/i;
+  function staleHandoffs(text: string): string[] {
+    return text.split('\n').filter((line) => (retiredExecutionTokens.test(line) || retiredProseHandoff.test(line)) && !migrationOnly.test(line));
+  }
+
+  it('distinguishes a labeled migration from an executable legacy fallback', () => {
+    assert.deepEqual(staleHandoffs('`$ralph` was removed; use `$ultragoal`.'), []);
+    assert.deepEqual(staleHandoffs('Read historical artifacts from `$autoresearch-goal`.'), []);
+    assert.equal(staleHandoffs('Use `$ralph` as a legacy fallback.').length, 1);
+    assert.equal(staleHandoffs('### Hand off to `$ralph`').length, 1);
+    assert.equal(staleHandoffs('Run a separate Ralph loop.').length, 1);
+    assert.equal(staleHandoffs('Use an explicit Ralph verification pass.').length, 1);
+  });
+
+  it('active and internal skill cards do not hand off to retired execution tokens', () => {
+    const failures = catalogSkills()
+      .filter((skill) => ['active', 'internal'].includes(skill.status))
+      .flatMap((skill) => staleHandoffs(readFileSync(join(repoRoot, 'skills', skill.name, 'SKILL.md'), 'utf-8'))
+        .map((line) => `${skill.name}: ${line}`));
+    assert.deepEqual(failures, []);
+  });
+});

--- a/src/hooks/__tests__/visual-ralph-skill.test.ts
+++ b/src/hooks/__tests__/visual-ralph-skill.test.ts
@@ -8,15 +8,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const skill = readFileSync(join(__dirname, '../../../skills/visual-ralph/SKILL.md'), 'utf-8');
 
 describe('visual-ralph skill contract', () => {
-  it('defines the approved-reference handoff to Ralph', () => {
+  it('defines the approved-reference handoff to Ultragoal', () => {
     assert.match(skill, /^---\nname: visual-ralph/m);
     assert.match(skill, /description:\s*"Visual Ralph orchestration/i);
     assert.match(skill, /generated references, static references, or live URL targets/i);
     assert.match(skill, /\$imagegen/);
     assert.match(skill, /## 3\. Approval gate/i);
     assert.match(skill, /obtain approval of one reference image\/state/i);
-    assert.match(skill, /Before approval, do not implement or invoke `\$ralph`/i);
-    assert.match(skill, /\$ralph/);
+    assert.match(skill, /Before approval, do not implement or invoke `\$ultragoal`/i);
+    assert.match(skill, /\$ultragoal/);
     assert.match(skill, /built-in visual verdict|Visual Ralph verdict/i);
   });
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -54,20 +54,17 @@ Keep runtime marker contracts stable and non-destructive when overlays are appli
 
 
 <delegation_rules>
-Default posture: work directly.
-
 Choose the lane before acting:
-- Default posture: work directly. The ordinary workflow is `understand -> execute -> verify -> report`.
+- Solo execute by default when scope is clear: work directly. The ordinary workflow is `understand -> execute -> verify -> report`.
 - Use `$autopilot` for explicit hands-off orchestration. Its defining default chain is `$deep-interview -> $ralplan -> $ultragoal`; these supervised stages must not be hollowed into optional hints.
 - Use `$deep-interview` when requirements, intent, non-goals, or decision boundaries are materially ambiguous; it is the independent Ouroboros-style Socratic deep interview stage before planning.
 - Use `$plan` for lightweight planning when a deep interview is unnecessary.
 - Use `$team` when an approved plan needs coordinated parallel execution across multiple lanes.
 - Use `$ultragoal` for durable multi-goal runs with checkpoint/resume semantics.
-- Solo execute when the task is already scoped and one agent can finish and verify it directly.
 - Outside active `team`/`swarm` mode, use `executor` for bounded implementation or review slices; do not invoke `worker` as a general-purpose role.
 - Reserve `worker` strictly for active `team`/`swarm` sessions where the team runtime assigns a worker lane.
 - `worker` is a team-runtime surface, not a general-purpose child role.
-- Autopilot owns the canonical staged path `$deep-interview -> $ralplan -> $ultragoal`; stages may also be invoked independently when their input contract is already satisfied. `$deep-interview` is not `$plan --interview`.
+- Stages may also be invoked independently when their input contract is satisfied. `$deep-interview` is not `$plan --interview`.
 
 
 Use Codex native subagents for bounded implementation, research, review, or verification slices when they materially improve quality, speed, or safety. Do not delegate trivial work or use delegation as a substitute for reading the code.
@@ -156,7 +153,7 @@ Verification loop: define the claim and success criteria, run the smallest valid
 </verification>
 
 <execution_protocols>
-Mode selection: use `$autopilot` when explicitly requested for the supervised `$deep-interview -> $ralplan -> $ultragoal` chain; use `$deep-interview` for standalone material requirements ambiguity, `$ralplan` for standalone architecture/consensus planning, `$team` for approved multi-lane parallel work, and `$ultragoal` for standalone durable multi-goal runs. Otherwise execute directly in solo mode. Switch modes only when evidence shows the current lane is mismatched or blocked.
+Mode selection: follow `<delegation_rules>` above. Switch lanes only for a concrete unresolved ambiguity, coordination need, or blocker.
 
 Command routing: use normal Codex repository inspection tools/subagents as the default surface for simple read-only repository lookup tasks; use `omx sparkshell` only for explicit shell-native read-only evidence or bounded verification.
 When to use what:


### PR DESCRIPTION
## Why
Active skill cards were handing users to retired prompt workflows and duplicating routing policy. This removes those dead ends without retiring the supported CLI, persistence, HUD, cancellation, or migration compatibility paths.

## Changes
- Replace retired prompt handoffs with direct execution or the supported explicit Team/Ultragoal path; do not launch a second workflow just to verify.
- Delete the duplicated Ralplan pre-execution routing gate and repeated template mode lists; keep canonical routing and authority boundaries.
- Add an active-card regression guard for retired tokens and bare semantic handoffs.
- Document separate prompt/runtime retirement boundaries; refresh plugin mirrors and capability hashes.

## Verification
- Regression guard demonstrated red before cleanup; final focused contract suite: **43 passed**.
- Guidance/catalog/inventory suite: **90 passed**.
- Build, lint, no-unused typecheck, generated consistency, native-agent verification, and diff check passed.
- Independent architecture re-review: CLEAR; canonical/plugin mirrors byte-identical.
- Full repository suite not run for this documentation/contract slice.

## Series
Independent PR against `dev` at `5190a9dc`; no dependency on the companion hook cleanup or measurement PR (#3646). No state/authority enforcement or runtime compatibility removed.
