### PR TITLE
fix(release): dogfood current Codex hooks on macOS

### DIFF
--- a/crates/omx-runtime/tests/execution.rs
+++ b/crates/omx-runtime/tests/execution.rs
@@ -439,6 +439,7 @@ fn concurrent_exec_queue_accepts_exactly_one_request_id() {
 // ---------------------------------------------------------------------------
 
 /// Helper: run `fs-rename-no-replace <from> <to>` and return (exit_ok, stdout, stderr).
+#[cfg(target_os = "linux")]
 fn run_rename_no_replace(from: &str, to: &str) -> (bool, String, String) {
     let output = Command::new(env!("CARGO_BIN_EXE_omx-runtime"))
         .args(["fs-rename-no-replace", from, to])

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -3685,7 +3685,6 @@ describe("project launch scope helpers", () => {
   });
 
   it("reaps a stale lock only when process-start identity proves PID reuse", async () => {
-    if (process.platform === "win32") return;
     const wd = await mkdtemp(join(tmpdir(), "omx-runtime-history-lock-pid-"));
     try {
       const lockPath = join(wd, ".omx-history.lock");
@@ -3693,8 +3692,16 @@ describe("project launch scope helpers", () => {
       await mkdir(lockPath, { mode: 0o700 });
       await writeFile(ownerPath, JSON.stringify({ token: "old", pid: process.pid, startIdentity: "reused" }));
       utimesSync(ownerPath, new Date(Date.now() - 1_000), new Date(Date.now() - 1_000));
-      const lease = await acquireHistoryPersistenceLock(wd, { staleMs: 30 });
-      await releaseHistoryPersistenceLock(lease);
+      if (process.platform === "linux") {
+        const lease = await acquireHistoryPersistenceLock(wd, { staleMs: 30 });
+        await releaseHistoryPersistenceLock(lease);
+      } else {
+        await assert.rejects(
+          acquireHistoryPersistenceLock(wd, { staleMs: 30, timeoutMs: 100 }),
+          /timed out waiting for history persistence lock/,
+        );
+        assert.equal(JSON.parse(await readFile(ownerPath, "utf-8")).token, "old");
+      }
     } finally {
       await rm(wd, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
+++ b/src/cli/__tests__/plugin-cache-symlink-provenance-3552.test.ts
@@ -16,7 +16,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import {
   PLUGIN_LAUNCHER_RECOVERY_HINT,
   hasExpectedOmxPluginCache,
@@ -33,6 +33,8 @@ import {
   resolvePackagedOmxMarketplace,
   setPluginCacheMutationHooksForTest,
 } from "../plugin-marketplace.js";
+
+import { sameFilePath } from "../../utils/paths.js";
 
 const packageRoot = process.cwd();
 
@@ -65,6 +67,10 @@ async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>):
   } finally {
     Object.defineProperty(process, "platform", { configurable: true, value: original });
   }
+}
+
+function directoryOperationPathForTest(fd: { fd: number }, visiblePath: string): string {
+  return process.platform === "linux" ? `/proc/self/fd/${fd.fd}` : resolve(visiblePath);
 }
 
 async function packagedPluginVersion(): Promise<string> {
@@ -1282,7 +1288,7 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         const { open } = await import("fs/promises");
         const { constants } = await import("fs");
         const fd = await open(cacheBase, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
-        const baseRef: unknown = { handle: fd, path: cacheBase, operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`, scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`, mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}` };
+        const baseRef: unknown = { handle: fd, path: cacheBase, operationPath: directoryOperationPathForTest(fd, cacheBase), scanOperationPath: directoryOperationPathForTest(fd, cacheBase), mutationPath: directoryOperationPathForTest(fd, cacheBase) };
         try {
           await removeChildIfIdentity(baseRef, victim, originalStats, { recursive: true, force: true });
         } catch (e) {
@@ -1332,9 +1338,9 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           const baseRef: unknown = {
             handle: fd,
             path: cacheBase,
-            operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
-            scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
-            mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            operationPath: directoryOperationPathForTest(fd, cacheBase),
+            scanOperationPath: directoryOperationPathForTest(fd, cacheBase),
+            mutationPath: directoryOperationPathForTest(fd, cacheBase),
           };
           try {
             await assert.rejects(
@@ -1373,12 +1379,12 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
         let destinationName: string | undefined;
         const resetHooks = setPluginCacheMutationHooksForTest({
           beforeMkdirExclusive: async (parentPath, name) => {
-            if (destinationName || parentPath !== cacheDir || name === ".omx-incomplete") return;
+            if (destinationName || !sameFilePath(parentPath, cacheDir) || name === ".omx-incomplete") return;
             destinationName = name;
             await writeFile(join(parentPath, name), "staging successor\n");
           },
           beforeExclusiveCreate: async (parentPath, name) => {
-            if (destinationName || parentPath !== cacheDir || name === ".omx-incomplete") return;
+            if (destinationName || !sameFilePath(parentPath, cacheDir) || name === ".omx-incomplete") return;
             destinationName = name;
             await writeFile(join(parentPath, name), "staging successor\n");
           },
@@ -1484,9 +1490,9 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           const baseRef: unknown = {
             handle: fd,
             path: cacheBase,
-            operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
-            scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
-            mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            operationPath: directoryOperationPathForTest(fd, cacheBase),
+            scanOperationPath: directoryOperationPathForTest(fd, cacheBase),
+            mutationPath: directoryOperationPathForTest(fd, cacheBase),
           };
           try {
             await assert.rejects(
@@ -1547,9 +1553,9 @@ describe("issue 3552 P1 symlink trust bypass in unchanged fast paths", () => {
           const baseRef: unknown = {
             handle: fd,
             path: cacheBase,
-            operationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
-            scanOperationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
-            mutationPath: `/proc/self/fd/${(fd as unknown as { fd: number }).fd}`,
+            operationPath: directoryOperationPathForTest(fd, cacheBase),
+            scanOperationPath: directoryOperationPathForTest(fd, cacheBase),
+            mutationPath: directoryOperationPathForTest(fd, cacheBase),
           };
           try {
             await assert.rejects(

--- a/src/compat/__tests__/doctor-contract.test.ts
+++ b/src/compat/__tests__/doctor-contract.test.ts
@@ -108,7 +108,11 @@ describe('compat doctor contract', () => {
       if (shouldSkipForSpawnPermissions(result.error)) return;
       assert.equal(result.status, Number.parseInt(readFixture('install-onboarding.exitcode.txt').trim(), 10), result.stderr || result.stdout);
       assert.equal(result.stderr, '');
-      assert.equal(normalizeInstallDoctorOutput(result.stdout, home, wd), readFixture('install-onboarding.stdout.txt'));
+      const expected = readFixture('install-onboarding.stdout.txt');
+      const platformExpected = process.platform === 'darwin' || process.platform === 'win32'
+        ? expected.replace('  [OK] Node.js: <NODE_VERSION>\n', '  [OK] Node.js: <NODE_VERSION>\n  [OK] Process identity: native process identity provider is ready\n')
+        : expected;
+      assert.equal(normalizeInstallDoctorOutput(result.stdout, home, wd), platformExpected);
       assert.ok(result.stdout.includes(SAFE_DOCTOR_RECOVERY) || result.stdout.includes(SAFE_DOCTOR_FAILURE));
       assert.doesNotMatch(result.stdout, /^Review (?:warnings|failed checks) above\.[^\n]*--force/m);
     } finally {

--- a/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
+++ b/src/hooks/__tests__/notify-hook-auto-nudge.test.ts
@@ -2,12 +2,13 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildTmuxSessionName } from '../../cli/index.js';
 import { classifyKeywordInput, recordSkillActivation } from '../keyword-detector.js';
 import { recordNotifySkillActivation, recordNotifySkillActivationNonFatal } from '../../scripts/notify-hook.js';
+import { defaultProcessInspectionProvider } from '../session.js';
 import { normalizeSkillActiveState } from '../../scripts/notify-hook/auto-nudge.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
@@ -47,41 +48,22 @@ async function withTempWorkingDir(run: (cwd: string) => Promise<void>): Promise<
 async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, JSON.stringify(value, null, 2));
 }
-
-function readLinuxStartTicks(pid: number): number | null {
-  try {
-    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-    const commandEnd = stat.lastIndexOf(')');
-    if (commandEnd === -1) return null;
-    const remainder = stat.slice(commandEnd + 1).trim();
-    const fields = remainder.split(/\s+/);
-    if (fields.length <= 19) return null;
-    const startTicks = Number(fields[19]);
-    return Number.isFinite(startTicks) ? startTicks : null;
-  } catch {
-    return null;
-  }
+function fixtureProcessIdentity(pid: number) {
+  const observation = defaultProcessInspectionProvider.observeProcess(pid, process.platform);
+  assert.equal(observation.kind, 'identity', `expected process identity observation for pid ${pid}`);
+  assert.equal(observation.identity.platform, process.platform, `expected ${process.platform} process identity for pid ${pid}`);
+  return observation.identity;
 }
-
-function readLinuxCmdline(pid: number): string | null {
-  try {
-    const raw = readFileSync(`/proc/${pid}/cmdline`);
-    const text = raw.toString('utf-8').replace(/\0+/g, ' ').trim();
-    return text.length > 0 ? text : null;
-  } catch {
-    return null;
-  }
-}
-
 async function writeManagedSessionState(stateDir: string, cwd: string): Promise<void> {
+  const processIdentity = fixtureProcessIdentity(process.pid);
   await writeJson(join(stateDir, 'session.json'), {
     session_id: 'sess-managed',
     started_at: new Date().toISOString(),
     cwd,
     pid: process.pid,
     platform: process.platform,
-    pid_start_ticks: readLinuxStartTicks(process.pid),
-    pid_cmdline: readLinuxCmdline(process.pid),
+    identity_schema_version: 2,
+    process_identity: processIdentity,
   });
 }
 
@@ -221,14 +203,15 @@ function runNotifyHook(
 ): ReturnType<typeof spawnSync> {
   if (extraEnv.OMX_TEST_UNMANAGED_SESSION !== '1' && !extraEnv.OMX_TEAM_WORKER) {
     const sessionPath = join(cwd, '.omx', 'state', 'session.json');
+    const processIdentity = fixtureProcessIdentity(process.pid);
     const sessionState = {
       session_id: 'sess-managed',
       started_at: new Date().toISOString(),
       cwd,
       pid: process.pid,
       platform: process.platform,
-      pid_start_ticks: readLinuxStartTicks(process.pid),
-      pid_cmdline: readLinuxCmdline(process.pid),
+      identity_schema_version: 2,
+      process_identity: processIdentity,
     };
     writeFileSync(sessionPath, JSON.stringify(sessionState, null, 2));
   }
@@ -446,14 +429,15 @@ describe('notify-hook auto-nudge', () => {
       const sleeperPid = Number((sleeper.stdout || '').trim());
       assert.ok(Number.isFinite(sleeperPid) && sleeperPid > 1, 'expected helper pid');
 
+      const processIdentity = fixtureProcessIdentity(sleeperPid);
       await writeJson(join(stateDir, 'session.json'), {
         session_id: 'sess-managed',
         started_at: new Date().toISOString(),
         cwd,
         pid: sleeperPid,
         platform: process.platform,
-        pid_start_ticks: readLinuxStartTicks(sleeperPid),
-        pid_cmdline: readLinuxCmdline(sleeperPid),
+        identity_schema_version: 2,
+        process_identity: processIdentity,
       });
 
       await writeFile(join(fakeBinDir, 'tmux'), buildFakeTmux(tmuxLogPath));

--- a/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-heal.test.ts
@@ -2,11 +2,11 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
-import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildTmuxSessionName } from '../../cli/index.js';
 import { handleTmuxInjection, resolvePaneTarget } from '../../scripts/notify-hook/tmux-injection.js';
+import { defaultProcessInspectionProvider } from '../session.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 
@@ -77,40 +77,23 @@ function withPatchedEnv<T>(patch: Record<string, string>, run: () => Promise<T>)
 }
 
 
-function readLinuxStartTicks(pid: number): number | null {
-  try {
-    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-    const commandEnd = stat.lastIndexOf(')');
-    if (commandEnd === -1) return null;
-    const remainder = stat.slice(commandEnd + 1).trim();
-    const fields = remainder.split(/\s+/);
-    if (fields.length <= 19) return null;
-    const startTicks = Number(fields[19]);
-    return Number.isFinite(startTicks) ? startTicks : null;
-  } catch {
-    return null;
-  }
-}
-
-function readLinuxCmdline(pid: number): string | null {
-  try {
-    const raw = readFileSync(`/proc/${pid}/cmdline`);
-    const text = raw.toString('utf-8').replace(/\0+/g, ' ').trim();
-    return text.length > 0 ? text : null;
-  } catch {
-    return null;
-  }
+function fixtureProcessIdentity(pid: number) {
+  const observation = defaultProcessInspectionProvider.observeProcess(pid, process.platform);
+  assert.equal(observation.kind, 'identity', `expected process identity observation for pid ${pid}`);
+  assert.equal(observation.identity.platform, process.platform, `expected ${process.platform} process identity for pid ${pid}`);
+  return observation.identity;
 }
 
 async function writeManagedSessionState(stateDir: string, cwd: string, sessionId: string): Promise<void> {
+  const processIdentity = fixtureProcessIdentity(process.pid);
   await writeJson(join(stateDir, 'session.json'), {
     session_id: sessionId,
     started_at: new Date().toISOString(),
     cwd,
     pid: process.pid,
     platform: process.platform,
-    pid_start_ticks: readLinuxStartTicks(process.pid),
-    pid_cmdline: readLinuxCmdline(process.pid),
+    identity_schema_version: 2,
+    process_identity: processIdentity,
   });
 }
 

--- a/src/hooks/__tests__/notify-hook-tmux-scrollback.test.ts
+++ b/src/hooks/__tests__/notify-hook-tmux-scrollback.test.ts
@@ -11,10 +11,10 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
-import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildTmuxSessionName } from '../../cli/index.js';
+import { defaultProcessInspectionProvider } from '../session.js';
 
 const NOTIFY_HOOK_SCRIPT = new URL('../../../dist/scripts/notify-hook.js', import.meta.url);
 
@@ -35,29 +35,11 @@ async function readJson<T>(path: string): Promise<T> {
   return JSON.parse(await readFile(path, 'utf-8')) as T;
 }
 
-function readLinuxStartTicks(pid: number): number | null {
-  try {
-    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
-    const commandEnd = stat.lastIndexOf(')');
-    if (commandEnd === -1) return null;
-    const remainder = stat.slice(commandEnd + 1).trim();
-    const fields = remainder.split(/\s+/);
-    if (fields.length <= 19) return null;
-    const startTicks = Number(fields[19]);
-    return Number.isFinite(startTicks) ? startTicks : null;
-  } catch {
-    return null;
-  }
-}
-
-function readLinuxCmdline(pid: number): string | null {
-  try {
-    const raw = readFileSync(`/proc/${pid}/cmdline`);
-    const text = raw.toString('utf-8').replace(/\0+/g, ' ').trim();
-    return text.length > 0 ? text : null;
-  } catch {
-    return null;
-  }
+function fixtureProcessIdentity(pid: number) {
+  const observation = defaultProcessInspectionProvider.observeProcess(pid, process.platform);
+  assert.equal(observation.kind, 'identity', `expected process identity observation for pid ${pid}`);
+  assert.equal(observation.identity.platform, process.platform, `expected ${process.platform} process identity for pid ${pid}`);
+  return observation.identity;
 }
 
 /** Build a fake tmux binary that responds to all required commands.
@@ -151,14 +133,15 @@ async function setupFixture(cwd: string, paneInMode: '0' | '1', skipIfScrolling 
   await mkdir(logsDir, { recursive: true });
   await mkdir(fakeBinDir, { recursive: true });
 
+  const processIdentity = fixtureProcessIdentity(process.pid);
   await writeJson(join(stateDir, 'session.json'), {
     session_id: sessionId,
     started_at: new Date().toISOString(),
     cwd,
     pid: process.pid,
     platform: process.platform,
-    pid_start_ticks: readLinuxStartTicks(process.pid),
-    pid_cmdline: readLinuxCmdline(process.pid),
+    identity_schema_version: 2,
+    process_identity: processIdentity,
   });
   await writeJson(join(sessionStateDir, 'ralph-state.json'), { active: true, iteration: 0 });
   await writeJson(join(omxDir, 'tmux-hook.json'), {

--- a/src/scripts/__tests__/codex-native-hook.test.ts
+++ b/src/scripts/__tests__/codex-native-hook.test.ts
@@ -25180,11 +25180,15 @@ describe("issue #3550: fresh --madmax detached-pointer root identity", () => {
     const pointerPath = join(stateDir, "session.json");
     const established = await establishLaunchSessionBinding(cwd, "omx-3550-launch");
     assert.equal(established.kind, "committed-released");
-    const metadata = await updateDetachedSessionMetadata(established.binding, {
-      tmuxSessionName: "omx-3550-detached",
-      tmuxPaneId: "%3550",
-    });
-    assert.equal(metadata.kind, "committed-released");
+    try {
+      const metadata = await updateDetachedSessionMetadata(established.binding, {
+        tmuxSessionName: "omx-3550-detached",
+        tmuxPaneId: "%3550",
+      });
+      assert.equal(metadata.kind, "committed-released");
+    } finally {
+      assert.equal((await closeLaunchSessionBindingOnce(established.binding)).status, "closed");
+    }
     const ownedPointer = JSON.parse(await readFile(pointerPath, "utf-8")) as Record<string, unknown>;
     await writeFile(pointerPath, JSON.stringify({
       ...ownedPointer,

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -210,7 +210,7 @@ test('packed install smoke retains narrow boot commands and adds the isolated li
   );
 });
 
-test('packed 0.144.5 fixture is sanitized, pointer-free, and kept separate from the 0.142.5 lifecycle pin', () => {
+test('packed 0.144.5 fixture is sanitized, pointer-free, and kept separate from the 0.153.4 lifecycle pin', () => {
   assert.deepEqual(PACKED_CODEX_01445_NO_POINTER_NO_TRACKER_FIXTURE, {
     hook_event_name: 'PreToolUse',
     session_id: 'packed-01445-session',
@@ -415,11 +415,13 @@ test('packed lifecycle parses the pinned hooks/list eventName schema', () => {
       cwd: project,
       hooks: [{
         eventName: 'preToolUse',
+        handlerType: 'command',
         command: 'node hook.js',
         sourcePath: hooksPath,
         key: `${hooksPath}:pre_tool_use:0:0`,
         currentHash: 'sha256:current',
         displayOrder: 0,
+        enabled: true,
         trustStatus: 'trusted',
       }],
       warnings: [],
@@ -431,7 +433,7 @@ test('packed lifecycle parses the pinned hooks/list eventName schema', () => {
   assert.equal(parsed.hooks[0]?.trustStatus, 'trusted');
 });
 
-test('packed lifecycle normalizes omitted enabled handlers and rejects disabled or non-integer hook metadata', () => {
+test('packed lifecycle requires enabled command handlers and integer hook metadata', () => {
   const project = '/tmp/project';
   const hooksPath = '/tmp/project/.codex/hooks.json';
   const response = {
@@ -439,11 +441,13 @@ test('packed lifecycle normalizes omitted enabled handlers and rejects disabled 
       cwd: project,
       hooks: [{
         eventName: 'preToolUse',
+        handlerType: 'command',
         command: 'node hook.js',
         sourcePath: hooksPath,
         key: `${hooksPath}:pre_tool_use:0:0`,
         currentHash: 'sha256:current',
         displayOrder: 0,
+        enabled: true,
         trustStatus: 'trusted',
       }],
       warnings: [],
@@ -454,15 +458,18 @@ test('packed lifecycle normalizes omitted enabled handlers and rejects disabled 
 
   for (const update of [
     { enabled: false },
+    { enabled: undefined },
     { enabled: 'true' },
     { enabled: true, displayOrder: 0.5 },
     { enabled: true, displayOrder: -1 },
+    { handlerType: 'mcpTool' },
+    { handlerType: undefined },
   ]) {
     const invalid = structuredClone(response);
     Object.assign(invalid.data[0]!.hooks[0]!, update);
     assert.throws(
       () => parseCodexHooksListResult(invalid, project, hooksPath),
-      /enabled command handler|invalid hooks\[0\]\.displayOrder/,
+      /enabled command handler|handlerType|not a command handler|invalid hooks\[0\]\.displayOrder/,
     );
   }
 });
@@ -599,7 +606,7 @@ test('packed lifecycle resolves Windows npm shims through safe command specs for
         platform: 'win32' as const,
         spawnSyncImpl: ((command: string, args: string[], options: Record<string, unknown>) => {
           versionSpawns.push({ command, args, options });
-          return { status: 0, stdout: 'codex-cli 0.142.5\n', stderr: '', error: undefined };
+          return { status: 0, stdout: 'codex-cli 0.153.4\n', stderr: '', error: undefined };
         }) as never,
         spawnImpl: ((command: string, args: string[], options: Record<string, unknown>) => {
           appSpawns.push({ command, args, options });
@@ -608,7 +615,7 @@ test('packed lifecycle resolves Windows npm shims through safe command specs for
       };
       const env = { PATH: bin, PATHEXT: extension.toUpperCase() };
 
-      assert.equal(probeCodexVersion(root, env, seam), 'codex-cli 0.142.5');
+      assert.equal(probeCodexVersion(root, env, seam), 'codex-cli 0.153.4');
       const server = await CodexAppServer.start({ cwd: root, env, commandSeam: seam });
       await server.close();
 
@@ -701,13 +708,13 @@ test('packed lifecycle bypasses an unrelated codex binary shadowing the pinned C
     const pinned = join(pinnedDir, 'codex');
     await Promise.all([
       writeFile(shadow, '#!/bin/sh\necho "codex 0.2.3"\n'),
-      writeFile(pinned, '#!/bin/sh\necho "codex-cli 0.142.5"\n'),
+      writeFile(pinned, '#!/bin/sh\necho "codex-cli 0.153.4"\n'),
     ]);
     await Promise.all([chmod(shadow, 0o755), chmod(pinned, 0o755)]);
 
     assert.equal(
       probeCodexVersion(root, { PATH: `${shadowDir}${delimiter}${pinnedDir}` }),
-      'codex-cli 0.142.5',
+      'codex-cli 0.153.4',
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -726,7 +733,7 @@ test('packed lifecycle deduplicates repeated PATH entries before enforcing the c
     ]);
     await Promise.all([
       writeFile(join(shadowDir, 'codex'), '#!/bin/sh\necho "codex 0.2.3"\n'),
-      writeFile(join(pinnedDir, 'codex'), '#!/bin/sh\necho "codex-cli 0.142.5"\n'),
+      writeFile(join(pinnedDir, 'codex'), '#!/bin/sh\necho "codex-cli 0.153.4"\n'),
     ]);
     await Promise.all([
       chmod(join(shadowDir, 'codex'), 0o755),
@@ -737,7 +744,7 @@ test('packed lifecycle deduplicates repeated PATH entries before enforcing the c
       probeCodexVersion(root, {
         PATH: [...Array.from({ length: 40 }, () => shadowDir), pinnedDir].join(delimiter),
       }),
-      'codex-cli 0.142.5',
+      'codex-cli 0.153.4',
     );
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -750,15 +757,16 @@ test('packed lifecycle accepts only the exact stable pinned Codex version output
   const candidateDir = join(root, 'candidate');
   const executable = join(candidateDir, 'codex');
   const candidates = [
-    { output: 'codex-cli 0.142.5', stderr: '', accepted: true },
-    { output: 'codex-cli 0.142.5', stderr: 'warning: harmless test diagnostic', accepted: true },
-    { output: 'codex-cli 0.142.5\nextra output', stderr: '', accepted: false },
-    { output: 'codex-cli 0.142.5-beta', stderr: '', accepted: false },
-    { output: 'codex-cli 0.142.5+meta', stderr: '', accepted: false },
-    { output: 'codex-cli 0.142.5.1', stderr: '', accepted: false },
-    { output: 'codex-cli v0.142.5', stderr: '', accepted: false },
+    { output: 'codex-cli 0.153.4', stderr: '', accepted: true },
+    { output: 'codex-cli 0.153.4', stderr: 'warning: harmless test diagnostic', accepted: true },
+    { output: 'codex-cli 0.153.4\nextra output', stderr: '', accepted: false },
+    { output: 'codex-cli 0.153.4-beta', stderr: '', accepted: false },
+    { output: 'codex-cli 0.153.4+meta', stderr: '', accepted: false },
+    { output: 'codex-cli 0.153.4.1', stderr: '', accepted: false },
+    { output: 'codex-cli v0.153.4', stderr: '', accepted: false },
+    { output: 'codex-cli 0.142.5', stderr: '', accepted: false },
     { output: 'codex-cli 0-142-5', stderr: '', accepted: false },
-    { output: 'codex-cli 0.142.5', stderr: 'unexpected version probe error', accepted: false },
+    { output: 'codex-cli 0.153.4', stderr: 'unexpected version probe error', accepted: false },
   ];
   try {
     await mkdir(candidateDir, { recursive: true });
@@ -769,11 +777,11 @@ test('packed lifecycle accepts only the exact stable pinned Codex version output
       );
       await chmod(executable, 0o755);
       if (candidate.accepted) {
-        assert.equal(probeCodexVersion(root, { PATH: candidateDir }), 'codex-cli 0.142.5');
+        assert.equal(probeCodexVersion(root, { PATH: candidateDir }), 'codex-cli 0.153.4');
       } else {
         assert.throws(
           () => probeCodexVersion(root, { PATH: candidateDir }),
-          /Unsupported installed Codex version for the 0\.142\.5 boundary/,
+          /Unsupported installed Codex version for the 0\.153\.4 boundary/,
         );
       }
     }
@@ -903,12 +911,12 @@ test('packed lifecycle continues after a timed-out version probe candidate', asy
     await Promise.all([mkdir(slowDir, { recursive: true }), mkdir(pinnedDir, { recursive: true })]);
     await Promise.all([
       writeFile(join(slowDir, 'codex'), '#!/bin/sh\nexec /bin/sleep 30\n'),
-      writeFile(join(pinnedDir, 'codex'), '#!/bin/sh\nprintf \'%s\\n\' \'codex-cli 0.142.5\'\n'),
+      writeFile(join(pinnedDir, 'codex'), '#!/bin/sh\nprintf \'%s\\n\' \'codex-cli 0.153.4\'\n'),
     ]);
     await Promise.all([chmod(join(slowDir, 'codex'), 0o755), chmod(join(pinnedDir, 'codex'), 0o755)]);
 
     const startedAt = Date.now();
-    assert.equal(probeCodexVersion(root, { PATH: `${slowDir}${delimiter}${pinnedDir}` }), 'codex-cli 0.142.5');
+    assert.equal(probeCodexVersion(root, { PATH: `${slowDir}${delimiter}${pinnedDir}` }), 'codex-cli 0.153.4');
     assert.ok(Date.now() - startedAt < 5_000, 'a timed-out candidate must not block later PATH candidates');
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -927,14 +935,14 @@ test('packed lifecycle fails instead of skipping when Codex disappears after sta
       'state="${0}.version-count"',
       'if [ "$1" = "--version" ]; then',
       '  if [ -f "$state" ]; then /bin/rm -f "$0"; else : > "$state"; fi',
-      '  printf \'%s\\n\' \'codex-cli 0.142.5\'',
+      '  printf \'%s\\n\' \'codex-cli 0.153.4\'',
       '  exit 0',
       'fi',
       'exit 1',
       '',
     ].join('\n'));
     await chmod(executable, 0o755);
-    assert.equal(probeCodexVersion(root, { PATH: candidateDir }), 'codex-cli 0.142.5');
+    assert.equal(probeCodexVersion(root, { PATH: candidateDir }), 'codex-cli 0.153.4');
 
     await assert.rejects(
       CodexAppServer.start({ cwd: root, env: { PATH: candidateDir } }),

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -422,6 +422,9 @@ test('packed lifecycle parses the pinned hooks/list eventName schema', () => {
         currentHash: 'sha256:current',
         displayOrder: 0,
         enabled: true,
+        isManaged: false,
+        source: 'project',
+        timeoutSec: 0,
         trustStatus: 'trusted',
       }],
       warnings: [],
@@ -448,6 +451,9 @@ test('packed lifecycle requires enabled command handlers and integer hook metada
         currentHash: 'sha256:current',
         displayOrder: 0,
         enabled: true,
+        isManaged: false,
+        source: 'project',
+        timeoutSec: 0,
         trustStatus: 'trusted',
       }],
       warnings: [],
@@ -464,13 +470,42 @@ test('packed lifecycle requires enabled command handlers and integer hook metada
     { enabled: true, displayOrder: -1 },
     { handlerType: 'mcpTool' },
     { handlerType: undefined },
+    { isManaged: 'false' },
+    { source: 'invalid' },
+    { timeoutSec: -1 },
+    { timeoutSec: 0.5 },
+    { timeoutSec: '10' },
+    { timeoutSec: Number.MAX_SAFE_INTEGER + 1 },
+    { eventName: 'toString' },
+    { eventName: 'unknownEvent' },
   ]) {
     const invalid = structuredClone(response);
     Object.assign(invalid.data[0]!.hooks[0]!, update);
     assert.throws(
       () => parseCodexHooksListResult(invalid, project, hooksPath),
-      /enabled command handler|handlerType|not a command handler|invalid hooks\[0\]\.displayOrder/,
+      /enabled command handler|handlerType|not a command handler|invalid hooks\[0\]|unsupported/,
     );
+  }
+  for (const field of Object.keys(response.data[0]!.hooks[0]!)) {
+    const invalid = structuredClone(response);
+    delete (invalid.data[0]!.hooks[0]! as Record<string, unknown>)[field];
+    assert.throws(() => parseCodexHooksListResult(invalid, project, hooksPath), `missing ${field} must fail closed`);
+  }
+  for (const field of ['hooks', 'warnings', 'errors']) {
+    const invalid = structuredClone(response);
+    delete (invalid.data[0]! as Record<string, unknown>)[field];
+    assert.throws(() => parseCodexHooksListResult(invalid, project, hooksPath), `missing ${field} must fail closed`);
+  }
+  for (const eventName of ['sessionEnd', 'interrupt']) {
+    const valid = structuredClone(response);
+    valid.data[0]!.hooks[0]!.eventName = eventName;
+    assert.doesNotThrow(() => parseCodexHooksListResult(valid, project, hooksPath));
+  }
+  for (const isManaged of [true, false]) {
+    const valid = structuredClone(response);
+    valid.data[0]!.hooks[0]!.isManaged = isManaged;
+    valid.data[0]!.hooks[0]!.timeoutSec = Number.MAX_SAFE_INTEGER;
+    assert.doesNotThrow(() => parseCodexHooksListResult(valid, project, hooksPath));
   }
 });
 

--- a/src/scripts/__tests__/smoke-packed-install.test.ts
+++ b/src/scripts/__tests__/smoke-packed-install.test.ts
@@ -507,6 +507,15 @@ test('packed lifecycle requires enabled command handlers and integer hook metada
     valid.data[0]!.hooks[0]!.timeoutSec = Number.MAX_SAFE_INTEGER;
     assert.doesNotThrow(() => parseCodexHooksListResult(valid, project, hooksPath));
   }
+  for (const source of [
+    'system', 'user', 'project', 'mdm', 'sessionFlags', 'plugin',
+    'cloudRequirements', 'cloudManagedConfig', 'legacyManagedConfigFile',
+    'legacyManagedConfigMdm', 'unknown',
+  ]) {
+    const valid = structuredClone(response);
+    valid.data[0]!.hooks[0]!.source = source;
+    assert.doesNotThrow(() => parseCodexHooksListResult(valid, project, hooksPath), `${source} is a valid hook source`);
+  }
 });
 
 

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -291,6 +291,12 @@ const CODEX_TRUST_STATUSES = new Set([
   'modified',
 ]);
 
+const CODEX_HOOK_SOURCES = new Set([
+  'system', 'user', 'project', 'mdm', 'sessionFlags', 'plugin',
+  'cloudRequirements', 'cloudManagedConfig', 'legacyManagedConfigFile',
+  'legacyManagedConfigMdm', 'unknown',
+]);
+
 const CODEX_EVENT_LABELS: Readonly<Record<string, string>> = {
   preToolUse: 'PreToolUse',
   permissionRequest: 'PermissionRequest',
@@ -298,10 +304,12 @@ const CODEX_EVENT_LABELS: Readonly<Record<string, string>> = {
   preCompact: 'PreCompact',
   postCompact: 'PostCompact',
   sessionStart: 'SessionStart',
+  sessionEnd: 'SessionEnd',
   userPromptSubmit: 'UserPromptSubmit',
   subagentStart: 'SubagentStart',
   subagentStop: 'SubagentStop',
   stop: 'Stop',
+  interrupt: 'Interrupt',
 };
 
 const PINNED_CODEX_VERSION = '0.153.4';
@@ -968,7 +976,10 @@ export function parseCodexHooksListResult(
   const hooks = entry.hooks.map((value, index) => {
     const hook = requireRecord(value, `hooks/list hook ${index}`);
     const rawEvent = requireString(hook.eventName, `hooks[${index}].eventName`);
-    const event = CODEX_EVENT_LABELS[rawEvent] ?? rawEvent;
+    if (!Object.hasOwn(CODEX_EVENT_LABELS, rawEvent)) {
+      throw new Error(`Codex hooks/list response has unsupported eventName ${rawEvent}`);
+    }
+    const event = CODEX_EVENT_LABELS[rawEvent];
     const handlerType = requireString(hook.handlerType, `hooks[${index}].handlerType`);
     if (handlerType !== 'command') {
       throw new Error(`Codex hooks/list hook ${index} is not a command handler`);
@@ -977,6 +988,16 @@ export function parseCodexHooksListResult(
     const enabled = hook.enabled;
     if (typeof enabled !== 'boolean' || enabled !== true) {
       throw new Error(`Codex hooks/list hook ${index} is not an enabled command handler`);
+    }
+    if (typeof hook.isManaged !== 'boolean') {
+      throw new Error(`Codex hooks/list response has invalid hooks[${index}].isManaged`);
+    }
+    const source = requireString(hook.source, `hooks[${index}].source`);
+    if (!CODEX_HOOK_SOURCES.has(source)) {
+      throw new Error(`Codex hooks/list response has unsupported source ${source}`);
+    }
+    if (typeof hook.timeoutSec !== 'number' || !Number.isSafeInteger(hook.timeoutSec) || hook.timeoutSec < 0) {
+      throw new Error(`Codex hooks/list response has invalid hooks[${index}].timeoutSec`);
     }
     const sourcePath = requireString(hook.sourcePath, `hooks[${index}].sourcePath`);
     const key = requireString(hook.key, `hooks[${index}].key`);

--- a/src/scripts/smoke-packed-install.ts
+++ b/src/scripts/smoke-packed-install.ts
@@ -304,7 +304,8 @@ const CODEX_EVENT_LABELS: Readonly<Record<string, string>> = {
   stop: 'Stop',
 };
 
-const PINNED_CODEX_VERSION = '0.142.5';
+const PINNED_CODEX_VERSION = '0.153.4';
+
 const PINNED_CODEX_VERSION_OUTPUT = `codex-cli ${PINNED_CODEX_VERSION}`;
 
 /** Sanitized Codex 0.144.5 PreToolUse shape: documented fields only, with no pointer or tracker state. */
@@ -968,9 +969,13 @@ export function parseCodexHooksListResult(
     const hook = requireRecord(value, `hooks/list hook ${index}`);
     const rawEvent = requireString(hook.eventName, `hooks[${index}].eventName`);
     const event = CODEX_EVENT_LABELS[rawEvent] ?? rawEvent;
+    const handlerType = requireString(hook.handlerType, `hooks[${index}].handlerType`);
+    if (handlerType !== 'command') {
+      throw new Error(`Codex hooks/list hook ${index} is not a command handler`);
+    }
     const command = requireString(hook.command, `hooks[${index}].command`);
-    const enabled = hook.enabled === undefined ? true : hook.enabled;
-    if (enabled !== true) {
+    const enabled = hook.enabled;
+    if (typeof enabled !== 'boolean' || enabled !== true) {
       throw new Error(`Codex hooks/list hook ${index} is not an enabled command handler`);
     }
     const sourcePath = requireString(hook.sourcePath, `hooks[${index}].sourcePath`);
@@ -984,7 +989,6 @@ export function parseCodexHooksListResult(
     if (!CODEX_TRUST_STATUSES.has(trustStatus)) {
       throw new Error(`Codex hooks/list response has unsupported trustStatus ${trustStatus}`);
     }
-
 
     if (sourcePath !== hooksPath) {
       throw new Error(`Codex hooks/list sourcePath mismatch: expected ${hooksPath}, got ${sourcePath}`);
@@ -4988,7 +4992,7 @@ export interface PackedHookTrustLifecycleResult {
 export async function smokePackedHookTrustLifecycle(
   omxPath: string,
 ): Promise<PackedHookTrustLifecycleResult> {
-  const lifecycleRoot = mkdtempSync(join(tmpdir(), 'omx-packed-hook-trust-'));
+  const lifecycleRoot = realpathSync(mkdtempSync(join(tmpdir(), 'omx-packed-hook-trust-')));
   const projectDir = resolve(lifecycleRoot, 'project');
   const home = join(lifecycleRoot, 'home');
   const codexHome = join(lifecycleRoot, 'codex-home');
@@ -5409,10 +5413,16 @@ function smokeInstalledPluginHookLauncher(packageRoot: string, omxPath: string):
       if (String(result.stdout ?? '') !== expectedStdout) {
         throw new Error(`installed plugin hook ${name} stdout changed: expected ${JSON.stringify(expectedStdout)}, received ${JSON.stringify(String(result.stdout ?? ''))}`);
       }
-      assert.deepStrictEqual(readPackedPluginHookDelegateCalls(capturePath), [{
+      const calls = readPackedPluginHookDelegateCalls(capturePath);
+      assert.equal(calls.length, 1, `installed plugin hook ${name} must invoke exactly one delegate`);
+      assertPackedLaunchCwdPreserved(
+        hookCwd,
+        calls[0].cwd,
+        `installed plugin hook ${name} must preserve delegate cwd`,
+      );
+      assert.deepStrictEqual(calls.map(({ argv, stdin }) => ({ argv, stdin })), [{
         argv: ['codex-native-hook'],
         stdin,
-        cwd: hookCwd,
       }], `installed plugin hook ${name} must forward exact delegate argv and stdin`);
     };
 
@@ -5493,10 +5503,16 @@ function smokeInstalledPluginHookLauncher(packageRoot: string, omxPath: string):
       /codex-native-hook exited with code 23/,
       'installed plugin hook Stop delegate failure',
     );
-    assert.deepStrictEqual(readPackedPluginHookDelegateCalls(capturePath), [{
+    const failedStopCalls = readPackedPluginHookDelegateCalls(capturePath);
+    assert.equal(failedStopCalls.length, 1, 'installed plugin hook Stop failure must invoke exactly one delegate');
+    assertPackedLaunchCwdPreserved(
+      hookCwd,
+      failedStopCalls[0].cwd,
+      'installed plugin hook Stop failure must preserve delegate cwd',
+    );
+    assert.deepStrictEqual(failedStopCalls.map(({ argv, stdin }) => ({ argv, stdin })), [{
       argv: ['codex-native-hook'],
       stdin: failedStopInput,
-      cwd: hookCwd,
     }], 'installed plugin hook Stop failure must still delegate exact argv and stdin');
   } finally {
     if (originalPinnedLauncher === undefined) {
@@ -5740,7 +5756,7 @@ async function main(): Promise<void> {
     const lifecycle = await smokePackedHookTrustLifecycle(omxPath);
     console.log(
       lifecycle.codexVersion !== null
-        ? `packed install smoke: installed Codex 0.142.5 lifecycle passed (${lifecycle.codexVersion})`
+        ? `packed install smoke: installed Codex 0.153.4 lifecycle passed (${lifecycle.codexVersion})`
         : 'packed install smoke: Codex executable absent; installed-Codex trust leg skipped after deterministic lifecycle',
     );
 

--- a/src/state/__tests__/mode-binding-lease.test.ts
+++ b/src/state/__tests__/mode-binding-lease.test.ts
@@ -18,6 +18,17 @@ import {
 } from '../process-identity.js';
 
 const roots: string[] = [];
+const BOOTSTRAP_OWNER_TOKEN = `99999999-1-${'0'.repeat(24)}`;
+
+async function waitForBootstrapCleanupBarrier(barrierDir: string, count: number): Promise<string[]> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const entries = (await readdir(barrierDir)).filter((entry) => entry.startsWith('arrival-'));
+    if (entries.length >= count) return entries;
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${count} bootstrap cleanup contenders`);
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 5));
+  }
+}
 const operationsModuleUrl = new URL('../operations.js', import.meta.url).href;
 
 async function runTransactionProcess(path: string): Promise<void> {
@@ -37,6 +48,7 @@ async function runTransactionProcess(path: string): Promise<void> {
   assert.deepEqual(result, { code: 0, signal: null }, stderr);
 }
 
+  delete process.env.OMX_TEST_MODE_BINDING_BOOTSTRAP_CLEANUP_BARRIER_DIR;
 afterEach(async () => {
   __setStateOperationTestHooksForTests({});
   __setCanonicalModeBindingLeaseTestHooksForTests({});
@@ -391,6 +403,29 @@ describe('canonical mode binding lease', () => {
         assert.deepEqual(await readdir(lockPath), []);
       }
     }
+  });
+
+  it('deterministically converges two bootstrap cleanup contenders after one observes ENOENT', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-mode-lease-bootstrap-race-'));
+    roots.push(cwd);
+    const path = join(cwd, '.omx', 'state', 'sessions', 'session-a', 'ralplan-state.json');
+    await withStateFileWriteTransaction(path, async () => undefined);
+    const lockPath = (await resolveValidatedCanonicalModeBinding(path)).leasePath;
+    const displacedToken = `99999999-${Date.now() - 10_000}-${'d'.repeat(24)}`;
+    await writeFile(join(lockPath, `owner-${BOOTSTRAP_OWNER_TOKEN}`), BOOTSTRAP_OWNER_TOKEN);
+    await writeFile(join(lockPath, `.owner-reclaim-${displacedToken}`), displacedToken);
+    const barrierDir = join(cwd, 'bootstrap-cleanup-barrier');
+    await mkdir(barrierDir);
+    process.env.OMX_TEST_MODE_BINDING_BOOTSTRAP_CLEANUP_BARRIER_DIR = barrierDir;
+
+    const contenders = [runTransactionProcess(path), runTransactionProcess(path)];
+    await waitForBootstrapCleanupBarrier(barrierDir, 2);
+    await writeFile(join(barrierDir, 'release'), 'go');
+    await Promise.all(contenders);
+
+    const evidence = (await readdir(barrierDir)).filter((entry) => entry.startsWith('enoent-'));
+    assert.ok(evidence.length >= 1, 'expected one contender to observe bootstrap unlink ENOENT');
+    assert.deepEqual(await readdir(lockPath), []);
   });
 
   it('recovers quarantine plus an aged dead partial successor', async () => {

--- a/src/state/__tests__/mode-binding-lease.test.ts
+++ b/src/state/__tests__/mode-binding-lease.test.ts
@@ -48,8 +48,8 @@ async function runTransactionProcess(path: string): Promise<void> {
   assert.deepEqual(result, { code: 0, signal: null }, stderr);
 }
 
-  delete process.env.OMX_TEST_MODE_BINDING_BOOTSTRAP_CLEANUP_BARRIER_DIR;
 afterEach(async () => {
+  delete process.env.OMX_TEST_MODE_BINDING_BOOTSTRAP_CLEANUP_BARRIER_DIR;
   __setStateOperationTestHooksForTests({});
   __setCanonicalModeBindingLeaseTestHooksForTests({});
   delete process.env.OMX_TEST_MODE_BINDING_RECLAIM_CRASH_PHASE;
@@ -108,6 +108,25 @@ describe('canonical mode binding lease', () => {
     assert.equal(ran, true);
     assert.deepEqual(await readdir(lockPath), []);
   });
+
+  for (const kind of ['malformed', 'partial', 'symlink', 'foreign-entry'] as const) {
+    it(`rejects ${kind} bootstrap state beside its own valid owner`, async () => {
+      const cwd = await mkdtemp(join(tmpdir(), `omx-mode-bootstrap-${kind}-`));
+      roots.push(cwd);
+      const path = join(cwd, '.omx', 'state', 'sessions', 'session-a', 'ralplan-state.json');
+      const lockPath = (await resolveValidatedCanonicalModeBinding(path)).leasePath;
+      const bootstrapPath = join(lockPath, `owner-${BOOTSTRAP_OWNER_TOKEN}`);
+      const external = join(cwd, 'external-bootstrap');
+      await writeFile(external, BOOTSTRAP_OWNER_TOKEN);
+      await assert.rejects(withStateFileWriteTransaction(path, async () => {
+        if (kind === 'symlink') await symlink(external, bootstrapPath);
+        else await writeFile(bootstrapPath, kind === 'malformed' ? 'tampered' : kind === 'partial' ? BOOTSTRAP_OWNER_TOKEN.slice(0, 8) : BOOTSTRAP_OWNER_TOKEN);
+        if (kind === 'foreign-entry') await writeFile(join(lockPath, 'foreign'), 'preserve');
+      }), kind === 'symlink' ? /ELOOP|lock ownership lost|ambiguous/ : /lock ownership lost|ambiguous/);
+      assert.equal(await readFile(external, 'utf8'), BOOTSTRAP_OWNER_TOKEN);
+      assert.equal((await readdir(lockPath)).filter((entry) => entry.startsWith('owner-')).length, 2);
+    });
+  }
 
   it('parses legacy owners and emits v3 owners bound to process start identity', async () => {
     const legacy = `${process.pid}-${Date.now()}-${'1'.repeat(24)}`;

--- a/src/state/mode-binding-lease-helper.ts
+++ b/src/state/mode-binding-lease-helper.ts
@@ -79,10 +79,11 @@ async function readPinnedOwner(expectedCurrentToken?: string): Promise<OwnerStat
   const candidateNames = entries.filter((entry) => entry.startsWith('.owner-publish-'));
   const bootstrapName = `owner-${BOOTSTRAP_OWNER_TOKEN}`;
   if (ownerNames.length === 2 && ownerNames.includes(bootstrapName)
-    && displacedNames.length === 0 && candidateNames.length === 0) {
+    && entries.length === 2 && displacedNames.length === 0 && candidateNames.length === 0) {
     if (expectedCurrentToken && ownerNames.includes(`owner-${expectedCurrentToken}`)) {
       const current = await readPinnedRecord(`owner-${expectedCurrentToken}`, expectedCurrentToken);
-      if (current.kind === 'valid') return { kind: 'valid', owner: current.owner };
+      const bootstrap = await readPinnedRecord(bootstrapName, BOOTSTRAP_OWNER_TOKEN);
+      if (current.kind === 'valid' && bootstrap.kind === 'valid') return { kind: 'valid', owner: current.owner };
     }
     return { kind: 'unstable' };
   }

--- a/src/state/mode-binding-lease-helper.ts
+++ b/src/state/mode-binding-lease-helper.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { constants as fsConstants } from 'node:fs';
 import { lstat, mkdir, open, readdir, rename, stat, type FileHandle, unlink, writeFile } from 'node:fs/promises';
-import { basename } from 'node:path';
+import { basename, join } from 'node:path';
 import { createInterface } from 'node:readline';
 import {
   formatProcessOwnerToken,
@@ -71,7 +71,7 @@ async function readPinnedRecord(name: string, token: string): Promise<PinnedReco
   } finally { await handle?.close(); }
 }
 
-async function readPinnedOwner(): Promise<OwnerState> {
+async function readPinnedOwner(expectedCurrentToken?: string): Promise<OwnerState> {
   const entries = await readdir('.');
   if (entries.length === 0) return { kind: 'ownerless' };
   const ownerNames = entries.filter((entry) => entry.startsWith('owner-'));
@@ -79,7 +79,13 @@ async function readPinnedOwner(): Promise<OwnerState> {
   const candidateNames = entries.filter((entry) => entry.startsWith('.owner-publish-'));
   const bootstrapName = `owner-${BOOTSTRAP_OWNER_TOKEN}`;
   if (ownerNames.length === 2 && ownerNames.includes(bootstrapName)
-    && displacedNames.length === 0 && candidateNames.length === 0) return { kind: 'unstable' };
+    && displacedNames.length === 0 && candidateNames.length === 0) {
+    if (expectedCurrentToken && ownerNames.includes(`owner-${expectedCurrentToken}`)) {
+      const current = await readPinnedRecord(`owner-${expectedCurrentToken}`, expectedCurrentToken);
+      if (current.kind === 'valid') return { kind: 'valid', owner: current.owner };
+    }
+    return { kind: 'unstable' };
+  }
   if (ownerNames.length > 1 || displacedNames.length > 1 || candidateNames.length > 1
     || ownerNames.length + displacedNames.length + candidateNames.length !== entries.length) return { kind: 'ambiguous', reason: `entries:${entries.join(',')}` };
   const owner = ownerNames[0]
@@ -205,6 +211,50 @@ async function restoreDisplacedOwner(displaced: OwnerRecord): Promise<boolean> {
   }
 }
 
+async function waitForObservedBootstrapCleanupBarrier(): Promise<void> {
+  const barrierDir = process.env.OMX_TEST_MODE_BINDING_BOOTSTRAP_CLEANUP_BARRIER_DIR;
+  if (!barrierDir) return;
+  const arrival = join(barrierDir, `arrival-${process.pid}`);
+  try { await writeFile(arrival, 'ready', { flag: 'wx', mode: 0o600 }); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+  const release = join(barrierDir, 'release');
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try { await stat(release); return; }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      if (Date.now() >= deadline) throw new Error('timed out waiting for bootstrap cleanup test barrier');
+      await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 5));
+    }
+  }
+}
+
+async function noteObservedBootstrapCleanupEnoent(): Promise<void> {
+  const barrierDir = process.env.OMX_TEST_MODE_BINDING_BOOTSTRAP_CLEANUP_BARRIER_DIR;
+  if (!barrierDir) return;
+  try {
+    await writeFile(join(barrierDir, `enoent-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`), 'ENOENT', { flag: 'wx', mode: 0o600 });
+  } catch {
+    // Test-only evidence must not change the cleanup result.
+  }
+}
+
+async function removeObservedBootstrap(observed: OwnerRecord): Promise<boolean> {
+  const expectedName = `owner-${BOOTSTRAP_OWNER_TOKEN}`;
+  if (observed.name !== expectedName || observed.token !== BOOTSTRAP_OWNER_TOKEN) {
+    throw new Error('canonical state lock bootstrap cleanup received an unexpected owner');
+  }
+  await waitForObservedBootstrapCleanupBarrier();
+  try { await unlink(expectedName); return true; }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    await noteObservedBootstrapCleanupEnoent();
+    return false;
+  }
+}
+
 async function maybeCrashReclaimPhase(phase: string): Promise<void> {
   if (process.env.OMX_TEST_MODE_BINDING_RECLAIM_CRASH_PHASE !== phase) return;
   const sentinel = process.env.OMX_TEST_MODE_BINDING_RECLAIM_CRASH_SENTINEL;
@@ -271,7 +321,8 @@ async function runPinnedClaimMode(args: string[]): Promise<void> {
       const confirmed = await readPinnedRecord(bootstrapName, BOOTSTRAP_OWNER_TOKEN);
       if (confirmed.kind === 'valid' && sameOwner(bootstrap.owner, confirmed.owner)
         && confirmedEntries.includes(bootstrapName) && confirmedEntries.length > 1) {
-        await unlink(bootstrapName);
+        const removed = await removeObservedBootstrap(bootstrap.owner);
+        if (!removed) { respond({ claimed: false }); return; }
         respond({ claimed: false }); return;
       }
     }
@@ -355,7 +406,10 @@ async function runPinnedClaimMode(args: string[]): Promise<void> {
       const visible = await readdir('.');
       if (bootstrap.kind === 'valid' && (visible.length !== 1 || visible[0] !== bootstrapName)) {
         const current = await readPinnedRecord(bootstrapName, BOOTSTRAP_OWNER_TOKEN);
-        if (current.kind === 'valid' && sameOwner(current.owner, bootstrap.owner)) await unlink(bootstrapName);
+        if (current.kind === 'valid' && sameOwner(current.owner, bootstrap.owner)) {
+          const removed = await removeObservedBootstrap(bootstrap.owner);
+          if (!removed) { respond({ claimed: false }); return; }
+        }
         respond({ claimed: false }); return;
       }
     } catch (error) {
@@ -423,10 +477,10 @@ async function assertPinnedLock(): Promise<void> {
   await assertPinnedNamespace();
   const pinned = await stat('.');
   let visible: Awaited<ReturnType<typeof lstat>>;
-  try { visible = await lstat(`../${lockName}`); } catch { throw new Error('canonical state lock ownership lost'); }
+  try { visible = await lstat(`../${lockName}`); } catch { throw new Error('canonical state lock ownership lost: pinned path missing'); }
   if (!pinned.isDirectory() || !visible.isDirectory() || visible.isSymbolicLink()
     || !sameIdentity(pinned, lockIdentity) || !sameIdentity(visible, lockIdentity)) {
-    throw new Error('canonical state lock ownership lost');
+    throw new Error('canonical state lock ownership lost: pinned identity changed');
   }
 }
 
@@ -485,8 +539,8 @@ async function acquire(): Promise<void> {
             throw new Error('canonical state lock changed after stale claim');
           }
           await enterPinnedLock(identity);
-          const claimed = await readPinnedOwner();
-          if (claimed.kind !== 'valid' || claimed.owner.token !== token) throw new Error('canonical state lock ownership lost');
+          const claimed = await readPinnedOwner(token);
+          if (claimed.kind !== 'valid' || claimed.owner.token !== token) throw new Error(`canonical state lock ownership lost: post-claim observed ${claimed.kind}`);
           return;
         }
       } else if (visible) {
@@ -505,8 +559,8 @@ async function acquire(): Promise<void> {
 
 async function release(): Promise<void> {
   await assertPinnedLock();
-  const observed = await readPinnedOwner();
-  if (observed.kind !== 'valid' || observed.owner.token !== token) throw new Error('canonical state lock ownership lost');
+  const observed = await readPinnedOwner(token);
+  if (observed.kind !== 'valid' || observed.owner.token !== token) throw new Error(`canonical state lock ownership lost: release observed ${observed.kind}`);
   await unlink(`owner-${token}`);
   // The persistent directory remains pinned; a successor converges through
   // the fixed bootstrap owner without depending on this process's liveness.
@@ -530,8 +584,8 @@ for await (const line of acquired ? lines : []) {
     id = request.id;
     if (request.op === 'assert') {
       await assertPinnedLock();
-      const observed = await readPinnedOwner();
-      if (observed.kind !== 'valid' || observed.owner.token !== token) throw new Error('canonical state lock ownership lost');
+      const observed = await readPinnedOwner(token);
+      if (observed.kind !== 'valid' || observed.owner.token !== token) throw new Error(`canonical state lock ownership lost: assert observed ${observed.kind}`);
       respond({ id, ok: true });
     } else if (request.op === 'close') {
       await release(); respond({ id, ok: true }); break;

--- a/src/team/__tests__/tmux-source-authority-realtmux.test.ts
+++ b/src/team/__tests__/tmux-source-authority-realtmux.test.ts
@@ -78,7 +78,7 @@ function expectedIfShellArgv(source: SourcePaneAuthority, effect: string, receip
     '-t',
     source.paneId,
     sourceAuthorityPredicate(source),
-    `${effect} ; display-message -p ${quoteTmuxString(receipt)}`,
+    `${effect} ; display-message -p ${quoteTmuxString(receipt.replaceAll('#', '##'))}`,
     "display-message -p ''",
   ];
 }
@@ -145,7 +145,7 @@ describe('runSourceAuthorizedTmux real private-server argv boundary', () => {
           expectedTransactions.push(guardedSplitTransaction);
 
           const hostileValue = "literal; no-command 'still literal'";
-          const hostileReceipt = `omx_source_hostile'; kill-session -t ${source.sessionName}; #`;
+          const hostileReceipt = `omx_source_hostile'; kill-session -t ${source.sessionName}; # #{pane_id} ##`;
           const hostileEffect = `set-option -p -t ${source.paneId} @omx_hostile_3459 ${quoteTmuxString(hostileValue)}`;
           expectedTransactions.push(expectedIfShellArgv(source, hostileEffect, hostileReceipt));
           assert.equal(runSourceAuthorizedTmux(source, hostileEffect, hostileReceipt), hostileReceipt);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -370,7 +370,7 @@ function bindSplitReceiptToPaneCommand(command: string, receipt: string): string
 export function runSourceAuthorizedTmux(source: SourcePaneAuthority, effect: string, receipt: string = sourceTransactionReceipt()): string {
   const result = runTmux([
     'if-shell', '-F', '-t', source.paneId, sourceAuthorityPredicate(source),
-    `${effect} ; display-message -p ${shellQuoteSingle(receipt)}`,
+    `${effect} ; display-message -p ${shellQuoteSingle(receipt.replaceAll('#', '##'))}`,
     "display-message -p ''",
   ]);
   if (!result.ok) throw new Error(`tmux source authority transaction failed: ${result.stderr}`);


### PR DESCRIPTION
## Summary
- Pin the real packed-install hook lifecycle to exact Codex 0.153.4 and enforce its required command handler/enabled metadata; reject obsolete/malformed versions.
- Compare delegate working directories by existing filesystem identity, retaining exact argv/stdin and exactly-one-invocation checks; canonicalize the isolated lifecycle root on macOS.
- Compile the Linux-only Rust rename helper only for its Linux callers, fixing macOS clippy -D warnings without suppression.

## Verification
- Latest targeted TypeScript compilation and smoke regression tests: 59/59 passed, including missing required fields and version negatives.
- Actual packed-install smoke passed with default macOS TMPDIR and installed codex-cli 0.153.4, including hooks/list, trust approval persistence, setup rerun, foreign hooks and uninstall lifecycle. No Codex PATH omission.
- check:no-unused, lint, generated artifacts, native agents and plugin-boundary tests passed.
- cargo fmt --all --check; cargo clippy --workspace --all-targets -- -D warnings; cargo test --workspace passed.
- Independent architect advisory: no source blockers; final release remains conditional on exact candidate CI and final boundary review.
- Full local npm test remains in progress and is not claimed passed.

## Release context
Historical v0.21.4 npm publication was missing its separate trusted workflow dispatch. Exact immutable SHA 304fb3b4825c4132c273732b14d2d5e86b54f8e3 was published through existing OIDC run 34436067953 after prior main/Release CI checks; public registry now reports 0.21.4 with provenance and isolated install/native hydration verified. This PR does not bump or publish 0.21.5.

Unrelated local README changes and historical runtime artifacts are not included.