### PR TITLE
fix(evals): allow supplied-record reports without deterministic baselines

### DIFF
--- a/missions/astra-default-evaluation/stage-transitions.md
+++ b/missions/astra-default-evaluation/stage-transitions.md
@@ -27,8 +27,10 @@ declare failures. It is not an execution-success gate. Invalid input returns the
 existing `{pass:false, score:0}` error contract and a diagnostic on stderr.
 
 `--configs` selects an alternate config directory while reusing the same fixtures;
-it is only available with `--report`. The report adds the existing deterministic
-Sparkshell baselines. The supplied JSON envelope requires `evidence` (`synthetic`
+it is only available with `--report`. The report adds any deterministic baselines
+declared by the suite, including the existing Sparkshell controls. Supplied-record
+reports also accept suites without baselines; the default evaluator still requires
+at least one. The supplied JSON envelope requires `evidence` (`synthetic`
 or `observed`) and `records`. This label describes the supplied records, not those
 locally computed no-model controls. `observed` is a submitter's assertion, not
 independent verification by the loader. Supplied checks must match fixture names

--- a/src/evals/astra-defaults/__tests__/stage-transition.test.ts
+++ b/src/evals/astra-defaults/__tests__/stage-transition.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -233,6 +233,34 @@ describe('model-free report entrypoint', () => {
     assert.equal(first.stdout, second.stdout);
     assert.equal(first.stdout, readFileSync(join(example, 'report.md'), 'utf-8'));
     assert.match(first.stdout, /deterministic-no-model/);
+  });
+
+  it('reports supplied records without baselines while the default evaluator still requires them', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omx-eval-no-baselines-'));
+    try {
+      mkdirSync(join(dir, 'fixtures'));
+      mkdirSync(join(dir, 'configs'));
+      for (const fixture of suite.fixtures) {
+        const custom = { ...fixture };
+        delete custom.deterministicBaseline;
+        writeFileSync(join(dir, 'fixtures', `${custom.id}.json`), JSON.stringify(custom));
+      }
+      for (const config of suite.configs) {
+        writeFileSync(join(dir, 'configs', `${config.id}.json`), JSON.stringify(config));
+      }
+      const result = spawnSync(process.execPath,
+        [script, dir, '--report', join(example, 'records.json')], { encoding: 'utf-8' });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout, `${renderReport(loadSuite(dir), supplied.records, null, supplied.evidence)}\n`);
+      assert.doesNotMatch(result.stdout, /deterministic-no-model/);
+
+      const defaultResult = spawnSync(process.execPath, [script, dir], { encoding: 'utf-8' });
+      assert.equal(defaultResult.status, 1);
+      assert.match(defaultResult.stderr, /suite declares no deterministic no-model baseline/);
+      assert.deepEqual(JSON.parse(defaultResult.stdout), { pass: false, score: 0 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('fails invalid external records and arguments without a success report', () => {

--- a/src/scripts/eval/eval-astra-defaults.ts
+++ b/src/scripts/eval/eval-astra-defaults.ts
@@ -18,7 +18,7 @@ try {
   if (options.has('--configs') && !options.has('--report')) throw new Error('--configs requires --report');
   const suite = loadSuite(suiteDir, options.get('--configs'));
   const deterministic = suite.fixtures.filter((fixture) => fixture.deterministicBaseline);
-  if (deterministic.length === 0) {
+  if (!options.has('--report') && deterministic.length === 0) {
     throw new Error('suite declares no deterministic no-model baseline');
   }
   const records = deterministic.map((fixture) => baselineRecord(fixture));


### PR DESCRIPTION
## Summary

Fix supplied-record report mode for valid custom suites without deterministic baselines. The guard introduced in #3665 rejected these suites before loading their records, although the records are sufficient to render a report.

We were implementing the regression test and fix for the [Codex connector finding](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665#discussion_r3997562668) when #3665 merged, before the correction could be pushed. This follow-up starts from its merged `dev` revision, `477e797d81e2a5a379bb6a742c15e6e9884c9836`.

## Changes

- Require a deterministic baseline only for the default evaluator. Report mode appends any declared controls and accepts none.
- Add a CLI regression test that reports supplied records without baselines and verifies the default evaluator still rejects that same suite.
- Document the distinction. Default JSON output and the existing synthetic report remain unchanged.

### Out-of-scope follow-ups

Auth, setup, tmux/hooks, MCP lifecycle, notifications, state-lease and team-runtime failures encountered during broad validation are outside this three-file correction. Same-environment clean-base comparisons reproduce the local failures independently of the evaluation contribution; that establishes the scope boundary, not a universal root-cause verdict. Four CLI failures specifically clear on both versions when macOS temporary paths are canonicalized. The oversized-stderr auth failure also reproduces outside the sandbox and directly in the unchanged redactor.

Those unrelated repairs are deferred unless separately requested in future work. They change production behavior and need their own reproduction, tests and review; bundling them here would make this report-mode fix harder to assess. A deferred failure remains a failed gate and does not establish merge readiness.

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run check:no-unused`
- [x] `node dist/scripts/run-test-files.js dist/evals/astra-defaults/__tests__` — **41 passed**. The new regression test failed before the guard correction and passed afterward.
- [x] Existing default JSON and byte-for-byte synthetic-report checks pass within that focused suite.
- [x] `git diff --check`, catalog check, prompt inventory check. Runtime build and native-agent/plugin/capabilities/prompt-guidance checks passed in the aggregate run; its catalog/inventory tail was checked separately because the test failure short-circuits the command chain.
- [ ] `npm test` — completed all **445 files** in **1,889.29 seconds** on `d971818d` (tree-identical to merged base `477e797d`): **8,234 passed, 49 failed, 11 skipped, 0 cancelled**; 16 files failed. All 49 failing cases were reproduced on clean original base `7a3cab64` and the original candidate with the same environment. The new fix has the separate 41/41 focused result above; no full-suite pass on the follow-up head is claimed.
- `omx doctor`: **not applicable**; no setup/runtime configuration behavior changed. Not run.

No live evaluation model calls were made. Validation host: macOS 26.6.2, Node.js 26.5.0, npm 11.17.0. The full run uses a task-local sandbox blocking real model executables/auth and writes to host configuration. Baseline comparisons use the same pinned Node and test-runner environment cleanup. Each failing case was rerun on both revisions using `node --test --test-concurrency=1` with a file/test-name selection; no full clean-base suite pass is claimed.

The previous PR's [Windows history-lock timeout](https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/34718268905/job/103619355439) concerns unchanged CLI code. The [maintainer review](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665#pullrequestreview-5188057960) identifies it as a Windows timing flake; the [exact-base job](https://github.com/Yeachan-Heo/oh-my-codex/actions/runs/34703637158/job/103579669907) passed. This is maintainer attribution, not a local Windows reproduction. CI for this follow-up is not awaited.

## Checklist

- [x] PR targets `dev` and contains only the report guard, regression test and relevant documentation.
- [x] Documentation updated.
- [x] Backward compatibility covered: default evaluator still requires a baseline; default JSON and existing report remain stable.

## Related

Merged contribution recorded in #3655’s [post-merge status and remaining live-evaluation work](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5649430885). The evaluator runs deterministic baselines or imports supplied records; it has no live model-execution/collection mode. Representative live comparisons and the evidence-backed recommendations remain outstanding under owner spend approval.

- Follow-up to merged #3665; addresses its [specific connector finding](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665#discussion_r3997562668).
- [Progress comment on #3665](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665#issuecomment-5648685277) records that validation and in-scope corrections were underway before the merge.
- Refs #3655, the open canonical evaluation issue. Its [harness-completion comment](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5633622567) links merged #3663, which introduced the evaluator this fix extends.
- The issue's [no-model results and remaining-work comment](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5634173052) explains that interpretation fixtures have no deterministic baseline. This correction allows supplied-record reports for valid suites containing those fixtures alone.
- The [owner's spend-approval boundary](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5647008360) still applies to live comparisons. The later [deterministic contribution invitation](https://github.com/Yeachan-Heo/oh-my-codex/issues/3664#issuecomment-5648392099) led to merged #3665. This follow-up fixes that contribution; it makes no live quality/cost or routing claim and leaves #3655 open.
