### PR TITLE
docs: clarify Astra evaluation declarations and validation limits

### DIFF
--- a/missions/astra-default-evaluation/configs/astra-defaults.json
+++ b/missions/astra-default-evaluation/configs/astra-defaults.json
@@ -1,6 +1,6 @@
 {
   "id": "astra-defaults",
-  "label": "OMX shipped defaults after #3622 (Astra)",
+  "label": "Uniform-medium Astra comparison baseline after #3622",
   "isBaseline": true,
   "omxRevision": "57d596de2a3c404577ae9861f419102c5c3a804d",
   "roles": {

--- a/missions/astra-default-evaluation/mission.md
+++ b/missions/astra-default-evaluation/mission.md
@@ -8,8 +8,9 @@ not a claim that the defaults are defective. Retaining the current defaults is a
 
 - `fixtures/*.json` — model-agnostic task fixtures with predeclared quality checks. They contain no
   model configuration and stay reusable across future OMX default changes.
-- `configs/*.json` — pinned, inspectable configurations: OMX revision, effective model and reasoning
-  effort per role, service tier, and observable cache conditions. Exactly one is the baseline.
+- `configs/*.json` — pinned, inspectable experiment declarations: OMX revision, comparison model and
+  reasoning effort per role, service tier, and cache conditions. These fields are not runtime
+  observations; unknown values stay explicit. Exactly one configuration is the comparison baseline.
 
 ## Covered surfaces
 
@@ -17,18 +18,25 @@ Optional supplied-record reporting and stage/accounting semantics are documented
 in [Deterministic stage-transition reports](stage-transitions.md). The default
 no-model evaluator remains unchanged.
 
-| surface | fixture | quality check |
+| surface | fixture | response-text check |
 | --- | --- | --- |
 | `explore` | `explore-locate-stop-nudge` | names the implementing source, no unrequested follow-up work |
-| `executor` | `executor-bounded-change` | required checks run, scope not inflated |
+| `executor` | `executor-bounded-change` | mentions the required test command, no scope-inflation phrases |
 | `code-reviewer` | `code-reviewer-known-defect` | finds the planted defect, no false positive on the clean control hunk |
-| Team low-complexity worker | `team-worker-delegated-task` | handoff names changed file and check outcome, no continuation after completion |
+| Team low-complexity worker | `team-worker-delegated-task` | handoff text names a docs path and mentions a check, no continuation after completion |
 | Sparkshell | `sparkshell-failing-tests`, `sparkshell-exit-status` | exact extraction; both carry a deterministic no-model baseline |
 
-## Rules the harness enforces
+These checks score returned text. They do not verify that an executor edited a fixture repository,
+that a required command ran, or that a Team worker used the declared surface. The two Sparkshell
+baselines are the narrower exception: local extractors compute answers from fixed command-output
+strings without invoking a model or executing those commands.
+
+## Experiment requirements
 
 - Task requirements, tools, and per-role reasoning effort stay fixed across the initial model
   comparison. Later effort tuning is a separate pass against the same predeclared requirements.
+- Actual runs record requested settings separately from launch-resolved and runtime-observed settings;
+  a declared configuration never substitutes for runtime evidence.
 - Usage that cannot be attributed is recorded as `unknown`, never as zero, and blocks a complete
   cost claim for that configuration.
 - Operator intervention, review, and repair time is reported separately from model usage, so work
@@ -37,9 +45,20 @@ no-model evaluator remains unchanged.
   frequency; otherwise only per-task results are reported.
 - Failed and difficult cases are reported separately from the aggregate.
 
-## Success
+## Implemented validation
 
-1. `node dist/scripts/eval/eval-astra-defaults.js` passes: the suite validates and every
-   deterministic no-model baseline reproduces its fixture's expected answer.
-2. A run over the pinned configurations produces the report sections above with no fabricated
-   usage, latency, or operator-effort values.
+- Suite loading validates fixture/configuration shape, requires one comparison baseline, and keeps
+  model configuration out of task fixtures.
+- `node dist/scripts/eval/eval-astra-defaults.js` validates the suite and checks that every declared
+  deterministic no-model extractor reproduces its fixture's expected response text. It does not run
+  the non-deterministic tasks or their required commands.
+- Report mode validates supplied-record shape and renders declared outcomes, response-text grades,
+  required-check status, settings observations, usage, latency, and operator effort as separate
+  fields. It does not verify that supplied observations are true.
+
+## Experiment success
+
+An owner-approved run over the pinned configurations must execute the tasks and required commands,
+capture available launch and runtime evidence, and produce the report sections above without
+fabricated usage, latency, or operator-effort values. The current harness accepts and reports those
+records; it does not collect them.

--- a/missions/astra-default-evaluation/stage-transitions.md
+++ b/missions/astra-default-evaluation/stage-transitions.md
@@ -59,12 +59,12 @@ check outcomes are synthetic; no fixture implementation or required command ran.
   unknown. A launch receipt, explicit pin, or parent fallback never fills runtime
   evidence. An override that changes launch settings should be identified in the
   launch source; separate requested provenance remains intact.
-- Existing `roles` pins and configs still load. They are legacy configured
-  values, not service observations. For staged workflows, `stages.requested`
-  describes the proposed stage pair; `roles` remains the configuration for
-  unstaged fixture surfaces. Example role pins use a deliberate uniform-medium
-  control, not a reproduction of shipped role efforts. No model or effort is
-  silently substituted or ranked.
+- Existing `roles` pins and configs still load. They are declared comparison
+  values, not launch-resolved or runtime observations. For staged workflows,
+  `stages.requested` describes the proposed stage pair; `roles` remains the
+  configuration for unstaged fixture surfaces. The primary baseline and example
+  role pins use a deliberate uniform-medium comparison, not a reproduction of
+  shipped role efforts. No model or effort is silently substituted or ranked.
 
 The loader rejects duplicate fixture/config records (including different workflow
 IDs) and reused workflow IDs within a config. Repeated trials remain unsupported;
@@ -133,7 +133,8 @@ compute or quality, and an accepted plan does not prove inexpensive execution.
 
 ## Deferred work
 
-This does not resolve #3655's owner-gated live comparison. It does not fix the
-historical `astra-defaults.json` shipped-effort label or upgrade the executor's
-response-content fixture into an actual editing/check-running experiment. Those
-remain separate work; existing Luna configs and Sparkshell are preserved.
+This does not resolve #3655's owner-gated live comparison. The corrected
+`astra-defaults.json` label now identifies its uniform-medium comparison role;
+it does not reconstruct shipped role efforts. Upgrading the executor's
+response-content fixture into an actual editing/check-running experiment remains
+separate work; existing Luna configs and Sparkshell are preserved.


### PR DESCRIPTION
## Summary

The evaluation documentation described configuration declarations as effective settings, response-text checks as executed work, and a uniform-medium comparison baseline as shipped defaults. Clarify those distinctions without changing evaluation behavior.

This is the bounded cleanup invited by the [owner’s #3655 clarification](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5649522719). At `dev@ca2a4dec`, the evaluator runs deterministic no-model baselines or imports supplied records through `--report`/`--configs`; it does not execute live model workflows or collect their observations. Merged #3665 and #3666 establish reporting/contracts, not comparative quality, savings, defaults, or automatic-routing conclusions.

**Draft with incomplete validation.** The focused evaluation checks pass, but the aggregate test run failed as detailed below. This PR does not claim full-suite success or merge readiness.

## Changes

- `missions/astra-default-evaluation/configs/astra-defaults.json`: relabel the baseline as “Uniform-medium Astra comparison baseline after #3622.” JSON semantics are unchanged except for `label`: revision, baseline identity, all model/effort pins, service tier, and cache conditions remain intact.
- `missions/astra-default-evaluation/mission.md`: distinguish experiment declarations from launch/runtime observations; describe executor and Team checks as response-text scoring; separate implemented suite/report validation from actual experiment success. Mentioning a command does not prove it ran, and importing observations does not verify their truth.
- `missions/astra-default-evaluation/stage-transitions.md`: clarify declared comparison settings and the corrected baseline label, while retaining deferred execution/collection work and the owner gate.

Only these three files change. There are no source, test, fixture, grading, evaluator/output-contract, routing, model-default, or effort-default changes. Existing Luna configurations and Sparkshell controls are preserved.

## Validation

Validation covers the unchanged three-file correction based on `ca2a4decdd3efb7533d23ed94a70e076fed384a0`, delivered in commit `986c2c1dc7fc98a5763ebd0d66c5cb55405631f2`.

- [x] `npm run build` — TypeScript build passed.
- [x] `npm run lint`.
- [x] `node dist/scripts/run-test-files.js dist/evals/astra-defaults/__tests__` — **41 passed**.
- [x] Default evaluator JSON matches clean HEAD: `{"pass":true,"score":1,"fixtures":6,"configs":3,"deterministicBaselines":2}`.
- [x] Synthetic stage-transition report reproduced byte for byte; SHA-256 `c6ffdff956685cfb8941cc272f06718b56737032749fbd3e81885a79415f240c`.
- [x] Configuration JSON semantics differ only in the authorized label.
- [x] Rust runtime build, native-agent verification, plugin-bundle verification, capabilities-lock verification, and prompt-guidance verification passed within the aggregate.
- [x] Complete diff/source review, exact three-file inventory, and `git diff --check`.
- [ ] `npm test` — **completed all 445 files in 1,891.597 seconds (31m32s), exit 1: 8,274 passed, 7 failed, 11 skipped, 0 cancelled; 4 files failed.** No full-suite pass is claimed.

The catalog-doc and prompt-inventory checks at the end of `npm test` were **not reached**, because the Node runner returned nonzero. `omx doctor` is **not applicable**: no setup or runtime configuration behavior changes. No model-backed setup smoke or live model/provider calls were performed.

### Remaining aggregate failures

| Test file | Aggregate result | Follow-up evidence |
| --- | --- | --- |
| `dist/adapt/herdr/__tests__/socket-live.test.js` | File-level Node assertion abort in `InternalCallbackScope::Close`. | Reproduced on the unchanged base; a focused rerun passed. The aggregate failure remains unresolved. |
| `dist/auth/__tests__/hotswap.test.js` | Oversized-stderr quota case expected `quota detected`, but received only the suppression message. | Reproduced on the unchanged base: 6 passed, 1 failed. Previously disclosed in #3665. |
| `dist/cli/__tests__/launch-fallback.test.js` | Parent-provider-environment case hit a 60-second child timeout. | Not reproduced in focused runs: all 38 tests passed on both the unchanged base and candidate. Cause remains unresolved. |
| `dist/cli/__tests__/uninstall.test.js` | Four rollback/recovery assertions failed with `ENAMETOOLONG`. | Reproduced on the unchanged base; a focused rerun passed all 80 tests. The aggregate failures remain unresolved. |

The seven reported failures are:

1. `socket-live.test.js` — file-level assertion abort before individual results.
2. `hotswap.test.js` — “still detects a quota line that follows an oversized stderr record.”
3. `launch-fallback.test.js` — “preserves parent provider env without replaying terminal state over an OMX-created tmux pane.”
4. `uninstall.test.js` — “rolls back hooks, shim, and config when config commit fails after hook mutation.”
5. `uninstall.test.js` — “does not roll back when preserved metadata drifts after staged-deletion cleanup finalization.”
6. `uninstall.test.js` — “preflights every staged uninstall recovery copy before rollback.”
7. `uninstall.test.js` — “stops later uninstall rollback restores when the first restored artifact drifts.”

The auth failure was already recorded in [merged #3665’s validation disclosure](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665), including historical reproductions on an unchanged base. The related redaction fix and regression test entered through [merged #3662](https://github.com/Yeachan-Heo/oh-my-codex/pull/3662). Those historical receipts are context, not validation passes for this candidate. Focused reruns used differing test conditions and do not replace the failed aggregate or establish that its failures are fixed. The aggregate was not rerun, weakened, or relabeled as passed.

## Scope and deferred work

Refs #3655. The issue remains open and its live comparison remains owner-gated. Per the [owner’s clarification](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5649522719), executing/collecting actual workflows and then conducting the representative live comparison require owner usage approval. This PR supplies neither path and makes no quality, cost, or savings claim.

Auth/launcher production repairs are separate maintenance work, not an expansion of #3655 or this correction. Reconstructing shipped role efforts, upgrading response-only fixtures into editing/check-running experiments, collector implementation, and live evaluation remain deferred. Draft publication does not establish merge readiness.

## Checklist

- [x] PR is focused: exactly the retained three-file documentation/metadata correction.
- [x] Evaluation documentation updated; no additional README/DEMO/COVERAGE/AGENTS-template change is needed.
- [x] Backward compatibility considered: configuration semantics except the label and all runtime/output contracts are preserved.
- [x] Known failures, skipped checks, and unresolved uncertainty are disclosed.
- [ ] Full aggregate validation is clean — it remains failed as detailed above.

Document-refresh: not-needed | Evaluation documentation is updated directly; no mapped runtime surface changed.

## Related

- [#3655 — canonical Astra evaluation issue](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655), which remains open.
- [Owner clarification and invitation for bounded cleanup](https://github.com/Yeachan-Heo/oh-my-codex/issues/3655#issuecomment-5649522719).
- [Merged #3622 — Astra-default policy change preserving effort and overrides](https://github.com/Yeachan-Heo/oh-my-codex/pull/3622), the evaluation’s basis.
- [Merged #3663 — reusable default-model evaluation suite](https://github.com/Yeachan-Heo/oh-my-codex/pull/3663).
- [Closed #3664 — stage-specific model/effort and context-transfer discussion](https://github.com/Yeachan-Heo/oh-my-codex/issues/3664), consolidated into #3655; [earlier maintainer invitation](https://github.com/Yeachan-Heo/oh-my-codex/issues/3664#issuecomment-5648392099).
- [Merged #3665 — deterministic stage-transition records and reporting](https://github.com/Yeachan-Heo/oh-my-codex/pull/3665), including the prior auth-failure disclosure.
- [Merged #3666 — supplied-record reports without deterministic baselines](https://github.com/Yeachan-Heo/oh-my-codex/pull/3666).
- [Merged #3662 — auth storage/TOML/PATH/redaction changes](https://github.com/Yeachan-Heo/oh-my-codex/pull/3662), relevant only to the deferred auth regression.
