### PR TITLE
fix(team): survive Windows EPERM fsync during Team startup

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -7774,6 +7774,69 @@ esac
     }
   });
 
+  it('keeps restored HUD debt durable on Windows when fsync reports EPERM (issue #3656)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omx-restored-hud-debt-win-eperm-'));
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const previousMsystem = process.env.MSYSTEM;
+    const previousWsl = process.env.WSL_DISTRO_NAME;
+    const previousWslInterop = process.env.WSL_INTEROP;
+    try {
+      // MSYS keeps isNativeWindows() false so this exercises the same startup
+      // persistence path as the reported `omx team` abort.
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.MSYSTEM = 'MINGW64';
+      delete process.env.WSL_DISTRO_NAME;
+      delete process.env.WSL_INTEROP;
+      await withMockTmuxFixture(
+        'omx-restored-hud-debt-win-eperm-',
+        (logPath) => `#!/bin/sh
+set -eu
+printf '%s\\n' "$*" >> "${logPath}"
+case "$1" in
+  list-panes)
+    if [ "$2" = "-a" ]; then
+      printf '%%11\\t0\\t2000000011\\n%%44\\t0\\t2000000044\\n'
+    else
+      printf '%%11\\tzsh\\tzsh\\n'
+    fi
+    ;;
+  split-window) printf '%%44\\n' ;;
+  *) exit 0 ;;
+esac
+`,
+        async () => {
+          let fsyncCalls = 0;
+          const paneId = withMockedFsyncSync(() => {
+            fsyncCalls += 1;
+            const error = new Error('EPERM: operation not permitted, fsync') as NodeJS.ErrnoException;
+            error.code = 'EPERM';
+            throw error;
+          }, () => restoreStandaloneHudPane('%11', cwd));
+          assert.equal(paneId, '%44');
+          assert.ok(fsyncCalls > 0, 'the durable write must still attempt fsync');
+          const debtPath = join(cwd, '.omx', 'state', '.restored-hud-cleanup-debt.json');
+          assert.deepEqual(JSON.parse(await readFile(debtPath, 'utf-8')), {
+            schema_version: 1,
+            operation: 'restored_hud_cleanup',
+            pane_id: '%44',
+            pane_pid: 2000000044,
+            leader_pane_id: '%11',
+            leader_pane_pid: 2000000011,
+            leader_pane_owner_id: null,
+            hud_owner_leader_pane_id: '%11',
+          });
+        },
+      );
+    } finally {
+      if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      if (typeof previousMsystem === 'string') process.env.MSYSTEM = previousMsystem;
+      else delete process.env.MSYSTEM;
+      if (typeof previousWsl === 'string') process.env.WSL_DISTRO_NAME = previousWsl;
+      if (typeof previousWslInterop === 'string') process.env.WSL_INTEROP = previousWslInterop;
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('reuses an existing standalone HUD pane across repeated restore calls', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'omx-standalone-reuse-hud-'));
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1,6 +1,6 @@
 import { spawnSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { closeSync, chmodSync, existsSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { closeSync, chmodSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
 
@@ -38,6 +38,7 @@ import {
   spawnPlatformCommandSync,
 } from '../utils/platform-command.js';
 import { resolveOmxCliEntryPath } from '../utils/paths.js';
+import { isUnsupportedWindowsSync, syncFileDescriptorSync } from '../utils/file-durability.js';
 import { readExactPaneProof, readExactPaneProofsSync, readExactPaneProofSync, type ExactPaneProof } from './exact-pane.js';
 import { resolveCanonicalTeamStateRoot } from './state-root.js';
 
@@ -460,11 +461,12 @@ function restoredHudCleanupDebtPath(cwd: string, stateRoot?: string | null): str
 function syncRestoredHudDebtParentSync(path: string): void {
   let descriptor: number | undefined;
   try {
+    // Windows can reject the directory open itself with EPERM, so the open and
+    // the fsync share one capability boundary.
     descriptor = openSync(dirname(path), 'r');
-    fsyncSync(descriptor);
+    syncFileDescriptorSync(descriptor);
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (!(code === 'EPERM' && process.platform === 'win32')) throw error;
+    if (!isUnsupportedWindowsSync(error)) throw error;
   } finally {
     if (descriptor !== undefined) closeSync(descriptor);
   }
@@ -485,7 +487,9 @@ function persistRestoredHudCleanupDebtSync(
   writeFileSync(temporaryPath, `${JSON.stringify(debt)}\n`, { mode: 0o600 });
   const temporaryDescriptor = openSync(temporaryPath, 'r');
   try {
-    fsyncSync(temporaryDescriptor);
+    // Windows reports EPERM for fsync on an otherwise valid handle; Team
+    // startup must degrade durability there rather than abort.
+    syncFileDescriptorSync(temporaryDescriptor);
   } finally {
     closeSync(temporaryDescriptor);
   }

--- a/src/utils/__tests__/file-durability.test.ts
+++ b/src/utils/__tests__/file-durability.test.ts
@@ -5,6 +5,7 @@ import {
 	recordDirectorySyncOutcome,
 	recordRegularFileSyncOutcome,
 	syncDirectory,
+	syncFileDescriptorSync,
 	syncRegularFile,
 	type RegularFileDurabilityTracker,
 } from "../file-durability.js";
@@ -60,6 +61,31 @@ for (const { description, platform, failure } of [
 	test(`regular-file sync preserves fatal error identity for ${description}`, async () => {
 		await assert.rejects(
 			syncRegularFile({ sync: async () => { throw failure; } }, platform),
+			(error: unknown) => error === failure,
+		);
+	});
+}
+
+test("synchronous descriptor sync returns the Windows EPERM durability outcome", () => {
+	const outcome = syncFileDescriptorSync(7, "win32", () => { throw errno("EPERM"); });
+	assert.equal(outcome, "unsupported-windows-eperm");
+});
+
+test("synchronous descriptor sync passes the descriptor through on success", () => {
+	const synced: number[] = [];
+	assert.equal(syncFileDescriptorSync(7, "win32", (fd) => { synced.push(fd); }), "synced");
+	assert.deepEqual(synced, [7]);
+});
+
+for (const { description, platform, failure } of [
+	{ description: "Linux EPERM", platform: "linux", failure: errno("EPERM") },
+	{ description: "Windows EACCES", platform: "win32", failure: errno("EACCES") },
+	{ description: "Windows non-string code", platform: "win32", failure: errno(1) },
+	{ description: "Windows message-only EPERM", platform: "win32", failure: new Error("EPERM") },
+] as const) {
+	test(`synchronous descriptor sync preserves fatal error identity for ${description}`, () => {
+		assert.throws(
+			() => syncFileDescriptorSync(7, platform, () => { throw failure; }),
 			(error: unknown) => error === failure,
 		);
 	});

--- a/src/utils/file-durability.ts
+++ b/src/utils/file-durability.ts
@@ -1,3 +1,4 @@
+import { fsyncSync } from "fs";
 import type { FileHandle } from "fs/promises";
 
 export type RegularFileSyncOutcome = "synced" | "unsupported-windows-eperm";
@@ -17,9 +18,9 @@ export interface RegularFileDurabilityTracker {
 	directoryDegraded?: boolean;
 }
 
-function isUnsupportedWindowsSync(
+export function isUnsupportedWindowsSync(
 	error: unknown,
-	platform: NodeJS.Platform,
+	platform: NodeJS.Platform = process.platform,
 ): boolean {
 	return platform === "win32"
 		&& typeof error === "object"
@@ -59,6 +60,26 @@ export async function syncDirectory(
 ): Promise<DirectorySyncOutcome> {
 	try {
 		await handle.sync();
+		return "synced";
+	} catch (error) {
+		if (!isUnsupportedWindowsSync(error, platform)) throw error;
+		return "unsupported-windows-eperm";
+	}
+}
+
+/**
+ * Synchronous counterpart for call sites that must stay synchronous, such as
+ * Team startup state that is persisted before any worker pane exists. The
+ * capability boundary is identical to the async helpers: only Windows EPERM is
+ * a durability limitation, every other failure stays fatal.
+ */
+export function syncFileDescriptorSync(
+	descriptor: number,
+	platform: NodeJS.Platform = process.platform,
+	syncImpl: (fd: number) => void = fsyncSync,
+): RegularFileSyncOutcome {
+	try {
+		syncImpl(descriptor);
 		return "synced";
 	} catch (error) {
 		if (!isUnsupportedWindowsSync(error, platform)) throw error;


### PR DESCRIPTION
Closes #3656.

## Problem

`omx team` aborted on Windows with a bare `EPERM: operation not permitted, fsync` before any worker pane or team state existed. `persistRestoredHudCleanupDebtSync` in `src/team/tmux-session.ts` called `fsyncSync` directly, while `syncRestoredHudDebtParentSync` immediately above it already treated exactly that platform/errno pair as a durability capability limit. `src/utils/file-durability.ts` exists for this case but only exposed async `FileHandle` helpers, so the synchronous Team startup path could not use it and grew its own ad-hoc guard instead.

## Change

- `syncFileDescriptorSync(descriptor, platform, syncImpl)` added to `src/utils/file-durability.ts` as the synchronous counterpart of `syncRegularFile`, with the same capability boundary: only Windows EPERM degrades, every other platform/error pair stays fatal.
- `isUnsupportedWindowsSync` exported so the directory helper, whose `openSync` can itself fail with EPERM on Windows, shares one predicate instead of an inline duplicate.
- Both Team fsync call sites now route through the shared helper. No parallel guard remains in `team/tmux-session.ts`, and its now-unused `fsyncSync` import is dropped.

## Verification

- `src/team/__tests__/tmux-session.test.ts`: new regression test drives `restoreStandaloneHudPane` under `process.platform = 'win32'` with `fsyncSync` throwing `EPERM`, and asserts the HUD pane is returned and the cleanup-debt file is written with the exact expected record. Reverting only the source guard makes it fail with the reported `EPERM: operation not permitted, fsync` at `persistRestoredHudCleanupDebtSync`; with the fix it passes. Full file: 304 passed, 0 failed.
- `src/utils/__tests__/file-durability.test.ts`: Windows-EPERM outcome, success passthrough, and four fatal-identity cases (Linux EPERM, Windows EACCES, non-string code, message-only EPERM) for the new helper. Full file: 23 passed, 0 failed.
- `tsc --noEmit` clean; `biome lint` clean on all four changed files.

Behavior on Linux and macOS is unchanged: an `EPERM` there still aborts.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
