### PR TITLE
evals: add deterministic stage-transition records and reporting

### DIFF
--- a/missions/astra-default-evaluation/examples/stage-transition/configs/continue-pair.json
+++ b/missions/astra-default-evaluation/examples/stage-transition/configs/continue-pair.json
@@ -1,0 +1,58 @@
+{
+  "id": "continue-pair",
+  "label": "Proposed native-agent stages continuing the same pair",
+  "isBaseline": true,
+  "omxRevision": "7a3cab6445db8313340779ba6298b3cae24eac6e",
+  "roles": {
+    "explore": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "executor": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "code-reviewer": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "team-worker": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "sparkshell": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    }
+  },
+  "serviceTier": "unknown",
+  "cacheConditions": "unknown; synthetic example does not observe cache reuse",
+  "stages": [
+    {
+      "id": "planner",
+      "role": "planner",
+      "surface": "native-agent",
+      "requested": {
+        "model": "gpt-6-astra",
+        "reasoningEffort": "high"
+      },
+      "overrideSource": {
+        "model": "proposed agentModels.planner",
+        "reasoningEffort": "proposed agentReasoning.planner"
+      }
+    },
+    {
+      "id": "executor",
+      "role": "executor",
+      "surface": "native-agent",
+      "requested": {
+        "model": "gpt-6-astra",
+        "reasoningEffort": "high"
+      },
+      "overrideSource": {
+        "model": "proposed agentModels.executor",
+        "reasoningEffort": "proposed agentReasoning.executor"
+      }
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/examples/stage-transition/configs/split-pair.json
+++ b/missions/astra-default-evaluation/examples/stage-transition/configs/split-pair.json
@@ -1,0 +1,58 @@
+{
+  "id": "split-pair",
+  "label": "Proposed native-agent planner/executor split",
+  "isBaseline": false,
+  "omxRevision": "7a3cab6445db8313340779ba6298b3cae24eac6e",
+  "roles": {
+    "explore": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "executor": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "code-reviewer": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "team-worker": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    },
+    "sparkshell": {
+      "model": "gpt-6-astra",
+      "reasoningEffort": "medium"
+    }
+  },
+  "serviceTier": "unknown",
+  "cacheConditions": "unknown; synthetic example does not observe cache reuse",
+  "stages": [
+    {
+      "id": "planner",
+      "role": "planner",
+      "surface": "native-agent",
+      "requested": {
+        "model": "gpt-6-astra",
+        "reasoningEffort": "high"
+      },
+      "overrideSource": {
+        "model": "proposed agentModels.planner",
+        "reasoningEffort": "proposed agentReasoning.planner"
+      }
+    },
+    {
+      "id": "executor",
+      "role": "executor",
+      "surface": "native-agent",
+      "requested": {
+        "model": "gpt-5.6-terra",
+        "reasoningEffort": "medium"
+      },
+      "overrideSource": {
+        "model": "proposed agentModels.executor",
+        "reasoningEffort": "proposed agentReasoning.executor"
+      }
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/examples/stage-transition/records.json
+++ b/missions/astra-default-evaluation/examples/stage-transition/records.json
@@ -1,0 +1,142 @@
+{
+  "evidence": "synthetic",
+  "records": [
+    {
+      "fixtureId": "executor-bounded-change",
+      "configId": "continue-pair",
+      "workflowId": "bounded-change-01",
+      "outcome": "pass",
+      "checks": [
+        {
+          "kind": "must-include",
+          "name": "reports-required-checks",
+          "passed": true
+        },
+        {
+          "kind": "must-not-include",
+          "name": "no-scope-inflation",
+          "passed": true
+        }
+      ],
+      "requiredChecksPassed": null,
+      "retries": 0,
+      "latencyMs": 250,
+      "usage": null,
+      "operatorMinutes": 2,
+      "difficult": false,
+      "usageScope": "stages",
+      "stages": [
+        {
+          "stageId": "planner",
+          "launchResolved": {
+            "model": "gpt-6-astra",
+            "reasoningEffort": "high",
+            "source": "synthetic launch receipt"
+          },
+          "usage": {
+            "inputTokens": 100,
+            "outputTokens": 20,
+            "uncachedInputTokens": 80,
+            "cacheReadTokens": 20,
+            "cacheWriteTokens": "unsupported",
+            "source": "synthetic token counters"
+          },
+          "latencyMs": 100,
+          "runtimeObserved": {
+            "model": "gpt-6-astra",
+            "reasoningEffort": "high",
+            "source": "synthetic runtime receipt"
+          }
+        },
+        {
+          "stageId": "executor",
+          "launchResolved": {
+            "model": "gpt-6-astra",
+            "reasoningEffort": "high",
+            "source": "synthetic launch receipt"
+          },
+          "usage": {
+            "inputTokens": 200,
+            "outputTokens": 40,
+            "uncachedInputTokens": 200,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": "unsupported",
+            "source": "synthetic token counters"
+          },
+          "latencyMs": 200
+        }
+      ],
+      "notes": "Synthetic response-content pass; no fixture edits, commands or model execution occurred."
+    },
+    {
+      "fixtureId": "executor-bounded-change",
+      "configId": "split-pair",
+      "workflowId": "bounded-change-01",
+      "outcome": "pass",
+      "checks": [
+        {
+          "kind": "must-include",
+          "name": "reports-required-checks",
+          "passed": true
+        },
+        {
+          "kind": "must-not-include",
+          "name": "no-scope-inflation",
+          "passed": true
+        }
+      ],
+      "requiredChecksPassed": false,
+      "retries": 1,
+      "latencyMs": 250,
+      "usage": null,
+      "operatorMinutes": 2,
+      "difficult": true,
+      "usageScope": "stages",
+      "stages": [
+        {
+          "stageId": "planner",
+          "launchResolved": {
+            "model": "gpt-6-astra",
+            "reasoningEffort": "high",
+            "source": "synthetic launch receipt"
+          },
+          "usage": {
+            "inputTokens": 100,
+            "outputTokens": 20,
+            "uncachedInputTokens": 80,
+            "cacheReadTokens": 20,
+            "cacheWriteTokens": "unsupported",
+            "source": "synthetic token counters"
+          },
+          "latencyMs": 100,
+          "runtimeObserved": {
+            "model": "gpt-6-astra",
+            "reasoningEffort": "high",
+            "source": "synthetic runtime receipt"
+          }
+        },
+        {
+          "stageId": "executor",
+          "launchResolved": {
+            "model": "gpt-5.6-sol",
+            "reasoningEffort": "high",
+            "source": "synthetic explicit launch override (model and effort)"
+          },
+          "usage": {
+            "inputTokens": 200,
+            "outputTokens": 40,
+            "cacheReadTokens": 0,
+            "source": "synthetic partial token counters"
+          },
+          "latencyMs": 200,
+          "runtimeObserved": {
+            "model": "gpt-6-astra",
+            "reasoningEffort": null,
+            "source": "synthetic runtime receipt; effort unexposed"
+          }
+        }
+      ],
+      "notes": "Synthetic response-content pass; no fixture edits, commands or model execution occurred."
+    }
+  ]
+}

--- a/missions/astra-default-evaluation/examples/stage-transition/report.md
+++ b/missions/astra-default-evaluation/examples/stage-transition/report.md
@@ -1,0 +1,73 @@
+# OMX default-model evaluation report
+
+**Synthetic supplied observations — accounting examples, not measured model results.**
+
+## Configurations
+| config | baseline | omx revision | service tier | cache | code-reviewer | executor | explore | sparkshell | team-worker |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| continue-pair | yes | 7a3cab6445db8313340779ba6298b3cae24eac6e | unknown | unknown; synthetic example does not observe cache reuse | gpt-6-astra / medium | gpt-6-astra / medium | gpt-6-astra / medium | gpt-6-astra / medium | gpt-6-astra / medium |
+| split-pair | no | 7a3cab6445db8313340779ba6298b3cae24eac6e | unknown | unknown; synthetic example does not observe cache reuse | gpt-6-astra / medium | gpt-6-astra / medium | gpt-6-astra / medium | gpt-6-astra / medium | gpt-6-astra / medium |
+Role pins above are configuration values; they do not prove runtime settings.
+
+## Stage settings
+| fixture / workflow | config / stage | surface / role | requested model / effort | override source (model / effort) | launch-resolved (source) | runtime-observed (source) |
+| --- | --- | --- | --- | --- | --- | --- |
+| executor-bounded-change / bounded-change-01 | continue-pair / planner | native-agent / planner | gpt-6-astra / high | proposed agentModels.planner / proposed agentReasoning.planner | gpt-6-astra / high (synthetic launch receipt) | gpt-6-astra / high (synthetic runtime receipt) |
+| executor-bounded-change / bounded-change-01 | continue-pair / executor | native-agent / executor | gpt-6-astra / high | proposed agentModels.executor / proposed agentReasoning.executor | gpt-6-astra / high (synthetic launch receipt) | unknown |
+| executor-bounded-change / bounded-change-01 | split-pair / planner | native-agent / planner | gpt-6-astra / high | proposed agentModels.planner / proposed agentReasoning.planner | gpt-6-astra / high (synthetic launch receipt) | gpt-6-astra / high (synthetic runtime receipt) |
+| executor-bounded-change / bounded-change-01 | split-pair / executor | native-agent / executor | gpt-5.6-terra / medium | proposed agentModels.executor / proposed agentReasoning.executor | gpt-5.6-sol / high (synthetic explicit launch override (model and effort)) | gpt-6-astra / unknown (synthetic runtime receipt; effort unexposed) |
+| sparkshell-exit-status / unknown | deterministic-no-model / unknown | unknown | unknown | unknown | unknown | unknown |
+| sparkshell-failing-tests / unknown | deterministic-no-model / unknown | unknown | unknown | unknown | unknown | unknown |
+
+## Per-task results
+| fixture | config | declared outcome | failed response checks | retries | workflow elapsed ms | input/output | operator min | response grade | required checks |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| executor-bounded-change | continue-pair | pass | — | 0 | 250 | 300/60 | 2 | pass | unknown |
+| executor-bounded-change | split-pair | pass | — | 1 | 250 | 300/60 | 2 | pass | fail |
+| sparkshell-exit-status | deterministic-no-model | pass | — | 0 | unknown | 0/0 | 0 | pass | unknown |
+| sparkshell-failing-tests | deterministic-no-model | pass | — | 0 | unknown | 0/0 | 0 | pass | unknown |
+
+## Aggregate per configuration
+| config | declared pass | fail | error | difficult | retries | sum workflow elapsed ms | input/output | operator min |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| continue-pair | 1 | 0 | 0 | 0 | 0 | 250 | 300/60 | 2 |
+| split-pair | 1 | 0 | 0 | 1 | 1 | 250 | 300/60 | 2 |
+| deterministic-no-model | 2 | 0 | 0 | 0 | 0 | unknown | 0/0 | 0 |
+
+## Usage observations
+Input/output are inclusive totals. Uncached input and cache reads partition input; cache writes are separate observations, never added to input. Reasoning is already in output.
+| scope | input | output | uncached input | cache read | cache write | source | stage duration ms |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| executor-bounded-change @ continue-pair: planner (canonical) | 100 | 20 | 80 | 20 | 1 unsupported | synthetic token counters | 100 |
+| executor-bounded-change @ continue-pair: executor (canonical) | 200 | 40 | 200 | 0 | 1 unsupported | synthetic token counters | 200 |
+| executor-bounded-change @ split-pair: planner (canonical) | 100 | 20 | 80 | 20 | 1 unsupported | synthetic token counters | 100 |
+| executor-bounded-change @ split-pair: executor (canonical) | 200 | 40 | 1 unknown | 0 | 1 unknown | synthetic partial token counters | 200 |
+| sparkshell-exit-status @ deterministic-no-model: workflow (canonical) | 0 | 0 | 0 | 0 | 1 not-applicable | deterministic extractor; no model invoked | not-applicable |
+| sparkshell-failing-tests @ deterministic-no-model: workflow (canonical) | 0 | 0 | 0 | 0 | 1 not-applicable | deterministic extractor; no model invoked | not-applicable |
+| continue-pair: aggregate canonical usage | 300 | 60 | 280 | 20 | 2 unsupported | supplied records above | not-applicable |
+| split-pair: aggregate canonical usage | 300 | 60 | 80 known; 1 unknown | 20 | 1 unknown, 1 unsupported | supplied records above | not-applicable |
+| deterministic-no-model: aggregate canonical usage | 0 | 0 | 0 | 0 | 2 not-applicable | supplied records above | not-applicable |
+Stage rows are not task outcomes. Stage durations are not workflow wall time; operator time is separate. Known sums exclude missing measurements.
+
+## Failed and difficult cases (including unverified checks)
+- `executor-bounded-change` @ `continue-pair`: pass
+  Required checks: unknown; declared outcome is not verified completion.
+- `executor-bounded-change` @ `split-pair`: pass (difficult)
+  Required checks: fail; declared outcome is not verified completion.
+- `sparkshell-exit-status` @ `deterministic-no-model`: pass
+  Required checks: unknown; declared outcome is not verified completion.
+- `sparkshell-failing-tests` @ `deterministic-no-model`: pass
+  Required checks: unknown; declared outcome is not verified completion.
+
+## Cost claims
+Usage attribution is incomplete for: continue-pair, split-pair. No complete cost claim is made for those configurations.
+A lower token count alone is not a successful result.
+Declared pass counts and rates do not certify executed checks, independent review, or accepted completion. No model quality, cost, or savings conclusion is established by this report.
+
+## Workload-weighted summary
+Not reported: documented, representative task frequencies are missing for at least one evaluated fixture. Per-task results above stand on their own and imply no representative savings.
+
+## Limitations
+- Estimates (implementation/maintenance effort) are labeled separately from measurements.
+- Identical reasoning-effort labels across models do not establish equivalent quality or cost.
+- Codex-owned context, caching, and compaction behavior is not controlled by this suite; such fields are recorded as observed or `unknown`.

--- a/missions/astra-default-evaluation/mission.md
+++ b/missions/astra-default-evaluation/mission.md
@@ -13,6 +13,10 @@ not a claim that the defaults are defective. Retaining the current defaults is a
 
 ## Covered surfaces
 
+Optional supplied-record reporting and stage/accounting semantics are documented
+in [Deterministic stage-transition reports](stage-transitions.md). The default
+no-model evaluator remains unchanged.
+
 | surface | fixture | quality check |
 | --- | --- | --- |
 | `explore` | `explore-locate-stop-nudge` | names the implementing source, no unrequested follow-up work |

--- a/missions/astra-default-evaluation/stage-transitions.md
+++ b/missions/astra-default-evaluation/stage-transitions.md
@@ -1,0 +1,137 @@
+# Deterministic stage-transition reports
+
+This extends the existing evaluation path for #3655 and the
+[maintainer invitation](https://github.com/Yeachan-Heo/oh-my-codex/issues/3664#issuecomment-5648392099).
+It imports supplied observations; it never launches configurations, calls models,
+collects telemetry, or changes routing. Live comparisons still require owner spend
+approval. No model ranking, quality result, price, or savings claim follows from
+these examples.
+
+## Reproduce
+
+From the checkout root, after `npm ci --ignore-scripts`:
+
+```sh
+npm run build
+node dist/scripts/eval/eval-astra-defaults.js
+node dist/scripts/eval/eval-astra-defaults.js \
+  --report missions/astra-default-evaluation/examples/stage-transition/records.json \
+  --configs missions/astra-default-evaluation/examples/stage-transition/configs
+node dist/scripts/run-test-files.js dist/evals/astra-defaults/__tests__
+```
+
+The default command retains its `{pass, score, fixtures, configs,
+deterministicBaselines}` JSON contract. Report mode renders Markdown and returns
+success when inputs validate and rendering succeeds, even when supplied tasks
+declare failures. It is not an execution-success gate. Invalid input returns the
+existing `{pass:false, score:0}` error contract and a diagnostic on stderr.
+
+`--configs` selects an alternate config directory while reusing the same fixtures;
+it is only available with `--report`. The report adds the existing deterministic
+Sparkshell baselines. The supplied JSON envelope requires `evidence` (`synthetic`
+or `observed`) and `records`. This label describes the supplied records, not those
+locally computed no-model controls. `observed` is a submitter's assertion, not
+independent verification by the loader. Supplied checks must match fixture names
+and kinds; this validates their shape, not their truth.
+
+The checked-in [example report](examples/stage-transition/report.md) is reproduced
+byte for byte by the test. It compares proposed native-agent planner/executor
+stage descriptors using the existing executor fixture. There is no planner
+fixture, planner quality grade, or exercised native-agent path here. Both proposed
+strategies use native agents; “continue-pair” keeps the pair across stages and
+does not assert same-session continuity. The split example deliberately supplies
+conflicting requested/launch/runtime pairs and incomplete usage. Its figures and
+check outcomes are synthetic; no fixture implementation or required command ran.
+
+## Identity and settings
+
+- `EvalConfig.stages` declares ordered, uniquely named stages: `id`, `role`,
+  `surface` (`main`, `native-agent`, `team-worker`, `sparkshell`), `requested`
+  model/effort and separate `overrideSource` strings for model and effort.
+  These are experiment descriptors, not a capability registry or launch API.
+- Each staged `RunRecord` has a `workflowId` and exactly the declared stage IDs.
+  Missing evidence uses a stage entry with `usage: null`, `latencyMs: null` and
+  absent setting observations. Stage rows cannot declare task outcomes.
+- `launchResolved` and `runtimeObserved` each carry nullable `model` and
+  `reasoningEffort` plus a concise `source`. Absent objects or null fields mean
+  unknown. A launch receipt, explicit pin, or parent fallback never fills runtime
+  evidence. An override that changes launch settings should be identified in the
+  launch source; separate requested provenance remains intact.
+- Existing `roles` pins and configs still load. They are legacy configured
+  values, not service observations. For staged workflows, `stages.requested`
+  describes the proposed stage pair; `roles` remains the configuration for
+  unstaged fixture surfaces. Example role pins use a deliberate uniform-medium
+  control, not a reproduction of shipped role efforts. No model or effort is
+  silently substituted or ranked.
+
+The loader rejects duplicate fixture/config records (including different workflow
+IDs) and reused workflow IDs within a config. Repeated trials remain unsupported;
+this prevents stage or repetition rows from producing weighted rates above 100%.
+Workload frequencies still require documentation. Declared pass rates retain the
+existing single-record semantics; they do not certify accepted completion.
+
+## Accounting and completion rules
+
+One `RunRecord` is one workflow/task outcome. `usageScope` selects the canonical
+usage level: `workflow` uses only `RunRecord.usage`, treating stage usage as
+non-additive detail; `stages` uses only constituent stage usage and requires
+`RunRecord.usage: null`. Without stages, the existing workflow accounting applies.
+Stage-scope counters must cover disjoint work, including relevant handoff,
+receiving-context, retries, review and repair. Do not supply inclusive parent and
+child counters as disjoint stages. The loader cannot verify counter provenance.
+Benchmark/judge overhead belongs outside the evaluated workflow's records.
+
+| Usage field | Meaning |
+| --- | --- |
+| `inputTokens` | Inclusive input total, including cache reads |
+| `outputTokens` | Inclusive output total, including reasoning tokens where present |
+| `uncachedInputTokens` | Non-cached input subset |
+| `cacheReadTokens` | Cached input subset; never added again to input |
+| `cacheWriteTokens` | Separately exposed write counter; never added to input/output or assumed to be disjoint from input |
+| `source` | Concise counter provenance; required when a breakdown is supplied |
+
+Input and output totals retain their existing required numeric fields within a
+non-null usage object. Breakdown fields are optional. Omitted/null means unknown;
+`unsupported` means the source cannot expose that category; `not-applicable`
+requires a source explaining why the category does not apply. Numeric zero is a
+measurement. The no-model extractor records zero input/output/reads and marks
+cache writes not applicable. No cache-write count is invented or inferred.
+
+Available uncached input plus cache reads cannot exceed inclusive input; when
+both are accounted for, they must equal it (`not-applicable` contributes no
+tokens). Records with incompatible provider definitions must leave the breakdown
+unknown instead of relabeling counters. Cache writes have no universal additive
+relationship imposed by this harness. All token counts must be safe nonnegative
+integers; durations/operator time must be finite and nonnegative. Unsafe token
+sums are rejected.
+
+Each category is summed independently. Partial sums show **known** measurements
+and counts of unknown, unsupported or not-applicable entries. A missing category
+does not hide other measurements. Legacy aggregate input/output stays null if
+any canonical usage is unavailable; the detailed table preserves available sums.
+Complete attribution now requires all five token categories and known provenance
+at the selected level. Even complete supplied token attribution is not complete
+billing evidence or a cost/savings result. Old records without breakdowns still
+render, with unavailable observations explicitly unknown.
+
+Workflow `latencyMs` means elapsed time to the reported endpoint; it is not the
+sum of stage durations. Aggregate elapsed time sums workflow values, not concurrent
+wall time. `operatorMinutes` remains separate. Counts/rates use declared outcomes;
+response-content grades and `requiredChecksPassed` are separately visible.
+A command mention is not an executed check. A pass with failed/unknown required
+checks is not verified completion. Required review and the authorized stopping
+boundary remain part of a future experiment's acceptance criteria.
+
+Context continuity does not prove cache reuse; a cache miss does not prove lost
+context. Receiving input includes composed instructions, tools, role prompts and
+retained context, not just a handoff packet. Record only exposed observations and
+concise provenance, never private reasoning traces, raw prompts or secrets.
+Model/effort choices remain hypotheses: equal effort labels do not mean equal
+compute or quality, and an accepted plan does not prove inexpensive execution.
+
+## Deferred work
+
+This does not resolve #3655's owner-gated live comparison. It does not fix the
+historical `astra-defaults.json` shipped-effort label or upgrade the executor's
+response-content fixture into an actual editing/check-running experiment. Those
+remain separate work; existing Luna configs and Sparkshell are preserved.

--- a/src/evals/astra-defaults/__tests__/stage-transition.test.ts
+++ b/src/evals/astra-defaults/__tests__/stage-transition.test.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { renderReport, summarize, weightedPassRates } from '../report.js';
+import { baselineRecord, EvalSuiteError, loadRunRecords, loadSuite, validateRunRecords, validateSuite } from '../suite.js';
+import { summarizeUsage } from '../usage.js';
+import type { RunRecord, Usage } from '../types.js';
+
+const mission = join(process.cwd(), 'missions/astra-default-evaluation');
+const example = join(mission, 'examples/stage-transition');
+const suite = loadSuite(mission, join(example, 'configs'));
+const supplied = loadRunRecords(join(example, 'records.json'), suite);
+const script = join(process.cwd(), 'dist/scripts/eval/eval-astra-defaults.js');
+
+function record(): RunRecord {
+  return structuredClone(supplied.records[0]);
+}
+
+function measured(): Usage {
+  return { inputTokens: 100, outputTokens: 20, uncachedInputTokens: 70, cacheReadTokens: 30,
+    cacheWriteTokens: 10, source: 'test receipt' };
+}
+
+function invalid(row: RunRecord, pattern: RegExp): void {
+  assert.throws(() => validateRunRecords([row], suite), (error) =>
+    error instanceof EvalSuiteError && pattern.test(error.message));
+}
+
+describe('stage configuration and supplied-record validation', () => {
+  it('loads old configurations unchanged and leaves new observations unknown', () => {
+    const legacy = loadSuite(mission);
+    assert.equal(legacy.configs.length, 3);
+    assert.ok(legacy.configs.every((config) => config.stages === undefined));
+    const fixture = legacy.fixtures.find((entry) => entry.deterministicBaseline)!;
+    const old = { ...baselineRecord(fixture), usage: { inputTokens: 0, outputTokens: 0 } };
+    assert.deepEqual(validateRunRecords([old], legacy), [old]);
+    const report = renderReport(legacy, [old]);
+    assert.match(report, /unknown \| unknown \| unknown \| unknown \|/);
+    assert.match(report, /No complete cost claim/);
+    assert.equal(summarize([old], old.configId).usageAttributionComplete, false);
+  });
+
+  it('keeps configs separate from fixture quality and rejects duplicate/malformed stages', () => {
+    assert.equal(suite.fixtures.some((entry) => String(entry.surface) === 'planner'), false);
+    for (const change of ['duplicate-stage', 'bad-pair', 'duplicate-config']) {
+      const bad = structuredClone(suite);
+      if (change === 'duplicate-stage') bad.configs[0].stages!.push(bad.configs[0].stages![0]);
+      if (change === 'bad-pair') bad.configs[0].stages![0].requested.reasoningEffort = '';
+      if (change === 'duplicate-config') bad.configs[1].id = bad.configs[0].id;
+      assert.throws(() => validateSuite(bad), EvalSuiteError);
+    }
+  });
+
+  it('requires exactly the declared stages, with null evidence for unavailable stages', () => {
+    const row = record();
+    row.stages!.pop();
+    invalid(row, /stages must match/);
+    row.stages = record().stages;
+    row.stages![1] = { stageId: 'executor', usage: null, latencyMs: null };
+    assert.doesNotThrow(() => validateRunRecords([row], suite));
+    row.stages![1].stageId = 'planner';
+    invalid(row, /duplicate stage/);
+  });
+
+  it('requires workflow identity and one accounting scope', () => {
+    const row = record();
+    delete row.workflowId;
+    invalid(row, /workflowId and usageScope/);
+    row.workflowId = 'one';
+    row.usage = measured();
+    invalid(row, /workflow usage to be null/);
+    delete row.stages;
+    invalid(row, /requires stages/);
+  });
+
+  it('rejects unsupported repetitions before reporting or weighting can overcount', () => {
+    const rows = [record(), { ...record(), workflowId: 'second-trial' }];
+    assert.throws(() => renderReport(suite, rows), /repeated trials unsupported/);
+    assert.throws(() => summarize(rows, rows[0].configId), /repeated trials unsupported/);
+    assert.throws(() => weightedPassRates(suite, rows, { 'executor-bounded-change': 1 }), /repeated trials unsupported/);
+  });
+
+  it('rejects unknown identities, mismatched response checks and stray record fields', () => {
+    const row = record();
+    row.fixtureId = 'missing';
+    invalid(row, /unknown fixture or config/);
+    row.fixtureId = record().fixtureId;
+    row.checks = [];
+    invalid(row, /checks must match/);
+    assert.throws(() => validateRunRecords([{ ...record(), stageId: 'accidental-task-row' }], suite), EvalSuiteError);
+  });
+
+  it('rejects invalid numeric input through the shared boundary', () => {
+    for (const value of [-1, 0.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, '10']) {
+      const row = record();
+      row.stages![0].usage!.inputTokens = value as number;
+      invalid(row, /inputTokens/);
+    }
+    for (const field of ['latencyMs', 'operatorMinutes', 'retries'] as const) {
+      const row = record();
+      row[field] = -1;
+      invalid(row, new RegExp(field));
+    }
+    for (const field of ['uncachedInputTokens', 'cacheReadTokens', 'cacheWriteTokens'] as const) {
+      const row = record();
+      row.stages![0].usage![field] = Infinity;
+      invalid(row, new RegExp(field));
+    }
+  });
+
+  it('requires breakdown provenance and consistent inclusive input', () => {
+    const row = record();
+    row.stages![0].usage = measured();
+    delete row.stages![0].usage.source;
+    invalid(row, /requires a source/);
+    row.stages![0].usage = { ...measured(), cacheReadTokens: 50 };
+    invalid(row, /subsets exceed/);
+    row.stages![0].usage = { ...measured(), cacheReadTokens: 20 };
+    invalid(row, /must equal/);
+    row.stages![0].usage = { ...measured(), uncachedInputTokens: 'not-applicable', cacheReadTokens: 'not-applicable' };
+    invalid(row, /must equal/);
+  });
+});
+
+describe('observation and accounting reports', () => {
+  it('preserves requested, launch-resolved and runtime-observed differences and sources', () => {
+    const report = renderReport(suite, supplied.records, null, 'synthetic');
+    const executor = report.split('\n').find((line) => line.includes('split-pair / executor'))!;
+    assert.match(executor, /gpt-5.6-terra \/ medium/);
+    assert.match(executor, /proposed agentModels.executor \/ proposed agentReasoning.executor/);
+    assert.match(executor, /gpt-5.6-sol \/ high \(synthetic explicit launch override/);
+    assert.match(executor, /gpt-6-astra \/ unknown \(synthetic runtime receipt/);
+    const missing = report.split('\n').find((line) => line.includes('continue-pair / executor'))!;
+    assert.match(missing, /synthetic launch receipt\) \| unknown \|$/);
+    assert.match(report, /Synthetic supplied observations/);
+  });
+
+  it('counts a staged workflow once without adding input subsets or reasoning twice', () => {
+    const row = record();
+    row.stages!.forEach((stage) => { stage.usage = measured(); });
+    const summary = summarize([row], row.configId);
+    assert.deepEqual([summary.total, summary.passed], [1, 1]);
+    assert.deepEqual(summary.totalUsage, { inputTokens: 200, outputTokens: 40 });
+    assert.equal(summary.usageBreakdown.cacheReadTokens.known, 60);
+    assert.equal(summary.usageBreakdown.cacheWriteTokens.known, 20);
+    assert.equal(summary.usageAttributionComplete, true);
+    assert.equal(summary.totalLatencyMs, 250); // Stage durations sum to 300.
+    assert.equal(summary.totalOperatorMinutes, 2);
+    assert.deepEqual(weightedPassRates(suite, [row], { 'executor-bounded-change': 1 }),
+      [{ configId: row.configId, weightedPassRate: 1 }]);
+  });
+
+  it('uses only workflow totals when stages are non-additive detail', () => {
+    const row = record();
+    row.usageScope = 'workflow';
+    row.usage = measured();
+    row.stages![0].usage = null;
+    const summary = summarize([row], row.configId);
+    assert.deepEqual(summary.totalUsage, { inputTokens: 100, outputTokens: 20 });
+    assert.equal(summary.usageAttributionComplete, true);
+    assert.match(renderReport(suite, [row]), /planner \(detail only\)/);
+  });
+
+  it('preserves zero, partial sums, unsupported and missing stage evidence separately', () => {
+    const row = record();
+    row.stages![0].usage = { ...measured(), cacheWriteTokens: 0 };
+    row.stages![1].usage = null;
+    const summary = summarize([row], row.configId);
+    assert.equal(summary.totalUsage, null);
+    assert.deepEqual(summary.usageBreakdown.cacheWriteTokens,
+      { known: 0, complete: false, unknown: 1, unsupported: 0, notApplicable: 0 });
+    assert.equal(summary.usageAttributionComplete, false);
+    assert.match(renderReport(suite, [row]), /0 known; 1 unknown/);
+    const parts = summarizeUsage([measured(), { ...measured(), cacheWriteTokens: 'unsupported' }]);
+    assert.equal(parts.cacheWriteTokens.known, 10);
+    assert.equal(parts.cacheWriteTokens.unsupported, 1);
+    assert.equal(parts.cacheWriteTokens.complete, false);
+    assert.equal(summarizeUsage([{ ...measured(), cacheWriteTokens: 'not-applicable' }]).cacheWriteTokens.known, null);
+  });
+
+  it('keeps an available cache-read zero when uncached/write measurements are absent', () => {
+    const row = structuredClone(supplied.records[1]);
+    const summary = summarize([row], row.configId);
+    assert.equal(summary.usageBreakdown.cacheReadTokens.complete, true);
+    assert.equal(summary.usageBreakdown.uncachedInputTokens.known, 80);
+    assert.equal(summary.usageBreakdown.uncachedInputTokens.complete, false);
+    assert.match(renderReport(suite, [row]), /80 known; 1 unknown/);
+  });
+
+  it('does not let a response-content pass imply required checks or cost completeness', () => {
+    const report = renderReport(suite, supplied.records);
+    assert.match(report, /\| pass \| unknown \|/);
+    assert.match(report, /\| pass \| fail \|/);
+    assert.match(report, /Required checks: fail; declared outcome is not verified completion/);
+    assert.match(report, /No complete cost claim/);
+    assert.match(report, /No model quality, cost, or savings conclusion/);
+  });
+
+  it('keeps externally supplied provenance inside its Markdown table cell', () => {
+    const row = record();
+    row.stages![0].runtimeObserved!.source = 'receipt | field\n<unknown>';
+    const report = renderReport(suite, [row]);
+    assert.match(report, /receipt &#124; field &lt;unknown&gt;/);
+    assert.equal(row.stages![0].runtimeObserved!.source, 'receipt | field\n<unknown>');
+  });
+
+  it('rejects unsafe token sums and refuses invalid frequency weights', () => {
+    const row = record();
+    row.stages!.forEach((stage) => { stage.usage = { inputTokens: Number.MAX_SAFE_INTEGER, outputTokens: 0 }; });
+    assert.throws(() => summarize([row], row.configId), /unsafe aggregate inputTokens/);
+    for (const value of [-1, Infinity, NaN]) {
+      assert.equal(weightedPassRates(suite, [record()], { 'executor-bounded-change': value }), null);
+    }
+  });
+});
+
+describe('model-free report entrypoint', () => {
+  it('preserves the default evaluator JSON contract', () => {
+    const result = spawnSync(process.execPath, [script], { encoding: 'utf-8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { pass: true, score: 1, fixtures: 6, configs: 3, deterministicBaselines: 2 });
+  });
+
+  it('reproduces supplied records plus existing deterministic baselines byte for byte', () => {
+    const args = [script, '--report', join(example, 'records.json'), '--configs', join(example, 'configs')];
+    const first = spawnSync(process.execPath, args, { encoding: 'utf-8' });
+    const second = spawnSync(process.execPath, args, { encoding: 'utf-8' });
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(first.stdout, second.stdout);
+    assert.equal(first.stdout, readFileSync(join(example, 'report.md'), 'utf-8'));
+    assert.match(first.stdout, /deterministic-no-model/);
+  });
+
+  it('fails invalid external records and arguments without a success report', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omx-eval-records-'));
+    try {
+      const path = join(dir, 'records.json');
+      const row = record();
+      row.stages![0].usage!.inputTokens = -5;
+      writeFileSync(path, JSON.stringify({ evidence: 'synthetic', records: [row] }));
+      const result = spawnSync(process.execPath,
+        [script, '--report', path, '--configs', join(example, 'configs')], { encoding: 'utf-8' });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /inputTokens/);
+      assert.deepEqual(JSON.parse(result.stdout), { pass: false, score: 0 });
+      const invalidArgs = spawnSync(process.execPath, [script, '--live'], { encoding: 'utf-8' });
+      assert.equal(invalidArgs.status, 1);
+      assert.match(invalidArgs.stderr, /usage:/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/evals/astra-defaults/report.ts
+++ b/src/evals/astra-defaults/report.ts
@@ -1,4 +1,6 @@
-import type { EvalConfig, EvalSuite, RunRecord, TaskFrequencies, Usage } from './types.js';
+import type { EvalConfig, EvalSuite, RunRecord, SettingsObservation, TaskFrequencies, Usage } from './types.js';
+import { validateRunRecords } from './suite.js';
+import { formatTokens, summarizeUsage, TOKEN_FIELDS, usageParts, type UsageSummary } from './usage.js';
 
 export interface ConfigSummary {
   configId: string;
@@ -13,24 +15,25 @@ export interface ConfigSummary {
   /** null when any record is missing usage attribution; never silently zero. */
   totalUsage: Usage | null;
   usageAttributionComplete: boolean;
+  usageBreakdown: UsageSummary;
   /** Operator effort stays separate so model savings cannot hide human work. */
   totalOperatorMinutes: number | null;
   operatorAttributionComplete: boolean;
 }
 
 export function summarize(records: RunRecord[], configId: string): ConfigSummary {
+  validateRunRecords(records);
   const rows = records.filter((record) => record.configId === configId);
   let latency: number | null = 0;
-  let usage: Usage | null = { inputTokens: 0, outputTokens: 0 };
+  const parts = rows.flatMap(usageParts);
+  const usageBreakdown = summarizeUsage(parts);
+  const { inputTokens, outputTokens } = usageBreakdown;
+  const usage: Usage | null = inputTokens.complete && outputTokens.complete
+    ? { inputTokens: inputTokens.known!, outputTokens: outputTokens.known! } : null;
   let operator: number | null = 0;
   for (const row of rows) {
     if (row.latencyMs === null) latency = null;
     else if (latency !== null) latency += row.latencyMs;
-    if (row.usage === null) usage = null;
-    else if (usage !== null) {
-      usage.inputTokens += row.usage.inputTokens;
-      usage.outputTokens += row.usage.outputTokens;
-    }
     if (row.operatorMinutes === null) operator = null;
     else if (operator !== null) operator += row.operatorMinutes;
   }
@@ -44,7 +47,9 @@ export function summarize(records: RunRecord[], configId: string): ConfigSummary
     retries: rows.reduce((sum, row) => sum + row.retries, 0),
     totalLatencyMs: latency,
     totalUsage: usage,
-    usageAttributionComplete: usage !== null,
+    usageAttributionComplete: TOKEN_FIELDS.every((field) => usageBreakdown[field].complete)
+      && parts.every((part) => Boolean(part?.source) && part?.source !== 'unknown'),
+    usageBreakdown,
     totalOperatorMinutes: operator,
     operatorAttributionComplete: operator !== null,
   };
@@ -65,13 +70,14 @@ export function weightedPassRates(
   records: RunRecord[],
   frequencies: TaskFrequencies | null,
 ): WeightedResult[] | null {
+  validateRunRecords(records, suite);
   if (!frequencies) return null;
   const known = new Set(suite.fixtures.map((fixture) => fixture.id));
   if (Object.keys(frequencies).some((id) => !known.has(id))) return null;
   const evaluated = [...new Set(records.map((record) => record.fixtureId))];
-  if (evaluated.some((id) => typeof frequencies[id] !== 'number')) return null;
+  if (evaluated.some((id) => !Number.isFinite(frequencies[id]) || frequencies[id] < 0)) return null;
   const totalWeight = evaluated.reduce((sum, id) => sum + frequencies[id], 0);
-  if (totalWeight <= 0) return null;
+  if (!Number.isFinite(totalWeight) || totalWeight <= 0) return null;
   const configIds = [...new Set(records.map((record) => record.configId))];
   return configIds.map((configId) => {
     const weighted = records
@@ -85,6 +91,24 @@ function num(value: number | null): string {
   return value === null ? 'unknown' : String(value);
 }
 
+function tableRow(cells: (string | number)[]): string {
+  return `| ${cells.map((cell) => String(cell).replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\|/g, '&#124;')
+    .replace(/[\r\n]+/g, ' ')).join(' | ')} |`;
+}
+
+function settings(value: SettingsObservation | undefined): string {
+  return value ? `${value.model ?? 'unknown'} / ${value.reasoningEffort ?? 'unknown'} (${value.source})` : 'unknown';
+}
+
+function responseStatus(record: RunRecord): string {
+  return record.checks.length === 0 ? 'unknown' : record.checks.every((check) => check.passed) ? 'pass' : 'fail';
+}
+
+function requiredStatus(record: RunRecord): string {
+  return record.requiredChecksPassed === null ? 'unknown' : record.requiredChecksPassed ? 'pass' : 'fail';
+}
+
 function configTable(configs: EvalConfig[], surfaces: string[]): string {
   const header = `| config | baseline | omx revision | service tier | cache | ${surfaces.join(' | ')} |`;
   const divider = `| --- | --- | --- | --- | --- | ${surfaces.map(() => '---').join(' | ')} |`;
@@ -93,7 +117,7 @@ function configTable(configs: EvalConfig[], surfaces: string[]): string {
       const role = config.roles[surface];
       return role ? `${role.model} / ${role.reasoningEffort}` : 'unknown';
     });
-    return `| ${config.id} | ${config.isBaseline ? 'yes' : 'no'} | ${config.omxRevision} | ${config.serviceTier} | ${config.cacheConditions} | ${cells.join(' | ')} |`;
+    return tableRow([config.id, config.isBaseline ? 'yes' : 'no', config.omxRevision, config.serviceTier, config.cacheConditions, ...cells]);
   });
   return [header, divider, ...rows].join('\n');
 }
@@ -102,7 +126,9 @@ export function renderReport(
   suite: EvalSuite,
   records: RunRecord[],
   frequencies: TaskFrequencies | null = null,
+  evidence?: 'synthetic' | 'observed',
 ): string {
+  validateRunRecords(records, suite);
   const surfaces = [...new Set(suite.fixtures.map((fixture) => fixture.surface))];
   const configIds = [...new Set(records.map((record) => record.configId))];
   const summaries = configIds.map((configId) => summarize(records, configId));
@@ -110,43 +136,89 @@ export function renderReport(
 
   lines.push('# OMX default-model evaluation report');
   lines.push('');
+  lines.push(evidence === 'synthetic'
+    ? '**Synthetic supplied observations — accounting examples, not measured model results.**'
+    : evidence === 'observed' ? 'Supplied observations; the report does not independently verify their provenance.'
+      : 'Evidence origin: unspecified (legacy records).');
+  lines.push('');
   lines.push('## Configurations');
   lines.push(configTable(suite.configs, surfaces));
+  lines.push('Role pins above are configuration values; they do not prove runtime settings.');
+  lines.push('');
+
+  lines.push('## Stage settings');
+  lines.push('| fixture / workflow | config / stage | surface / role | requested model / effort | override source (model / effort) | launch-resolved (source) | runtime-observed (source) |');
+  lines.push('| --- | --- | --- | --- | --- | --- | --- |');
+  for (const record of records) {
+    const config = suite.configs.find((entry) => entry.id === record.configId);
+    if (!record.stages) {
+      lines.push(tableRow([`${record.fixtureId} / ${record.workflowId ?? 'unknown'}`, `${record.configId} / unknown`, 'unknown', 'unknown', 'unknown', 'unknown', 'unknown']));
+    }
+    for (const stage of config?.stages ?? []) {
+      const observed = record.stages?.find((entry) => entry.stageId === stage.id);
+      lines.push(tableRow([`${record.fixtureId} / ${record.workflowId}`, `${record.configId} / ${stage.id}`,
+        `${stage.surface} / ${stage.role}`, `${stage.requested.model} / ${stage.requested.reasoningEffort}`,
+        `${stage.overrideSource.model} / ${stage.overrideSource.reasoningEffort}`,
+        settings(observed?.launchResolved), settings(observed?.runtimeObserved)]));
+    }
+  }
   lines.push('');
 
   lines.push('## Per-task results');
   lines.push(
-    '| fixture | config | outcome | failed checks | retries | latency ms | usage | operator min |',
+    '| fixture | config | declared outcome | failed response checks | retries | workflow elapsed ms | input/output | operator min | response grade | required checks |',
   );
-  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |');
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |');
   for (const record of records) {
     const failed = record.checks.filter((check) => !check.passed).map((check) => check.name);
-    const usage = record.usage
-      ? `${record.usage.inputTokens}/${record.usage.outputTokens}`
-      : 'unknown';
-    lines.push(
-      `| ${record.fixtureId} | ${record.configId} | ${record.outcome} | ${failed.join(', ') || '—'} | ${record.retries} | ${num(record.latencyMs)} | ${usage} | ${num(record.operatorMinutes)} |`,
-    );
+    const tokens = summarizeUsage(usageParts(record));
+    const usage = `${formatTokens(tokens.inputTokens)}/${formatTokens(tokens.outputTokens)}`;
+    lines.push(tableRow([record.fixtureId, record.configId, record.outcome, failed.join(', ') || '—',
+      record.retries, num(record.latencyMs), usage, num(record.operatorMinutes), responseStatus(record), requiredStatus(record)]));
   }
   lines.push('');
 
   lines.push('## Aggregate per configuration');
   lines.push(
-    '| config | pass | fail | error | difficult | retries | latency ms | usage | operator min |',
+    '| config | declared pass | fail | error | difficult | retries | sum workflow elapsed ms | input/output | operator min |',
   );
   lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- |');
   for (const summary of summaries) {
     const usage = summary.totalUsage
       ? `${summary.totalUsage.inputTokens}/${summary.totalUsage.outputTokens}`
       : 'unknown';
-    lines.push(
-      `| ${summary.configId} | ${summary.passed} | ${summary.failed} | ${summary.errored} | ${summary.difficult} | ${summary.retries} | ${num(summary.totalLatencyMs)} | ${usage} | ${num(summary.totalOperatorMinutes)} |`,
-    );
+    lines.push(tableRow([summary.configId, summary.passed, summary.failed, summary.errored, summary.difficult,
+      summary.retries, num(summary.totalLatencyMs), usage, num(summary.totalOperatorMinutes)]));
   }
   lines.push('');
 
-  const failures = records.filter((record) => record.outcome !== 'pass' || record.difficult);
-  lines.push('## Failed and difficult cases');
+  lines.push('## Usage observations');
+  lines.push('Input/output are inclusive totals. Uncached input and cache reads partition input; cache writes are separate observations, never added to input. Reasoning is already in output.');
+  lines.push('| scope | input | output | uncached input | cache read | cache write | source | stage duration ms |');
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |');
+  for (const record of records) {
+    const scope = `${record.fixtureId} @ ${record.configId}`;
+    if (record.usageScope !== 'stages') {
+      const usage = summarizeUsage([record.usage]);
+      lines.push(tableRow([`${scope}: workflow (canonical)`, ...TOKEN_FIELDS.map((field) => formatTokens(usage[field])),
+        record.usage?.source ?? 'unknown', 'not-applicable']));
+    }
+    for (const stage of record.stages ?? []) {
+      const usage = summarizeUsage([stage.usage]);
+      lines.push(tableRow([`${scope}: ${stage.stageId} (${record.usageScope === 'stages' ? 'canonical' : 'detail only'})`,
+        ...TOKEN_FIELDS.map((field) => formatTokens(usage[field])), stage.usage?.source ?? 'unknown', num(stage.latencyMs)]));
+    }
+  }
+  for (const summary of summaries) {
+    lines.push(tableRow([`${summary.configId}: aggregate canonical usage`,
+      ...TOKEN_FIELDS.map((field) => formatTokens(summary.usageBreakdown[field])), 'supplied records above', 'not-applicable']));
+  }
+  lines.push('Stage rows are not task outcomes. Stage durations are not workflow wall time; operator time is separate. Known sums exclude missing measurements.');
+  lines.push('');
+
+  const failures = records.filter((record) => record.outcome !== 'pass' || record.difficult
+    || responseStatus(record) !== 'pass' || record.requiredChecksPassed !== true);
+  lines.push('## Failed and difficult cases (including unverified checks)');
   if (failures.length === 0) lines.push('None recorded.');
   for (const record of failures) {
     const failed = record.checks.filter((check) => !check.passed);
@@ -156,6 +228,7 @@ export function renderReport(
           ? ` — ${failed.map((check) => `${check.name}: ${check.detail ?? 'failed'}`).join('; ')}`
           : ''),
     );
+    if (record.requiredChecksPassed !== true) lines.push(`  Required checks: ${requiredStatus(record)}; declared outcome is not verified completion.`);
   }
   lines.push('');
 
@@ -165,8 +238,10 @@ export function renderReport(
     lines.push(
       `Usage attribution is incomplete for: ${incomplete.map((summary) => summary.configId).join(', ')}. No complete cost claim is made for those configurations.`,
     );
+  } else if (summaries.length > 0) {
+    lines.push('All required token categories have supplied attribution; this is not a billing or savings result.');
   } else {
-    lines.push('Usage attribution is complete for every evaluated configuration.');
+    lines.push('No workflow observations supplied.');
   }
   const operatorIncomplete = summaries.filter((summary) => !summary.operatorAttributionComplete);
   if (operatorIncomplete.length > 0) {
@@ -175,6 +250,7 @@ export function renderReport(
     );
   }
   lines.push('A lower token count alone is not a successful result.');
+  lines.push('Declared pass counts and rates do not certify executed checks, independent review, or accepted completion. No model quality, cost, or savings conclusion is established by this report.');
   lines.push('');
 
   lines.push('## Workload-weighted summary');
@@ -186,7 +262,7 @@ export function renderReport(
   } else {
     for (const row of weighted) {
       lines.push(
-        `- ${row.configId}: ${(row.weightedPassRate * 100).toFixed(1)}% weighted pass rate`,
+        `- ${row.configId}: ${(row.weightedPassRate * 100).toFixed(1)}% weighted declared pass rate`,
       );
     }
   }

--- a/src/evals/astra-defaults/suite.ts
+++ b/src/evals/astra-defaults/suite.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { z } from 'zod';
 import type {
   CheckResult,
   EvalConfig,
@@ -7,9 +8,133 @@ import type {
   EvalSuite,
   QualityCheck,
   RunRecord,
+  SuppliedRecords,
 } from './types.js';
 
 export class EvalSuiteError extends Error {}
+
+const text = z.string().refine((value) => value.trim().length > 0, 'must be nonempty');
+const tokens = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const duration = z.number().nonnegative().finite().nullable();
+const pair = z.object({ model: text, reasoningEffort: text }).strict();
+const stageConfig = z.object({
+  id: text,
+  role: text,
+  surface: z.enum(['main', 'native-agent', 'team-worker', 'sparkshell']),
+  requested: pair,
+  overrideSource: pair,
+}).strict();
+const observation = z.object({
+  model: text.nullable(), reasoningEffort: text.nullable(), source: text,
+}).strict();
+const tokenObservation = z.union([tokens, z.enum(['unsupported', 'not-applicable'])]).nullable();
+const usage = z.object({
+  inputTokens: tokens,
+  outputTokens: tokens,
+  uncachedInputTokens: tokenObservation.optional(),
+  cacheReadTokens: tokenObservation.optional(),
+  cacheWriteTokens: tokenObservation.optional(),
+  source: text.optional(),
+}).strict().superRefine((value, ctx) => {
+  const parts = [value.uncachedInputTokens, value.cacheReadTokens, value.cacheWriteTokens];
+  if (parts.some((part) => part !== undefined && part !== null) && !value.source) {
+    ctx.addIssue({ code: 'custom', message: 'usage breakdown requires a source' });
+  }
+  // Reads and uncached input partition inclusive input. Writes are separately
+  // observed provider metadata; they are not added to either input or reads.
+  const knownInput = [value.uncachedInputTokens, value.cacheReadTokens]
+    .reduce<number>((sum, part) => sum + (typeof part === 'number' ? part : 0), 0);
+  if (knownInput > value.inputTokens) {
+    ctx.addIssue({ code: 'custom', message: 'input subsets exceed inputTokens' });
+  }
+  if ([value.uncachedInputTokens, value.cacheReadTokens].every((part) =>
+    typeof part === 'number' || part === 'not-applicable')
+      && knownInput !== value.inputTokens) {
+    ctx.addIssue({ code: 'custom', message: 'uncached input plus cache reads must equal inputTokens' });
+  }
+});
+const runRecord = z.object({
+  fixtureId: text, configId: text,
+  outcome: z.enum(['pass', 'fail', 'error']),
+  checks: z.array(z.object({
+    name: text, kind: z.enum(['must-include', 'must-not-include', 'exact-set']),
+    passed: z.boolean(), detail: z.string().optional(),
+  }).strict()),
+  requiredChecksPassed: z.boolean().nullable(),
+  retries: tokens, latencyMs: duration, usage: usage.nullable(), operatorMinutes: duration,
+  difficult: z.boolean(), notes: z.string().optional(),
+  workflowId: text.optional(), usageScope: z.enum(['workflow', 'stages']).optional(),
+  stages: z.array(z.object({
+    stageId: text, launchResolved: observation.optional(), runtimeObserved: observation.optional(),
+    usage: usage.nullable(), latencyMs: duration,
+  }).strict()).min(1).optional(),
+}).strict();
+
+function parse<T>(schema: z.ZodType<T>, value: unknown, label: string): T {
+  const result = schema.safeParse(value);
+  if (!result.success) throw new EvalSuiteError(`${label}: ${result.error.message}`);
+  return result.data;
+}
+
+/** Shared import/report boundary. Repeated trials are deliberately unsupported. */
+export function validateRunRecords(records: unknown, suite?: EvalSuite): RunRecord[] {
+  const rows = parse(z.array(runRecord), records, 'invalid run records');
+  const seen = new Set<string>();
+  const workflows = new Set<string>();
+  for (const row of rows) {
+    const key = JSON.stringify([row.fixtureId, row.configId]);
+    if (seen.has(key)) throw new EvalSuiteError(`duplicate fixture/config record ${key}; repeated trials unsupported`);
+    seen.add(key);
+    if (row.workflowId) {
+      const workflow = JSON.stringify([row.configId, row.workflowId]);
+      if (workflows.has(workflow)) throw new EvalSuiteError(`duplicate workflow ${workflow}`);
+      workflows.add(workflow);
+    }
+    if (row.stages) {
+      if (!row.workflowId || !row.usageScope) throw new EvalSuiteError(`${key}: stages require workflowId and usageScope`);
+      if (new Set(row.stages.map((stage) => stage.stageId)).size !== row.stages.length) {
+        throw new EvalSuiteError(`${key}: duplicate stage id`);
+      }
+      if (row.usageScope === 'stages' && row.usage !== null) {
+        throw new EvalSuiteError(`${key}: stage accounting requires workflow usage to be null`);
+      }
+    } else if (row.usageScope === 'stages') {
+      throw new EvalSuiteError(`${key}: stage accounting requires stages`);
+    }
+    if (!suite) continue;
+    const fixture = suite.fixtures.find((entry) => entry.id === row.fixtureId);
+    const config = suite.configs.find((entry) => entry.id === row.configId);
+    if (!fixture || (!config && row.configId !== 'deterministic-no-model')) {
+      throw new EvalSuiteError(`${key}: unknown fixture or config`);
+    }
+    if (!config && (!fixture.deterministicBaseline || row.stages)) {
+      throw new EvalSuiteError(`${key}: invalid deterministic baseline record`);
+    }
+    if (fixture.checks.length !== row.checks.length || fixture.checks.some((check) =>
+      row.checks.filter((result) => result.name === check.name && result.kind === check.kind).length !== 1)) {
+      throw new EvalSuiteError(`${key}: response checks must match the fixture checks`);
+    }
+    const expected = config?.stages?.map((stage) => stage.id) ?? [];
+    const actual = row.stages?.map((stage) => stage.stageId) ?? [];
+    if (expected.length !== actual.length || expected.some((id) => !actual.includes(id))) {
+      throw new EvalSuiteError(`${key}: stages must match configuration; use null observations for missing evidence`);
+    }
+  }
+  return rows;
+}
+
+export function loadRunRecords(path: string, suite: EvalSuite): SuppliedRecords {
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (error) {
+    throw new EvalSuiteError(`invalid records JSON in ${path}: ${(error as Error).message}`);
+  }
+  const supplied = parse(z.object({
+    evidence: z.enum(['synthetic', 'observed']), records: z.array(runRecord).min(1),
+  }).strict(), value, 'invalid supplied records');
+  return { ...supplied, records: validateRunRecords(supplied.records, suite) };
+}
 
 function readJsonDir<T>(dir: string): T[] {
   let entries: string[];
@@ -69,8 +194,19 @@ function validateConfigs(configs: EvalConfig[], fixtures: EvalFixture[]): void {
     throw new EvalSuiteError(`suite must declare exactly one baseline, found ${baselines.length}`);
   }
   const surfaces = new Set(fixtures.map((fixture) => fixture.surface));
+  const ids = new Set<string>();
   for (const config of configs) {
     if (!config.id) throw new EvalSuiteError('configuration is missing an id');
+    if (ids.has(config.id) || config.id === 'deterministic-no-model') {
+      throw new EvalSuiteError(`duplicate or reserved configuration id ${config.id}`);
+    }
+    ids.add(config.id);
+    if (config.stages !== undefined) {
+      parse(z.array(stageConfig).min(1), config.stages, `configuration ${config.id} stages`);
+      if (new Set(config.stages.map((stage) => stage.id)).size !== config.stages.length) {
+        throw new EvalSuiteError(`configuration ${config.id} has duplicate stage ids`);
+      }
+    }
     if (!config.omxRevision?.trim()) {
       throw new EvalSuiteError(`configuration ${config.id} is not pinned to an OMX revision`);
     }
@@ -102,10 +238,10 @@ export function validateSuite(suite: EvalSuite): EvalSuite {
   return suite;
 }
 
-export function loadSuite(suiteDir: string): EvalSuite {
+export function loadSuite(suiteDir: string, configsDir = join(suiteDir, 'configs')): EvalSuite {
   const suite: EvalSuite = {
     fixtures: readJsonDir<EvalFixture>(join(suiteDir, 'fixtures')),
-    configs: readJsonDir<EvalConfig>(join(suiteDir, 'configs')),
+    configs: readJsonDir<EvalConfig>(configsDir),
   };
   return validateSuite(suite);
 }
@@ -192,7 +328,10 @@ export function baselineRecord(
     requiredChecksPassed: null,
     retries: 0,
     latencyMs: null,
-    usage: { inputTokens: 0, outputTokens: 0 },
+    usage: {
+      inputTokens: 0, outputTokens: 0, uncachedInputTokens: 0, cacheReadTokens: 0,
+      cacheWriteTokens: 'not-applicable', source: 'deterministic extractor; no model invoked',
+    },
     operatorMinutes: 0,
     difficult: false,
     notes: 'deterministic extractor, no model invoked',

--- a/src/evals/astra-defaults/types.ts
+++ b/src/evals/astra-defaults/types.ts
@@ -42,6 +42,29 @@ export interface PinnedRoleConfig {
   reasoningEffort: string;
 }
 
+export interface StageConfig {
+  id: string;
+  role: string;
+  surface: 'main' | 'native-agent' | 'team-worker' | 'sparkshell';
+  requested: PinnedRoleConfig;
+  overrideSource: { model: string; reasoningEffort: string };
+}
+
+/** Supplied evidence, never inferred from configuration or parent fallback. */
+export interface SettingsObservation {
+  model: string | null;
+  reasoningEffort: string | null;
+  source: string;
+}
+
+export interface StageRecord {
+  stageId: string;
+  launchResolved?: SettingsObservation;
+  runtimeObserved?: SettingsObservation;
+  usage: Usage | null;
+  latencyMs: number | null;
+}
+
 export interface EvalConfig {
   id: string;
   label: string;
@@ -52,6 +75,8 @@ export interface EvalConfig {
   /** `unknown` is a valid, explicit value: OMX does not own Codex caching. */
   serviceTier: string;
   cacheConditions: string;
+  /** Experiment descriptors, not routing instructions or new fixture surfaces. */
+  stages?: StageConfig[];
 }
 
 export interface EvalSuite {
@@ -69,7 +94,13 @@ export interface CheckResult {
 export interface Usage {
   inputTokens: number;
   outputTokens: number;
+  uncachedInputTokens?: TokenObservation;
+  cacheReadTokens?: TokenObservation;
+  cacheWriteTokens?: TokenObservation;
+  source?: string;
 }
+
+export type TokenObservation = number | null | 'unsupported' | 'not-applicable';
 
 export interface RunRecord {
   fixtureId: string;
@@ -86,6 +117,15 @@ export interface RunRecord {
   operatorMinutes: number | null;
   difficult: boolean;
   notes?: string;
+  workflowId?: string;
+  /** Exactly one accounting level; stage scope requires usage: null above. */
+  usageScope?: 'workflow' | 'stages';
+  stages?: StageRecord[];
+}
+
+export interface SuppliedRecords {
+  evidence: 'synthetic' | 'observed';
+  records: RunRecord[];
 }
 
 /** Documented task frequencies; required before any workload-weighted claim. */

--- a/src/evals/astra-defaults/usage.ts
+++ b/src/evals/astra-defaults/usage.ts
@@ -1,0 +1,54 @@
+import { EvalSuiteError } from './suite.js';
+import type { RunRecord, Usage } from './types.js';
+
+export const TOKEN_FIELDS = [
+  'inputTokens', 'outputTokens', 'uncachedInputTokens', 'cacheReadTokens', 'cacheWriteTokens',
+] as const;
+export type TokenField = typeof TOKEN_FIELDS[number];
+
+export interface TokenSummary {
+  /** Sum of available measurements, not an estimate of missing observations. */
+  known: number | null;
+  complete: boolean;
+  unknown: number;
+  unsupported: number;
+  notApplicable: number;
+}
+
+export type UsageSummary = Record<TokenField, TokenSummary>;
+
+export function usageParts(record: RunRecord): (Usage | null)[] {
+  return record.usageScope === 'stages'
+    ? record.stages!.map((stage) => stage.usage)
+    : [record.usage];
+}
+
+export function summarizeUsage(parts: (Usage | null)[]): UsageSummary {
+  return Object.fromEntries(TOKEN_FIELDS.map((field) => {
+    let known: number | null = null;
+    let unknown = 0;
+    let unsupported = 0;
+    let notApplicable = 0;
+    for (const part of parts) {
+      const value = part?.[field];
+      if (typeof value === 'number') {
+        known = (known ?? 0) + value;
+        if (!Number.isSafeInteger(known)) throw new EvalSuiteError(`unsafe aggregate ${field}`);
+      } else if (value === 'not-applicable') notApplicable++;
+      else if (value === 'unsupported') unsupported++;
+      else unknown++;
+    }
+    return [field, { known, unknown, unsupported, notApplicable,
+      complete: parts.length > 0 && unknown === 0 && unsupported === 0 }];
+  })) as UsageSummary;
+}
+
+export function formatTokens(summary: TokenSummary): string {
+  const states = [
+    summary.unknown ? `${summary.unknown} unknown` : '',
+    summary.unsupported ? `${summary.unsupported} unsupported` : '',
+    summary.notApplicable ? `${summary.notApplicable} not-applicable` : '',
+  ].filter(Boolean);
+  if (summary.known === null) return states.join(', ') || 'unknown';
+  return `${summary.known}${states.length ? ` known; ${states.join(', ')}` : ''}`;
+}

--- a/src/scripts/eval/eval-astra-defaults.ts
+++ b/src/scripts/eval/eval-astra-defaults.ts
@@ -1,15 +1,32 @@
 import { join } from 'node:path';
-import { baselineRecord, loadSuite } from '../../evals/astra-defaults/suite.js';
-
-const suiteDir = process.argv[2] ?? join(process.cwd(), 'missions', 'astra-default-evaluation');
+import { baselineRecord, loadRunRecords, loadSuite } from '../../evals/astra-defaults/suite.js';
+import { renderReport } from '../../evals/astra-defaults/report.js';
 
 try {
-  const suite = loadSuite(suiteDir);
+  const args = process.argv.slice(2);
+  const suiteDir = args[0] && !args[0].startsWith('--')
+    ? args.shift()! : join(process.cwd(), 'missions', 'astra-default-evaluation');
+  const options = new Map<string, string>();
+  while (args.length) {
+    const option = args.shift()!;
+    const value = args.shift();
+    if (!['--report', '--configs'].includes(option) || !value || value.startsWith('--') || options.has(option)) {
+      throw new Error('usage: eval-astra-defaults [suite-dir] [--report records.json [--configs config-dir]]');
+    }
+    options.set(option, value);
+  }
+  if (options.has('--configs') && !options.has('--report')) throw new Error('--configs requires --report');
+  const suite = loadSuite(suiteDir, options.get('--configs'));
   const deterministic = suite.fixtures.filter((fixture) => fixture.deterministicBaseline);
   if (deterministic.length === 0) {
     throw new Error('suite declares no deterministic no-model baseline');
   }
   const records = deterministic.map((fixture) => baselineRecord(fixture));
+  if (options.has('--report')) {
+    const supplied = loadRunRecords(options.get('--report')!, suite);
+    process.stdout.write(`${renderReport(suite, [...supplied.records, ...records], null, supplied.evidence)}\n`);
+    process.exit(0);
+  }
   const passed = records.filter((record) => record.outcome === 'pass');
   const pass = passed.length === records.length;
   for (const record of records.filter((record) => record.outcome !== 'pass')) {


### PR DESCRIPTION
## Summary

The evaluation harness could describe role configurations but could not associate
planner/executor stages with one workflow or distinguish requested settings from
launch and runtime evidence. Add optional stage configuration and a validated,
model-free supplied-record report mode to the existing evaluator.

## Changes

- Keep one outcome per fixture/config workflow, with nested stage observations
  and explicit workflow-versus-stage usage accounting.
- Report requested model/effort and override provenance separately from
  launch-resolved and runtime-observed settings. Missing observations stay unknown.
- Preserve inclusive input/output totals and independently report uncached input,
  cache reads and cache writes, including partial measurements and provenance.
- Show declared outcome, response-content grade and required-check status
  separately. Synthetic records cannot establish model quality or savings.
- Add reproducible same-pair/split-pair synthetic configurations using existing
  fixtures and deterministic controls. Preserve the default evaluator JSON.

Duplicate fixture/config records are now rejected because the existing weighted
numerator could count repeated passes against a unique-fixture denominator.
Repeated trials remain unsupported; this prerequisite prevents overcounting without
adding a trial-statistics framework. Legacy valid single-record inputs still load.
Legacy usage without the new categories renders as incomplete attribution.

No routing/default changes, planner fixture, model collector, billing system, or
live comparison is included. The proposed native-agent stages are descriptors;
the example does not exercise an actual planner/executor workflow.

### Scope of repairs and deferred failures

This contribution is limited to deterministic evaluation configuration, record
validation and reporting. We will fix any regression caused by this diff.
Failures confirmed on the unchanged base are not being repaired in this PR:
changing auth, launch or other production modules would broaden the contribution
and require their own tests and review. Those repairs are deferred unless
separately requested in future work. Deferral does not turn a failed gate into a
pass or establish merge readiness. The complete model-free validation and clean-base comparisons are now recorded below. The report-mode correction from the connector review is delivered separately in #3666 because this PR merged before that correction could be pushed.

## Validation

Base revision: `7a3cab6445db8313340779ba6298b3cae24eac6e` (`dev`).
Validation host: macOS 26.6.2, Node.js 26.5.0, npm 11.17.0 in the checkout.
The completed aggregate run used a local no-model sandbox; clean-base comparisons and the separate unsandboxed auth reproduction are distinguished below.

Reproduce from the checkout root without model calls:

```sh
npm ci --ignore-scripts
npm run build
node dist/scripts/run-test-files.js dist/evals/astra-defaults/__tests__
node dist/scripts/eval/eval-astra-defaults.js
node dist/scripts/eval/eval-astra-defaults.js \
  --report missions/astra-default-evaluation/examples/stage-transition/records.json \
  --configs missions/astra-default-evaluation/examples/stage-transition/configs
```

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/run-test-files.js dist/evals/astra-defaults/__tests__` — 40 passed
- [x] Default evaluator JSON unchanged: 6 fixtures, 3 configs, 2 passing no-model baselines
- [x] Synthetic report reproduced byte for byte by the CLI test
- [x] Runtime build, native-agent/plugin/capabilities/prompt-guidance checks,
  catalog check and prompt inventory check
- [x] `git diff --check`
- [ ] `npm test` — completed all 445 files in 1,889.29 seconds at `d971818d` (tree-identical to merged `dev@477e797d`): **8,234 passed, 49 failed, 11 skipped, 0 cancelled**; 16 files failed. All 49 failing cases reproduced on the clean original base `7a3cab64` and this candidate under the same pinned Node/sandbox environment. Four CLI path failures pass on both revisions with a canonical macOS temporary path. The auth oversized-record failure also reproduces outside the sandbox and directly in the unchanged redactor. Remaining failures span setup, hooks/tmux, MCP lifecycle, notifications, state leases and team runtime; these are local baseline/environment reproductions, not claims that every failure is an upstream production defect. No full-suite pass is claimed.
- Follow-up #3666 fixes the [connector's supplied-record report finding](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665#discussion_r3997562668), with a failing-before/passing-after regression test and **41/41** focused checks. The fix was underway when this PR merged before it could be pushed.
- [x] One independent native review: CLEAN, no supported P0–P2 findings;
  reviewer independently reran all 40 focused tests

Template check — `omx doctor`: **not applicable** (no setup or runtime configuration behavior changes); not run. No model-backed setup smoke was run.
All experiment inputs are synthetic or deterministic. No live evaluation model
calls were made and no quality/cost result was established.

## Checklist

- [x] Focused local diff; existing Luna configurations and Sparkshell preserved
- [x] Accounting/observation semantics and reproduction documented
- [x] Compatibility impact explicit; no silent model/effort substitution

## Related

Merged contribution recorded in #3655’s [post-merge status and remaining live-evaluation work](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5649430885). The evaluator runs deterministic baselines or imports supplied records; it has no live model-execution/collection mode. Representative live comparisons and the evidence-backed recommendations remain outstanding under owner spend approval.

Refs #3655. Implements the deterministic contribution invited in
[#3664's maintainer response](https://github.com/Yeachan-Heo/oh-my-codex/issues/3664#issuecomment-5648392099).
#3655 remains open, and its live comparison still requires owner spend approval.

Context chain:

- [#3622](https://github.com/Yeachan-Heo/oh-my-codex/pull/3622) changed the default
  model policy while preserving effort and overrides; it explicitly did not
  establish comparative OMX quality/cost results.
- [#3655](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655) is the open,
  canonical evaluation issue.
- [#3663](https://github.com/Yeachan-Heo/oh-my-codex/pull/3663) merged the existing
  fixtures/config/reporting harness into `dev`; this contribution extends it.
- [#3664](https://github.com/Yeachan-Heo/oh-my-codex/issues/3664) was closed and
  consolidated into #3655. Its final maintainer response specifically invited
  this deterministic config/reporting PR after the earlier #3655 update had
  described harness work as complete. That invitation does not authorize live
  spend, changed defaults or automatic routing.

## Review guide

Start with the [accounting contract](https://github.com/ev78394/oh-my-codex/blob/d971818d8b4a610c36e9de9b13c860efe6725d5c/missions/astra-default-evaluation/stage-transitions.md)
and [synthetic report](https://github.com/ev78394/oh-my-codex/blob/d971818d8b4a610c36e9de9b13c860efe6725d5c/missions/astra-default-evaluation/examples/stage-transition/report.md).
The [regression tests](https://github.com/ev78394/oh-my-codex/blob/d971818d8b4a610c36e9de9b13c860efe6725d5c/src/evals/astra-defaults/__tests__/stage-transition.test.ts) cover the public import/report path.
Implementation entry points are [record validation](https://github.com/ev78394/oh-my-codex/blob/d971818d8b4a610c36e9de9b13c860efe6725d5c/src/evals/astra-defaults/suite.ts),
[usage aggregation](https://github.com/ev78394/oh-my-codex/blob/d971818d8b4a610c36e9de9b13c860efe6725d5c/src/evals/astra-defaults/usage.ts), and
[report rendering](https://github.com/ev78394/oh-my-codex/blob/d971818d8b4a610c36e9de9b13c860efe6725d5c/src/evals/astra-defaults/report.ts).

The main review decisions are whether the observation/provenance fields are
sufficient for a later planner/native-agent experiment, whether selecting one
accounting level prevents misleading attribution, and whether rejecting repeated
fixture/config records is the right compatibility boundary until trials are
supported. The response-only executor fixture remains unchanged; the example
does not prove edits, executed checks or actual planner/native-agent behavior.
