### PR TITLE
fix: harden auth storage, hotswap redaction, and TOML updates

### DIFF
--- a/src/auth/__tests__/config-sessions.test.ts
+++ b/src/auth/__tests__/config-sessions.test.ts
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readAuthConfig } from "../config.js";
-import { findLatestRolloutSession } from "../sessions.js";
+import { extractRolloutSessionId, findLatestRolloutSession } from "../sessions.js";
 
 describe("auth config", () => {
   it("merges project keys over user keys per absent key fallback", async () => {
@@ -27,6 +27,20 @@ describe("auth config", () => {
 });
 
 describe("Codex rollout session heuristic", () => {
+  it("uses session_meta payload identity instead of the timestamped filename", async () => {
+    const home = await mkdtemp(join(tmpdir(), "omx-auth-session-id-"));
+    try {
+      const id = "019c6e27-e55b-73d1-87d8-4e01f1f75043";
+      const file = join(home, `rollout-2026-09-10T10-00-00-${id}.jsonl`);
+      await writeFile(file, JSON.stringify({ type: "session_meta", payload: { id } }) + "\n");
+      assert.equal(await extractRolloutSessionId(file), id);
+      await writeFile(file, "invalid metadata\n");
+      assert.equal(await extractRolloutSessionId(file), id);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("returns newest rollout id by mtime", async () => {
     const home = await mkdtemp(join(tmpdir(), "omx-auth-sessions-"));
     try {

--- a/src/auth/__tests__/hotswap.test.ts
+++ b/src/auth/__tests__/hotswap.test.ts
@@ -79,6 +79,69 @@ describe("auth hotswap pointer abort lifecycle", () => {
     }
   });
 
+  it("still detects a quota line that follows an oversized stderr record", { skip: process.platform === "win32" }, async (t) => {
+    const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-oversized-quota-"));
+    const home = join(cwd, "home");
+    const runtimeHome = join(cwd, "runtime-codex-home");
+    const binDir = join(cwd, "bin");
+    const codexLog = join(cwd, "codex.log");
+    try {
+      await writeAuthSlot(home);
+      await writeFile(join(home, ".omx", "auth", "second.json"), '{"access_token":"second-secret"}\n');
+      await writeFile(
+        join(home, ".omx", "auth", "slots.json"),
+        JSON.stringify({
+          version: 1,
+          currentSlot: "first",
+          slots: [
+            { slot: "first", createdAt: "now", updatedAt: "now" },
+            { slot: "second", createdAt: "now", updatedAt: "now" },
+          ],
+        }),
+      );
+      await mkdir(binDir, { recursive: true });
+      // A verbose upstream payload overflows the redaction buffer before the
+      // quota marker. Suppressing the rest of stderr would hide the rotation
+      // signal and turn a recoverable quota exit into a plain failure.
+      await writeFile(
+        join(binDir, "codex"),
+        `#!/bin/sh\nprintf 'spawned\\n' >> ${JSON.stringify(codexLog)}\nawk 'BEGIN { while (i++ < 70000) printf "x" ; printf "\\n" }'  >&2\necho 'error: 429 quota exceeded' >&2\nexit 1\n`,
+      );
+      await chmod(join(binDir, "codex"), 0o755);
+      let captured = "";
+      const capture = t.mock.method(process.stderr, "write", (chunk: string | Uint8Array) => {
+        captured += String(chunk);
+        return true;
+      });
+
+      try {
+        await runAuthHotswap({
+          cwd,
+          home,
+          env: { CODEX_HOME: runtimeHome, PATH: `${binDir}:/usr/bin:/bin` },
+          argv: [],
+          lifecycle: lifecycle({
+            prepareCodexHomeForLaunch: async () => ({ codexHomeOverride: runtimeHome }),
+          }),
+        });
+      } finally {
+        capture.mock.restore();
+      }
+
+      assert.equal(await readFile(codexLog, "utf-8"), "spawned\n");
+      // Suppressing the rest of stderr would classify this as a plain failure,
+      // leaving the slot unmarked and skipping rotation entirely.
+      assert.match(captured, /quota detected/);
+      const metadata = JSON.parse(await readFile(join(home, ".omx", "auth", "slots.json"), "utf-8")) as {
+        slots: Array<{ slot: string; exhaustedAt?: string }>;
+      };
+      assert.ok(metadata.slots.find((slot) => slot.slot === "first")?.exhaustedAt);
+      assert.doesNotMatch(captured, /xxx/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("skips the initial slot mutation and postLaunch for a typed pointer abort", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-pointer-abort-"));
     const home = join(cwd, "home");

--- a/src/auth/__tests__/hotswap.test.ts
+++ b/src/auth/__tests__/hotswap.test.ts
@@ -53,6 +53,32 @@ async function writeAuthSlot(home: string, slot = "first"): Promise<string> {
 }
 
 describe("auth hotswap pointer abort lifecycle", () => {
+  it("redacts OAuth fields split across child stderr chunks", { skip: process.platform === "win32" }, async (t) => {
+    const home = await mkdtemp(join(tmpdir(), "omx-hotswap-stderr-"));
+    let output = "";
+    const capture = t.mock.method(process.stderr, "write", (chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    });
+    try {
+      await writeAuthSlot(home);
+      const bin = join(home, "bin");
+      await mkdir(bin);
+      const executable = join(bin, "codex");
+      await writeFile(executable, `#!${process.execPath}\nprocess.stderr.write('{"access_'); setTimeout(() => { process.stderr.write('token":"synthetic-secret"}\\n'); process.exitCode = 1; }, 100);\n`);
+      await chmod(executable, 0o755);
+      const status = await runAuthHotswap({
+        cwd: home, home, env: { PATH: bin }, argv: [], lifecycle: lifecycle(),
+      });
+      assert.equal(status, 1);
+      assert.match(output, /REDACTED/);
+      assert.doesNotMatch(output, /synthetic-secret/);
+    } finally {
+      capture.mock.restore();
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("skips the initial slot mutation and postLaunch for a typed pointer abort", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "omx-hotswap-pointer-abort-"));
     const home = join(cwd, "home");

--- a/src/auth/__tests__/redact.test.ts
+++ b/src/auth/__tests__/redact.test.ts
@@ -3,6 +3,19 @@ import assert from "node:assert/strict";
 import { createAuthStderrRedactor, redactAuthSecrets } from "../redact.js";
 
 describe("auth secret redaction", () => {
+  it("does not release a multiline token value after overflowing its field prefix", () => {
+    const prefix = '{"access_token":\n' + " ".repeat(65 * 1024);
+    const record = prefix + '\n"synthetic-secret"}\n';
+    for (const split of [0, 16, 64 * 1024, prefix.length, record.length]) {
+      let output = "";
+      const redactor = createAuthStderrRedactor((text) => { output += text; });
+      redactor.write(Buffer.from(record.slice(0, split)));
+      redactor.write(Buffer.from(record.slice(split)));
+      redactor.end();
+      assert.doesNotMatch(output, /synthetic-secret/);
+    }
+  });
+
   it("redacts every byte split of token records, including multiline fields and UTF-8", () => {
     for (const record of [
       '{"access_token":"synthetic-secret"}\n',
@@ -24,7 +37,7 @@ describe("auth secret redaction", () => {
     }
   });
 
-  it("streams completed safe lines and suppresses oversized records until newline", () => {
+  it("streams completed safe lines but suppresses the remaining stream after overflow", () => {
     let output = "";
     const redactor = createAuthStderrRedactor((text) => { output += text; });
     redactor.write(Buffer.from("safe line\n"));
@@ -33,7 +46,8 @@ describe("auth secret redaction", () => {
     redactor.write(Buffer.from('synthetic-secret"}\nquota exceeded\n'));
     redactor.end();
     assert.doesNotMatch(output, /synthetic-secret|xxx/);
-    assert.match(output, /suppressed\nquota exceeded\n$/);
+    assert.match(output, /remaining stderr suppressed\n$/);
+    assert.doesNotMatch(output, /quota exceeded/);
   });
 
   it("redacts JSON quoted OAuth token fields while preserving key names", () => {

--- a/src/auth/__tests__/redact.test.ts
+++ b/src/auth/__tests__/redact.test.ts
@@ -1,8 +1,41 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { redactAuthSecrets } from "../redact.js";
+import { createAuthStderrRedactor, redactAuthSecrets } from "../redact.js";
 
 describe("auth secret redaction", () => {
+  it("redacts every byte split of token records, including multiline fields and UTF-8", () => {
+    for (const record of [
+      '{"access_token":"synthetic-secret"}\n',
+      '{"refresh_token":\n "synthetic-secret"}\n',
+      '{"id_token"\n :\n "synthetic-secret"}\n',
+      "Bearer synthetic-secret\n",
+      'árvíz {"access_token":"synthetic-secret"}',
+    ]) {
+      const bytes = Buffer.from(record);
+      for (let split = 0; split <= bytes.length; split++) {
+        let output = "";
+        const redactor = createAuthStderrRedactor((text) => { output += text; });
+        redactor.write(bytes.subarray(0, split));
+        redactor.write(bytes.subarray(split));
+        redactor.end();
+        assert.equal(output, redactAuthSecrets(record), `split ${split}: ${record}`);
+        assert.doesNotMatch(output, /synthetic-secret/);
+      }
+    }
+  });
+
+  it("streams completed safe lines and suppresses oversized records until newline", () => {
+    let output = "";
+    const redactor = createAuthStderrRedactor((text) => { output += text; });
+    redactor.write(Buffer.from("safe line\n"));
+    assert.equal(output, "safe line\n");
+    redactor.write(Buffer.from('{"access_token":"' + "x".repeat(65 * 1024)));
+    redactor.write(Buffer.from('synthetic-secret"}\nquota exceeded\n'));
+    redactor.end();
+    assert.doesNotMatch(output, /synthetic-secret|xxx/);
+    assert.match(output, /suppressed\nquota exceeded\n$/);
+  });
+
   it("redacts JSON quoted OAuth token fields while preserving key names", () => {
     const redacted = redactAuthSecrets(
       '{"access_token":"sentinel-secret","refresh_token":"refresh-secret","id_token":"id-secret","safe":"visible"}',

--- a/src/auth/__tests__/redact.test.ts
+++ b/src/auth/__tests__/redact.test.ts
@@ -37,7 +37,7 @@ describe("auth secret redaction", () => {
     }
   });
 
-  it("streams completed safe lines but suppresses the remaining stream after overflow", () => {
+  it("suppresses an oversized record but resumes at the next safe boundary", () => {
     let output = "";
     const redactor = createAuthStderrRedactor((text) => { output += text; });
     redactor.write(Buffer.from("safe line\n"));
@@ -46,8 +46,28 @@ describe("auth secret redaction", () => {
     redactor.write(Buffer.from('synthetic-secret"}\nquota exceeded\n'));
     redactor.end();
     assert.doesNotMatch(output, /synthetic-secret|xxx/);
-    assert.match(output, /remaining stderr suppressed\n$/);
-    assert.doesNotMatch(output, /quota exceeded/);
+    assert.match(output, /oversized stderr record suppressed\nquota exceeded\n$/);
+  });
+
+  it("redacts multiline token fields that arrive after suppression resumes", () => {
+    let output = "";
+    const redactor = createAuthStderrRedactor((text) => { output += text; });
+    redactor.write(Buffer.from("x".repeat(65 * 1024)));
+    redactor.write(Buffer.from('padding\n{"refresh_token":\n'));
+    redactor.write(Buffer.from('"synthetic-secret"}\nquota exceeded\n'));
+    redactor.end();
+    assert.doesNotMatch(output, /synthetic-secret|xxx/);
+    assert.match(output, /"refresh_token":\n"\[REDACTED\]"\}\nquota exceeded\n$/);
+  });
+
+  it("never resumes on a blank tail long enough to evict the token field prefix", () => {
+    let output = "";
+    const redactor = createAuthStderrRedactor((text) => { output += text; });
+    redactor.write(Buffer.from('{"access_token":' + " ".repeat(65 * 1024)));
+    // A blank run far longer than the boundary window must not look safe.
+    redactor.write(Buffer.from(`${" ".repeat(8 * 1024)}\n"synthetic-secret"}\n`));
+    redactor.end();
+    assert.doesNotMatch(output, /synthetic-secret/);
   });
 
   it("redacts JSON quoted OAuth token fields while preserving key names", () => {

--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { link, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
@@ -50,6 +50,56 @@ describe("auth slot storage", () => {
       assert.ok((await readAuthMetadata(home)).slots.every(record => record.exhaustedAt));
       await Promise.all(names.map(name => clearSlotExhaustion(name, home)));
       assert.ok((await readAuthMetadata(home)).slots.every(record => !record.exhaustedAt));
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves access to an existing distinct Slots account and unrelated accounts", async (t) => {
+    const home = await tempHome();
+    try {
+      const authDir = resolveOmxAuthDir(home);
+      await mkdir(authDir, { recursive: true });
+      const legacyPath = join(authDir, "Slots.json");
+      const metadataPath = resolveAuthMetadataPath(home);
+      await writeFile(legacyPath, '{"access_token":"legacy-test-only"}\n');
+      await writeFile(join(authDir, "work.json"), '{"access_token":"work-test-only"}\n');
+      await writeFile(metadataPath, JSON.stringify({
+        version: 1,
+        slots: ["Slots", "work"].map(slot => ({ slot, createdAt: "2026-09-01", updatedAt: "2026-09-01" })),
+      }));
+      const [legacy, metadata] = await Promise.all([stat(legacyPath), stat(metadataPath)]);
+      if (legacy.dev === metadata.dev && legacy.ino === metadata.ino) {
+        t.skip("filesystem does not support distinct Slots.json and slots.json");
+        return;
+      }
+      assert.deepEqual((await listSlots(home)).map(slot => slot.slot), ["Slots", "work"]);
+      const live = join(home, "auth.json");
+      await useSlot("work", live, home);
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"work-test-only"}\n');
+      await useSlot("Slots", live, home);
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"legacy-test-only"}\n');
+      await addSlotFromAuthFile("Slots", live, home);
+      assert.deepEqual((await readAuthMetadata(home)).slots.map(slot => slot.slot), ["Slots", "work"]);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a case-variant credential path that aliases the metadata file", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, "auth.json");
+      await writeFile(live, '{"access_token":"test-only"}\n');
+      await addSlotFromAuthFile("work", live, home);
+      const metadataPath = resolveAuthMetadataPath(home);
+      const aliasPath = join(resolveOmxAuthDir(home), "Slots.json");
+      if (!existsSync(aliasPath)) await link(metadataPath, aliasPath);
+      const before = await readFile(metadataPath, "utf-8");
+      await assert.rejects(addSlotFromAuthFile("Slots", live, home), /reserved/i);
+      await assert.rejects(useSlot("Slots", live, home), /reserved/i);
+      assert.equal(await readFile(metadataPath, "utf-8"), before);
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"test-only"}\n');
     } finally {
       await rm(home, { recursive: true, force: true });
     }

--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -4,7 +4,9 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { atomicWriteFile, addSlotFromAuthFile, listSlots, readAuthMetadata, useSlot } from "../storage.js";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { atomicWriteFile, addSlotFromAuthFile, listSlots, readAuthMetadata, useSlot, markSlotQuota, clearSlotExhaustion } from "../storage.js";
 import {
   resolveAuthMetadataPath,
   resolveLiveAuthPath,
@@ -18,6 +20,83 @@ async function tempHome(): Promise<string> {
 }
 
 describe("auth slot storage", () => {
+  it("rejects the reserved metadata basename before changing any auth files", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, "auth.json");
+      await writeFile(live, '{"access_token":"test-only"}\n');
+      await addSlotFromAuthFile("work", live, home);
+      const before = await readFile(resolveAuthMetadataPath(home), "utf-8");
+      for (const reserved of ["slots", "Slots", "SLOTS"]) {
+        await assert.rejects(addSlotFromAuthFile(reserved, live, home), /reserved/i);
+        await assert.rejects(useSlot(reserved, live, home), /reserved/i);
+      }
+      assert.equal(await readFile(resolveAuthMetadataPath(home), "utf-8"), before);
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"test-only"}\n');
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves concurrent account additions and quota updates", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, "auth.json");
+      await writeFile(live, '{"access_token":"test-only"}\n');
+      const names = Array.from({ length: 8 }, (_, i) => `account-${i}`);
+      await Promise.all(names.map(name => addSlotFromAuthFile(name, live, home)));
+      assert.deepEqual((await listSlots(home)).map(record => record.slot), names);
+      await Promise.all(names.map(name => markSlotQuota(name, home)));
+      assert.ok((await readAuthMetadata(home)).slots.every(record => record.exhaustedAt));
+      await Promise.all(names.map(name => clearSlotExhaustion(name, home)));
+      assert.ok((await readAuthMetadata(home)).slots.every(record => !record.exhaustedAt));
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes account additions from separate CLI processes", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, "auth.json");
+      await writeFile(live, '{"access_token":"test-only"}\n');
+      const moduleUrl = new URL("../storage.js", import.meta.url).href;
+      const run = promisify(execFile);
+      await Promise.all(Array.from({ length: 4 }, (_, worker) => run(process.execPath, [
+        "--input-type=module", "-e",
+        `import { addSlotFromAuthFile } from ${JSON.stringify(moduleUrl)};
+         const [home, live, worker] = process.argv.slice(1);
+         await Promise.all(Array.from({ length: 3 }, (_, i) =>
+           addSlotFromAuthFile('worker-' + worker + '-' + i, live, home)));`,
+        home, live, String(worker),
+      ], { timeout: 15_000 })));
+      const slots = await listSlots(home);
+      assert.equal(slots.length, 12);
+      assert.equal(new Set(slots.map(slot => slot.slot)).size, 12);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the live credentials and current slot consistent after concurrent switches", async () => {
+    const home = await tempHome();
+    try {
+      const live = join(home, "auth.json");
+      const names = Array.from({ length: 4 }, (_, i) => `account-${i}`);
+      for (const name of names) {
+        await writeFile(live, JSON.stringify({ access_token: `test-only-${name}` }));
+        await addSlotFromAuthFile(name, live, home);
+      }
+      await Promise.all(names.map(name => useSlot(name, live, home)));
+      const metadata = await readAuthMetadata(home);
+      assert.ok(metadata.currentSlot);
+      assert.equal(await readFile(live, "utf-8"), await readFile(resolveSlotPath(metadata.currentSlot, home), "utf-8"));
+      assert.ok(metadata.slots.every(slot => slot.lastUsedAt));
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("adds, lists, and uses auth slots without exposing blob contents", async () => {
     const home = await tempHome();
     try {
@@ -114,6 +193,10 @@ describe("auth slot storage", () => {
       await assert.rejects(useSlot("work", live, home));
 
       assert.equal(await readFile(live, "utf-8"), '{"access_token":"original"}\n');
+      assert.equal(existsSync(join(resolveOmxAuthDir(home), ".metadata-lock")), false);
+      await writeFile(resolveAuthMetadataPath(home), '{"version":1,"slots":[]}\n');
+      await useSlot("work", live, home);
+      assert.equal(await readFile(live, "utf-8"), '{"access_token":"replacement"}\n');
     } finally {
       await rm(home, { recursive: true, force: true });
     }

--- a/src/auth/__tests__/storage.test.ts
+++ b/src/auth/__tests__/storage.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { setTimeout as delay } from "node:timers/promises";
 import { atomicWriteFile, addSlotFromAuthFile, listSlots, readAuthMetadata, useSlot, markSlotQuota, clearSlotExhaustion } from "../storage.js";
 import {
   resolveAuthMetadataPath,
@@ -20,6 +21,40 @@ async function tempHome(): Promise<string> {
 }
 
 describe("auth slot storage", () => {
+  for (const operation of [addSlotFromAuthFile, useSlot]) {
+    it(`rechecks legacy file identity after acquiring the lock in ${operation.name}`, async (t) => {
+      const home = await tempHome();
+      try {
+        const live = join(home, "auth.json");
+        await writeFile(live, '{"access_token":"test-only"}\n');
+        await addSlotFromAuthFile("work", live, home);
+        const metadataPath = resolveAuthMetadataPath(home);
+        const legacyPath = join(resolveOmxAuthDir(home), "Slots.json");
+        if (existsSync(legacyPath)) {
+          t.skip("requires case-distinct filenames");
+          return;
+        }
+        await writeFile(legacyPath, '{"access_token":"legacy"}\n');
+        const before = await readFile(metadataPath, "utf-8");
+        const lockPath = join(resolveOmxAuthDir(home), ".metadata-lock");
+        await mkdir(lockPath);
+        const result = operation("Slots", live, home).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        await delay(100);
+        await rm(legacyPath);
+        await link(metadataPath, legacyPath);
+        await rm(lockPath, { recursive: true });
+        assert.match(String(await result), /reserved/i);
+        assert.equal(await readFile(metadataPath, "utf-8"), before);
+        assert.equal(await readFile(live, "utf-8"), '{"access_token":"test-only"}\n');
+      } finally {
+        await rm(home, { recursive: true, force: true });
+      }
+    });
+  }
+
   it("rejects the reserved metadata basename before changing any auth files", async () => {
     const home = await tempHome();
     try {

--- a/src/auth/hotswap.ts
+++ b/src/auth/hotswap.ts
@@ -4,7 +4,7 @@ import { homedir } from "os";
 import { buildPlatformCommandSpec, classifySpawnError } from "../utils/platform-command.js";
 import { readAuthConfig } from "./config.js";
 import { isQuotaError } from "./quota-detector.js";
-import { redactAuthSecrets } from "./redact.js";
+import { createAuthStderrRedactor, redactAuthSecrets } from "./redact.js";
 import { buildRotationPlan, nextSlotAfter } from "./rotation.js";
 import { findLatestRolloutSession } from "./sessions.js";
 import { listSlots, markSlotQuota, readAuthMetadata, useSlot } from "./storage.js";
@@ -104,11 +104,11 @@ async function runCodexDirect(
       ...(process.platform === "win32" ? { windowsHide: true } : {}),
     });
     let stderr = "";
-    child.stderr?.on("data", (chunk: Buffer) => {
-      const text = redactAuthSecrets(chunk.toString("utf-8"));
+    const redactor = createAuthStderrRedactor((text) => {
       stderr += text;
       process.stderr.write(text);
     });
+    child.stderr?.on("data", (chunk: Buffer) => redactor.write(chunk));
     child.on("error", (error: NodeJS.ErrnoException) => {
       const kind = classifySpawnError(error);
       if (kind === "missing") {
@@ -120,6 +120,7 @@ async function runCodexDirect(
       }
     });
     child.on("close", (status, signal) => {
+      redactor.end();
       resolve({ status: typeof status === "number" ? status : 1, signal, stderr });
     });
   });

--- a/src/auth/paths.ts
+++ b/src/auth/paths.ts
@@ -1,4 +1,5 @@
 import { homedir } from "os";
+import { statSync } from "fs";
 import { basename, join, resolve } from "path";
 import { lstat, mkdir, stat } from "fs/promises";
 import { resolveCodexHomeForLaunch } from "../cli/codex-home.js";
@@ -24,7 +25,7 @@ export function validateSlotName(slot: string): string {
   if (trimmed === "." || trimmed === ".." || basename(trimmed) !== trimmed) {
     throw new Error("invalid auth slot name: path traversal is not allowed");
   }
-  if (trimmed.toLowerCase() === "slots") {
+  if (trimmed === "slots") {
     throw new Error("invalid auth slot name: 'slots' is reserved for auth metadata");
   }
   return trimmed;
@@ -37,6 +38,22 @@ export function resolveSlotPath(slot: string, home = homedir()): string {
   const expected = join(resolve(authDir), `${safeSlot}.json`);
   if (candidate !== expected) {
     throw new Error("invalid auth slot path");
+  }
+  if (safeSlot.toLowerCase() === "slots") {
+    // Preserve legacy case-variant accounts only when their file is demonstrably
+    // distinct from metadata. New names and case-insensitive aliases stay reserved.
+    let distinctLegacyFile = false;
+    try {
+      const credential = statSync(candidate);
+      const metadata = statSync(resolveAuthMetadataPath(home));
+      distinctLegacyFile = credential.isFile() && metadata.isFile()
+        && (credential.dev !== metadata.dev || credential.ino !== metadata.ino);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    if (!distinctLegacyFile) {
+      throw new Error("invalid auth slot name: 'slots' is reserved for auth metadata");
+    }
   }
   return candidate;
 }

--- a/src/auth/paths.ts
+++ b/src/auth/paths.ts
@@ -24,6 +24,9 @@ export function validateSlotName(slot: string): string {
   if (trimmed === "." || trimmed === ".." || basename(trimmed) !== trimmed) {
     throw new Error("invalid auth slot name: path traversal is not allowed");
   }
+  if (trimmed.toLowerCase() === "slots") {
+    throw new Error("invalid auth slot name: 'slots' is reserved for auth metadata");
+  }
   return trimmed;
 }
 

--- a/src/auth/redact.ts
+++ b/src/auth/redact.ts
@@ -26,6 +26,29 @@ export function redactAuthSecrets(value: unknown): string {
   return text;
 }
 
+const MAX_STDERR_RECORD_LENGTH = 64 * 1024;
+/**
+ * A boundary decision only inspects the tail of the buffer, so a small window
+ * of suppressed text is as authoritative as the whole record.
+ */
+const SECRET_BOUNDARY_WINDOW_LENGTH = 256;
+
+/** Keep pretty-printed token fields together when the value starts on the next line. */
+const INCOMPLETE_SECRET_PATTERN = /(?:["']?(?:access_token|refresh_token|id_token|(?:session|auth|api)[_-]?token)["']?\s*[:=]?|\bbearer)\s*$/i;
+
+/**
+ * Retains the trailing bytes needed to judge the next newline boundary.
+ * Whitespace runs are collapsed so an unbounded blank tail cannot push a key
+ * name out of the window; the boundary pattern ends in `\s*$` and matches a
+ * collapsed run identically.
+ */
+function appendSecretBoundaryWindow(window: string, text: string): string {
+  const joined = `${window}${text}`.replace(/\s{2,}/g, " ");
+  return joined.length > SECRET_BOUNDARY_WINDOW_LENGTH
+    ? joined.slice(-SECRET_BOUNDARY_WINDOW_LENGTH)
+    : joined;
+}
+
 /** Redact complete stderr records rather than arbitrary OS pipe chunks. */
 export function createAuthStderrRedactor(emit: (text: string) => void): {
   write: (chunk: Buffer) => void;
@@ -34,22 +57,31 @@ export function createAuthStderrRedactor(emit: (text: string) => void): {
   const decoder = new StringDecoder("utf8");
   let pending = "";
   let dropping = false;
-  // Keep pretty-printed token fields together when the value starts on the next line.
-  const incompleteSecret = /(?:["']?(?:access_token|refresh_token|id_token|(?:session|auth|api)[_-]?token)["']?\s*[:=]?|\bbearer)\s*$/i;
+  // Trailing bytes of the suppressed record, kept so suppression can end at a
+  // boundary that is provably not inside a pretty-printed token field.
+  let suppressedBoundaryWindow = "";
   const accept = (text: string) => {
-    if (dropping) return;
     for (const part of text.match(/[^\n]*\n|[^\n]+$/g) ?? []) {
+      if (dropping) {
+        // Never release suppressed bytes. Resume only once a newline boundary
+        // is reached whose retained tail cannot precede a secret value.
+        suppressedBoundaryWindow = appendSecretBoundaryWindow(suppressedBoundaryWindow, part);
+        if (!part.endsWith("\n")) continue;
+        if (INCOMPLETE_SECRET_PATTERN.test(suppressedBoundaryWindow)) continue;
+        dropping = false;
+        suppressedBoundaryWindow = "";
+        continue;
+      }
       pending += part;
-      // A newline after overflow might still precede a pretty-printed secret value.
-      // Without its buffered prefix, no later boundary is provably safe to emit.
-      if (pending.length > 64 * 1024) {
-        emit("[omx auth] oversized stderr record; remaining stderr suppressed\n");
+      if (pending.length > MAX_STDERR_RECORD_LENGTH) {
+        emit("[omx auth] oversized stderr record suppressed\n");
+        suppressedBoundaryWindow = appendSecretBoundaryWindow("", pending);
         pending = "";
         dropping = true;
-        return;
+        continue;
       }
       if (!part.endsWith("\n")) continue;
-      if (!incompleteSecret.test(pending)) {
+      if (!INCOMPLETE_SECRET_PATTERN.test(pending)) {
         emit(redactAuthSecrets(pending));
         pending = "";
       }

--- a/src/auth/redact.ts
+++ b/src/auth/redact.ts
@@ -1,3 +1,5 @@
+import { StringDecoder } from "node:string_decoder";
+
 const JSON_OAUTH_TOKEN_FIELD_PATTERN = /(["'](?:access_token|refresh_token|id_token)["']\s*:\s*)(["'])(?:\\.|(?!\2)[^\\])*\2/gi;
 
 const SECRET_PATTERNS: RegExp[] = [
@@ -22,4 +24,44 @@ export function redactAuthSecrets(value: unknown): string {
     });
   }
   return text;
+}
+
+/** Redact complete stderr records rather than arbitrary OS pipe chunks. */
+export function createAuthStderrRedactor(emit: (text: string) => void): {
+  write: (chunk: Buffer) => void;
+  end: () => void;
+} {
+  const decoder = new StringDecoder("utf8");
+  let pending = "";
+  let dropping = false;
+  // Keep pretty-printed token fields together when the value starts on the next line.
+  const incompleteSecret = /(?:["']?(?:access_token|refresh_token|id_token|(?:session|auth|api)[_-]?token)["']?\s*[:=]?|\bbearer)\s*$/i;
+  const accept = (text: string) => {
+    for (const part of text.match(/[^\n]*\n|[^\n]+$/g) ?? []) {
+      if (!dropping) {
+        pending += part;
+        // Never release a partial oversized record: it could end inside a token.
+        if (pending.length > 64 * 1024) {
+          emit("[omx auth] oversized stderr record suppressed\n");
+          pending = "";
+          dropping = true;
+        }
+      }
+      if (!part.endsWith("\n")) continue;
+      if (dropping) {
+        dropping = false;
+      } else if (!incompleteSecret.test(pending)) {
+        emit(redactAuthSecrets(pending));
+        pending = "";
+      }
+    }
+  };
+  return {
+    write: (chunk) => accept(decoder.write(chunk)),
+    end: () => {
+      accept(decoder.end());
+      if (pending) emit(redactAuthSecrets(pending));
+      pending = "";
+    },
+  };
 }

--- a/src/auth/redact.ts
+++ b/src/auth/redact.ts
@@ -37,20 +37,19 @@ export function createAuthStderrRedactor(emit: (text: string) => void): {
   // Keep pretty-printed token fields together when the value starts on the next line.
   const incompleteSecret = /(?:["']?(?:access_token|refresh_token|id_token|(?:session|auth|api)[_-]?token)["']?\s*[:=]?|\bbearer)\s*$/i;
   const accept = (text: string) => {
+    if (dropping) return;
     for (const part of text.match(/[^\n]*\n|[^\n]+$/g) ?? []) {
-      if (!dropping) {
-        pending += part;
-        // Never release a partial oversized record: it could end inside a token.
-        if (pending.length > 64 * 1024) {
-          emit("[omx auth] oversized stderr record suppressed\n");
-          pending = "";
-          dropping = true;
-        }
+      pending += part;
+      // A newline after overflow might still precede a pretty-printed secret value.
+      // Without its buffered prefix, no later boundary is provably safe to emit.
+      if (pending.length > 64 * 1024) {
+        emit("[omx auth] oversized stderr record; remaining stderr suppressed\n");
+        pending = "";
+        dropping = true;
+        return;
       }
       if (!part.endsWith("\n")) continue;
-      if (dropping) {
-        dropping = false;
-      } else if (!incompleteSecret.test(pending)) {
+      if (!incompleteSecret.test(pending)) {
         emit(redactAuthSecrets(pending));
         pending = "";
       }

--- a/src/auth/sessions.ts
+++ b/src/auth/sessions.ts
@@ -1,5 +1,6 @@
-import { existsSync } from "fs";
-import { readdir, stat, readFile } from "fs/promises";
+import { createReadStream, existsSync } from "fs";
+import { readdir, stat } from "fs/promises";
+import { createInterface } from "readline";
 import { basename, join } from "path";
 import { resolveDefaultCodexHome } from "./paths.js";
 
@@ -23,16 +24,31 @@ async function collectRollouts(dir: string, out: string[]): Promise<void> {
 }
 
 export async function extractRolloutSessionId(path: string): Promise<string> {
-  const fileMatch = basename(path).match(/^rollout-(.+)\.jsonl$/);
-  if (fileMatch?.[1]) return fileMatch[1];
-  const firstLine = (await readFile(path, "utf-8")).split(/\r?\n/, 1)[0] ?? "";
+  const stream = createReadStream(path, "utf-8");
+  const reader = createInterface({ input: stream, crlfDelay: Infinity });
   try {
-    const parsed = JSON.parse(firstLine) as Record<string, unknown>;
-    const id = parsed.id ?? parsed.session_id ?? parsed.sessionId;
-    if (typeof id === "string" && id.trim()) return id.trim();
+    for await (const line of reader) {
+      const parsed = JSON.parse(line) as {
+        type?: unknown;
+        payload?: { id?: unknown } | null;
+        id?: unknown;
+        session_id?: unknown;
+        sessionId?: unknown;
+      } | null;
+      const id = parsed?.type === "session_meta"
+        ? parsed.payload?.id
+        : parsed?.id ?? parsed?.session_id ?? parsed?.sessionId;
+      if (typeof id === "string" && id.trim()) return id.trim();
+      break;
+    }
   } catch {
     // fall through to basename fallback
+  } finally {
+    reader.close();
+    stream.destroy();
   }
+  const uuid = basename(path).match(/-([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\.jsonl$/i);
+  if (uuid) return uuid[1]!;
   return basename(path, ".jsonl").replace(/^rollout-/, "");
 }
 

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from "crypto";
-import { dirname } from "path";
-import { readFile, rename, rm, writeFile, chmod } from "fs/promises";
+import { dirname, join } from "path";
+import { readFile, rename, rm, writeFile, chmod, mkdir, rmdir } from "fs/promises";
 import { existsSync } from "fs";
+import { setTimeout as delay } from "node:timers/promises";
 import {
+  AUTH_DIR_MODE,
   AUTH_FILE_MODE,
   assertNoSymlink,
   assertReadableFile,
@@ -73,12 +75,41 @@ export async function readAuthMetadata(home?: string): Promise<AuthMetadata> {
   };
 }
 
-export async function writeAuthMetadata(metadata: AuthMetadata, home?: string): Promise<void> {
+async function withAuthStorageLock<T>(home: string | undefined, work: () => Promise<T>): Promise<T> {
+  const authDir = resolveOmxAuthDir(home);
+  await ensurePrivateDir(authDir);
+  const lockDir = join(authDir, ".metadata-lock");
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    try {
+      await mkdir(lockDir, { mode: AUTH_DIR_MODE });
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      // Never steal a lock on age alone: its owner may still be writing auth.json.
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for auth storage lock: ${lockDir}. Remove a stale lock only after confirming no auth operation is running.`);
+      }
+      await delay(25);
+    }
+  }
+  try {
+    return await work();
+  } finally {
+    await rmdir(lockDir);
+  }
+}
+
+async function writeAuthMetadataUnlocked(metadata: AuthMetadata, home?: string): Promise<void> {
   const authDir = resolveOmxAuthDir(home);
   await ensurePrivateDir(authDir);
   await atomicWriteFile(resolveAuthMetadataPath(home), `${JSON.stringify(metadata, null, 2)}\n`, {
     mode: AUTH_FILE_MODE,
   });
+}
+
+export async function writeAuthMetadata(metadata: AuthMetadata, home?: string): Promise<void> {
+  await withAuthStorageLock(home, () => writeAuthMetadataUnlocked(metadata, home));
 }
 
 function upsertSlotRecord(metadata: AuthMetadata, slot: string, nowIso: string): AuthSlotRecord {
@@ -105,11 +136,13 @@ export async function addSlotFromAuthFile(
   await ensurePrivateDir(resolveOmxAuthDir(home));
   const data = await readFile(liveAuthPath);
   const target = resolveSlotPath(safeSlot, home);
-  await atomicWriteFile(target, data, { mode: AUTH_FILE_MODE });
-  const metadata = await readAuthMetadata(home);
-  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
-  await writeAuthMetadata(metadata, home);
-  return record;
+  return withAuthStorageLock(home, async () => {
+    const metadata = await readAuthMetadata(home);
+    await atomicWriteFile(target, data, { mode: AUTH_FILE_MODE });
+    const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+    await writeAuthMetadataUnlocked(metadata, home);
+    return record;
+  });
 }
 
 export async function listSlots(home?: string): Promise<AuthSlotRecord[]> {
@@ -126,17 +159,19 @@ export async function useSlot(
   const safeSlot = validateSlotName(slot);
   const slotPath = resolveSlotPath(safeSlot, home);
   await assertReadableFile(slotPath, `auth slot ${safeSlot}`);
-  const metadata = await readAuthMetadata(home);
-  await ensurePrivateDir(dirname(liveAuthPath));
-  await assertNoSymlink(liveAuthPath, "live Codex auth.json");
-  const data = await readFile(slotPath);
-  await atomicWriteFile(liveAuthPath, data, { mode: AUTH_FILE_MODE });
-  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
-  record.lastUsedAt = now.toISOString();
-  delete record.exhaustedAt;
-  metadata.currentSlot = safeSlot;
-  await writeAuthMetadata(metadata, home);
-  return record;
+  return withAuthStorageLock(home, async () => {
+    const metadata = await readAuthMetadata(home);
+    await ensurePrivateDir(dirname(liveAuthPath));
+    await assertNoSymlink(liveAuthPath, "live Codex auth.json");
+    const data = await readFile(slotPath);
+    await atomicWriteFile(liveAuthPath, data, { mode: AUTH_FILE_MODE });
+    const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+    record.lastUsedAt = now.toISOString();
+    delete record.exhaustedAt;
+    metadata.currentSlot = safeSlot;
+    await writeAuthMetadataUnlocked(metadata, home);
+    return record;
+  });
 }
 
 export async function markSlotQuota(
@@ -145,19 +180,24 @@ export async function markSlotQuota(
   now = new Date(),
 ): Promise<AuthMetadata> {
   const safeSlot = validateSlotName(slot);
-  const metadata = await readAuthMetadata(home);
-  const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
-  record.lastQuotaAt = now.toISOString();
-  record.exhaustedAt = now.toISOString();
-  await writeAuthMetadata(metadata, home);
-  return metadata;
+  return withAuthStorageLock(home, async () => {
+    const metadata = await readAuthMetadata(home);
+    const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
+    record.lastQuotaAt = now.toISOString();
+    record.exhaustedAt = now.toISOString();
+    await writeAuthMetadataUnlocked(metadata, home);
+    return metadata;
+  });
 }
 
 export async function clearSlotExhaustion(slot: string, home?: string): Promise<void> {
-  const metadata = await readAuthMetadata(home);
-  const record = metadata.slots.find((entry) => entry.slot === validateSlotName(slot));
-  if (record) {
-    delete record.exhaustedAt;
-    await writeAuthMetadata(metadata, home);
-  }
+  const safeSlot = validateSlotName(slot);
+  await withAuthStorageLock(home, async () => {
+    const metadata = await readAuthMetadata(home);
+    const record = metadata.slots.find((entry) => entry.slot === safeSlot);
+    if (record) {
+      delete record.exhaustedAt;
+      await writeAuthMetadataUnlocked(metadata, home);
+    }
+  });
 }

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -135,8 +135,8 @@ export async function addSlotFromAuthFile(
   await assertReadableFile(liveAuthPath, "live Codex auth.json");
   await ensurePrivateDir(resolveOmxAuthDir(home));
   const data = await readFile(liveAuthPath);
-  const target = resolveSlotPath(safeSlot, home);
   return withAuthStorageLock(home, async () => {
+    const target = resolveSlotPath(safeSlot, home);
     const metadata = await readAuthMetadata(home);
     await atomicWriteFile(target, data, { mode: AUTH_FILE_MODE });
     const record = upsertSlotRecord(metadata, safeSlot, now.toISOString());
@@ -157,9 +157,9 @@ export async function useSlot(
   now = new Date(),
 ): Promise<AuthSlotRecord> {
   const safeSlot = validateSlotName(slot);
-  const slotPath = resolveSlotPath(safeSlot, home);
-  await assertReadableFile(slotPath, `auth slot ${safeSlot}`);
   return withAuthStorageLock(home, async () => {
+    const slotPath = resolveSlotPath(safeSlot, home);
+    await assertReadableFile(slotPath, `auth slot ${safeSlot}`);
     const metadata = await readAuthMetadata(home);
     await ensurePrivateDir(dirname(liveAuthPath));
     await assertNoSymlink(liveAuthPath, "live Codex auth.json");

--- a/src/config/generator.ts
+++ b/src/config/generator.ts
@@ -14,6 +14,7 @@ import { readFile, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join, resolve } from "path";
 import TOML from "@iarna/toml";
+import { analyzeTomlSource, type TomlSourceLexicalAnalysis } from "../utils/toml-source.js";
 import { DEFAULT_FRONTIER_MODEL } from "./models.js";
 import type { UnifiedMcpRegistryServer } from "./mcp-registry.js";
 import {
@@ -1552,95 +1553,6 @@ interface HookTrustStateStripResult {
 
 type ManagedHookTrustStateExpectations = ReadonlyMap<string, ReadonlySet<string>>;
 
-type TomlSourceStringMode =
-  | "basic"
-  | "literal"
-  | "multiline-basic"
-  | "multiline-literal";
-
-interface TomlSourceLexicalAnalysis {
-  lines: string[];
-  lineStartsOutsideMultiline: boolean[];
-  lineHasTomlComment: boolean[];
-  isUnambiguous: boolean;
-}
-
-function isMultilineTomlString(mode: TomlSourceStringMode | undefined): boolean {
-  return mode === "multiline-basic" || mode === "multiline-literal";
-}
-
-/**
- * Tracks only lexical boundaries needed to safely associate source lines with
- * TOML statements. TOML's parser gives us semantics; this prevents source
- * repair from treating table-like text in a multiline value as syntax.
- */
-function analyzeTomlSource(config: string): TomlSourceLexicalAnalysis {
-  const lines = config.split(/\r?\n/);
-  const lineStartsOutsideMultiline: boolean[] = [];
-  const lineHasTomlComment: boolean[] = [];
-  let mode: TomlSourceStringMode | undefined;
-  let isUnambiguous = true;
-
-  for (const line of lines) {
-    lineStartsOutsideMultiline.push(!isMultilineTomlString(mode));
-    let hasComment = false;
-
-    for (let index = 0; index < line.length; index += 1) {
-      const character = line[index]!;
-      if (mode === "basic") {
-        if (character === "\\") {
-          index += 1;
-        } else if (character === "\"") {
-          mode = undefined;
-        }
-        continue;
-      }
-      if (mode === "literal") {
-        if (character === "'") mode = undefined;
-        continue;
-      }
-      if (mode === "multiline-basic" || mode === "multiline-literal") {
-        const delimiter = mode === "multiline-basic" ? "\"" : "'";
-        if (mode === "multiline-basic" && character === "\\") {
-          index += 1;
-          continue;
-        }
-        if (character !== delimiter) continue;
-
-        let runEnd = index + 1;
-        while (line[runEnd] === delimiter) runEnd += 1;
-        if (runEnd - index >= 3) {
-          // TOML permits one or two delimiter characters immediately before
-          // the closing triple delimiter as string content.
-          mode = undefined;
-          index = runEnd - 1;
-        }
-        continue;
-      }
-
-      if (character === "#") {
-        hasComment = true;
-        break;
-      }
-      if (character !== "\"" && character !== "'") continue;
-
-      const isMultiline =
-        line[index + 1] === character && line[index + 2] === character;
-      if (isMultiline) {
-        mode = character === "\"" ? "multiline-basic" : "multiline-literal";
-        index += 2;
-      } else {
-        mode = character === "\"" ? "basic" : "literal";
-      }
-    }
-
-    lineHasTomlComment.push(hasComment);
-    if (mode === "basic" || mode === "literal") isUnambiguous = false;
-  }
-
-  if (isMultilineTomlString(mode)) isUnambiguous = false;
-  return { lines, lineStartsOutsideMultiline, lineHasTomlComment, isUnambiguous };
-}
 
 interface TomlSourceKeySegment {
   key?: string;

--- a/src/utils/__tests__/platform-command.test.ts
+++ b/src/utils/__tests__/platform-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -290,6 +290,7 @@ describe('resolveCommandPathForPlatform', () => {
     try {
       const nodePath = join(fakeBin, 'node');
       await writeFile(nodePath, '');
+      await chmod(nodePath, 0o755);
       assert.equal(
         resolveCommandPathForPlatform(
           'node',
@@ -338,6 +339,33 @@ describe('resolveCommandPathForPlatform', () => {
       ),
       '/usr/bin/node',
     );
+  });
+
+  it('skips non-executable POSIX candidates and rejects a blocked absolute path', { skip: process.platform === 'win32' }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omx-platform-executable-'));
+    try {
+      const first = join(root, 'first');
+      const second = join(root, 'second');
+      await mkdir(first);
+      await mkdir(second);
+      for (const binary of ['codex', 'tmux']) {
+        const blocked = join(first, binary);
+        const executable = join(second, binary);
+        await writeFile(blocked, '#!/bin/sh\n');
+        await chmod(blocked, 0o644);
+        await writeFile(executable, '#!/bin/sh\n');
+        await chmod(executable, 0o755);
+        const env = { PATH: [first, second].join(delimiter) };
+        assert.equal(resolveCommandPathForPlatform(binary, process.platform, env), executable);
+        assert.equal(resolveCommandPathForPlatform(blocked, process.platform, env), null);
+        assert.equal(resolveCommandPathForPlatform(binary, process.platform, { PATH: first }), null);
+        if (binary === 'tmux') {
+          assert.equal(resolveTmuxBinaryForPlatform(process.platform, env), executable);
+        }
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/utils/__tests__/toml.test.ts
+++ b/src/utils/__tests__/toml.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import TOML from "@iarna/toml";
+import { readTopLevelTomlString, upsertTopLevelTomlString } from "../toml.js";
+
+describe("quoted TOML table boundaries", () => {
+  for (const header of [
+    '[projects."/tmp/demo[1]"]',
+    "[projects.'/tmp/demo[1]']",
+    '[[entries."name[1]"]] # array of tables',
+  ]) {
+    it(`preserves the nested value and inserts at top level before ${header}`, () => {
+      const source = `${header}\r\nmodel_reasoning_effort = "low"\r\n`;
+      assert.equal(readTopLevelTomlString(source, "model_reasoning_effort"), null);
+      const updated = upsertTopLevelTomlString(source, "model_reasoning_effort", "high");
+      assert.equal(updated, `model_reasoning_effort = "high"\r\n${source}`);
+      const { model_reasoning_effort, ...nested } = TOML.parse(updated);
+      assert.equal(model_reasoning_effort, "high");
+      assert.deepEqual(nested, TOML.parse(source));
+    });
+  }
+});

--- a/src/utils/__tests__/toml.test.ts
+++ b/src/utils/__tests__/toml.test.ts
@@ -4,6 +4,21 @@ import TOML from "@iarna/toml";
 import { readTopLevelTomlString, upsertTopLevelTomlString } from "../toml.js";
 
 describe("quoted TOML table boundaries", () => {
+  for (const delimiter of ["'''", '\"\"\"']) {
+    for (const existing of [true, false]) {
+      it(`preserves multiline instructions (${delimiter}, existing=${existing})`, () => {
+        const instructions = `developer_instructions = ${delimiter}\nmodel_reasoning_effort = "low"\n[example]\n${delimiter}\n`;
+        const source = instructions + (existing ? 'model_reasoning_effort = "medium"\n' : "") + '[features]\nfoo = true\n';
+        assert.equal(readTopLevelTomlString(source, "model_reasoning_effort"), existing ? "medium" : null);
+        const updated = upsertTopLevelTomlString(source, "model_reasoning_effort", "high");
+        const parsed = TOML.parse(updated);
+        assert.equal(parsed.developer_instructions, TOML.parse(source).developer_instructions);
+        assert.equal(parsed.model_reasoning_effort, "high");
+        assert.deepEqual(parsed.features, { foo: true });
+      });
+    }
+  }
+
   for (const header of [
     '[projects."/tmp/demo[1]"]',
     "[projects.'/tmp/demo[1]']",

--- a/src/utils/platform-command.ts
+++ b/src/utils/platform-command.ts
@@ -1,4 +1,4 @@
-import { statSync } from 'fs';
+import { accessSync, constants, statSync } from 'fs';
 import {
   spawn,
   spawnSync,
@@ -46,6 +46,16 @@ const WINDOWS_NODE_HOSTED_COMMANDS: Record<string, string[]> = {
 function existsFileSync(path: string): boolean {
   try {
     return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isExecutableFileSync(path: string): boolean {
+  if (!existsFileSync(path)) return false;
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
   } catch {
     return false;
   }
@@ -216,7 +226,7 @@ export function resolveCommandPathForPlatform(
   command: string,
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  existsImpl: ExistsSyncLike = existsFileSync,
+  existsImpl: ExistsSyncLike = platform === 'win32' ? existsFileSync : isExecutableFileSync,
 ): string | null {
   if (platform === 'win32') {
     return resolveWindowsCommandPath(command, env, existsImpl);
@@ -227,7 +237,7 @@ export function resolveCommandPathForPlatform(
 export function resolveTmuxBinaryForPlatform(
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  existsImpl: ExistsSyncLike = existsFileSync,
+  existsImpl?: ExistsSyncLike,
 ): string | null {
   return resolveCommandPathForPlatform('tmux', platform, env, existsImpl);
 }

--- a/src/utils/toml-source.ts
+++ b/src/utils/toml-source.ts
@@ -1,0 +1,89 @@
+type TomlSourceStringMode =
+  | "basic"
+  | "literal"
+  | "multiline-basic"
+  | "multiline-literal";
+
+export interface TomlSourceLexicalAnalysis {
+  lines: string[];
+  lineStartsOutsideMultiline: boolean[];
+  lineHasTomlComment: boolean[];
+  isUnambiguous: boolean;
+}
+
+function isMultilineTomlString(mode: TomlSourceStringMode | undefined): boolean {
+  return mode === "multiline-basic" || mode === "multiline-literal";
+}
+
+/**
+ * Tracks only lexical boundaries needed to safely associate source lines with
+ * TOML statements. TOML's parser gives us semantics; this prevents source
+ * repair from treating table-like text in a multiline value as syntax.
+ */
+export function analyzeTomlSource(config: string): TomlSourceLexicalAnalysis {
+  const lines = config.split(/\r?\n/);
+  const lineStartsOutsideMultiline: boolean[] = [];
+  const lineHasTomlComment: boolean[] = [];
+  let mode: TomlSourceStringMode | undefined;
+  let isUnambiguous = true;
+
+  for (const line of lines) {
+    lineStartsOutsideMultiline.push(!isMultilineTomlString(mode));
+    let hasComment = false;
+
+    for (let index = 0; index < line.length; index += 1) {
+      const character = line[index]!;
+      if (mode === "basic") {
+        if (character === "\\") {
+          index += 1;
+        } else if (character === "\"") {
+          mode = undefined;
+        }
+        continue;
+      }
+      if (mode === "literal") {
+        if (character === "'") mode = undefined;
+        continue;
+      }
+      if (mode === "multiline-basic" || mode === "multiline-literal") {
+        const delimiter = mode === "multiline-basic" ? "\"" : "'";
+        if (mode === "multiline-basic" && character === "\\") {
+          index += 1;
+          continue;
+        }
+        if (character !== delimiter) continue;
+
+        let runEnd = index + 1;
+        while (line[runEnd] === delimiter) runEnd += 1;
+        if (runEnd - index >= 3) {
+          // TOML permits one or two delimiter characters immediately before
+          // the closing triple delimiter as string content.
+          mode = undefined;
+          index = runEnd - 1;
+        }
+        continue;
+      }
+
+      if (character === "#") {
+        hasComment = true;
+        break;
+      }
+      if (character !== "\"" && character !== "'") continue;
+
+      const isMultiline =
+        line[index + 1] === character && line[index + 2] === character;
+      if (isMultiline) {
+        mode = character === "\"" ? "multiline-basic" : "multiline-literal";
+        index += 2;
+      } else {
+        mode = character === "\"" ? "basic" : "literal";
+      }
+    }
+
+    lineHasTomlComment.push(hasComment);
+    if (mode === "basic" || mode === "literal") isUnambiguous = false;
+  }
+
+  if (isMultilineTomlString(mode)) isUnambiguous = false;
+  return { lines, lineStartsOutsideMultiline, lineHasTomlComment, isUnambiguous };
+}

--- a/src/utils/toml.ts
+++ b/src/utils/toml.ts
@@ -1,4 +1,5 @@
-const TABLE_HEADER = /^(?:\[[^[\]]+\]|\[\[[^[\]]+\]\])\s*(#.*)?$/;
+// Quoted table keys may themselves contain brackets (for example project paths).
+const TABLE_HEADER = /^\[.+\]\s*(#.*)?$/;
 
 export function readTopLevelTomlString(
   content: string,

--- a/src/utils/toml.ts
+++ b/src/utils/toml.ts
@@ -1,3 +1,5 @@
+import { analyzeTomlSource } from "./toml-source.js";
+
 // Quoted table keys may themselves contain brackets (for example project paths).
 const TABLE_HEADER = /^\[.+\]\s*(#.*)?$/;
 
@@ -6,8 +8,9 @@ export function readTopLevelTomlString(
   key: string,
 ): string | null {
   let inTopLevel = true;
-  const lines = content.split(/\r?\n/);
-  for (const line of lines) {
+  const { lines, lineStartsOutsideMultiline } = analyzeTomlSource(content);
+  for (const [index, line] of lines.entries()) {
+    if (!lineStartsOutsideMultiline[index]) continue;
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
     if (TABLE_HEADER.test(trimmed)) {
@@ -34,11 +37,13 @@ export function upsertTopLevelTomlString(
     return assignment + eol;
   }
 
-  const lines = content.split(/\r?\n/);
+  const { lines, lineStartsOutsideMultiline, isUnambiguous } = analyzeTomlSource(content);
+  if (!isUnambiguous) throw new Error("Cannot update TOML with unterminated strings");
   let replaced = false;
   let inTopLevel = true;
 
   for (let i = 0; i < lines.length; i++) {
+    if (!lineStartsOutsideMultiline[i]) continue;
     const line = lines[i];
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
@@ -56,8 +61,8 @@ export function upsertTopLevelTomlString(
   }
 
   if (!replaced) {
-    const firstTableIndex = lines.findIndex((line) =>
-      TABLE_HEADER.test(line.trim()),
+    const firstTableIndex = lines.findIndex((line, index) =>
+      lineStartsOutsideMultiline[index] && TABLE_HEADER.test(line.trim()),
     );
     if (firstTableIndex >= 0) {
       lines.splice(firstTableIndex, 0, assignment);


### PR DESCRIPTION
## Summary

Forward the seven reproduced correctness/security fixes from NagyVikt/oh-my-codex#1 onto current upstream `dev`. This branch contains only the five fix commits, not the fork's unrelated team-launch commits.

## Changes

- Prevent auth slot names from colliding with `slots.json`, while preserving existing case-distinct accounts whose file identity is demonstrably separate.
- Serialize auth mutation transactions across CLI processes, including quota updates and live account selection. Validate credential file identity inside the lock.
- Redact stderr across arbitrary chunk boundaries, preserving UTF-8 and multiline token fields. After a 64 KiB redaction-buffer overflow, suppress the remaining child stderr rather than risk exposing a token.
- Recover the actual rollout session ID from `session_meta.payload.id`, with a filename UUID fallback.
- Preserve bracket-containing quoted TOML tables and multiline instruction text when reading/updating top-level settings. Reuse the existing generator lexical scanner without changing its behavior.
- Ignore non-executable POSIX PATH candidates, preserving upstream's absent/empty/whitespace PATH behavior and Windows discovery.

## Validation

- Targeted regression tests cover all seven defects, legacy account compatibility, cross-process writes, and redaction overflow.
- Auth tests use temporary homes and synthetic credentials; hotswap checks use fake executables.
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] 650 focused auth/config/platform/TOML/tmux tests via the repository test runner (0 failures)
- [x] 16 focused CLI reasoning/TOML tests
- [ ] Full `npm test` (not run locally; focused checks and upstream CI are reported separately)
- No real OAuth login, native Windows, or case-insensitive-filesystem validation claimed.

## Compatibility and operational boundaries

- Auth mutex acquisition times out after 10 seconds. Locks left by a killed process are not stolen by age; remove one only after confirming no writer remains.
- Overflow suppression intentionally hides subsequent diagnostics/quota messages for that child.
- No global OMX installation, setup configuration, or dependency changes.
- Original fork PR is retained for traceability; this contribution targets upstream `dev`.
