### PR TITLE
docs(release): fix 0.21.5 PR-inventory attribution gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 
 ### Highlights
 
-- Show active Team identity and per-worker progress in the tmux HUD, preserving narrow layouts, selected runtime roots, leader space, and exact resize ownership.
+- Show active Team identity and per-worker progress in the tmux HUD, preserving narrow layouts, selected runtime roots, leader space, and exact resize ownership (#3644).
 - Align plugin-hook diagnostics/setup/uninstall with current Codex capabilities; preserve explicit reasoning effort and verify the real packed hook lifecycle against Codex 0.153.4 (#3627, #3631, #3632, #3650).
 - Allow ordinary native implementation/reporting under inherited permissions and remove active guidance handoffs to retired workflows (#3637, #3647).
 
@@ -16,14 +16,14 @@ All notable changes to this project are documented in this file.
 
 - Keep project runtime-home credentials ephemeral and export child-safe CODEX_HOME for Team workers (#3633).
 - Make Team startup preflight side-effect free and actionable (#3643); restore portable session recovery and hydrated native runtime lookup (#3638, #3639).
-- Respect TOML array-of-tables and POSIX PATH edge cases (#3645).
+- Respect TOML array-of-tables boundaries (#3645) and POSIX PATH edge cases in command discovery (#3644).
 - Fix a real bootstrap-sentinel ABA race in canonical mode-binding lease acquisition, found via post-merge concurrency stress testing; serialize the full lease lifecycle with a new descriptor-bound native OS advisory mutex (#3650, #3652).
 - Correct cross-platform dogfood fixtures without skipping adversarial identity, trust, or no-follow checks; preserve literal tmux receipt hashes and close retained fixture handles (#3650).
 
 ### Maintenance
 
 - Refresh dependency locks (#3640, #3641, #3642), add MIT LICENSE, and measure maintenance growth without additional runtime machinery (#3646).
-- Reconcile published main documentation/history before freezing the new release range.
+- Reconcile published main documentation/history before freezing the new release range (#3651).
 
 Full inventory, contributors, compatibility notes, and verification: [release notes](docs/release-notes-0.21.5.md) and [release readiness](docs/qa/release-readiness-0.21.5.md).
 

--- a/docs/release-notes-0.21.5.md
+++ b/docs/release-notes-0.21.5.md
@@ -2,7 +2,7 @@
 
 ## Highlights
 
-- **Active Team progress in the tmux HUD:** show the active team identity and each worker's status/task, retain readable narrow layouts and leader space, use the selected runtime state root, and fence resize reconciliation by exact session ownership.
+- **Active Team progress in the tmux HUD:** show the active team identity and each worker's status/task, retain readable narrow layouts and leader space, use the selected runtime state root, and fence resize reconciliation by exact session ownership (#3644).
 - **Current Codex lifecycle:** align plugin-hook diagnostics/setup/uninstall with current Codex capabilities; preserve user-owned reasoning effort; dogfood the real hook trust lifecycle against exact Codex CLI 0.153.4.
 - **Safe ordinary execution:** ordinary native implementation/reporting respects inherited permissions instead of obsolete workflow restrictions (#3637). Active guidance no longer hands users to retired workflows (#3647).
 
@@ -20,6 +20,7 @@ The packed-install live lifecycle is pinned to Codex 0.153.4. Unsupported instal
 
 ## Merged PR inventory
 
+- [#3644](https://github.com/Yeachan-Heo/oh-my-codex/pull/3644): active-team identity and per-worker progress in the tmux HUD, including POSIX PATH edge-case fixes and resize-hook session-owner fencing.
 - [#3627](https://github.com/Yeachan-Heo/oh-my-codex/pull/3627): current Codex hook capability diagnostics.
 - [#3631](https://github.com/Yeachan-Heo/oh-my-codex/pull/3631): preserve user-owned reasoning effort.
 - [#3632](https://github.com/Yeachan-Heo/oh-my-codex/pull/3632): remaining plugin-hook lifecycle corrections.
@@ -33,9 +34,10 @@ The packed-install live lifecycle is pinned to Codex 0.153.4. Unsupported instal
 - [#3646](https://github.com/Yeachan-Heo/oh-my-codex/pull/3646): maintenance inventory.
 - [#3647](https://github.com/Yeachan-Heo/oh-my-codex/pull/3647): retire stale workflow handoffs.
 - [#3650](https://github.com/Yeachan-Heo/oh-my-codex/pull/3650): current Codex/macOS dogfood, receipt and fixture corrections.
+- [#3651](https://github.com/Yeachan-Heo/oh-my-codex/pull/3651): 0.21.5 release preparation and reconciliation with published main.
 - [#3652](https://github.com/Yeachan-Heo/oh-my-codex/pull/3652): native OS mutex serialization for canonical mode-binding leases, fixing a real bootstrap-sentinel ABA race found via post-merge concurrency stress testing.
 
-The active-team HUD series and POSIX PATH correction also landed directly in the compare range. Main-only 0.21.4 documentation/history was merged back before freezing this candidate; it is preserved rather than described as a new feature.
+Main-only 0.21.4 documentation/history was merged back before freezing this candidate; it is preserved rather than described as a new feature.
 
 ## Validation evidence
 


### PR DESCRIPTION
Compare-range audit found PR #3644 (active-team tmux HUD, POSIX PATH fix, resize-hook ownership fencing) missing from the merged-PR inventory list in both release notes and CHANGELOG for 0.21.5, despite prose mentioning it. Also adds #3651 to the inventory. No source changes; docs-only correction to already-merged release collateral.