### PR TITLE
evals: reusable OMX default-model cost/quality suite (#3655)

### DIFF
--- a/missions/README.md
+++ b/missions/README.md
@@ -10,6 +10,7 @@ Current pilots / examples:
 - `cli-discoverability-pilot/`
 - `security-path-traversal-pilot/`
 - `in-action-cat-shellout-demo/` — a small self-hosted OMX optimization demo that removes the autoresearch loop's manifest `cat` shell-out and proves the fix with a focused evaluator
+- `astra-default-evaluation/` — reusable cost/quality fixtures for OMX's default-model policy (issue #3655). Task fixtures and quality checks live in `fixtures/`; pinned model configurations live in `configs/`, so the fixtures survive future default changes.
 
 You can run the evaluators directly today:
 
@@ -17,6 +18,7 @@ You can run the evaluators directly today:
 node scripts/eval-cli-discoverability.js
 node scripts/eval-security-path-traversal.js
 node scripts/eval-in-action-cat-shellout-demo.js
+node dist/scripts/eval/eval-astra-defaults.js
 ```
 
 To see a real end-to-end run, launch:

--- a/missions/astra-default-evaluation/configs/astra-defaults.json
+++ b/missions/astra-default-evaluation/configs/astra-defaults.json
@@ -1,0 +1,15 @@
+{
+  "id": "astra-defaults",
+  "label": "OMX shipped defaults after #3622 (Astra)",
+  "isBaseline": true,
+  "omxRevision": "57d596de2a3c404577ae9861f419102c5c3a804d",
+  "roles": {
+    "explore": { "model": "gpt-6-astra", "reasoningEffort": "medium" },
+    "executor": { "model": "gpt-6-astra", "reasoningEffort": "medium" },
+    "code-reviewer": { "model": "gpt-6-astra", "reasoningEffort": "medium" },
+    "team-worker": { "model": "gpt-6-astra", "reasoningEffort": "medium" },
+    "sparkshell": { "model": "gpt-6-astra", "reasoningEffort": "medium" }
+  },
+  "serviceTier": "unknown",
+  "cacheConditions": "unknown (Codex-owned; record observed conditions per run)"
+}

--- a/missions/astra-default-evaluation/configs/mixed-luna-light-roles.json
+++ b/missions/astra-default-evaluation/configs/mixed-luna-light-roles.json
@@ -1,0 +1,15 @@
+{
+  "id": "mixed-luna-light-roles",
+  "label": "Supported override: gpt-5.6-luna for lightweight roles, Astra retained for executor and review",
+  "isBaseline": false,
+  "omxRevision": "57d596de2a3c404577ae9861f419102c5c3a804d",
+  "roles": {
+    "explore": { "model": "gpt-5.6-luna", "reasoningEffort": "medium" },
+    "executor": { "model": "gpt-6-astra", "reasoningEffort": "medium" },
+    "code-reviewer": { "model": "gpt-6-astra", "reasoningEffort": "medium" },
+    "team-worker": { "model": "gpt-5.6-luna", "reasoningEffort": "medium" },
+    "sparkshell": { "model": "gpt-5.6-luna", "reasoningEffort": "medium" }
+  },
+  "serviceTier": "unknown",
+  "cacheConditions": "unknown (Codex-owned; record observed conditions per run)"
+}

--- a/missions/astra-default-evaluation/configs/terra-override.json
+++ b/missions/astra-default-evaluation/configs/terra-override.json
@@ -1,0 +1,15 @@
+{
+  "id": "terra-override",
+  "label": "Supported override: gpt-5.6-terra for every evaluated role, effort unchanged",
+  "isBaseline": false,
+  "omxRevision": "57d596de2a3c404577ae9861f419102c5c3a804d",
+  "roles": {
+    "explore": { "model": "gpt-5.6-terra", "reasoningEffort": "medium" },
+    "executor": { "model": "gpt-5.6-terra", "reasoningEffort": "medium" },
+    "code-reviewer": { "model": "gpt-5.6-terra", "reasoningEffort": "medium" },
+    "team-worker": { "model": "gpt-5.6-terra", "reasoningEffort": "medium" },
+    "sparkshell": { "model": "gpt-5.6-terra", "reasoningEffort": "medium" }
+  },
+  "serviceTier": "unknown",
+  "cacheConditions": "unknown (Codex-owned; record observed conditions per run)"
+}

--- a/missions/astra-default-evaluation/fixtures/code-reviewer-known-defect.json
+++ b/missions/astra-default-evaluation/fixtures/code-reviewer-known-defect.json
@@ -1,0 +1,21 @@
+{
+  "id": "code-reviewer-known-defect",
+  "surface": "code-reviewer",
+  "title": "Review a diff containing one planted defect plus a clean control hunk",
+  "prompt": "Review the diff below. Report blocking defects with file and reason. Report nothing that the diff does not support.",
+  "inputs": {
+    "diff": "--- a/src/redact.ts\n+++ b/src/redact.ts\n@@\n export function createRedactor(limit: number) {\n   let dropping = false;\n   return (chunk: string): string => {\n-    if (chunk.length > limit) return '[redacted]';\n+    if (chunk.length > limit) dropping = true;\n+    if (dropping) return '';\n     return chunk;\n   };\n }\n--- a/src/format.ts\n+++ b/src/format.ts\n@@\n-export function formatDuration(ms: number): string {\n-  return `${Math.round(ms / 1000)}s`;\n-}\n+export function formatDuration(ms: number): string {\n+  if (ms < 1000) return '<1s';\n+  return `${Math.round(ms / 1000)}s`;\n+}\n"
+  },
+  "checks": [
+    {
+      "kind": "must-include",
+      "name": "finds-permanent-suppression",
+      "values": ["redact", "dropping"]
+    },
+    {
+      "kind": "must-not-include",
+      "name": "no-false-positive-on-control",
+      "values": ["formatDuration is incorrect", "format.ts is a blocking"]
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/fixtures/executor-bounded-change.json
+++ b/missions/astra-default-evaluation/fixtures/executor-bounded-change.json
@@ -1,0 +1,22 @@
+{
+  "id": "executor-bounded-change",
+  "surface": "executor",
+  "title": "Implement a bounded change in a fixed fixture repository and run its required checks",
+  "prompt": "In the provided fixture repository, make `formatDuration` render durations below one second as `\"<1s\"` instead of `\"0s\"`. Change only the implementation and its existing test file, then run the repository's required checks. Do not add dependencies, options, or new files.",
+  "inputs": {
+    "requiredChecks": "npm run build && npm test",
+    "scopeBudget": "2 files"
+  },
+  "checks": [
+    {
+      "kind": "must-include",
+      "name": "reports-required-checks",
+      "values": ["npm test"]
+    },
+    {
+      "kind": "must-not-include",
+      "name": "no-scope-inflation",
+      "values": ["added dependency", "new configuration option", "refactored the module"]
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/fixtures/explore-locate-stop-nudge.json
+++ b/missions/astra-default-evaluation/fixtures/explore-locate-stop-nudge.json
@@ -1,0 +1,21 @@
+{
+  "id": "explore-locate-stop-nudge",
+  "surface": "explore",
+  "title": "Locate the Stop auto-nudge behavior and the files that implement it",
+  "prompt": "In the pinned OMX checkout, find where the Stop auto-nudge decides to continue a native child run. List the implementing source files and the function that makes the decision. Do not modify anything and do not propose follow-up work.",
+  "inputs": {
+    "repoHint": "Pinned OMX revision is supplied by the runner; the evaluated configuration receives the repository read-only."
+  },
+  "checks": [
+    {
+      "kind": "must-include",
+      "name": "names-the-hook-source",
+      "values": ["src/hooks", "stop"]
+    },
+    {
+      "kind": "must-not-include",
+      "name": "no-unrequested-followup",
+      "values": ["I will also refactor", "next I will implement", "opened a pull request"]
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/fixtures/sparkshell-exit-status.json
+++ b/missions/astra-default-evaluation/fixtures/sparkshell-exit-status.json
@@ -1,0 +1,20 @@
+{
+  "id": "sparkshell-exit-status",
+  "surface": "sparkshell",
+  "title": "Extract the exit status from fixed command output",
+  "prompt": "Report only the numeric exit status of the command output below.",
+  "inputs": {
+    "commandOutput": "running 12 checks\nbuild completed with warnings\n2 checks failed\nexit code: 2\n"
+  },
+  "deterministicBaseline": {
+    "extractor": "exit-status",
+    "source": "commandOutput"
+  },
+  "checks": [
+    {
+      "kind": "exact-set",
+      "name": "exact-exit-status",
+      "values": ["2"]
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/fixtures/sparkshell-failing-tests.json
+++ b/missions/astra-default-evaluation/fixtures/sparkshell-failing-tests.json
@@ -1,0 +1,23 @@
+{
+  "id": "sparkshell-failing-tests",
+  "surface": "sparkshell",
+  "title": "Extract the failing test names from fixed command output",
+  "prompt": "List the names of the failing tests in the command output below, one per line, and nothing else.",
+  "inputs": {
+    "commandOutput": "ok 1 - resolves the config path\nnot ok 2 - redactor resumes after an oversized record\nok 3 - formats short durations\nnot ok 4 - leader repairs a stale pane\nok 5 - writes the handoff file\nexit code: 1\n"
+  },
+  "deterministicBaseline": {
+    "extractor": "failing-test-names",
+    "source": "commandOutput"
+  },
+  "checks": [
+    {
+      "kind": "exact-set",
+      "name": "exact-failing-test-names",
+      "values": [
+        "redactor resumes after an oversized record",
+        "leader repairs a stale pane"
+      ]
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/fixtures/team-worker-delegated-task.json
+++ b/missions/astra-default-evaluation/fixtures/team-worker-delegated-task.json
@@ -1,0 +1,26 @@
+{
+  "id": "team-worker-delegated-task",
+  "surface": "team-worker",
+  "title": "Complete a bounded delegated task and hand the result back to the leader",
+  "prompt": "You are a Team worker. Add the missing `--json` flag documentation for `omx session list` to the fixture docs file, then hand back a summary stating exactly which file changed and whether the docs check passed.",
+  "inputs": {
+    "handoffContract": "Worker returns: changed files, check outcome, remaining risk. Leader repair time is recorded separately by the runner."
+  },
+  "checks": [
+    {
+      "kind": "must-include",
+      "name": "handoff-names-changed-file",
+      "values": ["docs/"]
+    },
+    {
+      "kind": "must-include",
+      "name": "handoff-states-check-outcome",
+      "values": ["check"]
+    },
+    {
+      "kind": "must-not-include",
+      "name": "no-continuation-after-completion",
+      "values": ["continuing with the next task", "starting additional work"]
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/mission.md
+++ b/missions/astra-default-evaluation/mission.md
@@ -1,0 +1,41 @@
+# Mission
+
+Measure where OMX's Astra defaults (merged in #3622) improve completed OMX work, and where a
+supported override reaches comparable quality with less usage or latency. This is an evaluation,
+not a claim that the defaults are defective. Retaining the current defaults is a valid outcome.
+
+## Layout
+
+- `fixtures/*.json` — model-agnostic task fixtures with predeclared quality checks. They contain no
+  model configuration and stay reusable across future OMX default changes.
+- `configs/*.json` — pinned, inspectable configurations: OMX revision, effective model and reasoning
+  effort per role, service tier, and observable cache conditions. Exactly one is the baseline.
+
+## Covered surfaces
+
+| surface | fixture | quality check |
+| --- | --- | --- |
+| `explore` | `explore-locate-stop-nudge` | names the implementing source, no unrequested follow-up work |
+| `executor` | `executor-bounded-change` | required checks run, scope not inflated |
+| `code-reviewer` | `code-reviewer-known-defect` | finds the planted defect, no false positive on the clean control hunk |
+| Team low-complexity worker | `team-worker-delegated-task` | handoff names changed file and check outcome, no continuation after completion |
+| Sparkshell | `sparkshell-failing-tests`, `sparkshell-exit-status` | exact extraction; both carry a deterministic no-model baseline |
+
+## Rules the harness enforces
+
+- Task requirements, tools, and per-role reasoning effort stay fixed across the initial model
+  comparison. Later effort tuning is a separate pass against the same predeclared requirements.
+- Usage that cannot be attributed is recorded as `unknown`, never as zero, and blocks a complete
+  cost claim for that configuration.
+- Operator intervention, review, and repair time is reported separately from model usage, so work
+  transferred to the operator cannot appear as savings.
+- Workload-weighted results are emitted only when every evaluated fixture has a documented
+  frequency; otherwise only per-task results are reported.
+- Failed and difficult cases are reported separately from the aggregate.
+
+## Success
+
+1. `node dist/scripts/eval/eval-astra-defaults.js` passes: the suite validates and every
+   deterministic no-model baseline reproduces its fixture's expected answer.
+2. A run over the pinned configurations produces the report sections above with no fabricated
+   usage, latency, or operator-effort values.

--- a/missions/astra-default-evaluation/sandbox.md
+++ b/missions/astra-default-evaluation/sandbox.md
@@ -1,0 +1,23 @@
+---
+evaluator:
+  command: node dist/scripts/eval/eval-astra-defaults.js
+  format: json
+  keep_policy: score_improvement
+---
+
+# Sandbox rules
+
+- Keep task fixtures free of model configuration; configuration belongs in `configs/`.
+- Do not weaken a quality check to make a configuration pass.
+- Do not invent usage, latency, or operator-effort numbers. Unattributed values are `null` and are
+  reported as `unknown`.
+- Required workflow stages and independent review stay intact in every evaluated configuration.
+- Adding a fixture requires its quality checks; adding a configuration requires the effective model
+  and reasoning effort for every surface the fixtures exercise.
+
+# Evaluation policy
+
+- `pass=true` means the suite validates and every deterministic no-model baseline reproduces its
+  fixture's expected answer.
+- `score` is the fraction of deterministic baselines that pass, from `0.00` to `1.00`.
+- Higher scores are better.

--- a/src/evals/astra-defaults/__tests__/report.test.ts
+++ b/src/evals/astra-defaults/__tests__/report.test.ts
@@ -102,6 +102,11 @@ describe('weightedPassRates', () => {
     assert.equal(weightedPassRates(suite, records, { a: 3 }), null);
   });
 
+  it('refuses frequencies that reference a fixture outside the suite', () => {
+    const records = [record(), record({ fixtureId: 'b' })];
+    assert.equal(weightedPassRates(suite, records, { a: 3, b: 1, ghost: 5 }), null);
+  });
+
   it('weights pass rate by documented frequency', () => {
     const records = [record(), record({ fixtureId: 'b', outcome: 'fail' })];
     const weighted = weightedPassRates(suite, records, { a: 3, b: 1 });

--- a/src/evals/astra-defaults/__tests__/report.test.ts
+++ b/src/evals/astra-defaults/__tests__/report.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { renderReport, summarize, weightedPassRates } from '../report.js';
+import type { EvalSuite, RunRecord } from '../types.js';
+
+const suite: EvalSuite = {
+  fixtures: [
+    {
+      id: 'a',
+      surface: 'explore',
+      title: 'a',
+      prompt: 'a',
+      inputs: {},
+      checks: [{ kind: 'must-include', name: 'c', values: ['x'] }],
+    },
+    {
+      id: 'b',
+      surface: 'sparkshell',
+      title: 'b',
+      prompt: 'b',
+      inputs: {},
+      checks: [{ kind: 'must-include', name: 'c', values: ['x'] }],
+    },
+  ],
+  configs: [
+    {
+      id: 'astra-defaults',
+      label: 'baseline',
+      isBaseline: true,
+      omxRevision: 'abc123',
+      roles: {
+        explore: { model: 'gpt-6-astra', reasoningEffort: 'medium' },
+        sparkshell: { model: 'gpt-6-astra', reasoningEffort: 'medium' },
+      },
+      serviceTier: 'unknown',
+      cacheConditions: 'unknown',
+    },
+  ],
+};
+
+function record(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    fixtureId: 'a',
+    configId: 'astra-defaults',
+    outcome: 'pass',
+    checks: [{ name: 'c', kind: 'must-include', passed: true }],
+    requiredChecksPassed: true,
+    retries: 0,
+    latencyMs: 1000,
+    usage: { inputTokens: 100, outputTokens: 20 },
+    operatorMinutes: 2,
+    difficult: false,
+    ...overrides,
+  };
+}
+
+describe('summarize', () => {
+  it('marks aggregate usage unknown when any record lacks attribution', () => {
+    const summary = summarize(
+      [record(), record({ fixtureId: 'b', usage: null })],
+      'astra-defaults',
+    );
+    assert.equal(summary.totalUsage, null);
+    assert.equal(summary.usageAttributionComplete, false);
+    assert.equal(summary.totalLatencyMs, 2000);
+  });
+
+  it('keeps operator effort separate and marks it unknown when missing', () => {
+    const summary = summarize(
+      [record(), record({ fixtureId: 'b', operatorMinutes: null })],
+      'astra-defaults',
+    );
+    assert.equal(summary.totalOperatorMinutes, null);
+    assert.equal(summary.operatorAttributionComplete, false);
+    assert.notEqual(summary.totalUsage, null);
+  });
+
+  it('counts failures, errors, difficult cases and retries', () => {
+    const summary = summarize(
+      [
+        record({ outcome: 'fail', retries: 2 }),
+        record({
+          fixtureId: 'b',
+          outcome: 'error',
+          difficult: true,
+          retries: 1,
+        }),
+      ],
+      'astra-defaults',
+    );
+    assert.deepEqual(
+      [summary.passed, summary.failed, summary.errored, summary.difficult, summary.retries],
+      [0, 1, 1, 1, 3],
+    );
+  });
+});
+
+describe('weightedPassRates', () => {
+  it('refuses to weight without documented frequencies for every evaluated fixture', () => {
+    const records = [record(), record({ fixtureId: 'b' })];
+    assert.equal(weightedPassRates(suite, records, null), null);
+    assert.equal(weightedPassRates(suite, records, { a: 3 }), null);
+  });
+
+  it('weights pass rate by documented frequency', () => {
+    const records = [record(), record({ fixtureId: 'b', outcome: 'fail' })];
+    const weighted = weightedPassRates(suite, records, { a: 3, b: 1 });
+    assert.deepEqual(weighted, [{ configId: 'astra-defaults', weightedPassRate: 0.75 }]);
+  });
+});
+
+describe('renderReport', () => {
+  it('reports unknown usage instead of a cost claim and omits weighted savings', () => {
+    const report = renderReport(suite, [record(), record({ fixtureId: 'b', usage: null })]);
+    assert.match(report, /No complete cost claim is made/);
+    assert.match(report, /\| unknown \|/);
+    assert.match(report, /Not reported: documented, representative task frequencies are missing/);
+    assert.match(report, /A lower token count alone is not a successful result\./);
+  });
+
+  it('lists failed and difficult cases separately with check detail', () => {
+    const report = renderReport(suite, [
+      record({
+        outcome: 'fail',
+        checks: [
+          {
+            name: 'c',
+            kind: 'must-include',
+            passed: false,
+            detail: 'missing: x',
+          },
+        ],
+      }),
+      record({ fixtureId: 'b', difficult: true }),
+    ]);
+    assert.match(report, /## Failed and difficult cases/);
+    assert.match(report, /`a` @ `astra-defaults`: fail — c: missing: x/);
+    assert.match(report, /`b` @ `astra-defaults`: pass \(difficult\)/);
+  });
+
+  it('pins the inspectable configuration table', () => {
+    const report = renderReport(suite, [record()]);
+    assert.match(
+      report,
+      /\| astra-defaults \| yes \| abc123 \| unknown \| unknown \| gpt-6-astra \/ medium/,
+    );
+  });
+});

--- a/src/evals/astra-defaults/__tests__/suite.test.ts
+++ b/src/evals/astra-defaults/__tests__/suite.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  baselineRecord,
+  EvalSuiteError,
+  loadSuite,
+  runDeterministicBaseline,
+  scoreResponse,
+  validateSuite,
+} from '../suite.js';
+import type { EvalConfig, EvalFixture } from '../types.js';
+
+const SUITE_DIR = join(process.cwd(), 'missions', 'astra-default-evaluation');
+
+function fixture(overrides: Partial<EvalFixture> = {}): EvalFixture {
+  return {
+    id: 'f1',
+    surface: 'sparkshell',
+    title: 'fixture',
+    prompt: 'do the thing',
+    inputs: { commandOutput: 'not ok 1 - alpha\nok 2 - beta\nexit code: 3\n' },
+    checks: [{ kind: 'exact-set', name: 'names', values: ['alpha'] }],
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<EvalConfig> = {}): EvalConfig {
+  return {
+    id: 'c1',
+    label: 'c1',
+    isBaseline: true,
+    omxRevision: 'abc123',
+    roles: { sparkshell: { model: 'gpt-6-astra', reasoningEffort: 'medium' } },
+    serviceTier: 'unknown',
+    cacheConditions: 'unknown',
+    ...overrides,
+  };
+}
+
+describe('astra-defaults suite loading', () => {
+  it('loads and validates the shipped mission suite', () => {
+    const suite = loadSuite(SUITE_DIR);
+    assert.ok(suite.fixtures.length >= 5);
+    assert.equal(suite.configs.filter((entry) => entry.isBaseline).length, 1);
+    const surfaces = new Set(suite.fixtures.map((entry) => entry.surface));
+    for (const surface of ['explore', 'executor', 'code-reviewer', 'team-worker', 'sparkshell']) {
+      assert.ok(surfaces.has(surface as never), `missing surface ${surface}`);
+    }
+  });
+
+  it('rejects a fixture that pins model configuration', () => {
+    const bad = {
+      ...fixture(),
+      model: 'gpt-6-astra',
+    } as unknown as EvalFixture;
+    assert.throws(
+      () => validateSuite({ fixtures: [bad], configs: [config()] }),
+      (error: unknown) =>
+        error instanceof EvalSuiteError && /must not pin model configuration/.test(String(error)),
+    );
+  });
+
+  it('rejects a configuration missing the effective model for an exercised surface', () => {
+    assert.throws(
+      () =>
+        validateSuite({
+          fixtures: [fixture()],
+          configs: [config({ roles: {} })],
+        }),
+      /missing effective model\/effort for sparkshell/,
+    );
+  });
+
+  it('requires exactly one baseline configuration', () => {
+    assert.throws(
+      () =>
+        validateSuite({
+          fixtures: [fixture()],
+          configs: [config(), config({ id: 'c2' })],
+        }),
+      /exactly one baseline/,
+    );
+  });
+
+  it('rejects a deterministic baseline pointing at a missing input', () => {
+    assert.throws(
+      () =>
+        validateSuite({
+          fixtures: [
+            fixture({
+              deterministicBaseline: {
+                extractor: 'exit-status',
+                source: 'nope',
+              },
+            }),
+          ],
+          configs: [config()],
+        }),
+      /references missing input nope/,
+    );
+  });
+});
+
+describe('deterministic no-model baselines', () => {
+  it('extracts failing test names and nothing else', () => {
+    const answer = runDeterministicBaseline(
+      fixture({
+        deterministicBaseline: {
+          extractor: 'failing-test-names',
+          source: 'commandOutput',
+        },
+      }),
+    );
+    assert.equal(answer, 'alpha');
+  });
+
+  it('extracts the exit status', () => {
+    const answer = runDeterministicBaseline(
+      fixture({
+        deterministicBaseline: {
+          extractor: 'exit-status',
+          source: 'commandOutput',
+        },
+      }),
+    );
+    assert.equal(answer, '3');
+  });
+
+  it('returns null for interpretation fixtures that declare no baseline', () => {
+    assert.equal(runDeterministicBaseline(fixture()), null);
+    assert.throws(() => baselineRecord(fixture()), /has no deterministic baseline/);
+  });
+
+  it('reproduces every shipped deterministic fixture answer', () => {
+    const suite = loadSuite(SUITE_DIR);
+    const deterministic = suite.fixtures.filter((entry) => entry.deterministicBaseline);
+    assert.ok(deterministic.length >= 2);
+    for (const entry of deterministic) {
+      const record = baselineRecord(entry);
+      assert.equal(record.outcome, 'pass', `${entry.id}: ${JSON.stringify(record.checks)}`);
+      assert.equal(record.operatorMinutes, 0);
+    }
+  });
+});
+
+describe('quality scoring', () => {
+  it('fails an exact-set check on extra tokens', () => {
+    const [result] = scoreResponse(fixture(), 'alpha\nbeta');
+    assert.equal(result.passed, false);
+    assert.match(String(result.detail), /extra: \[beta\]/);
+  });
+
+  it('reports missing substrings for must-include checks', () => {
+    const [result] = scoreResponse(
+      fixture({
+        checks: [{ kind: 'must-include', name: 'src', values: ['src/hooks', 'stop'] }],
+      }),
+      'the logic lives in src/hooks/handler.ts',
+    );
+    assert.equal(result.passed, false);
+    assert.match(String(result.detail), /missing: stop/);
+  });
+
+  it('flags unsupported findings for must-not-include checks', () => {
+    const [result] = scoreResponse(
+      fixture({
+        checks: [
+          {
+            kind: 'must-not-include',
+            name: 'no-followup',
+            values: ['opened a pull request'],
+          },
+        ],
+      }),
+      'Done. I also Opened A Pull Request for the cleanup.',
+    );
+    assert.equal(result.passed, false);
+  });
+});

--- a/src/evals/astra-defaults/index.ts
+++ b/src/evals/astra-defaults/index.ts
@@ -1,0 +1,3 @@
+export * from './report.js';
+export * from './suite.js';
+export * from './types.js';

--- a/src/evals/astra-defaults/report.ts
+++ b/src/evals/astra-defaults/report.ts
@@ -66,6 +66,8 @@ export function weightedPassRates(
   frequencies: TaskFrequencies | null,
 ): WeightedResult[] | null {
   if (!frequencies) return null;
+  const known = new Set(suite.fixtures.map((fixture) => fixture.id));
+  if (Object.keys(frequencies).some((id) => !known.has(id))) return null;
   const evaluated = [...new Set(records.map((record) => record.fixtureId))];
   if (evaluated.some((id) => typeof frequencies[id] !== 'number')) return null;
   const totalWeight = evaluated.reduce((sum, id) => sum + frequencies[id], 0);

--- a/src/evals/astra-defaults/report.ts
+++ b/src/evals/astra-defaults/report.ts
@@ -1,0 +1,204 @@
+import type { EvalConfig, EvalSuite, RunRecord, TaskFrequencies, Usage } from './types.js';
+
+export interface ConfigSummary {
+  configId: string;
+  total: number;
+  passed: number;
+  failed: number;
+  errored: number;
+  difficult: number;
+  retries: number;
+  /** null when any record is missing latency. */
+  totalLatencyMs: number | null;
+  /** null when any record is missing usage attribution; never silently zero. */
+  totalUsage: Usage | null;
+  usageAttributionComplete: boolean;
+  /** Operator effort stays separate so model savings cannot hide human work. */
+  totalOperatorMinutes: number | null;
+  operatorAttributionComplete: boolean;
+}
+
+export function summarize(records: RunRecord[], configId: string): ConfigSummary {
+  const rows = records.filter((record) => record.configId === configId);
+  let latency: number | null = 0;
+  let usage: Usage | null = { inputTokens: 0, outputTokens: 0 };
+  let operator: number | null = 0;
+  for (const row of rows) {
+    if (row.latencyMs === null) latency = null;
+    else if (latency !== null) latency += row.latencyMs;
+    if (row.usage === null) usage = null;
+    else if (usage !== null) {
+      usage.inputTokens += row.usage.inputTokens;
+      usage.outputTokens += row.usage.outputTokens;
+    }
+    if (row.operatorMinutes === null) operator = null;
+    else if (operator !== null) operator += row.operatorMinutes;
+  }
+  return {
+    configId,
+    total: rows.length,
+    passed: rows.filter((row) => row.outcome === 'pass').length,
+    failed: rows.filter((row) => row.outcome === 'fail').length,
+    errored: rows.filter((row) => row.outcome === 'error').length,
+    difficult: rows.filter((row) => row.difficult).length,
+    retries: rows.reduce((sum, row) => sum + row.retries, 0),
+    totalLatencyMs: latency,
+    totalUsage: usage,
+    usageAttributionComplete: usage !== null,
+    totalOperatorMinutes: operator,
+    operatorAttributionComplete: operator !== null,
+  };
+}
+
+export interface WeightedResult {
+  configId: string;
+  weightedPassRate: number;
+}
+
+/**
+ * Workload-weighted results are only produced when every evaluated fixture has
+ * a documented frequency. Otherwise callers must report per-task results and
+ * make no representative-savings claim.
+ */
+export function weightedPassRates(
+  suite: EvalSuite,
+  records: RunRecord[],
+  frequencies: TaskFrequencies | null,
+): WeightedResult[] | null {
+  if (!frequencies) return null;
+  const evaluated = [...new Set(records.map((record) => record.fixtureId))];
+  if (evaluated.some((id) => typeof frequencies[id] !== 'number')) return null;
+  const totalWeight = evaluated.reduce((sum, id) => sum + frequencies[id], 0);
+  if (totalWeight <= 0) return null;
+  const configIds = [...new Set(records.map((record) => record.configId))];
+  return configIds.map((configId) => {
+    const weighted = records
+      .filter((record) => record.configId === configId && record.outcome === 'pass')
+      .reduce((sum, record) => sum + frequencies[record.fixtureId], 0);
+    return { configId, weightedPassRate: weighted / totalWeight };
+  });
+}
+
+function num(value: number | null): string {
+  return value === null ? 'unknown' : String(value);
+}
+
+function configTable(configs: EvalConfig[], surfaces: string[]): string {
+  const header = `| config | baseline | omx revision | service tier | cache | ${surfaces.join(' | ')} |`;
+  const divider = `| --- | --- | --- | --- | --- | ${surfaces.map(() => '---').join(' | ')} |`;
+  const rows = configs.map((config) => {
+    const cells = surfaces.map((surface) => {
+      const role = config.roles[surface];
+      return role ? `${role.model} / ${role.reasoningEffort}` : 'unknown';
+    });
+    return `| ${config.id} | ${config.isBaseline ? 'yes' : 'no'} | ${config.omxRevision} | ${config.serviceTier} | ${config.cacheConditions} | ${cells.join(' | ')} |`;
+  });
+  return [header, divider, ...rows].join('\n');
+}
+
+export function renderReport(
+  suite: EvalSuite,
+  records: RunRecord[],
+  frequencies: TaskFrequencies | null = null,
+): string {
+  const surfaces = [...new Set(suite.fixtures.map((fixture) => fixture.surface))];
+  const configIds = [...new Set(records.map((record) => record.configId))];
+  const summaries = configIds.map((configId) => summarize(records, configId));
+  const lines: string[] = [];
+
+  lines.push('# OMX default-model evaluation report');
+  lines.push('');
+  lines.push('## Configurations');
+  lines.push(configTable(suite.configs, surfaces));
+  lines.push('');
+
+  lines.push('## Per-task results');
+  lines.push(
+    '| fixture | config | outcome | failed checks | retries | latency ms | usage | operator min |',
+  );
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |');
+  for (const record of records) {
+    const failed = record.checks.filter((check) => !check.passed).map((check) => check.name);
+    const usage = record.usage
+      ? `${record.usage.inputTokens}/${record.usage.outputTokens}`
+      : 'unknown';
+    lines.push(
+      `| ${record.fixtureId} | ${record.configId} | ${record.outcome} | ${failed.join(', ') || '—'} | ${record.retries} | ${num(record.latencyMs)} | ${usage} | ${num(record.operatorMinutes)} |`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Aggregate per configuration');
+  lines.push(
+    '| config | pass | fail | error | difficult | retries | latency ms | usage | operator min |',
+  );
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- |');
+  for (const summary of summaries) {
+    const usage = summary.totalUsage
+      ? `${summary.totalUsage.inputTokens}/${summary.totalUsage.outputTokens}`
+      : 'unknown';
+    lines.push(
+      `| ${summary.configId} | ${summary.passed} | ${summary.failed} | ${summary.errored} | ${summary.difficult} | ${summary.retries} | ${num(summary.totalLatencyMs)} | ${usage} | ${num(summary.totalOperatorMinutes)} |`,
+    );
+  }
+  lines.push('');
+
+  const failures = records.filter((record) => record.outcome !== 'pass' || record.difficult);
+  lines.push('## Failed and difficult cases');
+  if (failures.length === 0) lines.push('None recorded.');
+  for (const record of failures) {
+    const failed = record.checks.filter((check) => !check.passed);
+    lines.push(
+      `- \`${record.fixtureId}\` @ \`${record.configId}\`: ${record.outcome}${record.difficult ? ' (difficult)' : ''}` +
+        (failed.length
+          ? ` — ${failed.map((check) => `${check.name}: ${check.detail ?? 'failed'}`).join('; ')}`
+          : ''),
+    );
+  }
+  lines.push('');
+
+  lines.push('## Cost claims');
+  const incomplete = summaries.filter((summary) => !summary.usageAttributionComplete);
+  if (incomplete.length > 0) {
+    lines.push(
+      `Usage attribution is incomplete for: ${incomplete.map((summary) => summary.configId).join(', ')}. No complete cost claim is made for those configurations.`,
+    );
+  } else {
+    lines.push('Usage attribution is complete for every evaluated configuration.');
+  }
+  const operatorIncomplete = summaries.filter((summary) => !summary.operatorAttributionComplete);
+  if (operatorIncomplete.length > 0) {
+    lines.push(
+      `Operator effort is unknown for: ${operatorIncomplete.map((summary) => summary.configId).join(', ')}; reduced model usage cannot be read as reduced total effort.`,
+    );
+  }
+  lines.push('A lower token count alone is not a successful result.');
+  lines.push('');
+
+  lines.push('## Workload-weighted summary');
+  const weighted = weightedPassRates(suite, records, frequencies);
+  if (!weighted) {
+    lines.push(
+      'Not reported: documented, representative task frequencies are missing for at least one evaluated fixture. Per-task results above stand on their own and imply no representative savings.',
+    );
+  } else {
+    for (const row of weighted) {
+      lines.push(
+        `- ${row.configId}: ${(row.weightedPassRate * 100).toFixed(1)}% weighted pass rate`,
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## Limitations');
+  lines.push(
+    '- Estimates (implementation/maintenance effort) are labeled separately from measurements.',
+  );
+  lines.push(
+    '- Identical reasoning-effort labels across models do not establish equivalent quality or cost.',
+  );
+  lines.push(
+    '- Codex-owned context, caching, and compaction behavior is not controlled by this suite; such fields are recorded as observed or `unknown`.',
+  );
+  return lines.join('\n');
+}

--- a/src/evals/astra-defaults/suite.ts
+++ b/src/evals/astra-defaults/suite.ts
@@ -1,0 +1,200 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  CheckResult,
+  EvalConfig,
+  EvalFixture,
+  EvalSuite,
+  QualityCheck,
+  RunRecord,
+} from './types.js';
+
+export class EvalSuiteError extends Error {}
+
+function readJsonDir<T>(dir: string): T[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir).filter((name) => name.endsWith('.json'));
+  } catch {
+    throw new EvalSuiteError(`missing suite directory: ${dir}`);
+  }
+  entries.sort();
+  return entries.map((name) => {
+    const path = join(dir, name);
+    try {
+      return JSON.parse(readFileSync(path, 'utf-8')) as T;
+    } catch (error) {
+      throw new EvalSuiteError(`invalid JSON in ${path}: ${(error as Error).message}`);
+    }
+  });
+}
+
+const SURFACES = new Set(['explore', 'executor', 'code-reviewer', 'team-worker', 'sparkshell']);
+
+function validateFixture(fixture: EvalFixture): void {
+  if (!fixture.id) throw new EvalSuiteError('fixture is missing an id');
+  if (!SURFACES.has(fixture.surface)) {
+    throw new EvalSuiteError(`fixture ${fixture.id} has unknown surface ${fixture.surface}`);
+  }
+  if (!fixture.prompt?.trim()) {
+    throw new EvalSuiteError(`fixture ${fixture.id} is missing a prompt`);
+  }
+  if (!Array.isArray(fixture.checks) || fixture.checks.length === 0) {
+    throw new EvalSuiteError(`fixture ${fixture.id} declares no quality checks`);
+  }
+  for (const check of fixture.checks) {
+    if (!check.name) throw new EvalSuiteError(`fixture ${fixture.id} has an unnamed check`);
+    if (!Array.isArray(check.values) || check.values.length === 0) {
+      throw new EvalSuiteError(`check ${fixture.id}/${check.name} has no values`);
+    }
+  }
+  const baseline = fixture.deterministicBaseline;
+  if (baseline && !(baseline.source in fixture.inputs)) {
+    throw new EvalSuiteError(
+      `fixture ${fixture.id} baseline references missing input ${baseline.source}`,
+    );
+  }
+  // Model configuration must never leak into a task fixture.
+  for (const key of ['model', 'models', 'reasoningEffort', 'config'] as const) {
+    if (key in (fixture as unknown as Record<string, unknown>)) {
+      throw new EvalSuiteError(`fixture ${fixture.id} must not pin model configuration (${key})`);
+    }
+  }
+}
+
+function validateConfigs(configs: EvalConfig[], fixtures: EvalFixture[]): void {
+  if (configs.length === 0) throw new EvalSuiteError('suite declares no configurations');
+  const baselines = configs.filter((config) => config.isBaseline);
+  if (baselines.length !== 1) {
+    throw new EvalSuiteError(`suite must declare exactly one baseline, found ${baselines.length}`);
+  }
+  const surfaces = new Set(fixtures.map((fixture) => fixture.surface));
+  for (const config of configs) {
+    if (!config.id) throw new EvalSuiteError('configuration is missing an id');
+    if (!config.omxRevision?.trim()) {
+      throw new EvalSuiteError(`configuration ${config.id} is not pinned to an OMX revision`);
+    }
+    if (!config.serviceTier?.trim() || !config.cacheConditions?.trim()) {
+      throw new EvalSuiteError(
+        `configuration ${config.id} must record serviceTier and cacheConditions ("unknown" is allowed)`,
+      );
+    }
+    for (const surface of surfaces) {
+      const role = config.roles?.[surface];
+      if (!role?.model?.trim() || !role?.reasoningEffort?.trim()) {
+        throw new EvalSuiteError(
+          `configuration ${config.id} is missing effective model/effort for ${surface}`,
+        );
+      }
+    }
+  }
+}
+
+export function validateSuite(suite: EvalSuite): EvalSuite {
+  if (suite.fixtures.length === 0) throw new EvalSuiteError('suite declares no fixtures');
+  const seen = new Set<string>();
+  for (const fixture of suite.fixtures) {
+    validateFixture(fixture);
+    if (seen.has(fixture.id)) throw new EvalSuiteError(`duplicate fixture id ${fixture.id}`);
+    seen.add(fixture.id);
+  }
+  validateConfigs(suite.configs, suite.fixtures);
+  return suite;
+}
+
+export function loadSuite(suiteDir: string): EvalSuite {
+  const suite: EvalSuite = {
+    fixtures: readJsonDir<EvalFixture>(join(suiteDir, 'fixtures')),
+    configs: readJsonDir<EvalConfig>(join(suiteDir, 'configs')),
+  };
+  return validateSuite(suite);
+}
+
+function tokenize(response: string): Set<string> {
+  return new Set(
+    response
+      .split(/[\n,]/)
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0),
+  );
+}
+
+function evaluateCheck(check: QualityCheck, response: string): CheckResult {
+  const haystack = response.toLowerCase();
+  if (check.kind === 'must-include') {
+    const missing = check.values.filter((value) => !haystack.includes(value.toLowerCase()));
+    return {
+      name: check.name,
+      kind: check.kind,
+      passed: missing.length === 0,
+      detail: missing.length ? `missing: ${missing.join(', ')}` : undefined,
+    };
+  }
+  if (check.kind === 'must-not-include') {
+    const present = check.values.filter((value) => haystack.includes(value.toLowerCase()));
+    return {
+      name: check.name,
+      kind: check.kind,
+      passed: present.length === 0,
+      detail: present.length ? `unsupported content: ${present.join(', ')}` : undefined,
+    };
+  }
+  const actual = tokenize(response);
+  const expected = new Set(check.values);
+  const missing = [...expected].filter((value) => !actual.has(value));
+  const extra = [...actual].filter((value) => !expected.has(value));
+  return {
+    name: check.name,
+    kind: check.kind,
+    passed: missing.length === 0 && extra.length === 0,
+    detail:
+      missing.length || extra.length
+        ? `missing: [${missing.join(', ')}] extra: [${extra.join(', ')}]`
+        : undefined,
+  };
+}
+
+export function scoreResponse(fixture: EvalFixture, response: string): CheckResult[] {
+  return fixture.checks.map((check) => evaluateCheck(check, response));
+}
+
+/** Deterministic, no-model answer for fixtures whose output contract permits it. */
+export function runDeterministicBaseline(fixture: EvalFixture): string | null {
+  const spec = fixture.deterministicBaseline;
+  if (!spec) return null;
+  const source = fixture.inputs[spec.source] ?? '';
+  if (spec.extractor === 'failing-test-names') {
+    const names: string[] = [];
+    for (const line of source.split('\n')) {
+      const match = /^\s*(?:not ok\s+\d+\s+-\s+|FAIL\s+)(.+?)\s*$/.exec(line);
+      if (match) names.push(match[1]);
+    }
+    return names.join('\n');
+  }
+  const match = /^\s*exit(?:\s+code)?[:=]?\s*(\d+)\s*$/m.exec(source);
+  return match ? match[1] : '';
+}
+
+export function baselineRecord(
+  fixture: EvalFixture,
+  configId = 'deterministic-no-model',
+): RunRecord {
+  const response = runDeterministicBaseline(fixture);
+  if (response === null) {
+    throw new EvalSuiteError(`fixture ${fixture.id} has no deterministic baseline`);
+  }
+  const checks = scoreResponse(fixture, response);
+  return {
+    fixtureId: fixture.id,
+    configId,
+    outcome: checks.every((check) => check.passed) ? 'pass' : 'fail',
+    checks,
+    requiredChecksPassed: null,
+    retries: 0,
+    latencyMs: null,
+    usage: { inputTokens: 0, outputTokens: 0 },
+    operatorMinutes: 0,
+    difficult: false,
+    notes: 'deterministic extractor, no model invoked',
+  };
+}

--- a/src/evals/astra-defaults/types.ts
+++ b/src/evals/astra-defaults/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Model-agnostic evaluation contract for OMX role fixtures (issue #3655).
+ *
+ * Task fixtures and quality checks are deliberately kept separate from model
+ * configuration so the same fixtures stay reusable when OMX changes defaults.
+ * Astra defaults are only the initial baseline configuration.
+ */
+
+export type EvalSurface = 'explore' | 'executor' | 'code-reviewer' | 'team-worker' | 'sparkshell';
+
+export type QualityCheck =
+  | { kind: 'must-include'; name: string; values: string[] }
+  | { kind: 'must-not-include'; name: string; values: string[] }
+  | { kind: 'exact-set'; name: string; values: string[] };
+
+export type DeterministicExtractor = 'failing-test-names' | 'exit-status';
+
+export interface DeterministicBaselineSpec {
+  /** Extractor applied to `inputs[source]` to produce a no-model answer. */
+  extractor: DeterministicExtractor;
+  source: string;
+}
+
+export interface EvalFixture {
+  id: string;
+  surface: EvalSurface;
+  title: string;
+  /** Task statement handed to the evaluated configuration. */
+  prompt: string;
+  /** Fixed inputs (command output, diff, file excerpt) shared by every configuration. */
+  inputs: Record<string, string>;
+  checks: QualityCheck[];
+  /**
+   * Present only when the output contract permits a deterministic, no-model
+   * answer. Interpretation-heavy fixtures intentionally omit it.
+   */
+  deterministicBaseline?: DeterministicBaselineSpec;
+}
+
+export interface PinnedRoleConfig {
+  model: string;
+  reasoningEffort: string;
+}
+
+export interface EvalConfig {
+  id: string;
+  label: string;
+  isBaseline: boolean;
+  omxRevision: string;
+  /** Keyed by surface; every surface exercised by the fixtures must be present. */
+  roles: Record<string, PinnedRoleConfig>;
+  /** `unknown` is a valid, explicit value: OMX does not own Codex caching. */
+  serviceTier: string;
+  cacheConditions: string;
+}
+
+export interface EvalSuite {
+  fixtures: EvalFixture[];
+  configs: EvalConfig[];
+}
+
+export interface CheckResult {
+  name: string;
+  kind: QualityCheck['kind'];
+  passed: boolean;
+  detail?: string;
+}
+
+export interface Usage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface RunRecord {
+  fixtureId: string;
+  configId: string;
+  outcome: 'pass' | 'fail' | 'error';
+  checks: CheckResult[];
+  /** Required checks owned by the fixture repo (build/tests), not by the grader. */
+  requiredChecksPassed: boolean | null;
+  retries: number;
+  latencyMs: number | null;
+  /** `null` means usage attribution was unavailable, never zero. */
+  usage: Usage | null;
+  /** Operator intervention/review/repair time, reported separately from model cost. */
+  operatorMinutes: number | null;
+  difficult: boolean;
+  notes?: string;
+}
+
+/** Documented task frequencies; required before any workload-weighted claim. */
+export type TaskFrequencies = Record<string, number>;

--- a/src/scripts/eval/eval-astra-defaults.ts
+++ b/src/scripts/eval/eval-astra-defaults.ts
@@ -1,0 +1,37 @@
+import { join } from 'node:path';
+import { baselineRecord, loadSuite } from '../../evals/astra-defaults/suite.js';
+
+const suiteDir = process.argv[2] ?? join(process.cwd(), 'missions', 'astra-default-evaluation');
+
+try {
+  const suite = loadSuite(suiteDir);
+  const deterministic = suite.fixtures.filter((fixture) => fixture.deterministicBaseline);
+  if (deterministic.length === 0) {
+    throw new Error('suite declares no deterministic no-model baseline');
+  }
+  const records = deterministic.map((fixture) => baselineRecord(fixture));
+  const passed = records.filter((record) => record.outcome === 'pass');
+  const pass = passed.length === records.length;
+  for (const record of records.filter((record) => record.outcome !== 'pass')) {
+    process.stderr.write(
+      `${record.fixtureId}: ${record.checks
+        .filter((check) => !check.passed)
+        .map((check) => `${check.name} ${check.detail ?? ''}`)
+        .join('; ')}\n`,
+    );
+  }
+  process.stdout.write(
+    JSON.stringify({
+      pass,
+      score: Number((passed.length / records.length).toFixed(2)),
+      fixtures: suite.fixtures.length,
+      configs: suite.configs.length,
+      deterministicBaselines: records.length,
+    }),
+  );
+  process.exit(pass ? 0 : 1);
+} catch (error) {
+  process.stderr.write(`${(error as Error).message}\n`);
+  process.stdout.write(JSON.stringify({ pass: false, score: 0 }));
+  process.exit(1);
+}


### PR DESCRIPTION
Refs #3655.

Adds the reusable evaluation fixtures and harness the issue asks for as its completion criterion. Model comparison runs and the evidence-backed report are produced on top of this; no default, routing, accounting, or Codex-owned control is touched.

## What this adds

- **`missions/astra-default-evaluation/fixtures/`** — six model-agnostic task fixtures covering `explore`, `executor`, `code-reviewer`, Team low-complexity worker, and Sparkshell. Each fixture carries its own predeclared quality checks (`must-include`, `must-not-include`, `exact-set`). Validation **rejects** any fixture that pins model configuration, so the fixtures stay reusable across future default changes.
- **`missions/astra-default-evaluation/configs/`** — pinned, inspectable configurations: OMX revision, effective model and reasoning effort per role, service tier, observable cache conditions. Baseline is the shipped Astra defaults (`gpt-6-astra`, effort unchanged at `medium`); the two overrides are supported aliases at identical effort, so the initial comparison holds effort fixed. Validation requires exactly one baseline and a recorded model/effort for every surface the fixtures exercise; `unknown` is an allowed explicit value for Codex-owned fields.
- **Deterministic, no-model baselines** — the two Sparkshell fixtures whose output contract permits it (`failing-test-names`, `exit-status`) run with no model at all and are scored by the same checks. Interpretation-heavy fixtures deliberately declare none.
- **`src/evals/astra-defaults/report.ts`** — aggregation and markdown report with the issue's reporting rules enforced in code, not in prose:
  - unattributed usage is `null` → reported as `unknown` and it **blocks** a complete cost claim for that configuration (never silently zero);
  - operator intervention/review/repair time is aggregated and reported **separately** from model usage;
  - workload-weighted results are emitted **only** when every evaluated fixture has a documented frequency, otherwise the report states that no representative-savings claim is made;
  - failed and difficult cases are listed separately from the aggregate; estimates are labeled separately from measurements.
- **`src/scripts/eval/eval-astra-defaults.ts`** — evaluator entry point matching the existing `src/scripts/eval/*` convention, emitting `{pass, score, ...}`.

## Verification

- `node node_modules/typescript/bin/tsc` — clean.
- `node --test dist/evals/astra-defaults/__tests__/{suite,report}.test.js` — **20/20 pass**, covering fixture/config validation rejections, both deterministic extractors, each check kind's failure detail, unknown-usage propagation, operator-effort separation, and the weighted-claim refusal.
- `node dist/scripts/eval/eval-astra-defaults.js` → `{"pass":true,"score":1,"fixtures":6,"configs":3,"deterministicBaselines":2}`.
- `biome lint src` — clean.

## Out of scope here

Executing the live model comparison consumes real usage and belongs to a separately authorized run; this PR is the reusable half of the issue's completion criterion. Recommended optimizations, default changes, and accounting infrastructure remain separate follow-ups per the issue.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
